### PR TITLE
wholescale replacement of dct:author with dct:creator

### DIFF
--- a/schema/SCHEMA_QUDT-CITATION-v2.1.ttl
+++ b/schema/SCHEMA_QUDT-CITATION-v2.1.ttl
@@ -85,7 +85,7 @@ dc:title
   vaem:title "QUDT Schema for Citations - Version 2.1" ;
   vaem:turtleFileURL "http://qudt.org/2.0/schema/SCHEMA_QUDT-CITATION-v2.1.ttl"^^xsd:anyURI ;
   vaem:usesNonImportedResource dcterms:abstract ;
-  vaem:usesNonImportedResource dcterms:author ;
+  vaem:usesNonImportedResource dcterms:creator ;
   vaem:usesNonImportedResource dcterms:created ;
   vaem:usesNonImportedResource dcterms:modified ;
   vaem:usesNonImportedResource dcterms:rights ;

--- a/schema/SCHEMA_QUDT-DATATYPE-v2.1.ttl
+++ b/schema/SCHEMA_QUDT-DATATYPE-v2.1.ttl
@@ -93,7 +93,7 @@ dcterms:title
   vaem:title "QUDT Schema for Datatypes - Version 2.1" ;
   vaem:turtleFileURL "http://qudt.org/2.0/schema/SCHEMA_QUDT-DATATYPES-v2.0.ttl"^^xsd:anyURI ;
   vaem:usesNonImportedResource dcterms:abstract ;
-  vaem:usesNonImportedResource dcterms:author ;
+  vaem:usesNonImportedResource dcterms:creator ;
   vaem:usesNonImportedResource dcterms:created ;
   vaem:usesNonImportedResource dcterms:modified ;
   vaem:usesNonImportedResource dcterms:rights ;

--- a/schema/SCHEMA_QUDT-ENGINEERING-v2.0.ttl
+++ b/schema/SCHEMA_QUDT-ENGINEERING-v2.0.ttl
@@ -19,7 +19,7 @@
 @prefix voag: <http://voag.linkedmodel.org/schema/voag#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-dct:author
+dct:creator
   a rdf:Property ;
   rdfs:range xsd:string ;
 .
@@ -105,7 +105,7 @@ qudt:EngineeringUnit
 .
 qudt:GMD_QUDT-SCHEMA-ENGINEERING
   a vaem:GraphMetaData ;
-  dct:author "Ralph Hodgson" ;
+  dct:creator "Ralph Hodgson" ;
   dct:contributor "Daniel Mekonnen" ;
   dct:contributor "David Price" ;
   dct:contributor "Irene Polikoff" ;
@@ -134,7 +134,7 @@ qudt:GMD_QUDT-SCHEMA-ENGINEERING
   vaem:revision "2.0" ;
   vaem:title "QUDT Schema for Engineering - Version 2.0" ;
   vaem:usesNonImportedResource dct:abstract ;
-  vaem:usesNonImportedResource dct:author ;
+  vaem:usesNonImportedResource dct:creator ;
   vaem:usesNonImportedResource dct:contributor ;
   vaem:usesNonImportedResource dct:created ;
   vaem:usesNonImportedResource dct:description ;

--- a/schema/SCHEMA_QUDT-FINANCE-v2.0.ttl
+++ b/schema/SCHEMA_QUDT-FINANCE-v2.0.ttl
@@ -19,7 +19,7 @@
 @prefix voag: <http://voag.linkedmodel.org/schema/voag#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-dct:author
+dct:creator
   a rdf:Property ;
   rdfs:range xsd:string ;
 .
@@ -135,7 +135,7 @@ qudt:FinancialUnit
 .
 qudt:GMD_QUDT-SCHEMA-FINANCE
   a vaem:GraphMetaData ;
-  dct:author "Ralph Hodgson" ;
+  dct:creator "Ralph Hodgson" ;
   dct:contributor "Daniel Mekonnen" ;
   dct:contributor "David Price" ;
   dct:contributor "Irene Polikoff" ;
@@ -164,7 +164,7 @@ qudt:GMD_QUDT-SCHEMA-FINANCE
   vaem:revision "2.0" ;
   vaem:title "QUDT Schema for Finance - Version 2.0" ;
   vaem:usesNonImportedResource dct:abstract ;
