### PR TITLE
NanoSEC DBPedia & Wikipedia refs corrected

### DIFF
--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -11858,9 +11858,9 @@ unit:NanoSEC
   qudt:uneceCommonCode "C47" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "nanosecond" ;
-  skos:exactMatch <http://dbpedia.org/resource/Millisecond> ;
+  skos:exactMatch <http://dbpedia.org/resource/Nanosecond> ;
   skos:prefLabel "nanosecond" ;
-  prov:wasInfluencedBy <http://en.wikipedia.org/wiki/Millisecond?oldid=495102042> ;
+  prov:wasInfluencedBy <http://en.wikipedia.org/wiki/Nanosecond?oldid=919778950> ;
 .
 unit:NepaleseRupee
   a qudt:CurrencyUnit ;


### PR DESCRIPTION
The references to Wikipedia & DBPedia for Nanosecond are incorrect. This corrects the links.