### PR TITLE
 Removed link from Quantity to SystemOfQuantityKinds

### DIFF
--- a/schema/SCHEMA_QUDT-v2.1.ttl
+++ b/schema/SCHEMA_QUDT-v2.1.ttl
@@ -677,12 +677,6 @@ qudt:Quantity
       owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onProperty qudt:mathMLdefinition ;
     ] ;
-  rdfs:subClassOf [
-      a owl:Restriction ;
-      rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
-      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
-      owl:onProperty qudt:belongsToSystemOfQuantities ;
-    ] ;
 .
 qudt:QuantityKind
   a owl:Class ;


### PR DESCRIPTION
The concept of a Quantity is independent of a system (of QuantityKinds or of Units), so I removed this link. There is still a link from QuantityKind to SystemOfQuantityKinds, which makes sense.