-  vaem:usesNonImportedResource dct:author ;
+  vaem:usesNonImportedResource dct:creator ;
   vaem:usesNonImportedResource dct:contributor ;
   vaem:usesNonImportedResource dct:created ;
   vaem:usesNonImportedResource dct:description ;

--- a/schema/SCHEMA_QUDT-GEOSCIENCE-v2.1.ttl
+++ b/schema/SCHEMA_QUDT-GEOSCIENCE-v2.1.ttl
@@ -1,12 +1,15 @@
 # baseURI: http://qudt.org/2.1/schema/qudt/geoscience
 # imports: http://qudt.org/2.0/schema/qudt/science
 
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix qudt: <http://qudt.org/schema/qudt/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sdo: <https://schema.org/> .
 @prefix vaem: <http://www.linkedmodel.org/schema/vaem#> .
+@prefix voag: <http://voag.linkedmodel.org/schema/voag#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <http://qudt.org/2.1/schema/qudt/geoscience>
@@ -50,7 +53,6 @@ qudt:GMD_QUDT-SCHEMA-ENGINEERING
   vaem:isMetadataFor "http://qudt.org/2.1/schema/geoscience" ;
   vaem:revision "2.1" ;
   vaem:title "QUDT Schema for Geoscience" ;
-  vaem:usesNonImportedResource dct:abstract ;
   vaem:usesNonImportedResource dct:creator ;
   vaem:usesNonImportedResource dct:contributor ;
   vaem:usesNonImportedResource dct:created ;
@@ -62,9 +64,6 @@ qudt:GMD_QUDT-SCHEMA-ENGINEERING
   vaem:usesNonImportedResource dct:title ;
   vaem:usesNonImportedResource voag:QUDT-Attribution ;
   vaem:usesNonImportedResource <http://voag.linkedmodel.org/voag/CC-SHAREALIKE_3PT0-US> ;
-  vaem:usesNonImportedResource skos:closeMatch ;
-  vaem:usesNonImportedResource skos:exactMatch ;
-  vaem:usesNonImportedResource prov:wasInfluencedBy ;
   vaem:withAttributionTo voag:QUDT-Attribution ;
   rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt/geoscience> ;
   rdfs:isDefinedBy qudt:geoscience ;

--- a/schema/SCHEMA_QUDT-GEOSCIENCE-v2.1.ttl
+++ b/schema/SCHEMA_QUDT-GEOSCIENCE-v2.1.ttl
@@ -1,4 +1,4 @@
-# baseURI: http://qudt.org/2.0/schema/qudt/geoscience
+# baseURI: http://qudt.org/2.1/schema/qudt/geoscience
 # imports: http://qudt.org/2.0/schema/qudt/science
 
 @prefix dct: <http://purl.org/dc/terms/> .
@@ -6,21 +6,68 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sdo: <https://schema.org/> .
+@prefix vaem: <http://www.linkedmodel.org/schema/vaem#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<http://qudt.org/2.0/schema/qudt/geoscience>
+<http://qudt.org/2.1/schema/qudt/geoscience>
   a owl:Ontology ;
+  vaem:hasGraphMetadata qudt:GMD_QUDT-SCHEMA-GEOSCIENCE ;  
+  rdfs:label "QUDT Schema - Geoscience" ;  
   owl:imports <http://qudt.org/2.0/schema/qudt/science> ;
+  owl:versionIRI <http://qudt.org/2.1/schema/qudt/geoscience> ;  
 .
 <http://qudt.org/schema/qudt/GeocienceQuantityKind>
   a owl:Class ;
-  dct:description "A Geoscience Quantity Kind is a Quantity Kind pertaining to geoscience, also called earth science, which includes all fields of natural science related to the physical constitution of planet Earth" ;
-  rdfs:isDefinedBy <http://qudt.org/2.0/schema/qudt/geoscience> ;
+  dct:description "A Geoscience Quantity Kind is a Quantity Kind pertaining to geoscience, also called earth science, which includes all fields of natural science related to the physical constitution of planet Earth." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt/geoscience> ;
   rdfs:label "Geoscience Quantity Kind" ;
   rdfs:subClassOf <http://qudt.org/schema/qudt/ScienceQuantityKind> ;
