### PR TITLE
  Removed some cardinality restrictions related to Quantity

### DIFF
--- a/schema/SCHEMA_QUDT-v2.1.ttl
+++ b/schema/SCHEMA_QUDT-v2.1.ttl
@@ -713,11 +713,6 @@ qudt:Quantity
       owl:minCardinality "0"^^xsd:nonNegativeInteger ;
       owl:onProperty qudt:belongsToSystemOfQuantities ;
     ] ;
-  rdfs:subClassOf [
-      a owl:Restriction ;
-      owl:minCardinality "1"^^xsd:int ;
-      owl:onProperty qudt:quantityValue ;
-    ] ;
   skos:exactMatch <http://dbpedia.org/resource/Quantity> ;
 .
 qudt:QuantityKind
@@ -995,11 +990,6 @@ qudt:QuantityValue
       a owl:Restriction ;
       owl:cardinality "1"^^xsd:int ;
       owl:onProperty qudt:unit ;
-    ] ;
-  rdfs:subClassOf [
-      a owl:Restriction ;
-      owl:cardinality "1"^^xsd:nonNegativeInteger ;
-      owl:onProperty qudt:hasQuantityKind ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;


### PR DESCRIPTION
Specifically, a Quantity can have multiple QuantityValues, each with a single number and unit.
e.g. a temperature reading could be 32 degrees F, AND 0 degrees C, should one want to explicitly say so.

Also, a Quantity and a QuantityValue can have multiple QuantityKinds, provided they are still commensurate. This would be useful when they are serving multiple communities, or within an interoperability exercise.