### PR TITLE
Added Geoscience file

### DIFF
--- a/schema/SCHEMA_QUDT-GEOSCIENCE-v2.1.ttl
+++ b/schema/SCHEMA_QUDT-GEOSCIENCE-v2.1.ttl
@@ -1,12 +1,15 @@
 # baseURI: http://qudt.org/2.1/schema/qudt/geoscience
 # imports: http://qudt.org/2.0/schema/qudt/science
 
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix qudt: <http://qudt.org/schema/qudt/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sdo: <https://schema.org/> .
 @prefix vaem: <http://www.linkedmodel.org/schema/vaem#> .
+@prefix voag: <http://voag.linkedmodel.org/schema/voag#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <http://qudt.org/2.1/schema/qudt/geoscience>
@@ -50,7 +53,6 @@ qudt:GMD_QUDT-SCHEMA-ENGINEERING
   vaem:isMetadataFor "http://qudt.org/2.1/schema/geoscience" ;
   vaem:revision "2.1" ;
   vaem:title "QUDT Schema for Geoscience" ;
-  vaem:usesNonImportedResource dct:abstract ;
   vaem:usesNonImportedResource dct:creator ;
   vaem:usesNonImportedResource dct:contributor ;
   vaem:usesNonImportedResource dct:created ;
@@ -62,9 +64,6 @@ qudt:GMD_QUDT-SCHEMA-ENGINEERING
   vaem:usesNonImportedResource dct:title ;
   vaem:usesNonImportedResource voag:QUDT-Attribution ;
   vaem:usesNonImportedResource <http://voag.linkedmodel.org/voag/CC-SHAREALIKE_3PT0-US> ;
-  vaem:usesNonImportedResource skos:closeMatch ;
-  vaem:usesNonImportedResource skos:exactMatch ;
-  vaem:usesNonImportedResource prov:wasInfluencedBy ;
   vaem:withAttributionTo voag:QUDT-Attribution ;
   rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt/geoscience> ;
   rdfs:isDefinedBy qudt:geoscience ;

--- a/schema/SCHEMA_QUDT-GEOSCIENCE-v2.1.ttl
+++ b/schema/SCHEMA_QUDT-GEOSCIENCE-v2.1.ttl
@@ -1,4 +1,4 @@
-# baseURI: http://qudt.org/2.0/schema/qudt/geoscience
+# baseURI: http://qudt.org/2.1/schema/qudt/geoscience
 # imports: http://qudt.org/2.0/schema/qudt/science
 
 @prefix dct: <http://purl.org/dc/terms/> .
@@ -6,21 +6,68 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sdo: <https://schema.org/> .
+@prefix vaem: <http://www.linkedmodel.org/schema/vaem#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<http://qudt.org/2.0/schema/qudt/geoscience>
+<http://qudt.org/2.1/schema/qudt/geoscience>
   a owl:Ontology ;
+  vaem:hasGraphMetadata qudt:GMD_QUDT-SCHEMA-GEOSCIENCE ;  
+  rdfs:label "QUDT Schema - Geoscience" ;  
   owl:imports <http://qudt.org/2.0/schema/qudt/science> ;
+  owl:versionIRI <http://qudt.org/2.1/schema/qudt/geoscience> ;  
 .
 <http://qudt.org/schema/qudt/GeocienceQuantityKind>
   a owl:Class ;
-  dct:description "A Geoscience Quantity Kind is a Quantity Kind pertaining to geoscience, also called earth science, which includes all fields of natural science related to the physical constitution of planet Earth" ;
-  rdfs:isDefinedBy <http://qudt.org/2.0/schema/qudt/geoscience> ;
+  dct:description "A Geoscience Quantity Kind is a Quantity Kind pertaining to geoscience, also called earth science, which includes all fields of natural science related to the physical constitution of planet Earth." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt/geoscience> ;
   rdfs:label "Geoscience Quantity Kind" ;
   rdfs:subClassOf <http://qudt.org/schema/qudt/ScienceQuantityKind> ;