+.
+qudt:GMD_QUDT-SCHEMA-ENGINEERING
+  a vaem:GraphMetaData ;
+  dc:creator "Nicholas J. Car" ;
+  dct:creator [
+  	a sdo:Person ;
+  	sdo:name "Nicholas J. Car" ;
+  	sdo:identifier <https://orcid.org/0000-0002-8742-7730> ;
+  ] ;
   dct:contributor [
         a sdo:Organization ;
         sdo:name "Geological Survey of Queensland" ;
         sdo:identifier <http://linked.data.gov.au/org/gsq> ;
-    ] ;
+  ] ;
+  dct:created "2020-01-22"^^xsd:date ;
+  dct:description "The geoscience domain of QUDT defines the base classes, properties and restrictions used for modeling physical quantities, units of measure, and their dimensions for the domain of geoscience, sometimes called earth science." ;
+  dct:modified "2019-03-10T12:28:04.426-04:00"^^xsd:dateTime ;
+  dct:rights "The QUDT Ontologies are issued under a Creative Commons Attribution Share Alike 3.0 A License. Attribution should be made to NASA Ames Research Center, TopQuadrant, Inc. & Geological Survey of Queensland" ;
+  dct:subject "Quantities" , "Units" , "Dimensions" , "Types" ;
+  dct:title "QUDT Schema for Geoscience" ;
+  vaem:hasGraphRole vaem:SchemaGraph ;
+  vaem:hasLicenseType voag:CC-SHAREALIKE_3PT0-US ;
+  vaem:hasOwner vaem:QUDT ;
+  vaem:hasSteward vaem:QUDT ;
+  vaem:intent "Specifies the schema for quantities, units and dimensions within the geoscience domain. Types are defined in other schemas." ;
+  vaem:isMetadataFor "http://qudt.org/2.1/schema/geoscience" ;
+  vaem:revision "2.1" ;
+  vaem:title "QUDT Schema for Geoscience" ;
+  vaem:usesNonImportedResource dct:abstract ;
+  vaem:usesNonImportedResource dct:creator ;
+  vaem:usesNonImportedResource dct:contributor ;
+  vaem:usesNonImportedResource dct:created ;
+  vaem:usesNonImportedResource dct:description ;
+  vaem:usesNonImportedResource dct:modified ;
+  vaem:usesNonImportedResource dct:rights ;
+  vaem:usesNonImportedResource dct:source ;
+  vaem:usesNonImportedResource dct:subject ;
+  vaem:usesNonImportedResource dct:title ;
+  vaem:usesNonImportedResource voag:QUDT-Attribution ;
+  vaem:usesNonImportedResource <http://voag.linkedmodel.org/voag/CC-SHAREALIKE_3PT0-US> ;
+  vaem:usesNonImportedResource skos:closeMatch ;
+  vaem:usesNonImportedResource skos:exactMatch ;
+  vaem:usesNonImportedResource prov:wasInfluencedBy ;
+  vaem:withAttributionTo voag:QUDT-Attribution ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt/geoscience> ;
+  rdfs:isDefinedBy qudt:geoscience ;
+  rdfs:label "QUDT Schema for Geoscience" ;
+  owl:versionIRI <http://qudt.org/2.1/schema/qudt/geoscience> ;
 .

--- a/schema/SCHEMA_QUDT-GEOSCIENCE-v2.1.ttl
+++ b/schema/SCHEMA_QUDT-GEOSCIENCE-v2.1.ttl
@@ -1,0 +1,26 @@
+# baseURI: http://qudt.org/2.0/schema/qudt/geoscience
+# imports: http://qudt.org/2.0/schema/qudt/science
+
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sdo: <https://schema.org/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://qudt.org/2.0/schema/qudt/geoscience>
+  a owl:Ontology ;
+  owl:imports <http://qudt.org/2.0/schema/qudt/science> ;
+.
+<http://qudt.org/schema/qudt/GeocienceQuantityKind>
+  a owl:Class ;
+  dct:description "A Geoscience Quantity Kind is a Quantity Kind pertaining to geoscience, also called earth science, which includes all fields of natural science related to the physical constitution of planet Earth" ;
+  rdfs:isDefinedBy <http://qudt.org/2.0/schema/qudt/geoscience> ;
+  rdfs:label "Geoscience Quantity Kind" ;
+  rdfs:subClassOf <http://qudt.org/schema/qudt/ScienceQuantityKind> ;
+  dct:contributor [
+        a sdo:Organization ;
+        sdo:name "Geological Survey of Queensland" ;
+        sdo:identifier <http://linked.data.gov.au/org/gsq> ;
+    ] ;
+.

