### PR TITLE
Added two quanty kinds PPFD, PPF, dimension and linked the quantities to relevant units.

### DIFF
--- a/vocab/dimensionvectors/VOCAB_QUDT-DIMENSION-VECTORS-v2.1.ttl
+++ b/vocab/dimensionvectors/VOCAB_QUDT-DIMENSION-VECTORS-v2.1.ttl
@@ -3148,6 +3148,22 @@ qkdv:A1E0L-2I0M0H0T-1D0
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/dimensionvector> ;
   rdfs:label "A1E0L-2I0M0H0T-1D0" ;
 .
+qkdv:A1E0L-0I0M0H0T-1D0
+  a qudt:QuantityKindDimensionVector_CGS ;
+  a qudt:QuantityKindDimensionVector_ISO ;
+  a qudt:QuantityKindDimensionVector_Imperial ;
+  a qudt:QuantityKindDimensionVector_SI ;
+  qudt:dimensionExponentForAmountOfSubstance 1 ;
+  qudt:dimensionExponentForElectricCurrent 0 ;
+  qudt:dimensionExponentForLength 0 ;
+  qudt:dimensionExponentForLuminousIntensity 0 ;
+  qudt:dimensionExponentForMass 0 ;
+  qudt:dimensionExponentForThermodynamicTemperature 0 ;
+  qudt:dimensionExponentForTime -1 ;
+  qudt:dimensionlessExponent 0 ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/dimensionvector> ;
+  rdfs:label "A1E0L-0I0M0H0T-1D0" ;
+.
 qkdv:A1E0L-2I0M0H0T0D0
   a qudt:QuantityKindDimensionVector_CGS ;
   a qudt:QuantityKindDimensionVector_ISO ;

--- a/vocab/dimensionvectors/VOCAB_QUDT-DIMENSION-VECTORS-v2.1.ttl
+++ b/vocab/dimensionvectors/VOCAB_QUDT-DIMENSION-VECTORS-v2.1.ttl
@@ -3148,22 +3148,6 @@ qkdv:A1E0L-2I0M0H0T-1D0
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/dimensionvector> ;
   rdfs:label "A1E0L-2I0M0H0T-1D0" ;
 .
-qkdv:A1E0L-0I0M0H0T-1D0
-  a qudt:QuantityKindDimensionVector_CGS ;
-  a qudt:QuantityKindDimensionVector_ISO ;
-  a qudt:QuantityKindDimensionVector_Imperial ;
-  a qudt:QuantityKindDimensionVector_SI ;
-  qudt:dimensionExponentForAmountOfSubstance 1 ;
-  qudt:dimensionExponentForElectricCurrent 0 ;
-  qudt:dimensionExponentForLength 0 ;
-  qudt:dimensionExponentForLuminousIntensity 0 ;
-  qudt:dimensionExponentForMass 0 ;
-  qudt:dimensionExponentForThermodynamicTemperature 0 ;
-  qudt:dimensionExponentForTime -1 ;
-  qudt:dimensionlessExponent 0 ;
-  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/dimensionvector> ;
-  rdfs:label "A1E0L-0I0M0H0T-1D0" ;
-.
 qkdv:A1E0L-2I0M0H0T0D0
   a qudt:QuantityKindDimensionVector_CGS ;
   a qudt:QuantityKindDimensionVector_ISO ;

--- a/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
+++ b/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
@@ -7420,11 +7420,7 @@ quantitykind:InitialVelocity
 .
 quantitykind:InstantaneousPower
   a qudt:QuantityKind ;
