### PR TITLE
ARCMIN != RAD

### DIFF
--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -343,9 +343,7 @@ unit:ARCMIN
   dcterms:description "A minute of arc, arcminute, or minute arc (MOA), is a unit of angular measurement equal to one sixtieth (1/60) of one degree (circle/21,600), or \\(\\pi /10,800 radians\\). In turn, a second of arc or arcsecond is one sixtieth (1/60) of one minute of arc. Since one degree is defined as one three hundred and sixtieth (1/360) of a rotation, one minute of arc is 1/21,600 of a rotation. "^^qudt:LatexString ;
   qudt:conversionMultiplier "0.000290888209"^^xsd:double ;
   qudt:conversionOffset "0.0"^^xsd:double ;
-  qudt:exactMatch unit:ARCMIN ;
   qudt:exactMatch unit:MIN_Angle ;
-  qudt:exactMatch unit:RAD ;
   qudt:hasQuantityKind quantitykind:AngularMeasurement ;
   qudt:hasQuantityKind quantitykind:PlaneAngle ;
   qudt:iec61360Code "0112/2///62720#UAA097" ;
@@ -17503,7 +17501,6 @@ unit:RAD
   qudt:conversionMultiplier "1"^^xsd:double ;
   qudt:conversionOffset "0.0"^^xsd:double ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Radian"^^xsd:anyURI ;
-  qudt:exactMatch unit:ARCMIN ;
   qudt:guidance "<p>See NIST section <a href=\"http://physics.nist.gov/Pubs/SP811/sec07.html#7.10\">SP811 section7.10</a></p>"^^rdf:HTML ;
   qudt:hasQuantityKind quantitykind:PlaneAngle ;
   qudt:iec61360Code "0112/2///62720#UAA966" ;


### PR DESCRIPTION
A arcminute (`unit:ARCMIN`) doesn't equal a radian (`unit:RAD`). An arcmin is 1/60th of a degree, a radian about 57.3 degrees.