--- a/schema/SCHEMA_QUDT-MATHEMATICS-v2.0.ttl
+++ b/schema/SCHEMA_QUDT-MATHEMATICS-v2.0.ttl
@@ -19,7 +19,7 @@
 @prefix voag: <http://voag.linkedmodel.org/schema/voag#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-dct:author
+dct:creator
   a rdf:Property ;
   rdfs:range xsd:string ;
 .
@@ -107,7 +107,7 @@ qudt:CountingUnit
 .
 qudt:GMD_QUDT-SCHEMA-MATHEMATICS
   a vaem:GraphMetaData ;
-  dct:author "Ralph Hodgson" ;
+  dct:creator "Ralph Hodgson" ;
   dct:contributor "Daniel Mekonnen" ;
   dct:contributor "David Price" ;
   dct:contributor "Irene Polikoff" ;
@@ -136,7 +136,7 @@ qudt:GMD_QUDT-SCHEMA-MATHEMATICS
   vaem:revision "2.0" ;
   vaem:title "QUDT Schema for Mathematics - Version 2.0" ;
   vaem:usesNonImportedResource dct:abstract ;
-  vaem:usesNonImportedResource dct:author ;
+  vaem:usesNonImportedResource dct:creator ;
   vaem:usesNonImportedResource dct:contributor ;
   vaem:usesNonImportedResource dct:created ;
   vaem:usesNonImportedResource dct:description ;

--- a/schema/SCHEMA_QUDT-SCIENCE-v2.0.ttl
+++ b/schema/SCHEMA_QUDT-SCIENCE-v2.0.ttl
@@ -19,7 +19,7 @@
 @prefix voag: <http://voag.linkedmodel.org/schema/voag#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-dct:author
+dct:creator
   a rdf:Property ;
   rdfs:range xsd:string ;
 .
@@ -3425,7 +3425,7 @@ qudt:integerPercentage
 .
 vaem:GMD_QUDT-SCHEMA-SCIENCE
   a vaem:GraphMetaData ;
-  dct:author "Ralph Hodgson" ;
+  dct:creator "Ralph Hodgson" ;
   dct:contributor "Daniel Mekonnen" ;
   dct:contributor "David Price" ;
   dct:contributor "James E. Masters" ;
@@ -3453,7 +3453,7 @@ vaem:GMD_QUDT-SCHEMA-SCIENCE
   vaem:title "QUDT Schema for Science and Mathematics - Version 2.0" ;
   vaem:turtleFileURL "http://qudt.org/2.0/schema/SCHEMA_QUDT-SCIENCE-v2.0.ttl"^^xsd:anyURI ;
   vaem:usesNonImportedResource dct:abstract ;
-  vaem:usesNonImportedResource dct:author ;
+  vaem:usesNonImportedResource dct:creator ;
   vaem:usesNonImportedResource dct:contributor ;
   vaem:usesNonImportedResource dct:created ;
   vaem:usesNonImportedResource dct:description ;

--- a/schema/SCHEMA_QUDT-v2.1.ttl
+++ b/schema/SCHEMA_QUDT-v2.1.ttl
@@ -24,7 +24,7 @@ dct:abstract
   rdfs:label "abstract" ;
   rdfs:range xsd:string ;
 .
-dct:author
+dct:creator
   a rdf:Property ;
   rdfs:range xsd:string ;
 .
@@ -2702,7 +2702,7 @@ voag:supersededBy
 .
 vaem:GMD_QUDT-SCHEMA
   a vaem:GraphMetaData ;
-  dct:author "Ralph Hodgson" ;
+  dct:creator "Ralph Hodgson" ;
   dct:contributor "Daniel Mekonnen" ;
   dct:contributor "David Price" ;
   dct:contributor "Jack Hodges" ;
@@ -2736,7 +2736,7 @@ vaem:GMD_QUDT-SCHEMA
   vaem:title "Quantities, Units, Dimensions and Types (QUDT) Schema - Version 2.1" ;
   vaem:turtleFileURL "http://qudt.org/2.1/schema/qudt"^^xsd:anyURI ;
   vaem:usesNonImportedResource dct:abstract ;
-  vaem:usesNonImportedResource dct:author ;
+  vaem:usesNonImportedResource dct:creator ;
   vaem:usesNonImportedResource dct:contributor ;
   vaem:usesNonImportedResource dct:created ;
   vaem:usesNonImportedResource dct:description ;