-  dcterms:description """\"Instantaneous Power}, for a two-terminal element or a two-terminal circuit with terminals A and B, is the product of the voltage \\(u_{AB}\\) between the terminals and the electric current i in the element or circuit: \\(p = \\)u_{AB} \\cdot i\\(, where \\)u_{AB\" is the line integral of the electric field strength from A to B, and where the electric current in the element or circuit is taken positive if its direction is from A to B and negative in the opposite case.  For an n-terminal circuit, it is the sum of the instantaneous powers relative to the n - 1 pairs of terminals when one of the terminals is chosen as a common terminal for the pairs.
-
-
-
-For a polyphase element, it is the sum of the instantaneous powers in all phase elements of a polyphase element.  For a polyphase line consisting of m line conductors and one neutral conductor, it is the sum of the m instantaneous powers expressed for each line conductor by the product of the polyphase line-to-neutral voltage and the corresponding line current."""^^qudt:LatexString ;
+  dcterms:description """\"Instantaneous Power}, for a two-terminal element or a two-terminal circuit with terminals A and B, is the product of the voltage \\(u_{AB}\\) between the terminals and the electric current i in the element or circuit: \\(p = \\)u_{AB} \\cdot i\\(, where \\)u_{AB\" is the line integral of the electric field strength from A to B, and where the electric current in the element or circuit is taken positive if its direction is from A to B and negative in the opposite case.  For an n-terminal circuit, it is the sum of the instantaneous powers relative to the n - 1 pairs of terminals when one of the terminals is chosen as a common terminal for the pairs. For a polyphase element, it is the sum of the instantaneous powers in all phase elements of a polyphase element.  For a polyphase line consisting of m line conductors and one neutral conductor, it is the sum of the m instantaneous powers expressed for each line conductor by the product of the polyphase line-to-neutral voltage and the corresponding line current."""^^qudt:LatexString ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Power"^^xsd:anyURI ;
   qudt:informativeReference "http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=131-11-30"^^xsd:anyURI ;
   qudt:informativeReference "http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=131-11-31"^^xsd:anyURI ;

