### PR TITLE
Finished up units lacking a quantity kind

### DIFF
--- a/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
+++ b/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
@@ -4404,6 +4404,18 @@ quantitykind:LuminousEnergy
   skos:closeMatch quantitykind:RadiantEnergy ;
   skos:exactMatch <http://en.wikipedia.org/wiki/Luminous_energy> ;
 .
+quantitykind:LuminousExposure
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:LUX-HR ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M1H0T-1D0> ;
+  qudt:informativeReference "https://en.wikipedia.org/wiki/Exposure_(photography)#Photometric_and_radiometric_exposure"^^xsd:anyURI ;
+  qudt:plainTextDescription "Luminous Exposure is the time-integrated illuminance." ;
+  qudt:symbol "H_v" ;
+  qudt:symbol "Hv" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Luminous Exposure" ;
+  skos:exactMatch <http://en.wikipedia.org/wiki/Luminous_energy> ;
+.
 quantitykind:LuminousFlux
   a qudt:QuantityKind ;
   qudt:applicableUnit unit:LM ;

--- a/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
+++ b/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
@@ -2967,6 +2967,14 @@ quantitykind:FlightPathAngle
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
   rdfs:label "Flight Path Angle" ;
 .
+quantitykind:Flux
+  a qudt:QuantityKind ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L-2I0M0H0T-1D0> ;
+  qudt:informativeReference "https://en.wikipedia.org/wiki/Flux"^^xsd:anyURI ;
+  qudt:plainTextDescription "Flux describes any effect that appears to pass or travel (whether it actually moves or not) through a surface or substance. [Wikipedia]" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Flux" ;
+.
 quantitykind:Force
   a qudt:QuantityKind ;
   dcterms:description "\"Force\" is an influence that causes mass to accelerate. It may be experienced as a lift, a push, or a pull. Force is defined by Newton's Second Law as \\(F = m \\times a \\), where \\(F\\) is force, \\(m\\) is mass and \\(a\\) is acceleration. Net force is mathematically equal to the time rate of change of the momentum of the body on which it acts. Since momentum is a vector quantity (has both a magnitude and direction), force also is a vector quantity."^^qudt:LatexString ;

--- a/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
+++ b/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
@@ -6109,6 +6109,22 @@ quantitykind:PhotoThresholdOfAwarenessFunction
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
   rdfs:label "Photo Threshold of Awareness Function" ;
 .
+quantitykind:PhotonIntensity
+  a qudt:QuantityKind ;
+  dcterms:description "A measure of flux of photons per solid angle"^^qudt:LatexString ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T-1D0> ;
+  qudt:informativeReference "https://en.wikipedia.org/wiki/Photon_counting"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Photon Intensity" ;
+.
+quantitykind:PhotonRadiance
+  a qudt:QuantityKind ;
+  dcterms:description "A measure of flux of photons per surface area per solid angle"^^qudt:LatexString ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L-2I0M0H0T-1D0> ;
+  qudt:informativeReference "https://en.wikipedia.org/wiki/Photon_counting"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Photon Radiance" ;
+.
 quantitykind:PlanckFunction
   a qudt:QuantityKind ;
   dcterms:description """The \\(\\textit{Planck function}\\) is used to compute the radiance emitted from objects that radiate like a perfect \"Black Body}. The inverse of the \\(\\textit{Planck Function}\\) is used to find the \\(\\textit{Brightness Temperature}\\) of an object. 

--- a/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
+++ b/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
@@ -8258,9 +8258,9 @@ quantitykind:ThermodynamicTemperature
 Temperature is a physical property of matter that quantitatively expresses the common notions of hot and cold. 
 In thermodynamics, in a system of which the entropy is considered as an independent externally controlled variable, absolute, or thermodynamic temperature is defined as the derivative of the internal energy with respect to the entropy. This is a base quantity in the International System of Quantities, ISQ, on which the International System of Units, SI, is based.""" ;
   qudt:symbol "T" ;
-  rdfs:seeAlso quantitykind:Temperature ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
   rdfs:label "Thermodynamic Temperature" ;
+  rdfs:seeAlso quantitykind:Temperature ;
 .
 quantitykind:Thickness
   a qudt:QuantityKind ;