+.
+qudt:GMD_QUDT-SCHEMA-ENGINEERING
+  a vaem:GraphMetaData ;
+  dc:creator "Nicholas J. Car" ;
+  dct:creator [
+  	a sdo:Person ;
+  	sdo:name "Nicholas J. Car" ;
+  	sdo:identifier <https://orcid.org/0000-0002-8742-7730> ;
+  ] ;
   dct:contributor [
         a sdo:Organization ;
         sdo:name "Geological Survey of Queensland" ;
         sdo:identifier <http://linked.data.gov.au/org/gsq> ;
-    ] ;
+  ] ;
+  dct:created "2020-01-22"^^xsd:date ;
+  dct:description "The geoscience domain of QUDT defines the base classes, properties and restrictions used for modeling physical quantities, units of measure, and their dimensions for the domain of geoscience, sometimes called earth science." ;
+  dct:modified "2019-03-10T12:28:04.426-04:00"^^xsd:dateTime ;
+  dct:rights "The QUDT Ontologies are issued under a Creative Commons Attribution Share Alike 3.0 A License. Attribution should be made to NASA Ames Research Center, TopQuadrant, Inc. & Geological Survey of Queensland" ;
+  dct:subject "Quantities" , "Units" , "Dimensions" , "Types" ;
+  dct:title "QUDT Schema for Geoscience" ;
+  vaem:hasGraphRole vaem:SchemaGraph ;
+  vaem:hasLicenseType voag:CC-SHAREALIKE_3PT0-US ;
+  vaem:hasOwner vaem:QUDT ;
+  vaem:hasSteward vaem:QUDT ;
+  vaem:intent "Specifies the schema for quantities, units and dimensions within the geoscience domain. Types are defined in other schemas." ;
+  vaem:isMetadataFor "http://qudt.org/2.1/schema/geoscience" ;
+  vaem:revision "2.1" ;
+  vaem:title "QUDT Schema for Geoscience" ;
+  vaem:usesNonImportedResource dct:abstract ;
+  vaem:usesNonImportedResource dct:creator ;
+  vaem:usesNonImportedResource dct:contributor ;
+  vaem:usesNonImportedResource dct:created ;
+  vaem:usesNonImportedResource dct:description ;
+  vaem:usesNonImportedResource dct:modified ;
+  vaem:usesNonImportedResource dct:rights ;
+  vaem:usesNonImportedResource dct:source ;
+  vaem:usesNonImportedResource dct:subject ;
+  vaem:usesNonImportedResource dct:title ;
+  vaem:usesNonImportedResource voag:QUDT-Attribution ;
+  vaem:usesNonImportedResource <http://voag.linkedmodel.org/voag/CC-SHAREALIKE_3PT0-US> ;
+  vaem:usesNonImportedResource skos:closeMatch ;
+  vaem:usesNonImportedResource skos:exactMatch ;
+  vaem:usesNonImportedResource prov:wasInfluencedBy ;
+  vaem:withAttributionTo voag:QUDT-Attribution ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt/geoscience> ;
+  rdfs:isDefinedBy qudt:geoscience ;
+  rdfs:label "QUDT Schema for Geoscience" ;
+  owl:versionIRI <http://qudt.org/2.1/schema/qudt/geoscience> ;
 .

--- a/schema/SCHEMA_QUDT-GEOSCIENCE-v2.1.ttl
+++ b/schema/SCHEMA_QUDT-GEOSCIENCE-v2.1.ttl
@@ -1,0 +1,26 @@
+# baseURI: http://qudt.org/2.0/schema/qudt/geoscience
+# imports: http://qudt.org/2.0/schema/qudt/science
+
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sdo: <https://schema.org/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://qudt.org/2.0/schema/qudt/geoscience>
+  a owl:Ontology ;
+  owl:imports <http://qudt.org/2.0/schema/qudt/science> ;
+.
+<http://qudt.org/schema/qudt/GeocienceQuantityKind>
+  a owl:Class ;
+  dct:description "A Geoscience Quantity Kind is a Quantity Kind pertaining to geoscience, also called earth science, which includes all fields of natural science related to the physical constitution of planet Earth" ;
+  rdfs:isDefinedBy <http://qudt.org/2.0/schema/qudt/geoscience> ;
+  rdfs:label "Geoscience Quantity Kind" ;
+  rdfs:subClassOf <http://qudt.org/schema/qudt/ScienceQuantityKind> ;
+  dct:contributor [
+        a sdo:Organization ;
+        sdo:name "Geological Survey of Queensland" ;
+        sdo:identifier <http://linked.data.gov.au/org/gsq> ;
+    ] ;
+.


### PR DESCRIPTION
We would really like a dedicated class for all things Geoscience so I've created this file with the single `Geoscience Quantity Kind` class in it. Having it in its own file makes it easy to find and easier to manage than if it was merged in under science. We've versioned it "2.1" to match the other files, i.e. there isn't a v1.0, v2.0 etc.

I'm not sure if we will be adding more subclasses to this, but perhaps we might, looking at similar subclasses of `Quantity Kind`, such as `Atmospheric Quantity Kind` (4 subclasses) or `Biology Quantity Kind` (5 subclasses).

We will create individuals of types `Quantity`, `Quantity Kind` &`Quantity Kind Dimension Vector` in a separate submission which we will add not to the main file VOCAB_QUDT-QUANTITIES-v2.1.ttl but to a peer file within quantities/, VOCAB_QUDT-QUANTITIES-GEOSCIENCE-v2.1.ttl.