--- a/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
+++ b/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
@@ -64,7 +64,7 @@ quantitykind:AbsoluteHumidity
   qudt:informativeReference "http://en.wikipedia.org/wiki/Humidity"^^xsd:anyURI ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Humidity#Absolute_humidity"^^xsd:anyURI ;
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI ;
-  qudt:latexDefinition """\\(AH = \\frac{\\mathcal{M}_\\omega}{\\vee_{net}}\\), 
+  qudt:latexDefinition """\\(AH = \\frac{\\mathcal{M}_\\omega}{\\vee_{net}}\\),
 where \\(\\mathcal{M}_\\omega\\) is the mass of water vapor per unit volume of total air and \\(\\vee_{net}\\) is water vapor mixture."""^^qudt:LatexString ;
   qudt:symbol "AH" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
@@ -7420,7 +7420,7 @@ quantitykind:InitialVelocity
 .
 quantitykind:InstantaneousPower
   a qudt:QuantityKind ;
-  dcterms:description """\"Instantaneous Power}, for a two-terminal element or a two-terminal circuit with terminals A and B, is the product of the voltage \\(u_{AB}\\) between the terminals and the electric current i in the element or circuit: \\(p = \\)u_{AB} \\cdot i\\(, where \\)u_{AB\" is the line integral of the electric field strength from A to B, and where the electric current in the element or circuit is taken positive if its direction is from A to B and negative in the opposite case.  For an n-terminal circuit, it is the sum of the instantaneous powers relative to the n - 1 pairs of terminals when one of the terminals is chosen as a common terminal for the pairs. 
+  dcterms:description """\"Instantaneous Power}, for a two-terminal element or a two-terminal circuit with terminals A and B, is the product of the voltage \\(u_{AB}\\) between the terminals and the electric current i in the element or circuit: \\(p = \\)u_{AB} \\cdot i\\(, where \\)u_{AB\" is the line integral of the electric field strength from A to B, and where the electric current in the element or circuit is taken positive if its direction is from A to B and negative in the opposite case.  For an n-terminal circuit, it is the sum of the instantaneous powers relative to the n - 1 pairs of terminals when one of the terminals is chosen as a common terminal for the pairs.
 
 
 
@@ -11779,9 +11779,31 @@ quantitykind:PhotonRadiance
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
   rdfs:label "Photon Radiance"@en ;
 .
+quantitykind:PhotosyntheticPhotonFluxDensity
+  rdf:type qudt:QuantityKind ;
+  qudt:hasDimensionVector qkdv:A1E0L-2I0M0H0T-1D0 ;
+  qudt:plainTextDescription "Photosynthetically Active Radiation are the wavelengths of light within the visible range of 400 to 700 nanometers (nm) that are critical for photosynthesis. PPFD measures the amount of PAR light (photons) that arrive at the plant’s surface each second. The PPFD is measured at various distances with a Full-spectrum Quantum Sensor, also known as a PAR meter. Natural sunlight has a PAR value of 900-1500μMol/m2/s when the sun is directly overhead. For a grow light to be effective, it should have PAR values of 500-1500 μMol/m2/s." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Photosynthetic Photon Flux Density" ;
+  prov:wasDerivedFrom <https://www.dormgrow.com/par> ;
+  qudt:informativeReference "https://www.gigahertz-optik.com/en-us/service-and-support/knowledge-base/measurement-of-par/"^^xsd:anyURI ;
+  skos:altLabel "PPFD" ;
+  qudt:applicableUnit unit:MicroMOL-PER-M2-SEC ;
+.
+quantitykind:PhotosyntheticPhotonFlux
+  rdf:type qudt:QuantityKind ;
+  qudt:hasDimensionVector qkdv:A1E0L-0I0M0H0T-1D0 ;
+  qudt:plainTextDescription "Photosynthetic Photon Flux (PPF) is a measurement of the total number of photons emitted by a light source each second within the PAR wavelength range and is measured in μmol/s. Lighting manufacturers may specify their grow light products in terms of PPF. It can be considered as analogous to measuring the luminous flux (lumens) of visible light which would typically require the use of an integrating sphere or a goniometer system with spectroradiometer sensor." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Photosynthetic Photon Flux" ;
+  prov:wasDerivedFrom <https://www.gigahertz-optik.com/en-us/service-and-support/knowledge-base/measurement-of-par/#WasistPAR> ;
+  qudt:informativeReference "https://www.dormgrow.com/par/"^^xsd:anyURI ;
+  skos:altLabel "PPF" ;
+  qudt:applicableUnit unit:MicroMOL-PER-SEC ;
+.
 quantitykind:PlanckFunction
   a qudt:QuantityKind ;
-  dcterms:description """The \\(\\textit{Planck function}\\) is used to compute the radiance emitted from objects that radiate like a perfect \"Black Body\". The inverse of the \\(\\textit{Planck Function}\\) is used to find the \\(\\textit{Brightness Temperature}\\) of an object. 
+  dcterms:description """The \\(\\textit{Planck function}\\) is used to compute the radiance emitted from objects that radiate like a perfect \"Black Body\". The inverse of the \\(\\textit{Planck Function}\\) is used to find the \\(\\textit{Brightness Temperature}\\) of an object.
 The precise formula for the Planck Function depends on whether the radiance is determined on a \\(\\textit{per unit wavelength}\\) or a \\(\\textit{per unit frequency}\\). In the ISO System of Quantities, \\(\\textit{Planck Function}\\) is defined by the formula: \\(Y = -G/T\\), where \\(G\\) is Gibbs Energy and \\(T\\) is thermodynamic temperature."""^^qudt:LatexString ;
   qudt:expression "\\(B_{\\nu}(T)\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
@@ -14306,7 +14328,7 @@ quantitykind:SpecificActivity
 .
 quantitykind:SpecificEnergy
   a qudt:QuantityKind ;