--- a/vocab/VOCAB_QUDT-CITATION-v2.1.ttl
+++ b/vocab/VOCAB_QUDT-CITATION-v2.1.ttl
@@ -711,7 +711,7 @@ citation:ZhJoJo06
   vaem:title "QUDT Schema for Citations - Version 2.1" ;
   vaem:turtleFileURL "http://qudt.org/2.0/vocab/VOCAB_QUDT-CITATION-v2.1.ttl"^^xsd:anyURI ;
   vaem:usesNonImportedResource dcterms:abstract ;
-  vaem:usesNonImportedResource dcterms:author ;
+  vaem:usesNonImportedResource dcterms:creator ;
   vaem:usesNonImportedResource dcterms:created ;
   vaem:usesNonImportedResource dcterms:modified ;
   vaem:usesNonImportedResource dcterms:rights ;

--- a/vocab/constants/VOCAB_QUDT-CONSTANTS-v2.1.ttl
+++ b/vocab/constants/VOCAB_QUDT-CONSTANTS-v2.1.ttl
@@ -5903,7 +5903,7 @@ voag:withAttributionTo
 .
 vaem:GMD_QUDT-CONSTANTS
   a vaem:GraphMetaData ;
-  dct:author "Steve Ray" ;
+  dct:creator "Steve Ray" ;
   dct:contributor "Irene Polikoff" ;
   dct:contributor "Jack Hodges" ;
   dct:contributor "Ralph Hodgson" ;
@@ -5934,7 +5934,7 @@ vaem:GMD_QUDT-CONSTANTS
   vaem:url "http://qudt.org/2.1/vocab/constant.ttl"^^xsd:anyURI ;
   vaem:urlForHTML "http://qudt.org/2.1/vocab/constant.html"^^xsd:anyURI ;
   vaem:usesNonImportedResource dct:abstract ;
-  vaem:usesNonImportedResource dct:author ;
+  vaem:usesNonImportedResource dct:creator ;
   vaem:usesNonImportedResource dct:created ;
   vaem:usesNonImportedResource dct:modified ;
   vaem:usesNonImportedResource dct:title ;

--- a/vocab/dimensionvectors/VOCAB_QUDT-DIMENSION-VECTORS-v2.1.ttl
+++ b/vocab/dimensionvectors/VOCAB_QUDT-DIMENSION-VECTORS-v2.1.ttl
@@ -3126,7 +3126,7 @@ voag:QUDT-DIMENSIONS-VocabCatalogEntry
 .
 vaem:GMD_QUDT-DIMENSION-VECTORS
   a vaem:GraphMetaData ;
-  dct:author "Steve Ray" ;
+  dct:creator "Steve Ray" ;
   dct:contributor "Jack Hodges" ;
   dct:contributor "Steve Ray" ;
   dct:created "2019-08-01T16:25:54.850+00:00"^^xsd:dateTime ;
@@ -3159,7 +3159,7 @@ vaem:GMD_QUDT-DIMENSION-VECTORS
   vaem:usesNonImportedResource dc:rights ;
   vaem:usesNonImportedResource dc:subject ;
   vaem:usesNonImportedResource dc:title ;
-  vaem:usesNonImportedResource dct:author ;
+  vaem:usesNonImportedResource dct:creator ;
   vaem:usesNonImportedResource dct:contributor ;
   vaem:usesNonImportedResource dct:created ;
   vaem:usesNonImportedResource dct:creator ;

--- a/vocab/disciplines/VOCAB_QUDT-DISCIPLINES-v2.0.ttl
+++ b/vocab/disciplines/VOCAB_QUDT-DISCIPLINES-v2.0.ttl
@@ -13,7 +13,7 @@
 @prefix vaem: <http://www.linkedmodel.org/schema/vaem#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-dcterms:author
+dcterms:creator
   a owl:AnnotationProperty ;
   rdfs:label "author" ;
   rdfs:range xsd:string ;
@@ -672,7 +672,7 @@ discipline:VibrationAnalysis
 .
 vaem:GMD_QUDT-VOCAB-DISCIPLINES
   a vaem:GraphMetaData ;
-  dcterms:author "Ralph Hodgson" ;
+  dcterms:creator "Ralph Hodgson" ;
   dcterms:contributor "Jack Hodges" ;
   dcterms:contributor "James E. Masters" ;
   dcterms:contributor "Steve Ray" ;
