### PR TITLE
 Added import of qudt schema into skos extension

### DIFF
--- a/schema/extensions/skos.ttl
+++ b/schema/extensions/skos.ttl
@@ -1,17 +1,19 @@
 # baseURI: http://qudt.org/2.1/schema/extensions/skos
+# imports: http://qudt.org/2.1/schema/qudt
 # imports: http://www.w3.org/2004/02/skos/core
 # prefix: qudt-skos
 
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix qudt: <http://qudt.org/schema/qudt/> .
+@prefix qudt-skos: <http://qudt.org/2.1/schema/extensions/skos#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>
-@prefix qudt-skos: <http://qudt.org/2.1/schema/extensions/skos#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <http://qudt.org/2.1/schema/extensions/skos>
   a owl:Ontology ;
+  owl:imports <http://qudt.org/2.1/schema/qudt> ;
   owl:imports <http://www.w3.org/2004/02/skos/core> ;
   owl:versionInfo "Created with TopBraid Composer" ;
 .


### PR DESCRIPTION
This allows a linked model user import just the skos extension to get the whole extended QUDT schema.