-  dcterms:description """\\(\\textbf{Specific Energy}\\) is defined as the energy per unit mass. Common metric units are \\(J/kg\\). It is an intensive property. Contrast this with energy, which is an extensive property. There are two main types of specific energy: potential energy and specific kinetic energy. Others are the \\(\\textbf{gray}\\) and \\(\\textbf{sievert}\\), which are measures for the absorption of radiation. 
+  dcterms:description """\\(\\textbf{Specific Energy}\\) is defined as the energy per unit mass. Common metric units are \\(J/kg\\). It is an intensive property. Contrast this with energy, which is an extensive property. There are two main types of specific energy: potential energy and specific kinetic energy. Others are the \\(\\textbf{gray}\\) and \\(\\textbf{sievert}\\), which are measures for the absorption of radiation.
 The concept of specific energy applies to a particular or theoretical way of extracting useful energy from the material considered that is usually implied by context. These intensive properties are each symbolized by using the lower case letter of the symbol for the corresponding extensive property, which is symbolized by a capital letter. For example, the extensive thermodynamic property enthalpy is symbolized by \\(H\\); specific enthalpy is symbolized by \\(h\\)."""^^qudt:LatexString ;
   qudt:applicableUnit unit:BTU_IT-PER-LB ;
   qudt:applicableUnit unit:BTU_IT-PER-LB_F ;
@@ -15807,8 +15829,8 @@ quantitykind:ThermodynamicTemperature
   qudt:dbpediaMatch "http://dbpedia.org/page/Thermodynamic_temperature"^^xsd:anyURI ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H1T0D0 ;
   qudt:latexSymbol "\\(\\Theta\\)"^^qudt:LatexString ;
-  qudt:plainTextDescription """Thermodynamic temperature is the absolute measure of temperature and is one of the principal parameters of thermodynamics. 
-Temperature is a physical property of matter that quantitatively expresses the common notions of hot and cold. 
+  qudt:plainTextDescription """Thermodynamic temperature is the absolute measure of temperature and is one of the principal parameters of thermodynamics.
+Temperature is a physical property of matter that quantitatively expresses the common notions of hot and cold.
 In thermodynamics, in a system of which the entropy is considered as an independent externally controlled variable, absolute, or thermodynamic temperature is defined as the derivative of the internal energy with respect to the entropy. This is a base quantity in the International System of Quantities, ISQ, on which the International System of Units, SI, is based.""" ;
   qudt:symbol "T" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
@@ -16043,11 +16065,11 @@ quantitykind:Torque
   dcterms:description """In physics, a torque (\\(\\tau\\)) is a vector that measures the tendency of a force to rotate an object about some axis. The magnitude of a torque is defined as force times its lever arm. Just as a force is a push or a pull, a torque can be thought of as a twist. The SI unit for torque is newton meters (\\(N m\\)). In U.S. customary units, it is measured in foot pounds (ft lbf) (also known as \"pounds feet\").
 Mathematically, the torque on a particle (which has the position r in some reference frame) can be defined as the cross product: \\(τ = r x F\\)
 where,
-r is the particle's position vector relative to the fulcrum 
-F is the force acting on the particles, 
+r is the particle's position vector relative to the fulcrum
+F is the force acting on the particles,
 or, more generally, torque can be defined as the rate of change of angular momentum: \\(τ = dL/dt\\)
 where,
-L is the angular momentum vector 
+L is the angular momentum vector
 t stands for time."""^^qudt:LatexString ;
   qudt:applicableUnit unit:CentiN-M ;
   qudt:applicableUnit unit:DYN-CentiM ;

--- a/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
+++ b/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
@@ -11781,7 +11781,7 @@ quantitykind:PhotonRadiance
 .
 quantitykind:PhotosyntheticPhotonFluxDensity
   rdf:type qudt:QuantityKind ;
-  qudt:hasDimensionVector qkdv:A1E0L-2I0M0H0T-1D0 ;
+  qudt:hasDimensionVector qkdv:A1E0L0I0M0H0T-1D0 ;
   qudt:plainTextDescription "Photosynthetically Active Radiation are the wavelengths of light within the visible range of 400 to 700 nanometers (nm) that are critical for photosynthesis. PPFD measures the amount of PAR light (photons) that arrive at the plant’s surface each second. The PPFD is measured at various distances with a Full-spectrum Quantum Sensor, also known as a PAR meter. Natural sunlight has a PAR value of 900-1500μMol/m2/s when the sun is directly overhead. For a grow light to be effective, it should have PAR values of 500-1500 μMol/m2/s." ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
   rdfs:label "Photosynthetic Photon Flux Density" ;
@@ -11792,7 +11792,7 @@ quantitykind:PhotosyntheticPhotonFluxDensity
 .
 quantitykind:PhotosyntheticPhotonFlux
   rdf:type qudt:QuantityKind ;
-  qudt:hasDimensionVector qkdv:A1E0L-0I0M0H0T-1D0 ;
+  qudt:hasDimensionVector qkdv:A1E0L0I0M0H0T-1D0 ;
   qudt:plainTextDescription "Photosynthetic Photon Flux (PPF) is a measurement of the total number of photons emitted by a light source each second within the PAR wavelength range and is measured in μmol/s. Lighting manufacturers may specify their grow light products in terms of PPF. It can be considered as analogous to measuring the luminous flux (lumens) of visible light which would typically require the use of an integrating sphere or a goniometer system with spectroradiometer sensor." ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
   rdfs:label "Photosynthetic Photon Flux" ;