@@ -700,7 +700,7 @@ vaem:GMD_QUDT-VOCAB-DISCIPLINES
   vaem:title "Disciplines Taxonomy Version 2.0" ;
   vaem:turtleFileURL "http://qudt.org/2.0/vocab/VOCAB_QUDT-DISCIPLINES-v2.0.ttl"^^xsd:anyURI ;
   vaem:usesNonImportedResource dcterms:abstract ;
-  vaem:usesNonImportedResource dcterms:author ;
+  vaem:usesNonImportedResource dcterms:creator ;
   vaem:usesNonImportedResource dcterms:contributor ;
   vaem:usesNonImportedResource dcterms:created ;
   vaem:usesNonImportedResource dcterms:description ;

--- a/vocab/disciplines/VOCAB_QUDT-DISCIPLINES-v2.1.ttl
+++ b/vocab/disciplines/VOCAB_QUDT-DISCIPLINES-v2.1.ttl
@@ -15,7 +15,7 @@
 @prefix vaem: <http://www.linkedmodel.org/schema/vaem#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-dcterms:author
+dcterms:creator
   a owl:AnnotationProperty ;
   rdfs:label "author" ;
   rdfs:range xsd:string ;
@@ -1933,7 +1933,7 @@ discipline:VibrationAnalysis
 .
 <http://www.linkedmodel.org/schema/vaem#GMD_QUDT-2.1-VOCAB-DISCIPLINES>
   a vaem:GraphMetaData ;
-  dcterms:author "Steve Ray" ;
+  dcterms:creator "Steve Ray" ;
   dcterms:contributor "Jack Hodges" ;
   dcterms:contributor "James E. Masters" ;
   dcterms:contributor "Ralph Hodgson" ;
@@ -1960,7 +1960,7 @@ discipline:VibrationAnalysis
   vaem:revision "2.1" ;
   vaem:title "Disciplines Taxonomy Version 2.1" ;
   vaem:usesNonImportedResource dcterms:abstract ;
-  vaem:usesNonImportedResource dcterms:author ;
+  vaem:usesNonImportedResource dcterms:creator ;
   vaem:usesNonImportedResource dcterms:contributor ;
   vaem:usesNonImportedResource dcterms:created ;
   vaem:usesNonImportedResource dcterms:description ;

--- a/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
+++ b/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
@@ -10551,7 +10551,7 @@ unit:SpeedOfLight_Vacuum
 .
 vaem:GMD_QUDT-QUANTITY-KINDS-ALL
   a vaem:GraphMetaData ;
-  dct:author "Steve Ray" ;
+  dct:creator "Steve Ray" ;
   dct:contributor "Jack Hodges" ;
   dct:contributor "Steve Ray" ;
   dct:created "2019-08-01T16:25:54.850+00:00"^^xsd:dateTime ;
@@ -10583,7 +10583,7 @@ vaem:GMD_QUDT-QUANTITY-KINDS-ALL
   vaem:usesNonImportedResource dc:rights ;
   vaem:usesNonImportedResource dc:subject ;
   vaem:usesNonImportedResource dc:title ;
-  vaem:usesNonImportedResource dct:author ;
+  vaem:usesNonImportedResource dct:creator ;
   vaem:usesNonImportedResource dct:contributor ;
   vaem:usesNonImportedResource dct:created ;
   vaem:usesNonImportedResource dct:creator ;

--- a/vocab/quantitykinds/standards-based-quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-CGS-v2.0.ttl
+++ b/vocab/quantitykinds/standards-based-quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-CGS-v2.0.ttl
@@ -18,7 +18,7 @@
 
 <http://qudt.org/2.0/vocab/quantitykind/cgs>
   a owl:Ontology ;
-  dcterms:author "Ralph Hodgson" ;
+  dcterms:creator "Ralph Hodgson" ;
   dcterms:creator "James E. Masters" ;
   dcterms:subject "Measurable Quantities" ;
   dcterms:title "QUDT Quantity Kinds for CGS Systems of Quantities Version 2.0" ;
@@ -37,7 +37,7 @@
   vaem:namespacePrefix "qudt-quantity" ;
   vaem:revision "2.0" ;
   vaem:specificity 1 ;