@@ -8775,6 +8775,16 @@ These characteristics are closely related. The volumetric thermal expansion coef
 Some substances expand when cooled, such as freezing water, so they have negative thermal expansion coefficients. [Wikipedia]""" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
   rdfs:label "Volume Thermal Expansion" ;
+.
+quantitykind:VolumetricFlux
+  a qudt:QuantityKind ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L1I0M0H0T-1D0> ;
+  qudt:informativeReference "https://en.wikipedia.org/wiki/Volumetric_flux"^^xsd:anyURI ;
+  qudt:plainTextDescription "In fluid dynamics, the volumetric flux is the rate of volume flow across a unit area (m3·s−1·m−2).[Wikipedia]" ;
+  qudt:qkdvDenominator <http://qudt.org/vocab/dimensionvector/A0E0L2I0M0H0T0D0> ;
+  qudt:qkdvNumerator <http://qudt.org/vocab/dimensionvector/A0E0L3I0M0H0T-1D0> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Volumetric Flux" ;
 .
 quantitykind:VolumetricHeatCapacity
   a qudt:QuantityKind ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -9294,6 +9294,7 @@ unit:KiloLB_F-FT-PER-LB_M
   a qudt:Unit ;
   qudt:conversionMultiplier 2.989067e+03 ;
   qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:SpecificEnergy ;
   qudt:iec61360Code "0112/2///62720#UAB484" ;
   qudt:plainTextDescription "product of the Anglo-American unit pound-force and the Anglo-American unit foot divided by the Anglo-American unit pound (US) of mass" ;
   qudt:uneceCommonCode "G20" ;
@@ -16003,12 +16004,13 @@ unit:PER-SEC-M2
   qudt:ucumCaseSensitiveCode "s-1.m-2" ;
   qudt:ucumCode "S-1.M-2" ;
   qudt:ucumCode "s-1.m-2" ;
+  rdfs:comment "It is not clear this unit is ever used. [Editor]" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Per Second Meter Squared Unit" ;
 .
 unit:PER-SEC-M2-SR
   a qudt:Unit ;
-  dcterms:description "Per Second Meter Squared Steradian Unit is a a demominator unit with dimensions \\(/sec-m^2-sr\\)."^^qudt:LatexString ;
+  dcterms:description "Per Second Meter Squared Steradian Unit is a demominator unit with dimensions \\(/sec-m^2-sr\\)."^^qudt:LatexString ;
   qudt:conversionMultiplier "1"^^xsd:double ;
   qudt:conversionOffset "0.0"^^xsd:double ;
   qudt:expression "\\(/sec-m^2-sr\\)"^^qudt:LatexString ;
@@ -16016,12 +16018,13 @@ unit:PER-SEC-M2-SR
   qudt:ucumCaseSensitiveCode "s-1.m-2.sr-1" ;
   qudt:ucumCode "S-1.M-2.SR-1" ;
   qudt:ucumCode "s-1.m-2.sr-1" ;
+  rdfs:comment "It is not clear this unit is ever used. [Editor]" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Per Second Meter Squared Steradian Unit" ;
 .
 unit:PER-SEC-SR
   a qudt:Unit ;
-  dcterms:description "Per Second Steradian Unit is a a demominator unit with dimensions \\(/sec-sr\\)."^^qudt:LatexString ;
+  dcterms:description "Per Second Steradian Unit is a demominator unit with dimensions \\(/sec-sr\\)."^^qudt:LatexString ;
   qudt:conversionMultiplier "1"^^xsd:double ;
   qudt:conversionOffset "0.0"^^xsd:double ;
   qudt:expression "\\(/sec-sr\\)"^^qudt:LatexString ;
@@ -16029,6 +16032,7 @@ unit:PER-SEC-SR
   qudt:ucumCaseSensitiveCode "s-1.sr-1" ;
   qudt:ucumCode "S-1.SR-1" ;
   qudt:ucumCode "s-1.sr-1" ;
+  rdfs:comment "It is not clear this unit is ever used. [Editor]" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Per Second Steradian Unit" ;
 .

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -6578,6 +6578,7 @@ unit:GigaBQ
   a qudt:Unit ;
   qudt:conversionMultiplier 1e+09 ;
   qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Activity ;
   qudt:iec61360Code "0112/2///62720#UAB047" ;
   qudt:plainTextDescription "1 000 000 000-fold of the derived SI unit becquerel" ;
   qudt:uneceCommonCode "GBQ" ;
@@ -6661,18 +6662,15 @@ unit:GigaHZ
 .
 unit:GigaHZ-M
   a qudt:Unit ;
-  <http://qudt.org/schema/baseUnitDimensions> qkdv:A0E0L1I0M0H0T-1D0 ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:ConductionSpeed ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:GroupSpeedOfSound ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:LinearVelocity ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:PhaseSpeedOfSound ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:SoundParticleVelocity ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:Speed ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:SpeedOfLight ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:SpeedOfSound ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:Velocity ;
   qudt:conversionMultiplier 1e+09 ;
   qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ConductionSpeed ;
+  qudt:hasQuantityKind quantitykind:GroupSpeedOfSound ;
+  qudt:hasQuantityKind quantitykind:LinearVelocity ;
+  qudt:hasQuantityKind quantitykind:PhaseSpeedOfSound ;
+  qudt:hasQuantityKind quantitykind:SoundParticleVelocity ;
+  qudt:hasQuantityKind quantitykind:Speed ;
+  qudt:hasQuantityKind quantitykind:Velocity ;
   qudt:iec61360Code "0112/2///62720#UAA151" ;
   qudt:plainTextDescription "product of the 1 000 000 000-fold of the SI derived unit hertz and the SI base unit metre" ;
   qudt:uneceCommonCode "M18" ;
@@ -7281,17 +7279,16 @@ unit:HectoPA
 .
 unit:HectoPA-L-PER-SEC
   a qudt:Unit ;
-  <http://qudt.org/schema/baseUnitDimensions> qkdv:A0E0L2I0M1H0T-3D0 ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:ApparentPower ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:ComplexPower ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:ElectricPower ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:HeatFlowRate ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:NonActivePower ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:Power ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:RadiantFlux ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:ReactivePower ;
   qudt:conversionMultiplier 1e-01 ;
   qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ApparentPower ;
+  qudt:hasQuantityKind quantitykind:ComplexPower ;
+  qudt:hasQuantityKind quantitykind:ElectricPower ;
+  qudt:hasQuantityKind quantitykind:HeatFlowRate ;
+  qudt:hasQuantityKind quantitykind:NonActivePower ;
+  qudt:hasQuantityKind quantitykind:Power ;
+  qudt:hasQuantityKind quantitykind:RadiantFlux ;
+  qudt:hasQuantityKind quantitykind:ReactivePower ;
   qudt:iec61360Code "0112/2///62720#UAA530" ;
   qudt:plainTextDescription "product out of the 100-fold of the SI derived unit pascal and the unit litre divided by the SI base unit second" ;
   qudt:uneceCommonCode "F93" ;
@@ -7301,17 +7298,16 @@ unit:HectoPA-L-PER-SEC
 .
 unit:HectoPA-M3-PER-SEC
   a qudt:Unit ;
-  <http://qudt.org/schema/baseUnitDimensions> qkdv:A0E0L2I0M1H0T-3D0 ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:ApparentPower ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:ComplexPower ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:ElectricPower ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:HeatFlowRate ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:NonActivePower ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:Power ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:RadiantFlux ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:ReactivePower ;
   qudt:conversionMultiplier 1e+02 ;
   qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ApparentPower ;
+  qudt:hasQuantityKind quantitykind:ComplexPower ;
+  qudt:hasQuantityKind quantitykind:ElectricPower ;
+  qudt:hasQuantityKind quantitykind:HeatFlowRate ;
+  qudt:hasQuantityKind quantitykind:NonActivePower ;
+  qudt:hasQuantityKind quantitykind:Power ;
+  qudt:hasQuantityKind quantitykind:RadiantFlux ;
+  qudt:hasQuantityKind quantitykind:ReactivePower ;
   qudt:iec61360Code "0112/2///62720#UAA531" ;
   qudt:plainTextDescription "product out of the 100-fold of the SI unit pascal and the power of the SI base unit metre with the exponent 3 divided by the SI base unit second" ;
   qudt:uneceCommonCode "F94" ;
@@ -8623,10 +8619,9 @@ unit:KiloCAL_IT
 .
 unit:KiloCAL_IT-PER-HR-M-DEG_C
   a qudt:Unit ;
-  <http://qudt.org/schema/baseUnitDimensions> qkdv:A0E0L1I0M1H-1T-3D0 ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:ThermalConductivity ;
   qudt:conversionMultiplier 1.163e+00 ;
   qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ThermalConductivity ;
   qudt:iec61360Code "0112/2///62720#UAA588" ;
   qudt:plainTextDescription "1 000-fold of the no longer approved unit international calorie for energy divided by the product of the SI base unit metre, the unit hour for time and the unit degree Celsius for temperature" ;
   qudt:uneceCommonCode "K52" ;
@@ -8696,14 +8691,13 @@ unit:KiloCAL_TH-PER-SEC
 .
 unit:KiloCi
   a qudt:Unit ;
-  <http://qudt.org/schema/baseUnitDimensions> qkdv:A0E0L0I0M0H0T-1D0 ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:Activity ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:AngularFrequency ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:DataRate ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:DecayConstant ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:Frequency ;
   qudt:conversionMultiplier 1e+03 ;
   qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Activity ;
+  qudt:hasQuantityKind quantitykind:AngularFrequency ;
+  qudt:hasQuantityKind quantitykind:DataRate ;
+  qudt:hasQuantityKind quantitykind:DecayConstant ;
+  qudt:hasQuantityKind quantitykind:Frequency ;
   qudt:iec61360Code "0112/2///62720#UAB046" ;
   qudt:plainTextDescription "1 000-fold of the unit curie" ;
   qudt:uneceCommonCode "2R" ;
@@ -8832,8 +8826,6 @@ unit:KiloGM-M2-PER-SEC
 .
 unit:KiloGM-MilliM2
   a qudt:Unit ;
-  <http://qudt.org/schema/baseUnitDimensions> qkdv:A0E0L2I0M1H0T0D0 ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:MomentOfInertia ;
   qudt:conversionMultiplier 1e-06 ;
   qudt:conversionOffset 0e+00 ;
   qudt:hasQuantityKind quantitykind:MomentOfInertia ;
@@ -8920,8 +8912,6 @@ unit:KiloGM-PER-KiloGM
 .
 unit:KiloGM-PER-KiloMOL
   a qudt:Unit ;
-  <http://qudt.org/schema/baseUnitDimensions> qkdv:A-1E0L0I0M1H0T0D0 ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:MolarMass ;
   qudt:conversionMultiplier 1e-03 ;
   qudt:conversionOffset 0e+00 ;
   qudt:hasQuantityKind quantitykind:MolarMass ;
@@ -9010,12 +9000,11 @@ unit:KiloGM-PER-MOL
 .
 unit:KiloGM-PER-MilliM
   a qudt:Unit ;
-  <http://qudt.org/schema/baseUnitDimensions> qkdv:A0E0L-1I0M1H0T0D0 ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:BodyMassIndex ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:LinearDensity ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:MassPerLength ;
   qudt:conversionMultiplier 1e+03 ;
   qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:BodyMassIndex ;
+  qudt:hasQuantityKind quantitykind:LinearDensity ;
+  qudt:hasQuantityKind quantitykind:MassPerLength ;
   qudt:iec61360Code "0112/2///62720#UAB070" ;
   qudt:plainTextDescription "SI base unit kilogram divided by the 0,001-fold of the SI base unit metre" ;
   qudt:uneceCommonCode "KW" ;
@@ -9186,18 +9175,17 @@ unit:KiloHZ
 .
 unit:KiloHZ-M
   a qudt:Unit ;
-  <http://qudt.org/schema/baseUnitDimensions> qkdv:A0E0L1I0M0H0T-1D0 ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:ConductionSpeed ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:GroupSpeedOfSound ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:LinearVelocity ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:PhaseSpeedOfSound ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:SoundParticleVelocity ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:Speed ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:SpeedOfLight ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:SpeedOfSound ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:Velocity ;
   qudt:conversionMultiplier 1e+03 ;
   qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ConductionSpeed ;
+  qudt:hasQuantityKind quantitykind:GroupSpeedOfSound ;
+  qudt:hasQuantityKind quantitykind:LinearVelocity ;
+  qudt:hasQuantityKind quantitykind:PhaseSpeedOfSound ;
+  qudt:hasQuantityKind quantitykind:SoundParticleVelocity ;
+  qudt:hasQuantityKind quantitykind:Speed ;
+  qudt:hasQuantityKind quantitykind:SpeedOfLight ;
+  qudt:hasQuantityKind quantitykind:SpeedOfSound ;
+  qudt:hasQuantityKind quantitykind:Velocity ;
   qudt:iec61360Code "0112/2///62720#UAA567" ;
   qudt:plainTextDescription "product of the 1 000-fold of the SI derived unit hertz and the SI base unit metre" ;
   qudt:uneceCommonCode "M17" ;
@@ -9302,12 +9290,12 @@ unit:KiloLB_F-FT-PER-A
   rdfs:label "KiloLB_F FT PER A" ;
   skos:prefLabel "pound force foot per ampere" ;
 .
-unit:KiloLB_F-FT-PER-LB
+unit:KiloLB_F-FT-PER-LB_M
   a qudt:Unit ;
   qudt:conversionMultiplier 2.989067e+03 ;
   qudt:conversionOffset 0e+00 ;
   qudt:iec61360Code "0112/2///62720#UAB484" ;
-  qudt:plainTextDescription "product of the Anglo-American unit pound-force and the Anglo-American unit foot divided by the Anglo-American unit pound (US)" ;
+  qudt:plainTextDescription "product of the Anglo-American unit pound-force and the Anglo-American unit foot divided by the Anglo-American unit pound (US) of mass" ;
   qudt:uneceCommonCode "G20" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "KiloLB_F FT PER LB" ;
@@ -9428,10 +9416,9 @@ unit:KiloMOL
 .
 unit:KiloMOL-PER-HR
   a qudt:Unit ;
-  <http://qudt.org/schema/baseUnitDimensions> qkdv:A1E0L0I0M0H0T-1D0 ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:CatalyticActivity ;
   qudt:conversionMultiplier 2.77777777777778e-01 ;
   qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:CatalyticActivity ;
   qudt:iec61360Code "0112/2///62720#UAA641" ;
   qudt:plainTextDescription "1 000-fold of the SI base unit mole divided by the unit for time hour" ;
   qudt:uneceCommonCode "K58" ;
@@ -9543,12 +9530,12 @@ unit:KiloPA
 .
 unit:KiloPA-M2-PER-GM
   a qudt:Unit ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:Acceleration ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:LinearAcceleration ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:SoundParticleAcceleration ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:ThrustToMassRatio ;
   qudt:conversionMultiplier 1e+06 ;
   qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Acceleration ;
+  qudt:hasQuantityKind quantitykind:LinearAcceleration ;
+  qudt:hasQuantityKind quantitykind:SoundParticleAcceleration ;
+  qudt:hasQuantityKind quantitykind:ThrustToMassRatio ;
   qudt:iec61360Code "0112/2///62720#UAB130" ;
   qudt:plainTextDescription "sector-specific unit of the burst index as 1 000-fold of the derived unit for pressure pascal related to the substance, represented as a quotient from the 0,001-fold of the SI base unit kilogram divided by the power of the SI base unit metre by exponent 2" ;
   qudt:uneceCommonCode "33" ;
@@ -9581,10 +9568,9 @@ unit:KiloPA-PER-K
 .
 unit:KiloPA-PER-MilliM
   a qudt:Unit ;
-  <http://qudt.org/schema/baseUnitDimensions> qkdv:A0E0L-2I0M1H0T-2D0 ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:SpectralRadiantEnergyDensity ;
   qudt:conversionMultiplier 1.0e+05 ;
   qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:SpectralRadiantEnergyDensity ;
   qudt:iec61360Code "0112/2///62720#UAB060" ;
   qudt:plainTextDescription "1 000-fold of the derived SI unit pascal divided by the 0,001-fold of the SI base unit metre" ;
   qudt:uneceCommonCode "34" ;
@@ -10228,13 +10214,11 @@ unit:LB_M-MOL-DEG_F
 .
 unit:LB_M-PER-DAY
   a qudt:Unit ;
-  <http://qudt.org/schema/baseUnitDimensions> qkdv:A0E0L0I0M1H0T-1D0 ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:MagneticField ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:MassFlowRate ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:MassPerTime ;
   qudt:conversionMultiplier 5.249912e-06 ;
   qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MagneticField ;
   qudt:hasQuantityKind quantitykind:MassFlowRate ;
+  qudt:hasQuantityKind quantitykind:MassPerTime ;
   qudt:iec61360Code "0112/2///62720#UAA673" ;
   qudt:plainTextDescription "unit of the mass avoirdupois pound according to the avoirdupois system of units divided by the unit for time day" ;
   qudt:uneceCommonCode "K66" ;
@@ -10311,14 +10295,12 @@ unit:LB_M-PER-GAL
 .
 unit:LB_M-PER-GAL_UK
   a qudt:Unit ;
-  <http://qudt.org/schema/baseUnitDimensions> qkdv:A0E0L-3I0M1H0T0D0 ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:Density ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:MassConcentration ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:MassConcentrationOfWater ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:MassConcentrationOfWaterVapour ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:MassDensity ;
   qudt:conversionMultiplier 9.977637e+01 ;
   qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Density ;
+  qudt:hasQuantityKind quantitykind:MassConcentration ;
+  qudt:hasQuantityKind quantitykind:MassConcentrationOfWater ;
+  qudt:hasQuantityKind quantitykind:MassConcentrationOfWaterVapour ;
   qudt:hasQuantityKind quantitykind:MassDensity ;
   qudt:iec61360Code "0112/2///62720#UAA679" ;
   qudt:plainTextDescription "unit of the mass avoirdupois pound according to the avoirdupois system of units divided by the unit gallon (UK) according to the Imperial system of units" ;
@@ -10329,14 +10311,12 @@ unit:LB_M-PER-GAL_UK
 .
 unit:LB_M-PER-GAL_US
   a qudt:Unit ;
-  <http://qudt.org/schema/baseUnitDimensions> qkdv:A0E0L-3I0M1H0T0D0 ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:Density ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:MassConcentration ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:MassConcentrationOfWater ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:MassConcentrationOfWaterVapour ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:MassDensity ;
   qudt:conversionMultiplier 0e+00 ;
   qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Density ;
+  qudt:hasQuantityKind quantitykind:MassConcentration ;
+  qudt:hasQuantityKind quantitykind:MassConcentrationOfWater ;
+  qudt:hasQuantityKind quantitykind:MassConcentrationOfWaterVapour ;
   qudt:hasQuantityKind quantitykind:MassDensity ;
   qudt:iec61360Code "0112/2///62720#UAA680" ;
   qudt:plainTextDescription "unit of the mass avoirdupois pound according to the avoirdupois system divided by the unit gallon (US, liq.) according to the Anglo-American system of units" ;
@@ -10371,12 +10351,11 @@ unit:LB_M-PER-IN
 .
 unit:LB_M-PER-IN2
   a qudt:Unit ;
-  <http://qudt.org/schema/baseUnitDimensions> qkdv:A0E0L-2I0M1H0T0D0 ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:MassPerArea ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:MeanMassRange ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:SurfaceDensity ;
   qudt:conversionMultiplier 0e+00 ;
   qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassPerArea ;
+  qudt:hasQuantityKind quantitykind:MeanMassRange ;
+  qudt:hasQuantityKind quantitykind:SurfaceDensity ;
   qudt:iec61360Code "0112/2///62720#UAB137" ;
   qudt:plainTextDescription "unit of the areal-related mass as avoirdupois pound according to the avoirdupois system of units related to the area square inch according to the Anglo-American and Imperial system of units" ;
   qudt:uneceCommonCode "80" ;
@@ -10418,13 +10397,11 @@ unit:LB_M-PER-MIN
 .
 unit:LB_M-PER-SEC
   a qudt:Unit ;
-  <http://qudt.org/schema/baseUnitDimensions> qkdv:A0E0L0I0M1H0T-1D0 ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:MagneticField ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:MassFlowRate ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:MassPerTime ;
   qudt:conversionMultiplier 4.535924e-01 ;
   qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MagneticField ;
   qudt:hasQuantityKind quantitykind:MassFlowRate ;
+  qudt:hasQuantityKind quantitykind:MassPerTime ;
   qudt:iec61360Code "0112/2///62720#UAA692" ;
   qudt:plainTextDescription "unit of the mass avoirdupois pound according to the avoirdupois system of units divided by the SI base unit for time second" ;
   qudt:uneceCommonCode "K81" ;
@@ -13229,12 +13206,13 @@ unit:MilliC-PER-M3
   a qudt:Unit ;
   qudt:conversionMultiplier 1e-03 ;
   qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ElectricChargeVolumeDensity ;
   qudt:iec61360Code "0112/2///62720#UAA785" ;
   qudt:plainTextDescription "0.001-fold of the SI derived unit coulomb divided by the power of the SI base unit metre with the exponent 3" ;
   qudt:uneceCommonCode "D88" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "MilliC PER M3" ;
-  skos:prefLabel "millicoulomb per metre cubed" ;
+  skos:prefLabel "millicoulomb per cubic metre" ;
 .
 unit:MilliCi
   a qudt:Unit ;
@@ -13295,14 +13273,12 @@ unit:MilliG
 .
 unit:MilliGAL
   a qudt:Unit ;
-  <http://qudt.org/schema/baseUnitDimensions> qkdv:A0E0L1I0M0H0T-2D0 ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:Acceleration ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:LinearAcceleration ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:SoundParticleAcceleration ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:ThrustToMassRatio ;
   qudt:conversionMultiplier 1e-05 ;
   qudt:conversionOffset 0e+00 ;
   qudt:hasQuantityKind quantitykind:Acceleration ;
+  qudt:hasQuantityKind quantitykind:LinearAcceleration ;
+  qudt:hasQuantityKind quantitykind:SoundParticleAcceleration ;
+  qudt:hasQuantityKind quantitykind:ThrustToMassRatio ;
   qudt:iec61360Code "0112/2///62720#UAB043" ;
   qudt:plainTextDescription "0.001-fold of the unit of acceleration called gal according to the CGS system of units" ;
   qudt:uneceCommonCode "C11" ;
@@ -13552,18 +13528,17 @@ unit:MilliL
 .
 unit:MilliL-PER-CentiM2-MIN
   a qudt:Unit ;
-  <http://qudt.org/schema/baseUnitDimensions> qkdv:A0E0L1I0M0H0T-1D0 ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:ConductionSpeed ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:GroupSpeedOfSound ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:LinearVelocity ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:PhaseSpeedOfSound ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:SoundParticleVelocity ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:Speed ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:SpeedOfLight ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:SpeedOfSound ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:Velocity ;
   qudt:conversionMultiplier 1.6666667e-04 ;
   qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ConductionSpeed ;
+  qudt:hasQuantityKind quantitykind:GroupSpeedOfSound ;
+  qudt:hasQuantityKind quantitykind:LinearVelocity ;
+  qudt:hasQuantityKind quantitykind:PhaseSpeedOfSound ;
+  qudt:hasQuantityKind quantitykind:SoundParticleVelocity ;
+  qudt:hasQuantityKind quantitykind:Speed ;
+  qudt:hasQuantityKind quantitykind:SpeedOfLight ;
+  qudt:hasQuantityKind quantitykind:SpeedOfSound ;
+  qudt:hasQuantityKind quantitykind:Velocity ;
   qudt:iec61360Code "0112/2///62720#UAA858" ;
   qudt:plainTextDescription "quotient of the 0.001-fold of the unit litre and the unit minute divided by the 0,0001-fold of the power of the SI base unit metre with the exponent 2" ;
   qudt:uneceCommonCode "35" ;
@@ -15805,10 +15780,9 @@ unit:PER-K
 .
 unit:PER-KiloV-A-HR
   a qudt:Unit ;
-  <http://qudt.org/schema/baseUnitDimensions> qkdv:A0E0L-2I0M-1H0T2D0 ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:InverseEnergy ;
   qudt:conversionMultiplier 1e-03 ;
   qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:InverseEnergy ;
   qudt:iec61360Code "0112/2///62720#UAA098" ;
   qudt:plainTextDescription "reciprocal of the 1,000-fold of the product of the SI derived unit volt and the SI base unit ampere and the unit hour" ;
   qudt:uneceCommonCode "M21" ;
@@ -15906,12 +15880,11 @@ unit:PER-M3-SEC
 .
 unit:PER-MI-PER-PSI
   a qudt:Unit ;
-  <http://qudt.org/schema/baseUnitDimensions> qkdv:A0E0L1I0M-1H0T2D0 ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:InversePressure ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:IsothermalCompressibility ;
   qudt:conversionMultiplier 1.450377e-07 ;
   qudt:conversionOffset 0e+00 ;
   qudt:hasQuantityKind quantitykind:Compressibility ;
+  qudt:hasQuantityKind quantitykind:InversePressure ;
+  qudt:hasQuantityKind quantitykind:IsothermalCompressibility ;
   qudt:iec61360Code "0112/2///62720#UAA016" ;
   qudt:plainTextDescription "thousandth divided by the composed unit for pressure (pound-force per square inch)" ;
   qudt:uneceCommonCode "J12" ;
@@ -16424,15 +16397,13 @@ unit:PINT_US-PER-MIN
 .
 unit:PINT_US-PER-SEC
   a qudt:Unit ;
-  <http://qudt.org/schema/baseUnitDimensions> qkdv:A0E0L3I0M0H0T-1D0 ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:RecombinationCoefficient ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:SoundVolumeVelocity ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:VolumeFlowRate ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:VolumePerUnitTime ;
   qudt:conversionMultiplier 4.731765e-04 ;
   qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:RecombinationCoefficient ;
+  qudt:hasQuantityKind quantitykind:SoundVolumeVelocity ;
   qudt:hasQuantityKind quantitykind:Velocity ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
   qudt:iec61360Code "0112/2///62720#UAA961" ;
   qudt:plainTextDescription "unit of the volume pint (US liquid) according to the Anglo-American system of units divided by the SI base unit second" ;
   qudt:uneceCommonCode "L60" ;
@@ -16597,9 +16568,9 @@ unit:POISE
 .
 unit:POISE-PER-BAR
   a qudt:Unit ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:Time ;
   qudt:conversionMultiplier 1e-06 ;
   qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Time ;
   qudt:iec61360Code "0112/2///62720#UAA257" ;
   qudt:plainTextDescription "CGS unit poise divided by the unit bar" ;
   qudt:uneceCommonCode "F06" ;
@@ -19533,9 +19504,9 @@ unit:V-PER-SEC
 .
 unit:V-SEC-PER-M
   a qudt:Unit ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:MagneticFluxPerUnitLength ;
   qudt:conversionMultiplier 1e+00 ;
   qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MagneticFluxPerUnitLength ;
   qudt:hasQuantityKind quantitykind:MagneticVectorPotential ;
   qudt:hasQuantityKind quantitykind:ScalarMagneticPotential ;
   qudt:iec61360Code "0112/2///62720#UAA303" ;
@@ -19757,9 +19728,9 @@ unit:W-PER-K
 .
 unit:W-PER-KiloGM
   a qudt:Unit ;
-  <http://qudt.org/schema/hasQuantityKind> quantitykind:AbsorbedDoseRate ;
   qudt:conversionMultiplier 1e+00 ;
   qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:AbsorbedDoseRate ;
   qudt:iec61360Code "0112/2///62720#UAA316" ;
   qudt:plainTextDescription "SI derived unit watt divided by the SI base unit kilogram" ;
   qudt:uneceCommonCode "WA" ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -15996,15 +15996,15 @@ unit:PER-SEC
 .
 unit:PER-SEC-M2
   a qudt:Unit ;
-  dcterms:description "\\(\\textit{Per Second Meter Squared Unit}\\) is a demominator unit with dimensions \\(/sec-m^2\\)."^^qudt:LatexString ;
+  dcterms:description "\\(\\textit{Per Second Meter Squared Unit}\\) is a measure of flux with dimensions \\(/sec-m^2\\)."^^qudt:LatexString ;
   qudt:conversionMultiplier "1"^^xsd:double ;
   qudt:conversionOffset "0.0"^^xsd:double ;
   qudt:expression "\\(per-sec-m^2\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Flux ;
   qudt:ucumCaseInsensitiveCode "S-1.M-2" ;
   qudt:ucumCaseSensitiveCode "s-1.m-2" ;
   qudt:ucumCode "S-1.M-2" ;
   qudt:ucumCode "s-1.m-2" ;
-  rdfs:comment "It is not clear this unit is ever used. [Editor]" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Per Second Meter Squared Unit" ;
 .

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -16014,6 +16014,7 @@ unit:PER-SEC-M2-SR
   qudt:conversionMultiplier "1"^^xsd:double ;
   qudt:conversionOffset "0.0"^^xsd:double ;
   qudt:expression "\\(/sec-m^2-sr\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:PhotonRadiance ;
   qudt:ucumCaseInsensitiveCode "S-1.M-2.SR-1" ;
   qudt:ucumCaseSensitiveCode "s-1.m-2.sr-1" ;
   qudt:ucumCode "S-1.M-2.SR-1" ;
@@ -16028,13 +16029,13 @@ unit:PER-SEC-SR
   qudt:conversionMultiplier "1"^^xsd:double ;
   qudt:conversionOffset "0.0"^^xsd:double ;
   qudt:expression "\\(/sec-sr\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:PhotonIntensity ;
   qudt:ucumCaseInsensitiveCode "S-1.SR-1" ;
   qudt:ucumCaseSensitiveCode "s-1.sr-1" ;
   qudt:ucumCode "S-1.SR-1" ;
   qudt:ucumCode "s-1.sr-1" ;
-  rdfs:comment "It is not clear this unit is ever used. [Editor]" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
-  rdfs:label "Per Second Steradian Unit" ;
+  rdfs:label "Per Second Steradian" ;
 .
 unit:PER-T-M
   a qudt:DerivedCoherentUnit ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -10506,12 +10506,12 @@ unit:LUX
 unit:LUX-HR
   a qudt:DerivedUnit ;
   a qudt:Unit ;
-  dcterms:description """The SI unit for measuring the illumination (illuminance) of a surface. One lux is defined as an illumination of one lumen per square meter or 0.0001 phot. In considering the various light units, it's useful to think about light originating at a point and shining upon a surface. The intensity of the light source is measured in candelas; the total light flux in transit is measured in lumens (1 lumen = 1 candelau00b7steradian); and the amount of light received per unit of surface area is measured in lux (1 lux = 1 lumen/square meter). One lux is equal to approximately 0.09290 foot candle.
-Editors note: The quantity kind for LUX-HR needs checking. At first glance it should be a unit of energy rather than flux."""^^rdf:HTML ;
-  qudt:conversionMultiplier "1"^^xsd:double ;
+  dcterms:description "The SI unit for measuring the illumination (illuminance) of a surface. One lux is defined as an illumination of one lumen per square meter or 0.0001 phot. In considering the various light units, it's useful to think about light originating at a point and shining upon a surface. The intensity of the light source is measured in candelas; the total light flux in transit is measured in lumens (1 lumen = 1 candelau00b7steradian); and the amount of light received per unit of surface area is measured in lux (1 lux = 1 lumen/square meter). One lux is equal to approximately 0.09290 foot candle."^^rdf:HTML ;
+  qudt:conversionMultiplier "3600"^^xsd:double ;
   qudt:conversionOffset "0.0"^^xsd:double ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Lux"^^xsd:anyURI ;
   qudt:expression "\\(lx hr\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:LuminousExposure ;
   qudt:iec61360Code "0112/2///62720#UAA724" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Lux?oldid=494700274"^^xsd:anyURI ;
   qudt:siUnitsExpression "lm-hr/m^2" ;
@@ -13530,15 +13530,7 @@ unit:MilliL-PER-CentiM2-MIN
   a qudt:Unit ;
   qudt:conversionMultiplier 1.6666667e-04 ;
   qudt:conversionOffset 0e+00 ;
-  qudt:hasQuantityKind quantitykind:ConductionSpeed ;
-  qudt:hasQuantityKind quantitykind:GroupSpeedOfSound ;
-  qudt:hasQuantityKind quantitykind:LinearVelocity ;
-  qudt:hasQuantityKind quantitykind:PhaseSpeedOfSound ;
-  qudt:hasQuantityKind quantitykind:SoundParticleVelocity ;
-  qudt:hasQuantityKind quantitykind:Speed ;
-  qudt:hasQuantityKind quantitykind:SpeedOfLight ;
-  qudt:hasQuantityKind quantitykind:SpeedOfSound ;
-  qudt:hasQuantityKind quantitykind:Velocity ;
+  qudt:hasQuantityKind quantitykind:VolumetricFlux ;
   qudt:iec61360Code "0112/2///62720#UAA858" ;
   qudt:plainTextDescription "quotient of the 0.001-fold of the unit litre and the unit minute divided by the 0,0001-fold of the power of the SI base unit metre with the exponent 2" ;
   qudt:uneceCommonCode "35" ;
@@ -13550,6 +13542,7 @@ unit:MilliL-PER-CentiM2-SEC
   a qudt:Unit ;
   qudt:conversionMultiplier 1e-02 ;
   qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumetricFlux ;
   qudt:iec61360Code "0112/2///62720#UAB085" ;
   qudt:plainTextDescription "unit of the volume flow rate millilitre divided by second related to the transfer area as 0.0001-fold of the power of the SI base unit metre by exponent 2" ;
   qudt:uneceCommonCode "35" ;
@@ -13926,6 +13919,7 @@ unit:MilliOHM
   a qudt:Unit ;
   qudt:conversionMultiplier 1e-03 ;
   qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Resistance ;
   qudt:iec61360Code "0112/2///62720#UAA741" ;
   qudt:plainTextDescription "0.001-fold of the SI derived unit ohm" ;
   qudt:uneceCommonCode "E45" ;
@@ -16492,6 +16486,7 @@ unit:PK_US_DRY
   dcterms:description "A peck is an imperial and U.S. customary unit of dry volume, equivalent to 2 gallons or 8 dry quarts or 16 dry pints. Two pecks make a kenning (obsolete), and four pecks make a bushel. In Scotland, the peck was used as a dry measure until the introduction of imperial units as a result of the Weights and Measures Act of 1824. The peck was equal to about 9 litres (in the case of certain crops, such as wheat, peas, beans and meal) and about 13 litres (in the case of barley, oats and malt). A firlot was equal to 4 pecks and the peck was equal to 4 lippies or forpets. "^^rdf:HTML ;
   qudt:conversionMultiplier "0.00880976754"^^xsd:double ;
   qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:DryVolume ;
   qudt:symbol "pk" ;
   qudt:ucumCaseInsensitiveCode "[PK_US]" ;
   qudt:ucumCaseSensitiveCode "[pk_us]" ;


### PR DESCRIPTION
...except for these 3, which I am a bit suspicious of:

Units that are missing Quantity Kinds
unit:PER-SEC-M2
unit:PER-SEC-M2-SR
unit:PER-SEC-SR

(These have now been fixed in subsequent commits of this PR)