@@ -11803,8 +11803,7 @@ quantitykind:PhotosyntheticPhotonFlux
 .
 quantitykind:PlanckFunction
   a qudt:QuantityKind ;
-  dcterms:description """The \\(\\textit{Planck function}\\) is used to compute the radiance emitted from objects that radiate like a perfect \"Black Body\". The inverse of the \\(\\textit{Planck Function}\\) is used to find the \\(\\textit{Brightness Temperature}\\) of an object.
-The precise formula for the Planck Function depends on whether the radiance is determined on a \\(\\textit{per unit wavelength}\\) or a \\(\\textit{per unit frequency}\\). In the ISO System of Quantities, \\(\\textit{Planck Function}\\) is defined by the formula: \\(Y = -G/T\\), where \\(G\\) is Gibbs Energy and \\(T\\) is thermodynamic temperature."""^^qudt:LatexString ;
+  dcterms:description """The \\(\\textit{Planck function}\\) is used to compute the radiance emitted from objects that radiate like a perfect \"Black Body\". The inverse of the \\(\\textit{Planck Function}\\) is used to find the \\(\\textit{Brightness Temperature}\\) of an object. The precise formula for the Planck Function depends on whether the radiance is determined on a \\(\\textit{per unit wavelength}\\) or a \\(\\textit{per unit frequency}\\). In the ISO System of Quantities, \\(\\textit{Planck Function}\\) is defined by the formula: \\(Y = -G/T\\), where \\(G\\) is Gibbs Energy and \\(T\\) is thermodynamic temperature."""^^qudt:LatexString ;
   qudt:expression "\\(B_{\\nu}(T)\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:informativeReference "http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19680008986_1968008986.pdf"^^xsd:anyURI ;
@@ -14328,8 +14327,7 @@ quantitykind:SpecificActivity
 .
 quantitykind:SpecificEnergy
   a qudt:QuantityKind ;
-  dcterms:description """\\(\\textbf{Specific Energy}\\) is defined as the energy per unit mass. Common metric units are \\(J/kg\\). It is an intensive property. Contrast this with energy, which is an extensive property. There are two main types of specific energy: potential energy and specific kinetic energy. Others are the \\(\\textbf{gray}\\) and \\(\\textbf{sievert}\\), which are measures for the absorption of radiation.
-The concept of specific energy applies to a particular or theoretical way of extracting useful energy from the material considered that is usually implied by context. These intensive properties are each symbolized by using the lower case letter of the symbol for the corresponding extensive property, which is symbolized by a capital letter. For example, the extensive thermodynamic property enthalpy is symbolized by \\(H\\); specific enthalpy is symbolized by \\(h\\)."""^^qudt:LatexString ;
+  dcterms:description """\\(\\textbf{Specific Energy}\\) is defined as the energy per unit mass. Common metric units are \\(J/kg\\). It is an intensive property. Contrast this with energy, which is an extensive property. There are two main types of specific energy: potential energy and specific kinetic energy. Others are the \\(\\textbf{gray}\\) and \\(\\textbf{sievert}\\), which are measures for the absorption of radiation. The concept of specific energy applies to a particular or theoretical way of extracting useful energy from the material considered that is usually implied by context. These intensive properties are each symbolized by using the lower case letter of the symbol for the corresponding extensive property, which is symbolized by a capital letter. For example, the extensive thermodynamic property enthalpy is symbolized by \\(H\\); specific enthalpy is symbolized by \\(h\\)."""^^qudt:LatexString ;
   qudt:applicableUnit unit:BTU_IT-PER-LB ;
   qudt:applicableUnit unit:BTU_IT-PER-LB_F ;
   qudt:applicableUnit unit:BTU_TH-PER-LB ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -14104,7 +14104,7 @@ unit:MicroMOL-PER-SEC
   a qudt:Unit ;
   dcterms:description " This unit is used commonly to describe Photosynthetic Photon Flux (PPF) - the total number of photons emitted by a light source each second within the PAR wavelength range. "@en ;
   qudt:conversionMultiplier 0.000001 ;