-  vaem:usesNonImportedResource dcterms:author ;
+  vaem:usesNonImportedResource dcterms:creator ;
   vaem:usesNonImportedResource dcterms:contributor ;
   vaem:usesNonImportedResource dcterms:creator ;
   vaem:usesNonImportedResource dcterms:description ;

--- a/vocab/quantitykinds/standards-based-quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-CGS-v2.1.ttl
+++ b/vocab/quantitykinds/standards-based-quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-CGS-v2.1.ttl
@@ -18,7 +18,7 @@
 
 <http://qudt.org/2.1/vocab/quantitykind/cgs>
   a owl:Ontology ;
-  dcterms:author "Ralph Hodgson" ;
+  dcterms:creator "Ralph Hodgson" ;
   dcterms:creator "James E. Masters" ;
   dcterms:subject "Measurable Quantities" ;
   dcterms:title "QUDT Quantity Kinds for CGS Systems of Quantities Version 2.0" ;
@@ -36,7 +36,7 @@
   vaem:namespacePrefix "qudt-quantity" ;
   vaem:revision "2.0" ;
   vaem:specificity 1 ;
-  vaem:usesNonImportedResource dcterms:author ;
+  vaem:usesNonImportedResource dcterms:creator ;
   vaem:usesNonImportedResource dcterms:contributor ;
   vaem:usesNonImportedResource dcterms:creator ;
   vaem:usesNonImportedResource dcterms:description ;

--- a/vocab/quantitykinds/standards-based-quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-SI-v2.0.ttl
+++ b/vocab/quantitykinds/standards-based-quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-SI-v2.0.ttl
@@ -4472,7 +4472,7 @@ qudt:GMD_QUDT-QUANTITY-KINDS-SI
   dc:author "Ralph Hodgson" ;
   dc:rights "The QUDT Ontologies are issued under a Creative Commons Attribution Share Alike 3.0 United States License. Attribution should be made to NASA Ames Research Center and TopQuadrant, Inc." ;
   dc:subject "Measurable Quantities" ;
-  dct:author "Ralph Hodgson" ;
+  dct:creator "Ralph Hodgson" ;
   dct:contributor "Daniel Mekonnen" ;
   dct:contributor "David Price" ;
   dct:contributor "Irene Polikoff" ;
@@ -4508,7 +4508,7 @@ qudt:GMD_QUDT-QUANTITY-KINDS-SI
   vaem:specificity 1 ;
   vaem:title "QUDT Base Quantities - Version 2.0" ;
   vaem:turtleFileURL "http://qudt.org/2.0/vocab/VOCAB_QUDT-BASE-QUANTITY-KINDS-v2.0.ttl"^^xsd:anyURI ;
-  vaem:usesNonImportedResource dct:author ;
+  vaem:usesNonImportedResource dct:creator ;
   vaem:usesNonImportedResource dct:contributor ;
   vaem:usesNonImportedResource dct:creator ;
   vaem:usesNonImportedResource dct:description ;

--- a/vocab/quantitykinds/standards-based-quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-SI-v2.1.ttl
+++ b/vocab/quantitykinds/standards-based-quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-SI-v2.1.ttl
@@ -4471,7 +4471,7 @@ qudt:GMD_QUDT-QUANTITY-KINDS-SI
   a vaem:GraphMetaData ;
   dc:author "Ralph Hodgson" ;
   dc:subject "Measurable Quantities" ;
-  dct:author "Ralph Hodgson" ;
+  dct:creator "Ralph Hodgson" ;
   dct:contributor "Daniel Mekonnen" ;
   dct:contributor "David Price" ;
   dct:contributor "Irene Polikoff" ;
@@ -4507,7 +4507,7 @@ qudt:GMD_QUDT-QUANTITY-KINDS-SI
   vaem:specificity 1 ;
   vaem:title "QUDT Base Quantities - Version 2.0" ;
   vaem:turtleFileURL "http://qudt.org/2.0/vocab/VOCAB_QUDT-BASE-QUANTITY-KINDS-v2.0.ttl"^^xsd:anyURI ;
-  vaem:usesNonImportedResource dct:author ;
+  vaem:usesNonImportedResource dct:creator ;
   vaem:usesNonImportedResource dct:contributor ;
   vaem:usesNonImportedResource dct:creator ;
   vaem:usesNonImportedResource dct:description ;

