### PR TITLE
fix typo in UCUM code for unit:IN_H2O

### DIFF
--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -7131,7 +7131,7 @@ unit:IN_H2O
   qudt:iec61360Code "0112/2///62720#UAA553" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Inch_of_water?oldid=466175519"^^xsd:anyURI ;
   qudt:symbol "inAq" ;
-  qudt:ucumCode "[in_i'H2)]" ;
+  qudt:ucumCode "[in_i'H2O]" ;
   qudt:uneceCommonCode "F78" ;
   qudt:unitOfSystem <http://qudt.org/vocab/sou/SOU_CGS> ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;


### PR DESCRIPTION
Fix a typo in qudt:ucumCode of unit:IN_H2O.
Discovered by running cross-checks with Wikidata.