-  qudt:hasDimensionVector qkdv:A1E0L-0I0M0H0T-1D0 ;
+  qudt:hasDimensionVector qkdv:A1E0L0I0M0H0T-1D0 ;
   qudt:ucumCode "umol.s-1"^^qudt:UCUMcs ;
   qudt:ucumCode "umol/s"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -14069,12 +14069,13 @@ unit:MicroMOL-PER-M2-HR
 .
 unit:MicroMOL-PER-M2-SEC
   a qudt:Unit ;
-  dcterms:description "One part per 10**6 (million) of the SI unit of quantity of matter (the mole) per SI unit area per SI unit of time."@en ;
+  dcterms:description "One part per 10**6 (million) of the SI unit of quantity of matter (the mole) per SI unit area per SI unit of time.  This term is based on the number of photons in a certain waveband incident per unit time (s) on a unit area (m2) divided by the Avogadro constant (6.022 x 1023 mol-1). It is used commonly to describe PAR in the 400-700 nm waveband. Definition Source: Thimijan, Richard W., and Royal D. Heins. 1982. Photometric, Radiometric, and Quantum Light Units of Measure: A Review of Procedures for Interconversion. HortScience 18:818-822."@en ;
   qudt:conversionMultiplier 0.000001 ;
   qudt:hasDimensionVector qkdv:A1E0L-2I0M0H0T-1D0 ;
   qudt:ucumCode "umol.m-2.s-1"^^qudt:UCUMcs ;
   qudt:ucumCode "umol/m2/s"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  qudt:hasQuantityKind quantitykind:PhotosyntheticPhotonFluxDensity ;
   rdfs:label "Micromoles per square metre per second"@en ;
 .
 unit:MicroMOL-PER-MOL
@@ -14098,6 +14099,17 @@ unit:MicroMOL-PER-MicroMOL-DAY
   qudt:ucumCode "umol/umol/d"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Micromole per micromole of biomass per day"@en ;
+.
+unit:MicroMOL-PER-SEC
+  a qudt:Unit ;
+  dcterms:description " This unit is used commonly to describe Photosynthetic Photon Flux (PPF) - the total number of photons emitted by a light source each second within the PAR wavelength range. "@en ;
+  qudt:conversionMultiplier 0.000001 ;
+  qudt:hasDimensionVector qkdv:A1E0L-0I0M0H0T-1D0 ;
+  qudt:ucumCode "umol.s-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "umol/s"^^qudt:UCUMcs ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  qudt:hasQuantityKind quantitykind:PhotosyntheticPhotonFlux ;
+  rdfs:label "Micromoles per second"@en ;
 .
 unit:MicroN
   a qudt:Unit ;
@@ -15358,7 +15370,6 @@ unit:MilliMOL-PER-M2-DAY
 .
 unit:MilliMOL-PER-M2-SEC
   a qudt:Unit ;
-  dcterms:description "This term is based on the number of photons in a certain waveband incident per unit time (s) on a unit area (m2) divided by the Avogadro constant (6.022 x 1023 mol-1). It is used commonly to describe PAR in the 400-700 nm waveband. Definition Source: Thimijan, Richard W., and Royal D. Heins. 1982. Photometric, Radiometric, and Quantum Light Units of Measure: A Review of Procedures for Interconversion. HortScience 18:818-822."@en ;
   qudt:conversionMultiplier 0.001 ;
   qudt:hasDimensionVector qkdv:A1E0L-2I0M0H0T-1D0 ;
   qudt:ucumCode "mmol.m-2.s-1"^^qudt:UCUMcs ;


### PR DESCRIPTION
1. added dimension for the unit umol/s (qkdv:A1E0L-0I0M0H0T-1D0)
2. added two quantity kinds (quantitykind:PhotosyntheticPhotonFluxDensity, quantitykind:PhotosyntheticPhotonFlux)
3. linked the unit:MicroMOL-PER-SEC to PPF and unit:MilliMOL-PER-M2-SEC to PPFD
4. removed the definition of unit:MilliMOL-PER-M2-SEC as unit:MicroMOL-PER-M2-SEC is commonly unit for PPFD.
Ref related issue: https://github.com/qudt/qudt-public-repo/issues/409 