--- a/vocab/system-of-units/VOCAB_QUDT-SOU-SI-v2.0.ttl
+++ b/vocab/system-of-units/VOCAB_QUDT-SOU-SI-v2.0.ttl
@@ -343,7 +343,7 @@ voag:withAttributionTo
 .
 vaem:GMD_QUDT-SOU-SI
   a vaem:GraphMetaData ;
-  dct:author "Ralph Hodgson" ;
+  dct:creator "Ralph Hodgson" ;
   dct:contributor "Jack Hodges" ;
   dct:contributor "Steve Ray" ;
   dct:contributor "Stuart Chalk" ;
@@ -371,7 +371,7 @@ vaem:GMD_QUDT-SOU-SI
   vaem:title "SI System of Units Ontology Version 2.0" ;
   vaem:turtleFileURL "http://qudt.org/2.0/vocab/VOCAB_qudt-sou-si-v2.0.ttl"^^xsd:anyURI ;
   vaem:usesNonImportedResource dct:abstract ;
-  vaem:usesNonImportedResource dct:author ;
+  vaem:usesNonImportedResource dct:creator ;
   vaem:usesNonImportedResource dct:contributor ;
   vaem:usesNonImportedResource dct:created ;
   vaem:usesNonImportedResource dct:description ;

--- a/vocab/system-of-units/VOCAB_QUDT-SOU-SI-v2.1.ttl
+++ b/vocab/system-of-units/VOCAB_QUDT-SOU-SI-v2.1.ttl
@@ -343,7 +343,7 @@ voag:withAttributionTo
 .
 vaem:GMD_QUDT-SOU-SI
   a vaem:GraphMetaData ;
-  dct:author "Ralph Hodgson" ;
+  dct:creator "Ralph Hodgson" ;
   dct:contributor "Jack Hodges" ;
   dct:contributor "Steve Ray" ;
   dct:contributor "Stuart Chalk" ;
@@ -371,7 +371,7 @@ vaem:GMD_QUDT-SOU-SI
   vaem:title "SI System of Units Ontology Version 2.0" ;
   vaem:turtleFileURL "http://qudt.org/2.0/vocab/VOCAB_qudt-sou-si-v2.0.ttl"^^xsd:anyURI ;
   vaem:usesNonImportedResource dct:abstract ;
-  vaem:usesNonImportedResource dct:author ;
+  vaem:usesNonImportedResource dct:creator ;
   vaem:usesNonImportedResource dct:contributor ;
   vaem:usesNonImportedResource dct:created ;
   vaem:usesNonImportedResource dct:description ;

--- a/vocab/types/VOCAB_QUDT-datatypes-v2.1.ttl
+++ b/vocab/types/VOCAB_QUDT-datatypes-v2.1.ttl
@@ -76,7 +76,7 @@ dcterms:title
   vaem:releaseDate "2018-03-17"^^xsd:date ;
   vaem:revision "2.1" ;
   vaem:usesNonImportedResource dcterms:abstract ;
-  vaem:usesNonImportedResource dcterms:author ;
+  vaem:usesNonImportedResource dcterms:creator ;
   vaem:usesNonImportedResource dcterms:created ;
   vaem:usesNonImportedResource dcterms:modified ;
   vaem:usesNonImportedResource dcterms:rights ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -16959,7 +16959,7 @@ voag:withAttributionTo
 .
 vaem:GMD_QUDT-UNITS-ALL
   a vaem:GraphMetaData ;
-  dct:author "Steve Ray" ;
+  dct:creator "Steve Ray" ;
   dct:contributor "Jack Hodges" ;
   dct:contributor "Steve Ray" ;
   dct:created "2019-07-30"^^xsd:date ;
@@ -16985,7 +16985,7 @@ vaem:GMD_QUDT-UNITS-ALL
   vaem:title "All Units Ontology Version 2.1" ;
   vaem:turtleFileURL "http://qudt.org/2.1/vocab/unit"^^xsd:anyURI ;
   vaem:usesNonImportedResource dct:abstract ;
-  vaem:usesNonImportedResource dct:author ;
+  vaem:usesNonImportedResource dct:creator ;
   vaem:usesNonImportedResource dct:created ;
   vaem:usesNonImportedResource dct:modified ;
   vaem:usesNonImportedResource dct:title ;


### PR DESCRIPTION
`dct:author` is not a property within Dublin Core Terms (see https://dublincore.org/specifications/dublin-core/dcmi-terms/). 

The closest term is `dct:creator`