### PR TITLE
Small refactoring of scaling, addition of factor units and conversion targets

### DIFF
--- a/schema/SCHEMA_QUDT-v2.1.ttl
+++ b/schema/SCHEMA_QUDT-v2.1.ttl
@@ -2558,6 +2558,15 @@ qudt:isScalingOf
   rdfs:comment "This property connects a unit that uses a prefix to its base unit. For example, `unit:KiloGM` is a scaling of `unit:GM`" ;
   rdfs:label "is scaling of" ;
 .
+
+qudt:convertsTo
+    a owl:ObjectProperty ;
+    rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+    rdfs:domain qudt:Unit ;
+    rdfs:domain qudt:Unit ;
+    rdfs:comment "This property connects a unit that has a `qudt:conversionFactor` != 1 and/or `qudt:conversionOffset` != 0 to the unit yielded by the conversion using these constants." ;
+    rdfs:label "converts to" ;
+.
 qudt:FactorUnit
     a owl:Class ;
     rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;

--- a/schema/SCHEMA_QUDT-v2.1.ttl
+++ b/schema/SCHEMA_QUDT-v2.1.ttl
@@ -2555,8 +2555,31 @@ qudt:isScalingOf
   a owl:ObjectProperty ;
   a owl:TransitiveProperty ;
   rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
-  rdfs:comment "This property connects a unit that uses a prefix to its base unit. For example, 'KiloGM' is a scaling of 'GM'" ;
+  rdfs:comment "This property connects a unit that uses a prefix to its base unit. For example, `unit:KiloGM` is a scaling of `unit:GM`" ;
   rdfs:label "is scaling of" ;
+.
+qudt:FactorUnit
+    a owl:Class ;
+    rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+    rdfs:comment """Represents an attribution of factor unit and exponent to a derived unit via `qudt:unit` and `qudt:exponent`.
+    For example, `unit:PER-M3` has one `qudt:factorUnit`, which has a `qudt:unit unit:M` and a `qudt:exponent -3`."""@en ;
+    rdfs:label "factor unit" ;
+.
+qudt:exponent
+    a owl:DatatypeProperty  ;
+    rdfs:domain qudt:FactorUnit ;
+    rdfs:range xsd:integer ;
+    rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+    rdfs:comment "Denotes the exponent of the factor unit, e.g. the factor unit of `unit:PER-M3` has an exponent of -3."@en ;
+    rdfs:label "exponent" ;
+.
+qudt:factorUnit
+    a owl:DatatypeProperty  ;
+    rdfs:domain qudt:Unit ;
+    rdfs:range qudt:FactorUnit ;
+    rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+    rdfs:comment "Connects a derived unit to its factor units."@en ;
+    rdfs:label "factor unit" ;
 .
 qudt:isoNormativeReference
   a owl:DatatypeProperty ;

--- a/schema/SCHEMA_QUDT-v2.1.ttl
+++ b/schema/SCHEMA_QUDT-v2.1.ttl
@@ -2555,6 +2555,7 @@ qudt:isScalingOf
   a owl:ObjectProperty ;
   a owl:TransitiveProperty ;
   rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:comment "This property connects a unit that uses a prefix to its base unit. For example, 'KiloGM' is a scaling of 'GM'" ;
   rdfs:label "is scaling of" ;
 .
 qudt:isoNormativeReference

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -23444,8264 +23444,9694 @@ THE UCUM TABLE (IN ALL FORMATS), UCUM DEFINITIONS, AND SPECIFICATION ARE PROVIDE
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "All Units Ontology Version 2.1.15" ;
 .
-unit:FT-PER-HR
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:FT ] .
 
-unit:W-SEC-PER-M2
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:W ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] .
+unit:FT-PER-HR  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                   qudt:unit      unit:HR
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:FT
+                                 ] .
 
-unit:N-PER-C
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:N ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:C ] .
+unit:W-SEC-PER-M2  qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:W
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:SEC
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  -2 ;
+                                      qudt:unit      unit:M
+                                    ] .
 
-unit:MicroMOL-PER-M2
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MicroMOL ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] .
+unit:N-PER-C  qudt:factorUnit  [ qudt:exponent  1 ;
+                                 qudt:unit      unit:N
+                               ] ;
+              qudt:factorUnit  [ qudt:exponent  -1 ;
+                                 qudt:unit      unit:C
+                               ] .
 
-unit:CentiM3-PER-MIN
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MIN ] ;
-    qudt:factorUnit [ qudt:exponent 3 ;
-                      qudt:unit     unit:CentiM ] .
+unit:MicroMOL-PER-M2  qudt:factorUnit  [ qudt:exponent  1 ;
+                                         qudt:unit      unit:MicroMOL
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  -2 ;
+                                         qudt:unit      unit:M
+                                       ] .
 
-unit:J-M2-PER-KiloGM
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:KiloGM ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:J ] .
+unit:CentiM3-PER-MIN  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                         qudt:unit      unit:MIN
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  3 ;
+                                         qudt:unit      unit:CentiM
+                                       ] .
 
-unit:BAR-PER-K
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:K ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BAR ] .
+unit:J-M2-PER-KiloGM  qudt:factorUnit  [ qudt:exponent  2 ;
+                                         qudt:unit      unit:M
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  -1 ;
+                                         qudt:unit      unit:KiloGM
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  1 ;
+                                         qudt:unit      unit:J
+                                       ] .
 
-unit:CentiM3-PER-MOL
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MOL ] ;
-    qudt:factorUnit [ qudt:exponent 3 ;
-                      qudt:unit     unit:CentiM ] .
+unit:BAR-PER-K  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                   qudt:unit      unit:K
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:BAR
+                                 ] .
 
-unit:SLUG-PER-FT3
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:SLUG ] ;
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:FT ] .
+unit:CentiM3-PER-MOL  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                         qudt:unit      unit:MOL
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  3 ;
+                                         qudt:unit      unit:CentiM
+                                       ] .
 
-unit:DEG_C-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:DEG_C ] .
+unit:DEG_C-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:SEC
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:DEG_C
+                                     ] .
 
-unit:PER-FT3
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:FT ] .
+unit:SLUG-PER-FT3  qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:SLUG
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  -3 ;
+                                      qudt:unit      unit:FT
+                                    ] .
+
+unit:PER-FT3  qudt:factorUnit  [ qudt:exponent  -3 ;
+                                 qudt:unit      unit:FT
+                               ] .
 
 unit:KiloGM_F-M-PER-CentiM2
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloGM_F ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:CentiM ] .
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:M
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:KiloGM_F
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:CentiM
+                     ] .
 
 unit:KiloEV-PER-MicroM
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MicroM ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloEV ] .
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:MicroM
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:KiloEV
+                     ] .
+
+unit:KiloA-HR  qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:KiloA
+                                ] ;
+               qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:HR
+                                ] .
 
 unit:CAL_TH-PER-GM-DEG_C
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:GM ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DEG_C ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:CAL_TH ] .
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:GM
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:DEG_C
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:CAL_TH
+                     ] .
 
 unit:BTU_IT-PER-FT2-HR-DEG_F
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:FT ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DEG_F ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BTU_IT ] .
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:HR
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:FT
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:DEG_F
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:BTU_IT
+                     ] .
 
-unit:N-M-SEC-PER-M
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:N ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] .
+unit:N-M-SEC-PER-M  qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:SEC
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:N
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:M
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:M
+                                     ] .
 
-unit:OZ-PER-GAL_UK
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:OZ ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:GAL_UK ] .
+unit:OZ-PER-GAL_UK  qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:OZ
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:GAL_UK
+                                     ] .
 
-unit:C-PER-M3
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:C ] .
+unit:C-PER-M3  qudt:factorUnit  [ qudt:exponent  -3 ;
+                                  qudt:unit      unit:M
+                                ] ;
+               qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:C
+                                ] .
 
-unit:FT-LB_F-PER-MIN
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MIN ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:LB_F ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:FT ] .
+unit:FT-LB_F-PER-MIN  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                         qudt:unit      unit:MIN
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  1 ;
+                                         qudt:unit      unit:LB_F
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  1 ;
+                                         qudt:unit      unit:FT
+                                       ] .
 
 unit:MOL-PER-KiloGM-PA
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:PA ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MOL ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:KiloGM ] .
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:PA
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MOL
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:KiloGM
+                     ] .
 
 unit:KiloGM-PER-M2-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloGM ] .
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:SEC
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:M
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:KiloGM
+                     ] .
 
-unit:GI_UK-PER-MIN
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MIN ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:GI_UK ] .
+unit:GI_UK-PER-MIN  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:MIN
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:GI_UK
+                                     ] .
 
-unit:BIT-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BIT ] .
+unit:BIT-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                     qudt:unit      unit:SEC
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:BIT
+                                   ] .
 
-unit:KiloMOL-PER-HR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloMOL ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] .
+unit:KiloMOL-PER-HR  qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:KiloMOL
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:HR
+                                      ] .
 
-unit:YD3
-    qudt:factorUnit [ qudt:exponent 3 ;
-                      qudt:unit     unit:YD ] .
-
-unit:A-PER-M2-K2
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:K ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:A ] .
+unit:YD3  qudt:factorUnit  [ qudt:exponent  3 ;
+                             qudt:unit      unit:YD
+                           ] .
 
 unit:OZ_VOL_US-PER-MIN
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:OZ_VOL_US ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MIN ] .
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:OZ_VOL_US
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:MIN
+                     ] .
 
-unit:PER-J-M3
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:J ] .
+unit:A-PER-M2-K2  qudt:factorUnit  [ qudt:exponent  -2 ;
+                                     qudt:unit      unit:M
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  -2 ;
+                                     qudt:unit      unit:K
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:A
+                                   ] .
 
-unit:W-PER-M2-M
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:W ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] .
+unit:PER-J-M3  qudt:factorUnit  [ qudt:exponent  -3 ;
+                                  qudt:unit      unit:M
+                                ] ;
+               qudt:factorUnit  [ qudt:exponent  -1 ;
+                                  qudt:unit      unit:J
+                                ] .
+
+unit:W-PER-M2-M  qudt:factorUnit  [ qudt:exponent  1 ;
+                                    qudt:unit      unit:W
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  -2 ;
+                                    qudt:unit      unit:M
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  -1 ;
+                                    qudt:unit      unit:M
+                                  ] .
 
 unit:PicoMOL-PER-M-W-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:W ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:PicoMOL ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] .
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:W
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:SEC
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:PicoMOL
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:M
+                     ] .
 
-unit:V-PER-MicroSEC
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:V ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MicroSEC ] .
+unit:V-PER-MicroSEC  qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:V
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:MicroSEC
+                                      ] .
 
-unit:PA-SEC-PER-M3
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:PA ] ;
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:M ] .
+unit:PA-SEC-PER-M3  qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:SEC
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:PA
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -3 ;
+                                       qudt:unit      unit:M
+                                     ] .
 
-unit:L-PER-KiloGM
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:L ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:KiloGM ] .
+unit:L-PER-KiloGM  qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:L
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:KiloGM
+                                    ] .
 
-unit:KiloC-PER-M2
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloC ] .
+unit:KiloC-PER-M2  qudt:factorUnit  [ qudt:exponent  -2 ;
+                                      qudt:unit      unit:M
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:KiloC
+                                    ] .
 
-unit:KiloMOL-PER-MIN
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MIN ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloMOL ] .
+unit:LB-DEG_R  qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:LB
+                                ] ;
+               qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:DEG_R
+                                ] .
 
-unit:A-M2
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:A ] .
+unit:KiloMOL-PER-MIN  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                         qudt:unit      unit:MIN
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  1 ;
+                                         qudt:unit      unit:KiloMOL
+                                       ] .
 
-unit:BTU_TH-PER-LB
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:LB ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BTU_TH ] .
+unit:A-M2  qudt:factorUnit  [ qudt:exponent  2 ;
+                              qudt:unit      unit:M
+                            ] ;
+           qudt:factorUnit  [ qudt:exponent  1 ;
+                              qudt:unit      unit:A
+                            ] .
 
-unit:KiloWB
-    a            qudt:Unit ;
-    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
+unit:BTU_TH-PER-LB  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:LB
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:BTU_TH
+                                     ] .
 
-unit:GM-PER-DAY
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:GM ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DAY ] .
+unit:GM-PER-DAY  qudt:factorUnit  [ qudt:exponent  1 ;
+                                    qudt:unit      unit:GM
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  -1 ;
+                                    qudt:unit      unit:DAY
+                                  ] .
 
-unit:MilliV-PER-M
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliV ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] .
+unit:MilliV-PER-M  qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:MilliV
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:M
+                                    ] .
 
-unit:A-PER-RAD
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:RAD ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:A ] .
+unit:A-PER-RAD  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                   qudt:unit      unit:RAD
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:A
+                                 ] .
 
 unit:KiloCAL-PER-GM-DEG_C
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloCAL ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:GM ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DEG_C ] .
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:KiloCAL
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:GM
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:DEG_C
+                     ] .
 
-unit:KiloGM_F-PER-M2
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloGM_F ] .
+unit:KiloGM_F-PER-M2  qudt:factorUnit  [ qudt:exponent  -2 ;
+                                         qudt:unit      unit:M
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  1 ;
+                                         qudt:unit      unit:KiloGM_F
+                                       ] .
 
-unit:PA-PER-K
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:PA ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:K ] .
+unit:PA-PER-K  qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:PA
+                                ] ;
+               qudt:factorUnit  [ qudt:exponent  -1 ;
+                                  qudt:unit      unit:K
+                                ] .
 
-unit:KiloGM-PER-L
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:L ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloGM ] .
+unit:KiloGM-PER-L  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:L
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:KiloGM
+                                    ] .
 
-unit:CentiM2
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:CentiM ] .
+unit:CentiM2  qudt:factorUnit  [ qudt:exponent  2 ;
+                                 qudt:unit      unit:CentiM
+                               ] .
 
-unit:M3-PER-HR
-    qudt:factorUnit [ qudt:exponent 3 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] .
+unit:M3-PER-HR  qudt:factorUnit  [ qudt:exponent  3 ;
+                                   qudt:unit      unit:M
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  -1 ;
+                                   qudt:unit      unit:HR
+                                 ] .
 
-unit:NUM-PER-MilliGM
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:NUM ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MilliGM ] .
+unit:NUM-PER-MilliGM  qudt:factorUnit  [ qudt:exponent  1 ;
+                                         qudt:unit      unit:NUM
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  -1 ;
+                                         qudt:unit      unit:MilliGM
+                                       ] .
 
-unit:MicroM-PER-K
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MicroM ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:K ] .
+unit:T-M  qudt:factorUnit  [ qudt:exponent  1 ;
+                             qudt:unit      unit:T
+                           ] ;
+          qudt:factorUnit  [ qudt:exponent  1 ;
+                             qudt:unit      unit:M
+                           ] .
 
-unit:GI_US-PER-MIN
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MIN ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:GI_US ] .
+unit:MicroM-PER-K  qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:MicroM
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:K
+                                    ] .
 
-unit:CentiM3-PER-M3
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 3 ;
-                      qudt:unit     unit:CentiM ] .
+unit:GI_US-PER-MIN  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:MIN
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:GI_US
+                                     ] .
 
-unit:KiloM-PER-HR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloM ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] .
+unit:CentiM3-PER-M3  qudt:factorUnit  [ qudt:exponent  -3 ;
+                                        qudt:unit      unit:M
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  3 ;
+                                        qudt:unit      unit:CentiM
+                                      ] .
 
-unit:LB-PER-FT-HR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:LB ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:FT ] .
+unit:KiloM-PER-HR  qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:KiloM
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:HR
+                                    ] .
 
-unit:GM-PER-KiloM
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:KiloM ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:GM ] .
+unit:LB-PER-FT-HR  qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:LB
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:HR
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:FT
+                                    ] .
+
+unit:GM-PER-KiloM  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:KiloM
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:GM
+                                    ] .
 
 unit:MilliGM-PER-M3-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliGM ] ;
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:M ] .
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:SEC
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MilliGM
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -3 ;
+                       qudt:unit      unit:M
+                     ] .
 
-unit:MilliGM-PER-DAY
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliGM ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DAY ] .
+unit:MilliGM-PER-DAY  qudt:factorUnit  [ qudt:exponent  1 ;
+                                         qudt:unit      unit:MilliGM
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  -1 ;
+                                         qudt:unit      unit:DAY
+                                       ] .
 
-unit:KiloGM-PER-M2
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloGM ] .
+unit:KiloGM-PER-M2  qudt:factorUnit  [ qudt:exponent  -2 ;
+                                       qudt:unit      unit:M
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:KiloGM
+                                     ] .
+
+unit:MilliN-M  qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:MilliN
+                                ] ;
+               qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:M
+                                ] .
 
 unit:K-M2-PER-KiloGM-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:KiloGM ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:K ] .
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:SEC
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  2 ;
+                       qudt:unit      unit:M
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:KiloGM
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:K
+                     ] .
 
 unit:MilliMOL-PER-M2-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliMOL ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] .
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:SEC
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MilliMOL
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:M
+                     ] .
 
-unit:PER-PlanckMass2
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:PlanckMass ] .
+unit:PER-PlanckMass2  qudt:factorUnit  [ qudt:exponent  -2 ;
+                                         qudt:unit      unit:PlanckMass
+                                       ] .
 
-unit:LB-PER-MIN
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MIN ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:LB ] .
+unit:LB-PER-MIN  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                    qudt:unit      unit:MIN
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  1 ;
+                                    qudt:unit      unit:LB
+                                  ] .
 
-unit:PER-IN3
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:IN ] .
+unit:PER-IN3  qudt:factorUnit  [ qudt:exponent  -3 ;
+                                 qudt:unit      unit:IN
+                               ] .
 
-unit:PINT_UK-PER-MIN
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:PINT_UK ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MIN ] .
+unit:PINT_UK-PER-MIN  qudt:factorUnit  [ qudt:exponent  1 ;
+                                         qudt:unit      unit:PINT_UK
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  -1 ;
+                                         qudt:unit      unit:MIN
+                                       ] .
 
 unit:BTU_IT-PER-FT2-SEC-DEG_F
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:FT ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DEG_F ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BTU_IT ] .
-
-unit:MilliRAD_R
-    a            qudt:Unit ;
-    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:SEC
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:FT
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:DEG_F
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:BTU_IT
+                     ] .
 
 unit:BBL_US_PET-PER-HR
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BBL_US_PET ] .
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:HR
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:BBL_US_PET
+                     ] .
 
-unit:C-PER-MOL
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MOL ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:C ] .
+unit:C-PER-MOL  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                   qudt:unit      unit:MOL
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:C
+                                 ] .
 
-unit:N-PER-MilliM2
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:N ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:MilliM ] .
+unit:N-PER-MilliM2  qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:N
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -2 ;
+                                       qudt:unit      unit:MilliM
+                                     ] .
 
 unit:MilliMOL-PER-MOL
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliMOL ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MOL ] .
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MilliMOL
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:MOL
+                     ] .
 
-unit:GI_US-PER-HR
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:GI_US ] .
+unit:GI_US-PER-HR  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:HR
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:GI_US
+                                    ] .
 
-unit:M-K-PER-W
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:W ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:K ] .
+unit:M-K-PER-W  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                   qudt:unit      unit:W
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:M
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:K
+                                 ] .
 
-unit:J-PER-MOL-K
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MOL ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:K ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:J ] .
+unit:J-PER-MOL-K  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                     qudt:unit      unit:MOL
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                     qudt:unit      unit:K
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:J
+                                   ] .
 
 unit:NanoMOL-PER-CentiM3-HR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:NanoMOL ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] ;
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:CentiM ] .
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:NanoMOL
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:HR
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -3 ;
+                       qudt:unit      unit:CentiM
+                     ] .
 
 unit:GM_Nitrogen-PER-M2-DAY
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:GM_Nitrogen ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DAY ] .
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:M
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:GM_Nitrogen
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:DAY
+                     ] .
 
-unit:FT2
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:FT ] .
+unit:FT2  qudt:factorUnit  [ qudt:exponent  2 ;
+                             qudt:unit      unit:FT
+                           ] .
 
-unit:KiloCAL-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloCAL ] .
+unit:KiloCAL-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                         qudt:unit      unit:SEC
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  1 ;
+                                         qudt:unit      unit:KiloCAL
+                                       ] .
 
 unit:MicroMOL-PER-MOL
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MicroMOL ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MOL ] .
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MicroMOL
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:MOL
+                     ] .
 
-unit:MOL-PER-M3-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MOL ] ;
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:M ] .
+unit:MOL-PER-M3-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:SEC
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:MOL
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -3 ;
+                                        qudt:unit      unit:M
+                                      ] .
 
 unit:KiloJ-PER-KiloGM
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloJ ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:KiloGM ] .
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:KiloJ
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:KiloGM
+                     ] .
 
-unit:W-PER-KiloGM
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:W ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:KiloGM ] .
+unit:W-PER-KiloGM  qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:W
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:KiloGM
+                                    ] .
 
-unit:FT2-HR-DEG_F
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:HR ] ;
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:FT ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:DEG_F ] .
+unit:FT2-HR-DEG_F  qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:HR
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  2 ;
+                                      qudt:unit      unit:FT
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:DEG_F
+                                    ] .
 
-unit:MOL-PER-M3
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MOL ] ;
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:M ] .
+unit:MOL-PER-M3  qudt:factorUnit  [ qudt:exponent  1 ;
+                                    qudt:unit      unit:MOL
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  -3 ;
+                                    qudt:unit      unit:M
+                                  ] .
 
-unit:A-PER-MilliM
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MilliM ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:A ] .
+unit:A-PER-MilliM  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:MilliM
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:A
+                                    ] .
 
-unit:MicroW-PER-M2
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MicroW ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] .
+unit:MicroW-PER-M2  qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:MicroW
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -2 ;
+                                       qudt:unit      unit:M
+                                     ] .
 
-unit:EV-PER-T
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:T ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:EV ] .
+unit:EV-PER-T  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                  qudt:unit      unit:T
+                                ] ;
+               qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:EV
+                                ] .
 
-unit:TONNE-PER-MIN
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:TONNE ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MIN ] .
+unit:TONNE-PER-MIN  qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:TONNE
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:MIN
+                                     ] .
 
-unit:KiloJ-PER-K
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloJ ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:K ] .
+unit:KiloJ-PER-K  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:KiloJ
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                     qudt:unit      unit:K
+                                   ] .
 
 unit:M3-PER-KiloGM-SEC2
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 3 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:KiloGM ] .
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:SEC
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  3 ;
+                       qudt:unit      unit:M
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:KiloGM
+                     ] .
 
-unit:FLIGHT
-    a            qudt:Unit ;
-    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
-
-unit:FRAME
-    a            qudt:Unit ;
-    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
-
-unit:L-PER-MicroMOL
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MicroMOL ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:L ] .
+unit:L-PER-MicroMOL  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:MicroMOL
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:L
+                                      ] .
 
 unit:BTU_IT-FT-PER-FT2-HR-DEG_F
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:FT ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:FT ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DEG_F ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BTU_IT ] .
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:HR
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:FT
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:FT
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:DEG_F
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:BTU_IT
+                     ] .
 
 unit:BBL_UK_PET-PER-HR
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BBL_UK_PET ] .
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:HR
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:BBL_UK_PET
+                     ] .
 
-unit:N-M-PER-A
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:N ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:A ] .
+unit:N-M-PER-A  qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:N
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:M
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  -1 ;
+                                   qudt:unit      unit:A
+                                 ] .
 
-unit:PINT_US-PER-MIN
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:PINT_US ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MIN ] .
+unit:PINT_US-PER-MIN  qudt:factorUnit  [ qudt:exponent  1 ;
+                                         qudt:unit      unit:PINT_US
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  -1 ;
+                                         qudt:unit      unit:MIN
+                                       ] .
 
 unit:HectoPA-M3-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 3 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:HectoPA ] .
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:SEC
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  3 ;
+                       qudt:unit      unit:M
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:HectoPA
+                     ] .
 
-unit:K-PER-MIN
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MIN ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:K ] .
+unit:K-PER-MIN  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                   qudt:unit      unit:MIN
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:K
+                                 ] .
 
-unit:M3-PER-C
-    qudt:factorUnit [ qudt:exponent 3 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:C ] .
+unit:M3-PER-C  qudt:factorUnit  [ qudt:exponent  3 ;
+                                  qudt:unit      unit:M
+                                ] ;
+               qudt:factorUnit  [ qudt:exponent  -1 ;
+                                  qudt:unit      unit:C
+                                ] .
 
-unit:NUM-PER-MicroL
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:NUM ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MicroL ] .
+unit:NUM-PER-MicroL  qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:NUM
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:MicroL
+                                      ] .
 
 unit:KiloLB_F-FT-PER-A
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloLB_F ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:FT ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:A ] .
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:KiloLB_F
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:FT
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:A
+                     ] .
 
-unit:M2-PER-GM_DRY
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:GM_DRY ] .
+unit:M2-PER-GM_DRY  qudt:factorUnit  [ qudt:exponent  2 ;
+                                       qudt:unit      unit:M
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:GM_DRY
+                                     ] .
 
-unit:MilliM4
-    qudt:factorUnit [ qudt:exponent 4 ;
-                      qudt:unit     unit:MilliM ] .
+unit:MilliM4  qudt:factorUnit  [ qudt:exponent  4 ;
+                                 qudt:unit      unit:MilliM
+                               ] .
 
-unit:MilliMOL-PER-M3
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliMOL ] ;
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:M ] .
+unit:MilliMOL-PER-M3  qudt:factorUnit  [ qudt:exponent  1 ;
+                                         qudt:unit      unit:MilliMOL
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  -3 ;
+                                         qudt:unit      unit:M
+                                       ] .
 
 unit:KiloGM-PER-KiloGM
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloGM ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:KiloGM ] .
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:KiloGM
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:KiloGM
+                     ] .
 
-unit:KiloL-PER-HR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloL ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] .
+unit:KiloL-PER-HR  qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:KiloL
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:HR
+                                    ] .
 
-unit:DYN-PER-CentiM
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:DYN ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:CentiM ] .
+unit:DYN-PER-CentiM  qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:DYN
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:CentiM
+                                      ] .
+
+unit:LB_F-IN  qudt:factorUnit  [ qudt:exponent  1 ;
+                                 qudt:unit      unit:LB_F
+                               ] ;
+              qudt:factorUnit  [ qudt:exponent  1 ;
+                                 qudt:unit      unit:IN
+                               ] .
 
 unit:GM_F-PER-CentiM2
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:GM_F ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:CentiM ] .
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:GM_F
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:CentiM
+                     ] .
 
 unit:BTU_IT-PER-HR-FT2
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:FT ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BTU_IT ] .
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:HR
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:FT
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:BTU_IT
+                     ] .
 
-unit:SAMPLE-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:SAMPLE ] .
+unit:SAMPLE-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:SEC
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:SAMPLE
+                                      ] .
 
-unit:BU_UK-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BU_UK ] .
+unit:LB-IN  qudt:factorUnit  [ qudt:exponent  1 ;
+                               qudt:unit      unit:LB
+                             ] ;
+            qudt:factorUnit  [ qudt:exponent  1 ;
+                               qudt:unit      unit:IN
+                             ] .
+
+unit:BU_UK-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:SEC
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:BU_UK
+                                     ] .
 
 unit:MilliGM-PER-M2-HR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliGM ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] .
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MilliGM
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:M
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:HR
+                     ] .
 
-unit:M3-PER-MIN
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MIN ] ;
-    qudt:factorUnit [ qudt:exponent 3 ;
-                      qudt:unit     unit:M ] .
+unit:M3-PER-MIN  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                    qudt:unit      unit:MIN
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  3 ;
+                                    qudt:unit      unit:M
+                                  ] .
 
-unit:MOL-PER-MIN
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MOL ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MIN ] .
+unit:MOL-PER-MIN  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:MOL
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                     qudt:unit      unit:MIN
+                                   ] .
 
-unit:C-PER-KiloGM
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:KiloGM ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:C ] .
+unit:C-PER-KiloGM  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:KiloGM
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:C
+                                    ] .
 
-unit:M3-PER-MOL
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MOL ] ;
-    qudt:factorUnit [ qudt:exponent 3 ;
-                      qudt:unit     unit:M ] .
+unit:M3-PER-MOL  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                    qudt:unit      unit:MOL
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  3 ;
+                                    qudt:unit      unit:M
+                                  ] .
 
-unit:MOL-PER-MOL
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MOL ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MOL ] .
+unit:MOL-PER-MOL  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:MOL
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                     qudt:unit      unit:MOL
+                                   ] .
 
-unit:W-PER-CentiM2
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:W ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:CentiM ] .
+unit:W-PER-CentiM2  qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:W
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -2 ;
+                                       qudt:unit      unit:CentiM
+                                     ] .
 
-unit:A-PER-M
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:A ] .
+unit:A-PER-M  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                 qudt:unit      unit:M
+                               ] ;
+              qudt:factorUnit  [ qudt:exponent  1 ;
+                                 qudt:unit      unit:A
+                               ] .
 
 unit:PK_US_DRY-PER-HR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:PK_US_DRY ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] .
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:PK_US_DRY
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:HR
+                     ] .
 
-unit:KiloA-PER-M2
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloA ] .
+unit:KiloA-PER-M2  qudt:factorUnit  [ qudt:exponent  -2 ;
+                                      qudt:unit      unit:M
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:KiloA
+                                    ] .
 
-unit:IN2
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:IN ] .
+unit:IN2  qudt:factorUnit  [ qudt:exponent  2 ;
+                             qudt:unit      unit:IN
+                           ] .
 
 unit:MilliW-PER-CentiM2-MicroM-SR
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SR ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliW ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MicroM ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:CentiM ] .
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:SR
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MilliW
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:MicroM
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:CentiM
+                     ] .
 
 unit:MicroS-PER-CentiM
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MicroS ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:CentiM ] .
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MicroS
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:CentiM
+                     ] .
 
-unit:J-PER-M4
-    qudt:factorUnit [ qudt:exponent -4 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:J ] .
+unit:J-PER-M4  qudt:factorUnit  [ qudt:exponent  -4 ;
+                                  qudt:unit      unit:M
+                                ] ;
+               qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:J
+                                ] .
 
-unit:NUM-PER-M
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:NUM ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] .
+unit:NUM-PER-M  qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:NUM
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  -1 ;
+                                   qudt:unit      unit:M
+                                 ] .
 
 unit:PK_US_DRY-PER-DAY
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:PK_US_DRY ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DAY ] .
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:PK_US_DRY
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:DAY
+                     ] .
 
 unit:DEG_C-KiloGM-PER-M2
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloGM ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:DEG_C ] .
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:M
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:KiloGM
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:DEG_C
+                     ] .
 
-unit:RAD-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:RAD ] .
+unit:RAD-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                     qudt:unit      unit:SEC
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:RAD
+                                   ] .
 
-unit:CAL_TH-PER-GM
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:GM ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:CAL_TH ] .
+unit:CAL_TH-PER-GM  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:GM
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:CAL_TH
+                                     ] .
 
-unit:MicroS-PER-M
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MicroS ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] .
+unit:MicroS-PER-M  qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:MicroS
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:M
+                                    ] .
 
 unit:OZ_VOL_UK-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:OZ_VOL_UK ] .
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:SEC
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:OZ_VOL_UK
+                     ] .
 
 unit:MilliMOL-PER-KiloGM
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliMOL ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:KiloGM ] .
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MilliMOL
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:KiloGM
+                     ] .
 
-unit:FT3-PER-MIN-FT2
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MIN ] ;
-    qudt:factorUnit [ qudt:exponent 3 ;
-                      qudt:unit     unit:FT ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:FT ] .
+unit:FT3-PER-MIN-FT2  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                         qudt:unit      unit:MIN
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  3 ;
+                                         qudt:unit      unit:FT
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  -2 ;
+                                         qudt:unit      unit:FT
+                                       ] .
 
-unit:V-PER-CentiM
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:V ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:CentiM ] .
+unit:V-PER-CentiM  qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:V
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:CentiM
+                                    ] .
 
-unit:MilliGM-PER-GM
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliGM ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:GM ] .
+unit:MilliGM-PER-GM  qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:MilliGM
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:GM
+                                      ] .
 
-unit:KiloM-PER-DAY
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloM ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DAY ] .
+unit:KiloM-PER-DAY  qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:KiloM
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:DAY
+                                     ] .
 
-unit:M-PER-K
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:K ] .
+unit:M-PER-K  qudt:factorUnit  [ qudt:exponent  1 ;
+                                 qudt:unit      unit:M
+                               ] ;
+              qudt:factorUnit  [ qudt:exponent  -1 ;
+                                 qudt:unit      unit:K
+                               ] .
 
 unit:FT2-HR-DEG_F-PER-BTU_IT
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:HR ] ;
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:FT ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:DEG_F ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:BTU_IT ] .
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:HR
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  2 ;
+                       qudt:unit      unit:FT
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:DEG_F
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:BTU_IT
+                     ] .
 
-unit:CentiM3-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 3 ;
-                      qudt:unit     unit:CentiM ] .
+unit:CentiM3-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                         qudt:unit      unit:SEC
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  3 ;
+                                         qudt:unit      unit:CentiM
+                                       ] .
 
-unit:W-PER-M2-NanoM
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:W ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:NanoM ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] .
+unit:W-PER-M2-NanoM  qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:W
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:NanoM
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -2 ;
+                                        qudt:unit      unit:M
+                                      ] .
 
 unit:BTU_IT-IN-PER-HR-FT2-DEG_F
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:IN ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:FT ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DEG_F ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BTU_IT ] .
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:IN
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:HR
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:FT
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:DEG_F
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:BTU_IT
+                     ] .
 
-unit:CentiMOL
-    a            qudt:Unit ;
-    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
+unit:BBL_US-PER-MIN  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:MIN
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:BBL_US
+                                      ] .
 
-unit:BBL_US-PER-MIN
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MIN ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BBL_US ] .
+unit:MegaJ-PER-M3  qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:MegaJ
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  -3 ;
+                                      qudt:unit      unit:M
+                                    ] .
 
-unit:MegaJ-PER-M3
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MegaJ ] ;
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:M ] .
-
-unit:M2-HZ3
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 3 ;
-                      qudt:unit     unit:HZ ] .
+unit:M2-HZ3  qudt:factorUnit  [ qudt:exponent  2 ;
+                                qudt:unit      unit:M
+                              ] ;
+             qudt:factorUnit  [ qudt:exponent  3 ;
+                                qudt:unit      unit:HZ
+                              ] .
 
 unit:MicroMOL-PER-M2-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MicroMOL ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] .
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:SEC
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MicroMOL
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:M
+                     ] .
 
-unit:MI3
-    qudt:factorUnit [ qudt:exponent 3 ;
-                      qudt:unit     unit:MI ] .
+unit:MI3  qudt:factorUnit  [ qudt:exponent  3 ;
+                             qudt:unit      unit:MI
+                           ] .
 
-unit:C-PER-MilliM3
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:MilliM ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:C ] .
+unit:C-PER-MilliM3  qudt:factorUnit  [ qudt:exponent  -3 ;
+                                       qudt:unit      unit:MilliM
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:C
+                                     ] .
 
 unit:FemtoGM-PER-KiloGM
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:KiloGM ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:FemtoGM ] .
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:KiloGM
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:FemtoGM
+                     ] .
 
-unit:BTU_IT-PER-FT3
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:FT ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BTU_IT ] .
+unit:BTU_IT-PER-FT3  qudt:factorUnit  [ qudt:exponent  -3 ;
+                                        qudt:unit      unit:FT
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:BTU_IT
+                                      ] .
 
-unit:FT-LB_F-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:LB_F ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:FT ] .
+unit:FT-LB_F-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                         qudt:unit      unit:SEC
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  1 ;
+                                         qudt:unit      unit:LB_F
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  1 ;
+                                         qudt:unit      unit:FT
+                                       ] .
 
-unit:FT-LB_F-PER-HR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:LB_F ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:FT ] .
+unit:FT-LB_F-PER-HR  qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:LB_F
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:HR
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:FT
+                                      ] .
 
-unit:M2-PER-KiloGM
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:KiloGM ] .
+unit:M2-PER-KiloGM  qudt:factorUnit  [ qudt:exponent  2 ;
+                                       qudt:unit      unit:M
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:KiloGM
+                                     ] .
 
-unit:KiloGM-CentiM2
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloGM ] ;
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:CentiM ] .
+unit:KiloGM-CentiM2  qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:KiloGM
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  2 ;
+                                        qudt:unit      unit:CentiM
+                                      ] .
 
 unit:PER-MILLE-PER-PSI
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:PSI ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MILLE ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MILLE ] .
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:PSI
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MILLE
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:MILLE
+                     ] .
 
-unit:GI_UK-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:GI_UK ] .
+unit:GI_UK-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:SEC
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:GI_UK
+                                     ] .
+
+unit:EV-SEC  qudt:factorUnit  [ qudt:exponent  1 ;
+                                qudt:unit      unit:SEC
+                              ] ;
+             qudt:factorUnit  [ qudt:exponent  1 ;
+                                qudt:unit      unit:EV
+                              ] .
 
 unit:DEATHS-PER-1000I-YR
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:YR ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:DEATHS ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:1000I ] .
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:YR
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:DEATHS
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:1000I
+                     ] .
 
-unit:DeciM2
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:DeciM ] .
+unit:DeciM2  qudt:factorUnit  [ qudt:exponent  2 ;
+                                qudt:unit      unit:DeciM
+                              ] .
 
-unit:M-PER-MIN
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MIN ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:M ] .
+unit:M-PER-MIN  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                   qudt:unit      unit:MIN
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:M
+                                 ] .
 
 unit:DEG_F-HR-FT2-PER-BTU_IT
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:HR ] ;
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:FT ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:DEG_F ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:BTU_IT ] .
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:HR
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  2 ;
+                       qudt:unit      unit:FT
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:DEG_F
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:BTU_IT
+                     ] .
 
-unit:BTU_IT-PER-LB_F
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:LB_F ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BTU_IT ] .
+unit:BTU_IT-PER-LB_F  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                         qudt:unit      unit:LB_F
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  1 ;
+                                         qudt:unit      unit:BTU_IT
+                                       ] .
 
-unit:SEC2
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:SEC ] .
+unit:SEC2  qudt:factorUnit  [ qudt:exponent  2 ;
+                              qudt:unit      unit:SEC
+                            ] .
 
-unit:N-PER-KiloGM
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:N ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:KiloGM ] .
+unit:N-PER-KiloGM  qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:N
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:KiloGM
+                                    ] .
 
 unit:MilliBAR-L-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliBAR ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:L ] .
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:SEC
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MilliBAR
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:L
+                     ] .
 
-unit:N-M-PER-M2
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:N ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] .
+unit:N-M-PER-M2  qudt:factorUnit  [ qudt:exponent  1 ;
+                                    qudt:unit      unit:N
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  1 ;
+                                    qudt:unit      unit:M
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  -2 ;
+                                    qudt:unit      unit:M
+                                  ] .
 
-unit:GM-PER-DEG_C
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:GM ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DEG_C ] .
+unit:GM-PER-DEG_C  qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:GM
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:DEG_C
+                                    ] .
 
-unit:KiloPA-PER-BAR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloPA ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:BAR ] .
+unit:KiloPA-PER-BAR  qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:KiloPA
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:BAR
+                                      ] .
 
-unit:PA-PER-MIN
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:PA ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MIN ] .
+unit:PA-PER-MIN  qudt:factorUnit  [ qudt:exponent  1 ;
+                                    qudt:unit      unit:PA
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  -1 ;
+                                    qudt:unit      unit:MIN
+                                  ] .
 
-unit:1000I
-    a            qudt:Unit ;
-    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
+unit:V-A-HR  qudt:factorUnit  [ qudt:exponent  1 ;
+                                qudt:unit      unit:V
+                              ] ;
+             qudt:factorUnit  [ qudt:exponent  1 ;
+                                qudt:unit      unit:HR
+                              ] ;
+             qudt:factorUnit  [ qudt:exponent  1 ;
+                                qudt:unit      unit:A
+                              ] .
 
-unit:KiloMOL-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloMOL ] .
+unit:KiloMOL-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                         qudt:unit      unit:SEC
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  1 ;
+                                         qudt:unit      unit:KiloMOL
+                                       ] .
 
-unit:GI_UK-PER-HR
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:GI_UK ] .
+unit:GI_UK-PER-HR  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:HR
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:GI_UK
+                                    ] .
 
-unit:HectoPA-PER-BAR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:HectoPA ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:BAR ] .
+unit:HectoPA-PER-BAR  qudt:factorUnit  [ qudt:exponent  1 ;
+                                         qudt:unit      unit:HectoPA
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  -1 ;
+                                         qudt:unit      unit:BAR
+                                       ] .
 
-unit:MicroSV-PER-HR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MicroSV ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] .
+unit:MicroSV-PER-HR  qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:MicroSV
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:HR
+                                      ] .
 
-unit:KIP_F-PER-IN2
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KIP_F ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:IN ] .
+unit:KIP_F-PER-IN2  qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:KIP_F
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -2 ;
+                                       qudt:unit      unit:IN
+                                     ] .
 
-unit:MilliL-PER-L
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliL ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:L ] .
+unit:MilliL-PER-L  qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:MilliL
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:L
+                                    ] .
 
-unit:DeciL-PER-GM
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:GM ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:DeciL ] .
+unit:DeciL-PER-GM  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:GM
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:DeciL
+                                    ] .
 
-unit:BQ-SEC-PER-M3
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BQ ] .
+unit:BQ-SEC-PER-M3  qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:SEC
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -3 ;
+                                       qudt:unit      unit:M
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:BQ
+                                     ] .
 
 unit:TON_SHORT-PER-HR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:TON_SHORT ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] .
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:TON_SHORT
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:HR
+                     ] .
 
 unit:KiloCAL-PER-CentiM2
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloCAL ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:CentiM ] .
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:KiloCAL
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:CentiM
+                     ] .
 
-unit:AT-PER-IN
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:IN ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:AT ] .
+unit:AT-PER-IN  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                   qudt:unit      unit:IN
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:AT
+                                 ] .
 
-unit:PER-K
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:K ] .
+unit:PER-K  qudt:factorUnit  [ qudt:exponent  -1 ;
+                               qudt:unit      unit:K
+                             ] .
 
-unit:PER-PA
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:PA ] .
+unit:PER-PA  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                qudt:unit      unit:PA
+                              ] .
 
-unit:KiloLB_F-PER-FT
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloLB_F ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:FT ] .
+unit:KiloLB_F-PER-FT  qudt:factorUnit  [ qudt:exponent  1 ;
+                                         qudt:unit      unit:KiloLB_F
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  -1 ;
+                                         qudt:unit      unit:FT
+                                       ] .
 
-unit:PSI-YD3-PER-SEC
-    qudt:factorUnit [ qudt:exponent 3 ;
-                      qudt:unit     unit:YD ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:PSI ] .
+unit:A_Reactive  a    qudt:Unit ;
+                 rdfs:comment  "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
 
-unit:HZ-PER-V
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:V ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:HZ ] .
+unit:PSI-YD3-PER-SEC  qudt:factorUnit  [ qudt:exponent  3 ;
+                                         qudt:unit      unit:YD
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  -1 ;
+                                         qudt:unit      unit:SEC
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  1 ;
+                                         qudt:unit      unit:PSI
+                                       ] .
+
+unit:HZ-PER-V  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                  qudt:unit      unit:V
+                                ] ;
+               qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:HZ
+                                ] .
+
+unit:GI_US-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:SEC
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:GI_US
+                                     ] .
 
 unit:KiloGM-PER-KiloM2
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:KiloM ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloGM ] .
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:KiloM
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:KiloGM
+                     ] .
 
-unit:GI_US-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:GI_US ] .
+unit:MilliH-PER-OHM  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:OHM
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:MilliH
+                                      ] .
 
-unit:MilliH-PER-OHM
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:OHM ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliH ] .
-
-unit:NanoFARAD-PER-M
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:NanoFARAD ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] .
+unit:NanoFARAD-PER-M  qudt:factorUnit  [ qudt:exponent  1 ;
+                                         qudt:unit      unit:NanoFARAD
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  -1 ;
+                                         qudt:unit      unit:M
+                                       ] .
 
 unit:LB_F-PER-IN2-DEG_F
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:LB_F ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:IN ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DEG_F ] .
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:LB_F
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:IN
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:DEG_F
+                     ] .
 
-unit:MegaS-PER-M
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MegaS ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] .
+unit:MegaS-PER-M  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:MegaS
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                     qudt:unit      unit:M
+                                   ] .
 
 unit:KiloGM-PER-MilliM
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MilliM ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloGM ] .
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:MilliM
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:KiloGM
+                     ] .
 
-unit:LB-PER-GAL
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:LB ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:GAL ] .
+unit:LB-PER-GAL  qudt:factorUnit  [ qudt:exponent  1 ;
+                                    qudt:unit      unit:LB
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  -1 ;
+                                    qudt:unit      unit:GAL
+                                  ] .
 
-unit:DEG2
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:DEG ] .
+unit:GigaW-HR  qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:HR
+                                ] ;
+               qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:GigaW
+                                ] .
 
-unit:YD-PER-DEG_F
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:YD ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DEG_F ] .
+unit:DEG2  qudt:factorUnit  [ qudt:exponent  2 ;
+                              qudt:unit      unit:DEG
+                            ] .
 
-unit:BTU_TH-PER-HR
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BTU_TH ] .
+unit:YD-PER-DEG_F  qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:YD
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:DEG_F
+                                    ] .
 
-unit:ERG-PER-CentiM
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:ERG ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:CentiM ] .
+unit:BTU_TH-PER-HR  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:HR
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:BTU_TH
+                                     ] .
 
-unit:LB-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:LB ] .
+unit:ERG-PER-CentiM  qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:ERG
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:CentiM
+                                      ] .
 
-unit:DeciS-PER-M
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:DeciS ] .
+unit:LB-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                    qudt:unit      unit:SEC
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  1 ;
+                                    qudt:unit      unit:LB
+                                  ] .
+
+unit:DeciS-PER-M  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                     qudt:unit      unit:M
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:DeciS
+                                   ] .
 
 unit:M2-HR-DEG_C-PER-KiloCAL_IT
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:KiloCAL_IT ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:HR ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:DEG_C ] .
+    qudt:factorUnit  [ qudt:exponent  2 ;
+                       qudt:unit      unit:M
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:KiloCAL_IT
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:HR
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:DEG_C
+                     ] .
 
-unit:PINT_UK-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:PINT_UK ] .
+unit:PINT_UK-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                         qudt:unit      unit:SEC
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  1 ;
+                                         qudt:unit      unit:PINT_UK
+                                       ] .
+
+unit:OZ-PER-GAL_US  qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:OZ
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:GAL_US
+                                     ] .
 
 unit:MilliW-PER-M2-NanoM
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:NanoM ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliW ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] .
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:NanoM
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MilliW
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:M
+                     ] .
 
-unit:OZ-PER-GAL_US
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:OZ ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:GAL_US ] .
+unit:RAD-PER-HR  qudt:factorUnit  [ qudt:exponent  1 ;
+                                    qudt:unit      unit:RAD
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  -1 ;
+                                    qudt:unit      unit:HR
+                                  ] .
 
-unit:RAD-PER-HR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:RAD ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] .
+unit:PER-SEC2  qudt:factorUnit  [ qudt:exponent  -2 ;
+                                  qudt:unit      unit:SEC
+                                ] .
 
-unit:PER-SEC2
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:SEC ] .
-
-unit:BQ-PER-M3
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BQ ] .
+unit:BQ-PER-M3  qudt:factorUnit  [ qudt:exponent  -3 ;
+                                   qudt:unit      unit:M
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:BQ
+                                 ] .
 
 unit:MilliMOL-PER-M3-DAY
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliMOL ] ;
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DAY ] .
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MilliMOL
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -3 ;
+                       qudt:unit      unit:M
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:DAY
+                     ] .
 
-unit:MegaC-PER-M3
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MegaC ] ;
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:M ] .
+unit:MegaC-PER-M3  qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:MegaC
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  -3 ;
+                                      qudt:unit      unit:M
+                                    ] .
 
 unit:KiloCAL_TH-PER-MIN
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MIN ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloCAL_TH ] .
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:MIN
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:KiloCAL_TH
+                     ] .
 
 unit:MicroMOL-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MicroMOL ] .
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:SEC
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MicroMOL
+                     ] .
 
-unit:PA2-SEC
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:PA ] .
+unit:MegaN-M  qudt:factorUnit  [ qudt:exponent  1 ;
+                                 qudt:unit      unit:MegaN
+                               ] ;
+              qudt:factorUnit  [ qudt:exponent  1 ;
+                                 qudt:unit      unit:M
+                               ] .
+
+unit:PA2-SEC  qudt:factorUnit  [ qudt:exponent  1 ;
+                                 qudt:unit      unit:SEC
+                               ] ;
+              qudt:factorUnit  [ qudt:exponent  2 ;
+                                 qudt:unit      unit:PA
+                               ] .
 
 unit:MilliBAR-M3-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliBAR ] ;
-    qudt:factorUnit [ qudt:exponent 3 ;
-                      qudt:unit     unit:M ] .
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:SEC
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MilliBAR
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  3 ;
+                       qudt:unit      unit:M
+                     ] .
 
-unit:NUM-PER-GM
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:NUM ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:GM ] .
+unit:NUM-PER-GM  qudt:factorUnit  [ qudt:exponent  1 ;
+                                    qudt:unit      unit:NUM
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  -1 ;
+                                    qudt:unit      unit:GM
+                                  ] .
 
-unit:PER-MilliM3
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:MilliM ] .
+unit:PER-MilliM3  qudt:factorUnit  [ qudt:exponent  -3 ;
+                                     qudt:unit      unit:MilliM
+                                   ] .
 
-unit:OZ-PER-MIN
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:OZ ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MIN ] .
+unit:OZ-PER-MIN  qudt:factorUnit  [ qudt:exponent  1 ;
+                                    qudt:unit      unit:OZ
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  -1 ;
+                                    qudt:unit      unit:MIN
+                                  ] .
 
-unit:MilliL-PER-MIN
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliL ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MIN ] .
+unit:TeraW-HR  qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:TeraW
+                                ] ;
+               qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:HR
+                                ] .
+
+unit:MilliL-PER-MIN  qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:MilliL
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:MIN
+                                      ] .
 
 unit:MicroM-PER-MilliL
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MilliL ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MicroM ] .
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:MilliL
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MicroM
+                     ] .
 
-unit:KiloA-PER-M
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloA ] .
+unit:KiloA-PER-M  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                     qudt:unit      unit:M
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:KiloA
+                                   ] .
 
-unit:N-M2-PER-A
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:N ] ;
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:A ] .
+unit:N-M2-PER-A  qudt:factorUnit  [ qudt:exponent  1 ;
+                                    qudt:unit      unit:N
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  2 ;
+                                    qudt:unit      unit:M
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  -1 ;
+                                    qudt:unit      unit:A
+                                  ] .
 
 unit:MilliS-PER-CentiM
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliS ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:CentiM ] .
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MilliS
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:CentiM
+                     ] .
 
 unit:HectoPA-L-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:L ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:HectoPA ] .
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:SEC
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:L
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:HectoPA
+                     ] .
 
-unit:TONNE-PER-SEC
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:TONNE ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] .
+unit:TONNE-PER-SEC  qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:TONNE
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:SEC
+                                     ] .
 
 unit:MicroMOL-PER-M2-DAY
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MicroMOL ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DAY ] .
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MicroMOL
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:M
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:DAY
+                     ] .
 
 unit:MOL-PER-M2-SEC-M-SR
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SR ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MOL ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] .
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:SR
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:SEC
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MOL
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:M
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:M
+                     ] .
 
-unit:C-PER-M
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:C ] .
+unit:C-PER-M  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                 qudt:unit      unit:M
+                               ] ;
+              qudt:factorUnit  [ qudt:exponent  1 ;
+                                 qudt:unit      unit:C
+                               ] .
 
-unit:PER-PA-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:PA ] .
+unit:PER-PA-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                    qudt:unit      unit:SEC
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  -1 ;
+                                    qudt:unit      unit:PA
+                                  ] .
 
 unit:MicroMOL-PER-MicroMOL-DAY
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MicroMOL ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MicroMOL ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DAY ] .
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MicroMOL
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:MicroMOL
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:DAY
+                     ] .
 
-unit:S-PER-M
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:S ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] .
+unit:S-PER-M  qudt:factorUnit  [ qudt:exponent  1 ;
+                                 qudt:unit      unit:S
+                               ] ;
+              qudt:factorUnit  [ qudt:exponent  -1 ;
+                                 qudt:unit      unit:M
+                               ] .
 
 unit:MicroMOL-PER-KiloGM
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MicroMOL ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:KiloGM ] .
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MicroMOL
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:KiloGM
+                     ] .
 
-unit:GAL_UK-PER-DAY
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:GAL_UK ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DAY ] .
+unit:GAL_UK-PER-DAY  qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:GAL_UK
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:DAY
+                                      ] .
 
-unit:N-PER-A
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:N ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:A ] .
+unit:N-PER-A  qudt:factorUnit  [ qudt:exponent  1 ;
+                                 qudt:unit      unit:N
+                               ] ;
+              qudt:factorUnit  [ qudt:exponent  -1 ;
+                                 qudt:unit      unit:A
+                               ] .
 
-unit:M3
-    qudt:factorUnit [ qudt:exponent 3 ;
-                      qudt:unit     unit:M ] .
+unit:M3  qudt:factorUnit  [ qudt:exponent  3 ;
+                            qudt:unit      unit:M
+                          ] .
 
-unit:V-PER-IN
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:V ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:IN ] .
+unit:BTU_IT-FT  qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:FT
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:BTU_IT
+                                 ] .
 
-unit:PicoMOL-PER-M3
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:PicoMOL ] ;
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:M ] .
+unit:V-PER-IN  qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:V
+                                ] ;
+               qudt:factorUnit  [ qudt:exponent  -1 ;
+                                  qudt:unit      unit:IN
+                                ] .
 
-unit:PINT_US-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:PINT_US ] .
+unit:PicoMOL-PER-M3  qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:PicoMOL
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -3 ;
+                                        qudt:unit      unit:M
+                                      ] .
 
-unit:K-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:K ] .
+unit:PINT_US-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                         qudt:unit      unit:SEC
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  1 ;
+                                         qudt:unit      unit:PINT_US
+                                       ] .
 
-unit:M2-PER-K
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:K ] .
+unit:K-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                   qudt:unit      unit:SEC
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:K
+                                 ] .
+
+unit:M2-PER-K  qudt:factorUnit  [ qudt:exponent  2 ;
+                                  qudt:unit      unit:M
+                                ] ;
+               qudt:factorUnit  [ qudt:exponent  -1 ;
+                                  qudt:unit      unit:K
+                                ] .
 
 unit:BTU_IT-IN-PER-SEC-FT2-DEG_F
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:IN ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:FT ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DEG_F ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BTU_IT ] .
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:SEC
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:IN
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:FT
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:DEG_F
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:BTU_IT
+                     ] .
 
 unit:FARAD_Ab-PER-CentiM
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:FARAD_Ab ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:CentiM ] .
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:FARAD_Ab
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:CentiM
+                     ] .
 
-unit:MilliGM-PER-M2
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliGM ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] .
+unit:MilliGM-PER-M2  qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:MilliGM
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -2 ;
+                                        qudt:unit      unit:M
+                                      ] .
 
 unit:KiloJ-PER-KiloGM-K
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloJ ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:KiloGM ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:K ] .
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:KiloJ
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:KiloGM
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:K
+                     ] .
 
-unit:K2
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:K ] .
+unit:K2  qudt:factorUnit  [ qudt:exponent  2 ;
+                            qudt:unit      unit:K
+                          ] .
 
 unit:GM_Carbon-PER-M2-DAY
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:GM_Carbon ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DAY ] .
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:M
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:GM_Carbon
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:DAY
+                     ] .
 
-unit:W-PER-FT2
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:W ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:FT ] .
+unit:W-PER-FT2  qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:W
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  -2 ;
+                                   qudt:unit      unit:FT
+                                 ] .
 
-unit:MicroGAL
-    a            qudt:Unit ;
-    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
+unit:ERG-PER-CentiM3  qudt:factorUnit  [ qudt:exponent  1 ;
+                                         qudt:unit      unit:ERG
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  -3 ;
+                                         qudt:unit      unit:CentiM
+                                       ] .
 
-unit:ERG-PER-CentiM3
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:ERG ] ;
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:CentiM ] .
+unit:KiloJ-PER-MOL  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:MOL
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:KiloJ
+                                     ] .
 
-unit:KiloJ-PER-MOL
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MOL ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloJ ] .
+unit:V-PER-MilliM  qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:V
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:MilliM
+                                    ] .
 
-unit:V-PER-MilliM
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:V ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MilliM ] .
+unit:KiloMOL-PER-M3  qudt:factorUnit  [ qudt:exponent  -3 ;
+                                        qudt:unit      unit:M
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:KiloMOL
+                                      ] .
 
-unit:KiloMOL-PER-M3
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloMOL ] .
-
-unit:FemtoGM-PER-L
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:L ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:FemtoGM ] .
+unit:FemtoGM-PER-L  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:L
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:FemtoGM
+                                     ] .
 
 unit:OZ_VOL_US-PER-HR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:OZ_VOL_US ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] .
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:OZ_VOL_US
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:HR
+                     ] .
 
-unit:MegaHZ-PER-K
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MegaHZ ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:K ] .
+unit:MegaHZ-PER-K  qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:MegaHZ
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:K
+                                    ] .
 
-unit:LB-PER-YD3
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:YD ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:LB ] .
+unit:LB-PER-YD3  qudt:factorUnit  [ qudt:exponent  -3 ;
+                                    qudt:unit      unit:YD
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  1 ;
+                                    qudt:unit      unit:LB
+                                  ] .
 
 unit:BTU_IT-PER-LB_F-DEG_R
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:LB_F ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DEG_R ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BTU_IT ] .
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:LB_F
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:DEG_R
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:BTU_IT
+                     ] .
 
-unit:BTU_TH-PER-MIN
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MIN ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BTU_TH ] .
+unit:BTU_TH-PER-MIN  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:MIN
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:BTU_TH
+                                      ] .
 
 unit:KiloGM-PER-KiloMOL
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:KiloMOL ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloGM ] .
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:KiloMOL
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:KiloGM
+                     ] .
 
 unit:KiloGM-M2-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloGM ] .
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:SEC
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  2 ;
+                       qudt:unit      unit:M
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:KiloGM
+                     ] .
 
-unit:MilliW-PER-M2
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliW ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] .
+unit:MilliW-PER-M2  qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:MilliW
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -2 ;
+                                       qudt:unit      unit:M
+                                     ] .
 
-unit:IN2-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:IN ] .
+unit:IN2-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                     qudt:unit      unit:SEC
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  2 ;
+                                     qudt:unit      unit:IN
+                                   ] .
 
-unit:W-PER-M2-M-SR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:W ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SR ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] .
+unit:W-PER-M2-M-SR  qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:W
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:SR
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -2 ;
+                                       qudt:unit      unit:M
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:M
+                                     ] .
 
-unit:FT-LB_F-PER-FT2
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:LB_F ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:FT ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:FT ] .
+unit:ERG-SEC  qudt:factorUnit  [ qudt:exponent  1 ;
+                                 qudt:unit      unit:SEC
+                               ] ;
+              qudt:factorUnit  [ qudt:exponent  1 ;
+                                 qudt:unit      unit:ERG
+                               ] .
+
+unit:A-HR  qudt:factorUnit  [ qudt:exponent  1 ;
+                              qudt:unit      unit:HR
+                            ] ;
+           qudt:factorUnit  [ qudt:exponent  1 ;
+                              qudt:unit      unit:A
+                            ] .
+
+unit:FT-LB_F-PER-FT2  qudt:factorUnit  [ qudt:exponent  1 ;
+                                         qudt:unit      unit:LB_F
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  1 ;
+                                         qudt:unit      unit:FT
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  -2 ;
+                                         qudt:unit      unit:FT
+                                       ] .
 
 unit:J-PER-CentiM2-DAY
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:J ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DAY ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:CentiM ] .
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:J
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:DAY
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:CentiM
+                     ] .
 
-unit:W-PER-M2-K
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:W ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:K ] .
+unit:W-PER-M2-K  qudt:factorUnit  [ qudt:exponent  1 ;
+                                    qudt:unit      unit:W
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  -2 ;
+                                    qudt:unit      unit:M
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  -1 ;
+                                    qudt:unit      unit:K
+                                  ] .
 
-unit:N-M-PER-KiloGM
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:N ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:KiloGM ] .
+unit:N-M-PER-KiloGM  qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:N
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:M
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:KiloGM
+                                      ] .
 
-unit:PER-WK
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:WK ] .
+unit:PER-WK  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                qudt:unit      unit:WK
+                              ] .
 
-unit:M3-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 3 ;
-                      qudt:unit     unit:M ] .
+unit:M3-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                    qudt:unit      unit:SEC
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  3 ;
+                                    qudt:unit      unit:M
+                                  ] .
 
 unit:BTU_IT-PER-LB-DEG_F
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:LB ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DEG_F ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BTU_IT ] .
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:LB
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:DEG_F
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:BTU_IT
+                     ] .
 
-unit:MOL-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MOL ] .
+unit:MOL-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                     qudt:unit      unit:SEC
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:MOL
+                                   ] .
 
-unit:GAL_US-PER-DAY
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:GAL_US ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DAY ] .
+unit:GAL_US-PER-DAY  qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:GAL_US
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:DAY
+                                      ] .
 
-unit:M2-SEC-PER-RAD
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:RAD ] ;
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:M ] .
+unit:M2-SEC-PER-RAD  qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:SEC
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:RAD
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  2 ;
+                                        qudt:unit      unit:M
+                                      ] .
 
-unit:GRAIN-PER-GAL
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:GRAIN ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:GAL ] .
+unit:GRAIN-PER-GAL  qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:GRAIN
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:GAL
+                                     ] .
 
 unit:KiloGM2-PER-SEC2
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:KiloGM ] .
-
-unit:PER-GM
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:GM ] .
-
-unit:MicroM-PER-N
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:N ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MicroM ] .
-
-unit:L-PER-L
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:L ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:L ] .
-
-unit:LB-PER-HR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:LB ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] .
-
-unit:J-PER-GM
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:J ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:GM ] .
-
-unit:SAMPLE
-    a            qudt:Unit ;
-    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
-
-unit:N-PER-MilliM
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:N ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MilliM ] .
-
-unit:M3-PER-M3
-    qudt:factorUnit [ qudt:exponent 3 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:M ] .
-
-unit:PicoGM-PER-GM
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:PicoGM ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:GM ] .
-
-unit:DEG_F-PER-SEC2
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:DEG_F ] .
-
-unit:YD3-PER-HR
-    qudt:factorUnit [ qudt:exponent 3 ;
-                      qudt:unit     unit:YD ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] .
-
-unit:LB_F-PER-FT
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:LB_F ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:FT ] .
-
-unit:PicoPA
-    a            qudt:Unit ;
-    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
-
-unit:1000000I
-    a            qudt:Unit ;
-    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
-
-unit:KiloGM-PER-CentiM3
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloGM ] ;
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:CentiM ] .
-
-unit:PINT_US-PER-HR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:PINT_US ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] .
-
-unit:PA-M3-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:PA ] ;
-    qudt:factorUnit [ qudt:exponent 3 ;
-                      qudt:unit     unit:M ] .
-
-unit:PA-PER-BAR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:PA ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:BAR ] .
-
-unit:MOL-PER-DeciM3
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MOL ] ;
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:DeciM ] .
-
-unit:KiloGM-PER-HR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloGM ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] .
-
-unit:PERCENT-PER-HR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:PERCENT ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] .
-
-unit:LB-PER-FT-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:LB ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:FT ] .
-
-unit:PER-PSI
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:PSI ] .
-
-unit:BU_US_DRY-PER-MIN
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MIN ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BU_US_DRY ] .
-
-unit:W-PER-M2
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:W ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] .
-
-unit:A-PER-DEG_C
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DEG_C ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:A ] .
-
-unit:ERG-PER-GM
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:GM ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:ERG ] .
-
-unit:M3-PER-K
-    qudt:factorUnit [ qudt:exponent 3 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:K ] .
-
-unit:M2-PER-HZ
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HZ ] .
-
-unit:WB-PER-MilliM
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:WB ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MilliM ] .
-
-unit:BTU_IT-PER-LB
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:LB ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BTU_IT ] .
-
-unit:FT-LB_F-PER-FT2-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:LB_F ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:FT ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:FT ] .
-
-unit:KiloCAL-PER-CentiM2-MIN
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MIN ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloCAL ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:CentiM ] .
-
-unit:W-PER-IN2
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:W ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:IN ] .
-
-unit:FARAD-PER-KiloM
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:KiloM ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:FARAD ] .
-
-unit:M2-PER-HZ2
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:HZ ] .
-
-unit:LB-PER-FT2
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:LB ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:FT ] .
-
-unit:TON_UK-PER-YD3
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:YD ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:TON_UK ] .
-
-unit:KiloGM-PER-DeciM3
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloGM ] ;
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:DeciM ] .
-
-unit:MDOLLAR
-    a            qudt:Unit ;
-    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
-
-unit:MOL-PER-L
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MOL ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:L ] .
-
-unit:GM-PER-CentiM2-YR
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:YR ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:GM ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:CentiM ] .
-
-unit:M-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:M ] .
-
-unit:DEG-PER-HR
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:DEG ] .
-
-unit:NUM-PER-M2
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:NUM ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] .
-
-unit:IN3-PER-HR
-    qudt:factorUnit [ qudt:exponent 3 ;
-                      qudt:unit     unit:IN ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] .
-
-unit:PA-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:PA ] .
-
-unit:CentiM3-PER-K
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:K ] ;
-    qudt:factorUnit [ qudt:exponent 3 ;
-                      qudt:unit     unit:CentiM ] .
-
-unit:J-PER-M3-K
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:K ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:J ] .
-
-unit:MilliM-PER-DAY
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliM ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DAY ] .
-
-unit:M2-PER-SR-J
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SR ] ;
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:J ] .
-
-unit:PA-L-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:PA ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:L ] .
-
-unit:MilliGM-PER-M2-DAY
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliGM ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DAY ] .
-
-unit:MicroGM-PER-MilliL
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MilliL ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MicroGM ] .
-
-unit:MilliV-PER-MIN
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliV ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MIN ] .
-
-unit:DEG_C-PER-M
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:DEG_C ] .
-
-unit:MilliGM-PER-KiloGM
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliGM ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:KiloGM ] .
-
-unit:W-PER-M2-SR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:W ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SR ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] .
-
-unit:DecaM3
-    qudt:factorUnit [ qudt:exponent 3 ;
-                      qudt:unit     unit:DecaM ] .
-
-unit:NanoBQ-PER-L
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:NanoBQ ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:L ] .
-
-unit:TON_US-PER-YD3
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:YD ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:TON_US ] .
-
-unit:MilliM2
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:MilliM ] .
-
-unit:DeciBAR-PER-YR
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:YR ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:DeciBAR ] .
-
-unit:RAD-PER-SEC2
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:RAD ] .
-
-unit:EV-PER-M
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:EV ] .
-
-unit:KiloS-PER-M
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloS ] .
-
-unit:PER-M-NanoM-SR
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SR ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:NanoM ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] .
-
-unit:V-PER-M2
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:V ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] .
-
-unit:TON_LONG-PER-YD3
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:YD ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:TON_LONG ] .
-
-unit:NanoGM-PER-MilliL
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:NanoGM ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MilliL ] .
-
-unit:MilliBQ
-    a            qudt:Unit ;
-    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
-
-unit:W-M2
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:W ] ;
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:M ] .
-
-unit:KiloM3-PER-SEC2
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 3 ;
-                      qudt:unit     unit:KiloM ] .
-
-unit:MOL-PER-M2-DAY
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MOL ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DAY ] .
-
-unit:KiloLB_F
-    a            qudt:Unit ;
-    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
-
-unit:PPTH-PER-HR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:PPTH ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] .
-
-unit:FRAME-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:FRAME ] .
-
-unit:SEC-PER-RAD-M3
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:RAD ] ;
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:M ] .
-
-unit:C_Stat-PER-CentiM2
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:CentiM ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:C_Stat ] .
-
-unit:MOL-PER-KiloGM
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MOL ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:KiloGM ] .
-
-unit:SpeedOfLight
-    a            qudt:Unit ;
-    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
-
-unit:C3-M-PER-J2
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:J ] ;
-    qudt:factorUnit [ qudt:exponent 3 ;
-                      qudt:unit     unit:C ] .
-
-unit:GM-PER-MilliL
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MilliL ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:GM ] .
-
-unit:J-PER-T
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:T ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:J ] .
-
-unit:LB-PER-IN2
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:LB ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:IN ] .
-
-unit:PER-M2
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] .
-
-unit:OZ-PER-GAL
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:OZ ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:GAL ] .
-
-unit:KiloCAL_TH-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloCAL_TH ] .
-
-unit:OZ_VOL_UK-PER-HR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:OZ_VOL_UK ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] .
-
-unit:J-PER-M2
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:J ] .
-
-unit:MILLE
-    a            qudt:Unit ;
-    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
-
-unit:OZ-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:OZ ] .
-
-unit:KiloGM_F-M-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloGM_F ] .
-
-unit:MilliL-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliL ] .
-
-unit:MillionUSD-PER-YR
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:YR ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MillionUSD ] .
-
-unit:RAD-M2-PER-KiloGM
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:RAD ] ;
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:KiloGM ] .
-
-unit:C-PER-KiloGM-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:KiloGM ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:C ] .
-
-unit:PicoMOL-PER-L
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:PicoMOL ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:L ] .
-
-unit:V_Stat-PER-CentiM
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:V_Stat ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:CentiM ] .
-
-unit:M3-PER-KiloGM
-    qudt:factorUnit [ qudt:exponent 3 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:KiloGM ] .
-
-unit:K-M-PER-W
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:W ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:K ] .
-
-unit:KiloGM-PER-M-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloGM ] .
-
-unit:CAL_TH-PER-SEC-CentiM-K
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:K ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:CentiM ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:CAL_TH ] .
-
-unit:MicroGM-PER-M3
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MicroGM ] ;
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:M ] .
-
-unit:NanoS-PER-M
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:NanoS ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] .
-
-unit:KiloGM-PER-M-HR
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloGM ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] .
-
-unit:BTU_IT-IN-PER-FT2-HR-DEG_F
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:IN ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:FT ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DEG_F ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BTU_IT ] .
-
-unit:M2-PER-HA
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HA ] .
-
-unit:CentiM2-MIN
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MIN ] ;
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:CentiM ] .
-
-unit:MilliGM-PER-CentiM2
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliGM ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:CentiM ] .
-
-unit:PINT_UK-PER-HR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:PINT_UK ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] .
-
-unit:MegaEV-PER-SpeedOfLight
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SpeedOfLight ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MegaEV ] .
-
-unit:V-PER-M
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:V ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] .
-
-unit:CAL_IT-PER-GM
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:GM ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:CAL_IT ] .
-
-unit:KiloCAL-PER-GM
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloCAL ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:GM ] .
-
-unit:BTU_TH-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BTU_TH ] .
-
-unit:MI-PER-MIN
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MIN ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MI ] .
-
-unit:CentiM-PER-SEC2
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:CentiM ] .
-
-unit:MilliGM-PER-M3-DAY
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliGM ] ;
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DAY ] .
-
-unit:DEG_F-PER-MIN
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MIN ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:DEG_F ] .
-
-unit:MilliMOL-PER-M2-DAY
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliMOL ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DAY ] .
-
-unit:K-PER-T
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:T ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:K ] .
-
-unit:OZ-PER-YD3
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:YD ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:OZ ] .
-
-unit:TON_US-PER-HR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:TON_US ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] .
-
-unit:AT-PER-M
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:AT ] .
-
-unit:A_Ab-PER-CentiM2
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:CentiM ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:A_Ab ] .
-
-unit:QT_UK-PER-MIN
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:QT_UK ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MIN ] .
-
-unit:M2-PER-SR
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SR ] ;
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:M ] .
-
-unit:C4-M4-PER-J3
-    qudt:factorUnit [ qudt:exponent 4 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:J ] ;
-    qudt:factorUnit [ qudt:exponent 4 ;
-                      qudt:unit     unit:C ] .
-
-unit:HZ-PER-T
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:T ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:HZ ] .
-
-unit:KiloGM-PER-SEC-M2
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloGM ] .
-
-unit:M3-PER-SEC2
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 3 ;
-                      qudt:unit     unit:M ] .
-
-unit:BAR-M3-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 3 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BAR ] .
-
-unit:SEC-PER-M
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] .
-
-unit:BU_US_DRY-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BU_US_DRY ] .
-
-unit:GM-PER-L
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:L ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:GM ] .
-
-unit:LB_F-PER-FT2
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:LB_F ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:FT ] .
-
-unit:N-PER-CentiM
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:N ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:CentiM ] .
-
-unit:KiloCAL-PER-CentiM2-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloCAL ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:CentiM ] .
-
-unit:KiloGM-SEC2
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloGM ] .
-
-unit:OZ_VOL_US-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:OZ_VOL_US ] .
-
-unit:MicroL-PER-L
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MicroL ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:L ] .
-
-unit:N-PER-M2
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:N ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] .
-
-unit:DEG-PER-MIN
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MIN ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:DEG ] .
-
-unit:PSI-IN3-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:PSI ] ;
-    qudt:factorUnit [ qudt:exponent 3 ;
-                      qudt:unit     unit:IN ] .
-
-unit:DEG_R-PER-HR
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:DEG_R ] .
-
-unit:DeciM3-PER-HR
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] ;
-    qudt:factorUnit [ qudt:exponent 3 ;
-                      qudt:unit     unit:DeciM ] .
-
-unit:HART-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:HART ] .
-
-unit:W-PER-M
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:W ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] .
-
-unit:SLUG-PER-MIN
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:SLUG ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MIN ] .
-
-unit:QT_US-PER-MIN
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:QT_US ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MIN ] .
-
-unit:PER-MIN
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MIN ] .
-
-unit:M2-PER-N
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:N ] ;
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:M ] .
-
-unit:KiloGM-MilliM2
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:MilliM ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloGM ] .
-
-unit:CentiPOISE-PER-BAR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:CentiPOISE ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:BAR ] .
-
-unit:PER-MOL
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MOL ] .
-
-unit:FT3-PER-MIN
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MIN ] ;
-    qudt:factorUnit [ qudt:exponent 3 ;
-                      qudt:unit     unit:FT ] .
-
-unit:BU_US_DRY
-    a            qudt:Unit ;
-    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
-
-unit:TON_Metric-PER-MIN
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:TON_Metric ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MIN ] .
-
-unit:MilliL-PER-M2-DAY
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliL ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DAY ] .
-
-unit:BU_UK-PER-DAY
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DAY ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BU_UK ] .
-
-unit:NanoMOL-PER-L-DAY
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:NanoMOL ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:L ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DAY ] .
-
-unit:NUM-PER-NanoL
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:NanoL ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:NUM ] .
-
-unit:J-PER-KiloGM-K-M3
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:KiloGM ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:K ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:J ] .
-
-unit:CAL_IT-PER-GM-DEG_C
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:GM ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DEG_C ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:CAL_IT ] .
-
-unit:MilliL-PER-KiloGM
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliL ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:KiloGM ] .
-
-unit:OZ-PER-FT2
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:OZ ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:FT ] .
-
-unit:MilliGM-PER-HR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliGM ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] .
-
-unit:BTU_IT-PER-HR
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BTU_IT ] .
-
-unit:MegaS
-    a            qudt:Unit ;
-    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
-
-unit:MilliBQ-PER-GM
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliBQ ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:GM ] .
-
-unit:A_Stat-PER-CentiM2
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:CentiM ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:A_Stat ] .
-
-unit:PA-PER-HR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:PA ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] .
-
-unit:CentiMOL-PER-KiloGM
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:KiloGM ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:CentiMOL ] .
-
-unit:BEAT
-    a            qudt:Unit ;
-    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
-
-unit:FT3-PER-HR
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] ;
-    qudt:factorUnit [ qudt:exponent 3 ;
-                      qudt:unit     unit:FT ] .
-
-unit:PER-M-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] .
-
-unit:J-PER-T2
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:T ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:J ] .
-
-unit:MicroFARAD-PER-M
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MicroFARAD ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] .
-
-unit:BU_US_DRY-PER-HR
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BU_US_DRY ] .
-
-unit:OZ-PER-HR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:OZ ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] .
-
-unit:GM-PER-GM
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:GM ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:GM ] .
-
-unit:PER-T-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:T ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] .
-
-unit:KiloC-PER-M3
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloC ] .
-
-unit:W-PER-M-K
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:W ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:K ] .
-
-unit:TONNE-PER-M3
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:TONNE ] ;
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:M ] .
-
-unit:V_Ab-PER-CentiM
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:V_Ab ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:CentiM ] .
-
-unit:LB-PER-FT
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:LB ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:FT ] .
-
-unit:J-PER-MOL
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MOL ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:J ] .
-
-unit:OZ_VOL_UK-PER-DAY
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:OZ_VOL_UK ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DAY ] .
-
-unit:MilliH-PER-KiloOHM
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliH ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:KiloOHM ] .
-
-unit:BTU_IT-PER-SEC-FT2-DEG_R
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:FT ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DEG_R ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BTU_IT ] .
-
-unit:LB-PER-M3
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:LB ] .
-
-unit:KiloGM-PER-M
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloGM ] .
-
-unit:MicroC-PER-M2
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MicroC ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] .
-
-unit:LB_F-PER-IN2
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:LB_F ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:IN ] .
-
-unit:L-PER-HR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:L ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] .
-
-unit:CentiM3
-    qudt:factorUnit [ qudt:exponent 3 ;
-                      qudt:unit     unit:CentiM ] .
-
-unit:CentiM3-PER-DAY
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DAY ] ;
-    qudt:factorUnit [ qudt:exponent 3 ;
-                      qudt:unit     unit:CentiM ] .
-
-unit:KiloCAL_IT-PER-HR-M-DEG_C
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloCAL_IT ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DEG_C ] .
-
-unit:A-M2-PER-J-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:J ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:A ] .
-
-unit:C-M2-PER-V
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:V ] ;
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:C ] .
-
-unit:PER-M3-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:M ] .
-
-unit:H-PER-M
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:H ] .
-
-unit:K-PA-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:PA ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:K ] .
-
-unit:MicroGM-PER-L
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MicroGM ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:L ] .
-
-unit:PK_UK-PER-MIN
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:PK_UK ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MIN ] .
-
-unit:PicoS-PER-M
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:PicoS ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] .
-
-unit:KiloGM-M2
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloGM ] .
-
-unit:KiloGM-PER-M3
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloGM ] .
-
-unit:MicroM2
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:MicroM ] .
-
-unit:MilliA-PER-MilliM
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MilliM ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliA ] .
-
-unit:DEG_F-HR-PER-BTU_IT
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:HR ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:DEG_F ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:BTU_IT ] .
-
-unit:HP-PER-V
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:V ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:HP ] .
-
-unit:MegaPA-PER-K
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MegaPA ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:K ] .
-
-unit:GI_UK-PER-DAY
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:GI_UK ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DAY ] .
-
-unit:OZ_VOL_US-PER-DAY
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:OZ_VOL_US ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DAY ] .
-
-unit:FT2-PER-HR
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] ;
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:FT ] .
-
-unit:M-PER-SEC2
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:M ] .
-
-unit:MI_N-PER-HR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MI_N ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] .
-
-unit:DYN-SEC-PER-CentiM
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:DYN ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:CentiM ] .
-
-unit:A-PER-M2
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:A ] .
-
-unit:FT3
-    qudt:factorUnit [ qudt:exponent 3 ;
-                      qudt:unit     unit:FT ] .
-
-unit:TON_Metric-PER-M3
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:TON_Metric ] ;
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:M ] .
-
-unit:FARAD-PER-M
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:FARAD ] .
-
-unit:BTU_IT-PER-LB_F-DEG_F
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:LB_F ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DEG_F ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BTU_IT ] .
-
-unit:BBL_UK_PET-PER-MIN
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MIN ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BBL_UK_PET ] .
-
-unit:MegaPA-M3-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MegaPA ] ;
-    qudt:factorUnit [ qudt:exponent 3 ;
-                      qudt:unit     unit:M ] .
-
-unit:PER-SEC-SR
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SR ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] .
-
-unit:CentiM2-SEC
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:CentiM ] .
-
-unit:MilliW-PER-M2-NanoM-SR
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SR ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:NanoM ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliW ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] .
-
-unit:PDL-PER-FT2
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:PDL ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:FT ] .
-
-unit:H-PER-OHM
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:OHM ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:H ] .
-
-unit:NanoMOL-PER-L-HR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:NanoMOL ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:L ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] .
-
-unit:PA-M-PER-SEC2
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:PA ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:M ] .
-
-unit:KiloWB-PER-M
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloWB ] .
-
-unit:BTU_IT-PER-LB-MOL
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MOL ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:LB ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BTU_IT ] .
-
-unit:A-PER-CentiM2
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:CentiM ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:A ] .
-
-unit:N-SEC-PER-M3
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:N ] ;
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:M ] .
-
-unit:NUM-PER-HR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:NUM ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] .
-
-unit:K-PER-HR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:K ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] .
-
-unit:GI_US-PER-DAY
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:GI_US ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DAY ] .
-
-unit:PicoW-PER-CentiM2-L
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:PicoW ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:L ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:CentiM ] .
-
-unit:TONNE-PER-HA
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:TONNE ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HA ] .
-
-unit:BAR-L-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:L ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BAR ] .
-
-unit:DEG_F-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:DEG_F ] .
-
-unit:C_Ab-PER-CentiM2
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:CentiM ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:C_Ab ] .
-
-unit:C-M2
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:C ] .
-
-unit:LB-PER-DAY
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:LB ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DAY ] .
-
-unit:MilliC-PER-KiloGM
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliC ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:KiloGM ] .
-
-unit:BU_UK-PER-HR
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BU_UK ] .
-
-unit:C-PER-CentiM2
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:CentiM ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:C ] .
-
-unit:SLUG-PER-HR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:SLUG ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] .
-
-unit:PINT_UK-PER-DAY
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:PINT_UK ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DAY ] .
-
-unit:PER-BAR
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:BAR ] .
-
-unit:HectoPA-PER-HR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:HectoPA ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] .
-
-unit:BTU_TH-IN-PER-FT2-HR-DEG_F
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:IN ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:FT ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DEG_F ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BTU_TH ] .
-
-unit:KiloPA-PER-MilliM
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MilliM ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloPA ] .
-
-unit:MicroGAL-PER-M
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MicroGAL ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] .
-
-unit:L-PER-MIN
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MIN ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:L ] .
-
-unit:L-PER-MOL
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MOL ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:L ] .
-
-unit:DEG_C-PER-K
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:K ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:DEG_C ] .
-
-unit:QT_UK-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:QT_UK ] .
-
-unit:MilliBQ-PER-M2-DAY
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliBQ ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DAY ] .
-
-unit:EV-PER-K
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:K ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:EV ] .
-
-unit:J-SEC-PER-MOL
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MOL ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:J ] .
-
-unit:KiloGM-PER-MIN
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MIN ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloGM ] .
-
-unit:KiloGM-PER-HA
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloGM ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HA ] .
-
-unit:MilliBQ-PER-KiloGM
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliBQ ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:KiloGM ] .
-
-unit:KiloGM-PER-MOL
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MOL ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloGM ] .
-
-unit:PER-MilliSEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MilliSEC ] .
-
-unit:MicroV-PER-M
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MicroV ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] .
-
-unit:GM-PER-M2
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:GM ] .
-
-unit:TONNE-PER-DAY
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:TONNE ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DAY ] .
-
-unit:IN3
-    qudt:factorUnit [ qudt:exponent 3 ;
-                      qudt:unit     unit:IN ] .
-
-unit:QT_US-PER-HR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:QT_US ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] .
-
-unit:IN3-PER-MIN
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MIN ] ;
-    qudt:factorUnit [ qudt:exponent 3 ;
-                      qudt:unit     unit:IN ] .
-
-unit:V-SEC-PER-M
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:V ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] .
-
-unit:M-PER-FARAD
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:FARAD ] .
-
-unit:FT-PER-SEC2
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:FT ] .
-
-unit:POISE-PER-BAR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:POISE ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:BAR ] .
-
-unit:CD-PER-M2
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:CD ] .
-
-unit:KiloGM-PER-SEC2
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloGM ] .
-
-unit:IN-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:IN ] .
-
-unit:PicoPA-PER-KiloM
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:PicoPA ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:KiloM ] .
-
-unit:PINT_US-PER-DAY
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:PINT_US ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DAY ] .
-
-unit:PER-HR
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] .
-
-unit:DEG_R-PER-MIN
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MIN ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:DEG_R ] .
-
-unit:M2-K
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:K ] .
-
-unit:TON_Metric-PER-HA
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:TON_Metric ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HA ] .
-
-unit:J-PER-HR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:J ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] .
-
-unit:DEG-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:DEG ] .
-
-unit:J-M-PER-MOL
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MOL ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:J ] .
-
-unit:FT-PER-MIN
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MIN ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:FT ] .
-
-unit:DeciM3-PER-MIN
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MIN ] ;
-    qudt:factorUnit [ qudt:exponent 3 ;
-                      qudt:unit     unit:DeciM ] .
-
-unit:SLUG-PER-SEC
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:SLUG ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] .
-
-unit:QT_US-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:QT_US ] .
-
-unit:PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] .
-
-unit:DeciM3-PER-MOL
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MOL ] ;
-    qudt:factorUnit [ qudt:exponent 3 ;
-                      qudt:unit     unit:DeciM ] .
-
-unit:LB_F-SEC-PER-FT2
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:LB_F ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:FT ] .
-
-unit:GM-PER-CentiM2
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:GM ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:CentiM ] .
-
-unit:YD3-PER-MIN
-    qudt:factorUnit [ qudt:exponent 3 ;
-                      qudt:unit     unit:YD ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MIN ] .
-
-unit:FT3-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 3 ;
-                      qudt:unit     unit:FT ] .
-
-unit:MicroFARAD-PER-KiloM
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MicroFARAD ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:KiloM ] .
-
-unit:TON_Metric-PER-SEC
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:TON_Metric ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] .
-
-unit:M2-HZ4
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 4 ;
-                      qudt:unit     unit:HZ ] .
-
-unit:BTU_IT-PER-MIN
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MIN ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BTU_IT ] .
-
-unit:MegaJ-PER-KiloGM
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MegaJ ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:KiloGM ] .
-
-unit:CAL_TH-PER-SEC-CentiM2-K
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:K ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:CentiM ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:CAL_TH ] .
-
-unit:TON_UK-PER-DAY
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:TON_UK ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DAY ] .
-
-unit:BBL_US_PET
-    a            qudt:Unit ;
-    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
-
-unit:J-PER-M
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:J ] .
-
-unit:LB-FT2
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:LB ] ;
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:FT ] .
-
-unit:M3-PER-DAY
-    qudt:factorUnit [ qudt:exponent 3 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DAY ] .
-
-unit:LB-PER-GAL_UK
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:LB ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:GAL_UK ] .
-
-unit:DEATHS-PER-1000000I-YR
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:YR ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:DEATHS ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:1000000I ] .
-
-unit:KiloGM_F-PER-M
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloGM_F ] .
-
-unit:DeciM3
-    qudt:factorUnit [ qudt:exponent 3 ;
-                      qudt:unit     unit:DeciM ] .
-
-unit:PER-M-SR
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SR ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] .
-
-unit:GM_DRY
-    a            qudt:Unit ;
-    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
-
-unit:KiloGM_F-PER-CentiM2
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloGM_F ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:CentiM ] .
-
-unit:NUM-PER-KiloM2
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:NUM ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:KiloM ] .
-
-unit:K-PER-W
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:W ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:K ] .
-
-unit:V-PER-K
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:V ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:K ] .
-
-unit:J-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:J ] .
-
-unit:MI_N-PER-MIN
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MI_N ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MIN ] .
-
-unit:H_Stat-PER-CentiM
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:H_Stat ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:CentiM ] .
-
-unit:TON_US-PER-DAY
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:TON_US ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DAY ] .
-
-unit:MegaV-PER-M
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MegaV ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] .
-
-unit:NanoGM-PER-M3
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:NanoGM ] ;
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:M ] .
-
-unit:BTU_IT-PER-DEG_R
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DEG_R ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BTU_IT ] .
-
-unit:GM-PER-DeciM3
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:GM ] ;
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:DeciM ] .
-
-unit:PER-L
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:L ] .
-
-unit:MilliGAL-PER-MO
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliGAL ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MO ] .
-
-unit:BTU_IT-PER-HR-FT2-DEG_R
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:FT ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DEG_R ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BTU_IT ] .
-
-unit:PER-YD3
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:YD ] .
-
-unit:EV-PER-ANGSTROM
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:EV ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:ANGSTROM ] .
-
-unit:NUM-PER-YR
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:YR ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:NUM ] .
-
-unit:BBL_US-PER-DAY
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DAY ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BBL_US ] .
-
-unit:N-SEC-PER-RAD
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:RAD ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:N ] .
-
-unit:BEAT-PER-MIN
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MIN ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BEAT ] .
-
-unit:PK_UK-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:PK_UK ] .
-
-unit:PER-M-NanoM
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:NanoM ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] .
-
-unit:NanoH-PER-M
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:NanoH ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] .
-
-unit:ERG-PER-GM-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:GM ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:ERG ] .
-
-unit:LB_F-SEC-PER-IN2
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:LB_F ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:IN ] .
-
-unit:FT-PER-DEG_F
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:FT ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DEG_F ] .
-
-unit:PicoGM-PER-MilliL
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:PicoGM ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MilliL ] .
-
-unit:K-PER-M
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:K ] .
-
-unit:LB-IN2
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:LB ] ;
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:IN ] .
-
-unit:MilliA-PER-IN
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliA ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:IN ] .
-
-unit:KiloCAL-PER-CentiM-SEC-DEG_C
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloCAL ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DEG_C ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:CentiM ] .
-
-unit:FT2-DEG_F
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:FT ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:DEG_F ] .
-
-unit:FemtoMOL-PER-L
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:L ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:FemtoMOL ] .
-
-unit:J-M2
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:J ] .
-
-unit:PER-T-M
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:T ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] .
-
-unit:MilliC-PER-M2
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliC ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] .
-
-unit:BBL_UK_PET-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BBL_UK_PET ] .
-
-unit:MI-PER-HR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MI ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] .
-
-unit:DeciM3-PER-M3
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 3 ;
-                      qudt:unit     unit:DeciM ] .
-
-unit:BTU_IT-IN-PER-FT2-SEC-DEG_F
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:IN ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:FT ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DEG_F ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BTU_IT ] .
-
-unit:S-M2-PER-MOL
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:S ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MOL ] ;
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:M ] .
-
-unit:MicroGM-PER-KiloGM
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MicroGM ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:KiloGM ] .
-
-unit:MilliGM-PER-L
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliGM ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:L ] .
-
-unit:GM-PER-MIN
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MIN ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:GM ] .
-
-unit:PicoS
-    a            qudt:Unit ;
-    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
-
-unit:MicroH-PER-M
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MicroH ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] .
-
-unit:GRAIN-PER-GAL_US
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:GRAIN ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:GAL_US ] .
-
-unit:KiloLB_F-PER-IN2
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloLB_F ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:IN ] .
-
-unit:FT2-PER-BTU_IT-IN
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:IN ] ;
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:FT ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:BTU_IT ] .
-
-unit:GM-PER-MOL
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MOL ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:GM ] .
-
-unit:MegaJ-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MegaJ ] .
-
-unit:W-PER-K
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:W ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:K ] .
-
-unit:M4
-    qudt:factorUnit [ qudt:exponent 4 ;
-                      qudt:unit     unit:M ] .
-
-unit:MicroBQ-PER-L
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MicroBQ ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:L ] .
-
-unit:C_Stat-PER-MOL
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MOL ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:C_Stat ] .
-
-unit:PER-YR
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:YR ] .
-
-unit:MilliMOL-PER-GM
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliMOL ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:GM ] .
-
-unit:N-PER-RAD
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:RAD ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:N ] .
-
-unit:MilliGM-PER-M3
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliGM ] ;
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:M ] .
-
-unit:MilliM-PER-HR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliM ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] .
-
-unit:PicoMOL-PER-M3-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:PicoMOL ] ;
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:M ] .
-
-unit:NanoGM-PER-KiloGM
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:NanoGM ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:KiloGM ] .
-
-unit:QT_UK-PER-HR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:QT_UK ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] .
-
-unit:SLUG-PER-FT2
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:SLUG ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:FT ] .
-
-unit:A_Ab-CentiM2
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:CentiM ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:A_Ab ] .
-
-unit:PER-M2-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] .
-
-unit:MilliGM-PER-MIN
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliGM ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MIN ] .
-
-unit:GM-PER-M2-DAY
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:GM ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DAY ] .
-
-unit:C-PER-M2
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:C ] .
-
-unit:C2-M-PER-J
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:J ] ;
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:C ] .
-
-unit:FemtoMOL
-    a            qudt:Unit ;
-    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
-
-unit:L-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:L ] .
-
-unit:GM-PER-KiloGM
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:KiloGM ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:GM ] .
-
-unit:PicoW-PER-M2
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:PicoW ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] .
-
-unit:REV-PER-MIN
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:REV ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MIN ] .
-
-unit:PSI-M3-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:PSI ] ;
-    qudt:factorUnit [ qudt:exponent 3 ;
-                      qudt:unit     unit:M ] .
-
-unit:YD2
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:YD ] .
-
-unit:BTU_TH-IN-PER-FT2-SEC-DEG_F
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:IN ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:FT ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DEG_F ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BTU_TH ] .
-
-unit:KiloPA-M2-PER-GM
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloPA ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:GM ] .
-
-unit:OZ-PER-DAY
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:OZ ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DAY ] .
-
-unit:KiloGM-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloGM ] .
-
-unit:MilliL-PER-DAY
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliL ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DAY ] .
-
-unit:KiloMOL-PER-KiloGM
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloMOL ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:KiloGM ] .
-
-unit:M-PER-HR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] .
-
-unit:IN3-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 3 ;
-                      qudt:unit     unit:IN ] .
-
-unit:DEG_F-PER-K
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:K ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:DEG_F ] .
-
-unit:MicroGM-PER-L-HR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MicroGM ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:L ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] .
-
-unit:PicoA-PER-MicroMOL-L
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:PicoA ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MicroMOL ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:L ] .
-
-unit:DEG_R-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:DEG_R ] .
-
-unit:ERG-PER-CentiM2-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:ERG ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:CentiM ] .
-
-unit:MilliL-PER-HR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliL ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] .
-
-unit:W-PER-M2-PA
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:W ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:PA ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] .
-
-unit:FT-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:FT ] .
-
-unit:NanoMOL-PER-M2-DAY
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:NanoMOL ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DAY ] .
-
-unit:DeciM3-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 3 ;
-                      qudt:unit     unit:DeciM ] .
-
-unit:W-PER-M3
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:W ] ;
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:M ] .
-
-unit:PicoFARAD-PER-M
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:PicoFARAD ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] .
-
-unit:KN-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KN ] .
-
-unit:MilliN-PER-M
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliN ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] .
-
-unit:NanoMOL-PER-KiloGM
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:NanoMOL ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:KiloGM ] .
-
-unit:REV-PER-SEC2
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:REV ] .
-
-unit:YD3-PER-SEC
-    qudt:factorUnit [ qudt:exponent 3 ;
-                      qudt:unit     unit:YD ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] .
-
-unit:PER-WB
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:WB ] .
-
-unit:BTU_IT-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BTU_IT ] .
-
-unit:DEG_F-PER-HR
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:DEG_F ] .
-
-unit:CentiM-PER-HR
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:CentiM ] .
-
-unit:PK_UK-PER-HR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:PK_UK ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] .
-
-unit:LB-PER-FT3
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:LB ] ;
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:FT ] .
-
-unit:MegaBIT-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MegaBIT ] .
-
-unit:MilliL-PER-CentiM2-MIN
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliL ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MIN ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:CentiM ] .
-
-unit:PA-SEC-PER-BAR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:PA ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:BAR ] .
-
-unit:CD-PER-IN2
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:IN ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:CD ] .
-
-unit:MicroM3-PER-M3
-    qudt:factorUnit [ qudt:exponent 3 ;
-                      qudt:unit     unit:MicroM ] ;
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:M ] .
-
-unit:CAL_TH-PER-G
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:G ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:CAL_TH ] .
-
-unit:MOL-PER-M2
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MOL ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] .
-
-unit:NUM-PER-M3
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:NUM ] ;
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:M ] .
-
-unit:M2-PER-V-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:V ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:M ] .
-
-unit:MOL-PER-M2-SEC-SR
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SR ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MOL ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] .
-
-unit:KiloV-PER-M
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloV ] .
-
-unit:W-M-PER-M2-SR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:W ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SR ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] .
-
-unit:PK_US_DRY-PER-MIN
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:PK_US_DRY ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MIN ] .
-
-unit:DEG_F-HR-FT2-PER-BTU_TH
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:HR ] ;
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:FT ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:DEG_F ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:BTU_TH ] .
-
-unit:LB_F-PER-IN2-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:LB_F ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:IN ] .
-
-unit:SLUG-PER-FT
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:SLUG ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:FT ] .
-
-unit:NanoMOL
-    a            qudt:Unit ;
-    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
-
-unit:BU_US_DRY-PER-DAY
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DAY ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BU_US_DRY ] .
-
-unit:KiloPA-PER-K
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloPA ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:K ] .
-
-unit:MilliM3
-    qudt:factorUnit [ qudt:exponent 3 ;
-                      qudt:unit     unit:MilliM ] .
-
-unit:MilliMOL-PER-M2
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliMOL ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] .
-
-unit:OHM-M2-PER-M
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:OHM ] ;
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] .
-
-unit:M2-PER-SEC2
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:M ] .
-
-unit:PicoMOL-PER-L-DAY
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:PicoMOL ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:L ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DAY ] .
-
-unit:PERCENT-PER-M
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:PERCENT ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] .
-
-unit:KiloBIT
-    a            qudt:Unit ;
-    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
-
-unit:M2-PER-MOL
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MOL ] ;
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:M ] .
-
-unit:KiloBYTE-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloBYTE ] .
-
-unit:MilliM-PER-YR
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:YR ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliM ] .
-
-unit:KiloCAL-PER-MOL-DEG_C
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MOL ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloCAL ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DEG_C ] .
-
-unit:CentiM-PER-K
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:K ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:CentiM ] .
-
-unit:CASES-PER-1000I-YR
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:YR ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:CASES ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:1000I ] .
-
-unit:PA-M-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:PA ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:M ] .
-
-unit:YD3-PER-DEG_F
-    qudt:factorUnit [ qudt:exponent 3 ;
-                      qudt:unit     unit:YD ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DEG_F ] .
-
-unit:NUM-PER-M2-DAY
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:NUM ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DAY ] .
-
-unit:PER-GigaEV2
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:GigaEV ] .
-
-unit:GM-PER-HR
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:GM ] .
-
-unit:W-PER-M2-NanoM-SR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:W ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SR ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:NanoM ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] .
-
-unit:NUM-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:NUM ] .
-
-unit:HectoPA-PER-K
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:K ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:HectoPA ] .
-
-unit:MilliBAR-PER-K
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliBAR ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:K ] .
-
-unit:GM-PER-MilliM
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MilliM ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:GM ] .
-
-unit:LB-PER-IN3
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:LB ] ;
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:IN ] .
-
-unit:CAL_IT-PER-SEC-CentiM2-K
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:K ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:CentiM ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:CAL_IT ] .
-
-unit:V-PER-SEC
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:V ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] .
-
-unit:LB-PER-GAL_US
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:LB ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:GAL_US ] .
-
-unit:PER-M3
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:M ] .
-
-unit:CentiM2-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:CentiM ] .
-
-unit:J-PER-M3
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:J ] .
-
-unit:NUM-PER-L
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:NUM ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:L ] .
-
-unit:V2-PER-K2
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:V ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:K ] .
-
-unit:DYN-PER-CentiM2
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:DYN ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:CentiM ] .
-
-unit:MilliPA-SEC-PER-BAR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliPA ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:BAR ] .
-
-unit:M-PER-YR
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:YR ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:M ] .
-
-unit:GM-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:GM ] .
-
-unit:NanoS
-    a            qudt:Unit ;
-    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
-
-unit:M2-HZ
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:HZ ] .
-
-unit:A-PER-MilliM2
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:MilliM ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:A ] .
-
-unit:KiloLB_F-FT-PER-LB
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:LB ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloLB_F ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:FT ] .
-
-unit:NUM-PER-HA
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:NUM ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HA ] .
-
-unit:BREATH
-    a            qudt:Unit ;
-    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
-
-unit:GM_F
-    a            qudt:Unit ;
-    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
-
-unit:MicroH-PER-KiloOHM
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MicroH ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:KiloOHM ] .
-
-unit:N-M-PER-RAD
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:RAD ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:N ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:M ] .
-
-unit:MegaJ-PER-M2
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MegaJ ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] .
-
-unit:M2-HZ2
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:HZ ] .
-
-unit:MegaEV-PER-CentiM
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MegaEV ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:CentiM ] .
-
-unit:PA2-PER-SEC2
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:PA ] .
-
-unit:MI2
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:MI ] .
-
-unit:MilliGM-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliGM ] .
-
-unit:J-PER-K
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:K ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:J ] .
-
-unit:C-PER-MilliM2
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:MilliM ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:C ] .
-
-unit:BTU_IT-PER-FT2
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:FT ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BTU_IT ] .
-
-unit:PicoMOL
-    a            qudt:Unit ;
-    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
-
-unit:W-PER-SR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:W ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SR ] .
-
-unit:DEATHS
-    a            qudt:Unit ;
-    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
-
-unit:REV-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:REV ] .
-
-unit:NanoMOL-PER-MicroGM-HR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:NanoMOL ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MicroGM ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] .
-
-unit:PicoGM-PER-L
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:PicoGM ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:L ] .
-
-unit:NAT-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:NAT ] .
-
-unit:NanoMOL-PER-MicroMOL
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:NanoMOL ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MicroMOL ] .
-
-unit:MilliBQ-PER-L
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliBQ ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:L ] .
-
-unit:LB_F-PER-IN
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:LB_F ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:IN ] .
-
-unit:H-PER-KiloOHM
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:KiloOHM ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:H ] .
-
-unit:CAL_IT-PER-GM-K
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:K ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:GM ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:CAL_IT ] .
-
-unit:MilliL-PER-K
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliL ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:K ] .
-
-unit:GAL_UK-PER-MIN
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MIN ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:GAL_UK ] .
-
-unit:DeciS
-    a            qudt:Unit ;
-    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
-
-unit:DEG_C2-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:DEG_C ] .
-
-unit:PER-ANGSTROM
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:ANGSTROM ] .
-
-unit:FemtoMOL-PER-KiloGM
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:KiloGM ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:FemtoMOL ] .
-
-unit:J-PER-CentiM2
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:J ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:CentiM ] .
-
-unit:LM-PER-W
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:W ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:LM ] .
-
-unit:MilliGM-PER-DeciL
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliGM ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DeciL ] .
-
-unit:GM-PER-M
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:GM ] .
-
-unit:BTU_TH-FT-PER-HR-FT2-DEG_F
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:FT ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:FT ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DEG_F ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BTU_TH ] .
-
-unit:BQ-PER-L
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:L ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BQ ] .
-
-unit:DEG_C-PER-HR
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:DEG_C ] .
-
-unit:SHANNON-PER-SEC
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:SHANNON ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] .
-
-unit:K-PER-K
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:K ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:K ] .
-
-unit:N-PER-M3
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:N ] ;
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:M ] .
-
-unit:BQ-PER-M2
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BQ ] .
-
-unit:MegaC-PER-M2
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MegaC ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] .
-
-unit:KiloGM-PER-M-SEC2
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloGM ] .
-
-unit:MilliL-PER-CentiM2-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliL ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:CentiM ] .
-
-unit:MegaHZ-PER-T
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:T ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MegaHZ ] .
-
-unit:GAL_US-PER-MIN
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MIN ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:GAL_US ] .
-
-unit:BTU_IT-PER-DEG_F
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DEG_F ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BTU_IT ] .
-
-unit:M2-PER-GM
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:GM ] .
-
-unit:REV-PER-HR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:REV ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] .
-
-unit:PA-SEC-PER-M
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:PA ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] .
-
-unit:KiloGM_F-PER-MilliM2
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:MilliM ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloGM_F ] .
-
-unit:CAL_TH-PER-CentiM-SEC-DEG_C
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DEG_C ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:CentiM ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:CAL_TH ] .
-
-unit:FT3-PER-DEG_F
-    qudt:factorUnit [ qudt:exponent 3 ;
-                      qudt:unit     unit:FT ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DEG_F ] .
-
-unit:N-PER-CentiM2
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:N ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:CentiM ] .
-
-unit:BTU_IT-PER-MOL-DEG_F
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MOL ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DEG_F ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BTU_IT ] .
-
-unit:QT_UK-PER-DAY
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:QT_UK ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DAY ] .
-
-unit:HZ-PER-K
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:K ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:HZ ] .
-
-unit:PK_US_DRY-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:PK_US_DRY ] .
-
-unit:PER-SR
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SR ] .
-
-unit:M2
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:M ] .
-
-unit:MicroBQ-PER-KiloGM
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MicroBQ ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:KiloGM ] .
-
-unit:NanoGM-PER-DAY
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:NanoGM ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DAY ] .
-
-unit:MilliM-PER-K
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliM ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:K ] .
-
-unit:M2-PER-J
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:J ] .
-
-unit:CAL_TH-PER-GM-K
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:K ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:GM ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:CAL_TH ] .
-
-unit:S-PER-CentiM
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:S ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:CentiM ] .
-
-unit:KiloM-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloM ] .
-
-unit:NanoM2
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:NanoM ] .
-
-unit:K-M-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:K ] .
-
-unit:M2-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:M ] .
-
-unit:PER-MO
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MO ] .
-
-unit:WB-PER-M
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:WB ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] .
-
-unit:PER-M-K
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:K ] .
-
-unit:NanoBQ
-    a            qudt:Unit ;
-    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
-
-unit:CAL_IT-PER-SEC-CentiM-K
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:K ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:CentiM ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:CAL_IT ] .
-
-unit:MilliGM-PER-M3-HR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliGM ] ;
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] .
-
-unit:N-M-SEC-PER-RAD
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:RAD ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:N ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:M ] .
-
-unit:PA-PER-M
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:PA ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] .
-
-unit:SLUG-PER-DAY
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:SLUG ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DAY ] .
-
-unit:QT_US-PER-DAY
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:QT_US ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DAY ] .
-
-unit:MicroC-PER-M3
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MicroC ] ;
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:M ] .
-
-unit:GM_Carbon
-    a            qudt:Unit ;
-    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
-
-unit:PER-DAY
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DAY ] .
-
-unit:BTU_TH-PER-FT3
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:FT ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BTU_TH ] .
-
-unit:MicroGM-PER-M2-DAY
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MicroGM ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DAY ] .
-
-unit:BTU_TH-PER-LB-DEG_F
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:LB ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DEG_F ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BTU_TH ] .
-
-unit:MilliM2-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:MilliM ] .
-
-unit:BQ-PER-KiloGM
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:KiloGM ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BQ ] .
-
-unit:FT3-PER-DAY
-    qudt:factorUnit [ qudt:exponent 3 ;
-                      qudt:unit     unit:FT ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DAY ] .
-
-unit:L-PER-K
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:L ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:K ] .
-
-unit:M2-PER-HZ-DEG
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HZ ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DEG ] .
-
-unit:TON_Metric-PER-DAY
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:TON_Metric ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DAY ] .
-
-unit:CentiM-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:CentiM ] .
-
-unit:N-M-PER-M
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:N ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] .
-
-unit:PicoMOL-PER-M2-DAY
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:PicoMOL ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DAY ] .
-
-unit:MicroM3
-    qudt:factorUnit [ qudt:exponent 3 ;
-                      qudt:unit     unit:MicroM ] .
-
-unit:M2-K-PER-W
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:W ] ;
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:K ] .
-
-unit:KiloGM-PER-M3-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloGM ] .
-
-unit:MilliBAR-PER-BAR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliBAR ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:BAR ] .
-
-unit:MilliL-PER-M3
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliL ] ;
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:M ] .
-
-unit:GM_Nitrogen
-    a            qudt:Unit ;
-    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
-
-unit:CentiM3-PER-HR
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] ;
-    qudt:factorUnit [ qudt:exponent 3 ;
-                      qudt:unit     unit:CentiM ] .
-
-unit:M2-SR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:SR ] ;
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:M ] .
-
-unit:PicoMOL-PER-KiloGM
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:PicoMOL ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:KiloGM ] .
-
-unit:KiloGM-PER-CentiM2
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloGM ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:CentiM ] .
-
-unit:MilliM-PER-MIN
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliM ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MIN ] .
-
-unit:GRAY-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:GRAY ] .
-
-unit:OZ-PER-IN3
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:OZ ] ;
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:IN ] .
-
-unit:BTU_IT-PER-SEC-FT-DEG_R
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:FT ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DEG_R ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BTU_IT ] .
-
-unit:MicroGM-PER-GM
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MicroGM ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:GM ] .
-
-unit:J-PER-KiloGM-K-PA
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:PA ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:KiloGM ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:K ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:J ] .
-
-unit:GAL_US-PER-HR
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:GAL_US ] .
-
-unit:NanoMOL-PER-MicroMOL-DAY
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:NanoMOL ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MicroMOL ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DAY ] .
-
-unit:IN-PER-SEC2
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:IN ] .
-
-unit:CAL_TH-PER-MIN
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MIN ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:CAL_TH ] .
-
-unit:KiloCAL_TH-PER-HR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloCAL_TH ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] .
-
-unit:MicroMOL-PER-L-HR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MicroMOL ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:L ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] .
-
-unit:PERCENT-PER-DAY
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:PERCENT ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DAY ] .
-
-unit:MOL-PER-HR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MOL ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] .
-
-unit:FT2-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:FT ] .
-
-unit:MOL-PER-M2-SEC-M
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MOL ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] .
-
-unit:MegaA-PER-M2
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MegaA ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] .
-
-unit:DEG_C-PER-MIN
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MIN ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:DEG_C ] .
-
-unit:DEG_C-PER-YR
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:YR ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:DEG_C ] .
-
-unit:PK_UK-PER-DAY
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:PK_UK ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DAY ] .
-
-unit:TON_SHORT-PER-YD3
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:YD ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:TON_SHORT ] .
-
-unit:IN-PER-DEG_F
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:IN ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DEG_F ] .
-
-unit:HP-PER-M
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:HP ] .
-
-unit:PicoMOL-PER-L-HR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:PicoMOL ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:L ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] .
-
-unit:M4-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 4 ;
-                      qudt:unit     unit:M ] .
-
-unit:BBL_US_PET-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BBL_US_PET ] .
-
-unit:C-PER-CentiM3
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:CentiM ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:C ] .
-
-unit:J-PER-KiloGM-K
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:KiloGM ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:K ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:J ] .
-
-unit:MilliRAD_R-PER-HR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliRAD_R ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] .
-
-unit:NanoGM-PER-L
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:NanoGM ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:L ] .
-
-unit:MilliS-PER-M
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliS ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] .
-
-unit:PicoGM-PER-KiloGM
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:PicoGM ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:KiloGM ] .
-
-unit:DYN-SEC-PER-CentiM3
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:DYN ] ;
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:CentiM ] .
-
-unit:BAR-PER-BAR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BAR ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:BAR ] .
-
-unit:W-HR-PER-M3
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:W ] ;
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:HR ] .
-
-unit:PSI-L-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:PSI ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:L ] .
-
-unit:ERG-PER-G
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:G ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:ERG ] .
-
-unit:LB_F-PER-LB
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:LB_F ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:LB ] .
-
-unit:BBL_UK_PET-PER-DAY
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DAY ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BBL_UK_PET ] .
-
-unit:N-M2-PER-KiloGM2
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:N ] ;
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:KiloGM ] .
-
-unit:GAL_UK-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:GAL_UK ] .
-
-unit:MicroH-PER-OHM
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:OHM ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MicroH ] .
-
-unit:J-PER-KiloGM
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:KiloGM ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:J ] .
-
-unit:GM-PER-M3
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:GM ] .
-
-unit:IN4
-    qudt:factorUnit [ qudt:exponent 4 ;
-                      qudt:unit     unit:IN ] .
-
-unit:SEC-FT2
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:FT ] .
-
-unit:NUM-PER-HectoGM
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:NUM ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HectoGM ] .
-
-unit:FT2-SEC-DEG_F
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:FT ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:DEG_F ] .
-
-unit:MegaPA-L-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MegaPA ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:L ] .
-
-unit:A-PER-J
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:J ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:A ] .
-
-unit:PER-CentiM
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:CentiM ] .
-
-unit:RAD-M2-PER-MOL
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:RAD ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MOL ] ;
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:M ] .
-
-unit:MDOLLAR-PER-FLIGHT
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MDOLLAR ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:FLIGHT ] .
-
-unit:ERG-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:ERG ] .
-
-unit:IU-PER-L
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:L ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:IU ] .
-
-unit:W-M2-PER-SR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:W ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SR ] ;
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:M ] .
-
-unit:GM-PER-CentiM3
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:GM ] ;
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:CentiM ] .
-
-unit:N-SEC-PER-M
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:N ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] .
-
-unit:GAL_US-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:GAL_US ] .
-
-unit:L-PER-DAY
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:L ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DAY ] .
-
-unit:DEG-PER-M
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:DEG ] .
-
-unit:KiloCAL-PER-MIN
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MIN ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloCAL ] .
-
-unit:KiloGM-PER-DAY
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloGM ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DAY ] .
-
-unit:MilliM3-PER-M3
-    qudt:factorUnit [ qudt:exponent 3 ;
-                      qudt:unit     unit:MilliM ] ;
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:M ] .
-
-unit:KiloCAL-PER-MOL
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MOL ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloCAL ] .
-
-unit:PER-CentiM3
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:CentiM ] .
-
-unit:DEG-PER-SEC2
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:DEG ] .
-
-unit:RAD-PER-M
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:RAD ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] .
-
-unit:HR-FT2
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:HR ] ;
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:FT ] .
-
-unit:KiloBIT-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloBIT ] .
-
-unit:FT-LB_F-PER-M2
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:LB_F ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:FT ] .
-
-unit:MicroMOL-PER-L
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MicroMOL ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:L ] .
-
-unit:NUM-PER-CentiM-KiloYR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:NUM ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:KiloYR ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:CentiM ] .
-
-unit:LB-PER-IN
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:LB ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:IN ] .
-
-unit:CASES
-    a            qudt:Unit ;
-    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
-
-unit:KiloGM-M-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:KiloGM ] .
-
-unit:NanoL
-    a            qudt:Unit ;
-    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
-
-unit:MegaGM-PER-M3
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MegaGM ] ;
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:M ] .
-
-unit:MicroMOL-PER-M2-HR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MicroMOL ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] .
-
-unit:PER-MicroMOL-L
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MicroMOL ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:L ] .
-
-unit:MegaJ-PER-K
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MegaJ ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:K ] .
-
-unit:MOL-PER-GM-HR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MOL ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:GM ] .
-
-unit:PER-SEC-M2-SR
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SR ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] .
-
-unit:DeciM3-PER-DAY
-    qudt:factorUnit [ qudt:exponent 3 ;
-                      qudt:unit     unit:DeciM ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DAY ] .
-
-unit:GAL_UK-PER-HR
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:GAL_UK ] .
-
-unit:NanoS-PER-CentiM
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:NanoS ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:CentiM ] .
-
-unit:PER-M
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] .
-
-unit:FemtoGM
-    a            qudt:Unit ;
-    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
-
-unit:YD3-PER-DAY
-    qudt:factorUnit [ qudt:exponent 3 ;
-                      qudt:unit     unit:YD ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DAY ] .
-
-unit:PERCENT-PER-WK
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:WK ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:PERCENT ] .
-
-unit:CentiM2-PER-CentiM3
-    qudt:factorUnit [ qudt:exponent 2 ;
-                      qudt:unit     unit:CentiM ] ;
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:CentiM ] .
-
-unit:BREATH-PER-MIN
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MIN ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BREATH ] .
-
-unit:N-PER-M
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:N ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] .
-
-unit:OZ-PER-YD2
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:YD ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:OZ ] .
-
-unit:BU_UK-PER-MIN
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MIN ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BU_UK ] .
-
-unit:PER-KiloV-A-HR
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:KiloV ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:A ] .
-
-unit:PER-SEC-M2
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] .
-
-unit:MilliMOL-PER-L
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliMOL ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:L ] .
-
-unit:GAL
-    a            qudt:Unit ;
-    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
-
-unit:MegaPA-PER-BAR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MegaPA ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:BAR ] .
-
-unit:PER-H
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:H ] .
-
-unit:CentiM-PER-KiloYR
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:KiloYR ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:CentiM ] .
-
-unit:MegaBIT
-    a            qudt:Unit ;
-    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
-
-unit:SLUG-PER-FT-SEC
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:SLUG ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:FT ] .
-
-unit:A-PER-CentiM
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:CentiM ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:A ] .
-
-unit:MilliM-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliM ] .
-
-unit:KiloYR
-    a            qudt:Unit ;
-    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
-
-unit:MilliGM-PER-M2-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliGM ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] .
-
-unit:MicroM-PER-L-DAY
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MicroM ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:L ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DAY ] .
-
-unit:MicroGM-PER-M3-HR
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MicroGM ] ;
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] .
-
-unit:NanoGM-PER-MicroL
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:NanoGM ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MicroL ] .
-
-unit:MilliC-PER-M3
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliC ] ;
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:M ] .
-
-unit:GigaC-PER-M3
-    qudt:factorUnit [ qudt:exponent -3 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:GigaC ] .
-
-unit:RAD-PER-MIN
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:RAD ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MIN ] .
-
-unit:BTU_IT-PER-LB-DEG_R
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:LB ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DEG_R ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BTU_IT ] .
-
-unit:BTU_TH-FT-PER-FT2-HR-DEG_F
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:HR ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:FT ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:FT ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:DEG_F ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BTU_TH ] .
-
-unit:BTU_IT-PER-SEC-FT2
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:FT ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:BTU_IT ] .
-
-unit:MicroM3-PER-MilliL
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MilliL ] ;
-    qudt:factorUnit [ qudt:exponent 3 ;
-                      qudt:unit     unit:MicroM ] .
-
-unit:PSI-PER-PSI
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:PSI ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:PSI ] .
-
-unit:W-PER-M2-K4
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:W ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] ;
-    qudt:factorUnit [ qudt:exponent -4 ;
-                      qudt:unit     unit:K ] .
-
-unit:MilliGM-PER-M
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MilliGM ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:M ] .
-
-unit:CAL_TH-PER-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:CAL_TH ] .
-
-unit:OZ_VOL_UK-PER-MIN
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:OZ_VOL_UK ] ;
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:MIN ] .
-
-unit:MOL-PER-M2-SEC
-    qudt:factorUnit [ qudt:exponent -1 ;
-                      qudt:unit     unit:SEC ] ;
-    qudt:factorUnit [ qudt:exponent 1 ;
-                      qudt:unit     unit:MOL ] ;
-    qudt:factorUnit [ qudt:exponent -2 ;
-                      qudt:unit     unit:M ] .
-
-unit:KiloBIT
-    qudt:isScalingOf unit:BIT ;
-    qudt:prefix      prefix:Kilo .
-
-unit:PebiBYTE
-    qudt:isScalingOf unit:BYTE ;
-    qudt:prefix      prefix:Pebi .
-
-unit:GM-PER-KiloM
-    qudt:isScalingOf unit:GM-PER-M .
-
-unit:CentiM3-PER-HR
-    qudt:convertsTo  unit:M3-PER-SEC ;
-    qudt:isScalingOf unit:M3-PER-SEC .
-
-unit:PicoGM
-    qudt:isScalingOf unit:GM ;
-    qudt:prefix      prefix:Pico .
-
-unit:KiloCi
-    qudt:isScalingOf unit:Ci ;
-    qudt:prefix      prefix:Kilo .
-
-unit:MilliM3-PER-M3
-    qudt:convertsTo  unit:M3-PER-M3 ;
-    qudt:isScalingOf unit:M3-PER-M3 .
-
-unit:KiloSEC
-    qudt:convertsTo  unit:SEC ;
-    qudt:isScalingOf unit:SEC ;
-    qudt:prefix      prefix:Kilo .
-
-unit:MicroPA
-    qudt:convertsTo  unit:PA ;
-    qudt:isScalingOf unit:PA ;
-    qudt:prefix      prefix:Micro .
-
-unit:KiloJ-PER-MOL
-    qudt:convertsTo  unit:J-PER-MOL ;
-    qudt:isScalingOf unit:J-PER-MOL .
-
-unit:C-PER-CentiM3
-    qudt:convertsTo  unit:C-PER-M3 ;
-    qudt:isScalingOf unit:C-PER-M3 .
-
-unit:GigaJ
-    qudt:convertsTo  unit:J ;
-    qudt:isScalingOf unit:J ;
-    qudt:prefix      prefix:Giga .
-
-unit:TeraW-HR
-    qudt:convertsTo  unit:W-SEC ;
-    qudt:isScalingOf unit:W-SEC .
-
-unit:PER-CentiM3
-    qudt:convertsTo  unit:PER-M3 ;
-    qudt:isScalingOf unit:PER-M3 .
-
-unit:MegaBQ
-    qudt:convertsTo  unit:BQ ;
-    qudt:isScalingOf unit:BQ ;
-    qudt:prefix      prefix:Mega .
-
-unit:V-PER-MicroSEC
-    qudt:convertsTo  unit:V-PER-SEC ;
-    qudt:isScalingOf unit:V-PER-SEC .
-
-unit:FARAD-PER-KiloM
-    qudt:convertsTo  unit:FARAD-PER-M ;
-    qudt:isScalingOf unit:FARAD-PER-M .
-
-unit:KiloN-M
-    qudt:convertsTo  unit:N-M ;
-    qudt:isScalingOf unit:N-M .
-
-unit:MilliBAR-L-PER-SEC
-    qudt:isScalingOf unit:BAR-L-PER-SEC .
-
-unit:MicroJ
-    qudt:convertsTo  unit:J ;
-    qudt:isScalingOf unit:J ;
-    qudt:prefix      prefix:Micro .
-
-unit:CentiM-PER-K
-    qudt:convertsTo  unit:M-PER-K ;
-    qudt:isScalingOf unit:M-PER-K .
-
-unit:KiloGM-PER-HR
-    qudt:isScalingOf unit:GM-PER-SEC .
-
-unit:MilliT
-    qudt:convertsTo  unit:T ;
-    qudt:isScalingOf unit:T ;
-    qudt:prefix      prefix:Milli .
-
-unit:MilliN-PER-M
-    qudt:convertsTo  unit:N-PER-M ;
-    qudt:isScalingOf unit:N-PER-M .
-
-unit:PER-CentiM
-    qudt:convertsTo  unit:PER-M ;
-    qudt:isScalingOf unit:PER-M .
-
-unit:N-PER-CentiM2
-    qudt:convertsTo  unit:N-PER-M2 ;
-    qudt:isScalingOf unit:N-PER-M2 .
-
-unit:PetaBYTE
-    qudt:isScalingOf unit:BYTE ;
-    qudt:prefix      prefix:Peta .
-
-unit:MicroMOL-PER-L
-    qudt:isScalingOf unit:MOL-PER-L .
-
-unit:DecaARE
-    qudt:isScalingOf unit:ARE ;
-    qudt:prefix      prefix:Deca .
-
-unit:KiloPA-PER-MilliM
-    qudt:convertsTo  unit:PA-PER-M ;
-    qudt:isScalingOf unit:PA-PER-M .
-
-unit:NanoGM-PER-KiloGM
-    qudt:convertsTo  unit:GM-PER-GM ;
-    qudt:isScalingOf unit:GM-PER-GM .
-
-unit:CentiMOL
-    qudt:isScalingOf unit:MOL ;
-    qudt:prefix      prefix:Centi .
-
-unit:PicoW-PER-M2
-    qudt:convertsTo  unit:W-PER-M2 ;
-    qudt:isScalingOf unit:W-PER-M2 .
-
-unit:KiloV-A_Reactive
-    qudt:convertsTo  unit:V-A_Reactive ;
-    qudt:isScalingOf unit:V-A_Reactive .
-
-unit:NanoFARAD-PER-M
-    qudt:convertsTo  unit:FARAD-PER-M ;
-    qudt:isScalingOf unit:FARAD-PER-M .
-
-unit:GigaBQ
-    qudt:convertsTo  unit:BQ ;
-    qudt:isScalingOf unit:BQ ;
-    qudt:prefix      prefix:Giga .
-
-unit:ExaBYTE
-    qudt:isScalingOf unit:BYTE ;
-    qudt:prefix      prefix:Exa .
-
-unit:MilliM3
-    qudt:convertsTo  unit:M3 ;
-    qudt:isScalingOf unit:M3 ;
-    qudt:prefix      prefix:Milli .
-
-unit:KiloA-PER-M
-    qudt:convertsTo  unit:A-PER-M ;
-    qudt:isScalingOf unit:A-PER-M .
-
-unit:MegaJ-PER-M2
-    qudt:convertsTo  unit:J-PER-M2 ;
-    qudt:isScalingOf unit:J-PER-M2 .
-
-unit:GigaOHM
-    qudt:convertsTo  unit:OHM ;
-    qudt:isScalingOf unit:OHM ;
-    qudt:prefix      prefix:Giga .
-
-unit:MilliMOL-PER-MOL
-    qudt:convertsTo  unit:MOL-PER-MOL ;
-    qudt:isScalingOf unit:MOL-PER-MOL .
-
-unit:L-PER-MicroMOL
-    qudt:isScalingOf unit:L-PER-MOL .
-
-unit:MicroW-PER-M2
-    qudt:convertsTo  unit:W-PER-M2 ;
-    qudt:isScalingOf unit:W-PER-M2 .
-
-unit:MicroMOL-PER-SEC
-    qudt:convertsTo  unit:MOL-PER-SEC ;
-    qudt:isScalingOf unit:MOL-PER-SEC .
-
-unit:HectoPA-M3-PER-SEC
-    qudt:convertsTo  unit:PA-M3-PER-SEC ;
-    qudt:isScalingOf unit:PA-M3-PER-SEC .
-
-unit:MilliW-PER-M2-NanoM
-    qudt:convertsTo  unit:W-PER-M2-M ;
-    qudt:isScalingOf unit:W-PER-M2-M .
-
-unit:PicoS-PER-M
-    qudt:convertsTo  unit:S-PER-M ;
-    qudt:isScalingOf unit:S-PER-M .
-
-unit:MilliGM-PER-M
-    qudt:isScalingOf unit:GM-PER-M .
-
-unit:MicroV-PER-M
-    qudt:convertsTo  unit:V-PER-M ;
-    qudt:isScalingOf unit:V-PER-M .
-
-unit:TeraHZ
-    qudt:convertsTo  unit:HZ ;
-    qudt:isScalingOf unit:HZ ;
-    qudt:prefix      prefix:Tera .
-
-unit:NanoGM-PER-L
-    qudt:convertsTo  unit:GM-PER-L ;
-    qudt:isScalingOf unit:GM-PER-L .
-
-unit:NanoGM-PER-MilliL
-    qudt:convertsTo  unit:GM-PER-L ;
-    qudt:isScalingOf unit:GM-PER-L .
-
-unit:MilliW-PER-M2
-    qudt:convertsTo  unit:W-PER-M2 ;
-    qudt:isScalingOf unit:W-PER-M2 .
-
-unit:NanoGM-PER-DAY
-    qudt:isScalingOf unit:GM-PER-SEC .
-
-unit:W-PER-M2-NanoM-SR
-    qudt:convertsTo  unit:W-PER-M2-M-SR ;
-    qudt:isScalingOf unit:W-PER-M2-M-SR .
-
-unit:MegaJ-PER-KiloGM
-    qudt:isScalingOf unit:J-PER-GM .
-
-unit:MilliGM-PER-HR
-    qudt:isScalingOf unit:GM-PER-SEC .
-
-unit:CentiC
-    qudt:convertsTo  unit:C ;
-    qudt:isScalingOf unit:C ;
-    qudt:prefix      prefix:Centi .
-
-unit:PicoMOL-PER-M3
-    qudt:convertsTo  unit:MOL-PER-M3 ;
-    qudt:isScalingOf unit:MOL-PER-M3 .
-
-unit:DeciGM
-    qudt:isScalingOf unit:GM ;
-    qudt:prefix      prefix:Deci .
-
-unit:CentiM3-PER-SEC
-    qudt:convertsTo  unit:M3-PER-SEC ;
-    qudt:isScalingOf unit:M3-PER-SEC .
-
-unit:MicroMOL-PER-M2-DAY
-    qudt:convertsTo  unit:MOL-PER-M2-SEC ;
-    qudt:isScalingOf unit:MOL-PER-M2-SEC .
-
-unit:MilliH-PER-OHM
-    qudt:convertsTo  unit:H-PER-OHM ;
-    qudt:isScalingOf unit:H-PER-OHM .
-
-unit:MicroM3-PER-M3
-    qudt:convertsTo  unit:M3-PER-M3 ;
-    qudt:isScalingOf unit:M3-PER-M3 .
-
-unit:KiloJ
-    qudt:convertsTo  unit:J ;
-    qudt:isScalingOf unit:J ;
-    qudt:prefix      prefix:Kilo .
-
-unit:KiloV-PER-M
-    qudt:convertsTo  unit:V-PER-M ;
-    qudt:isScalingOf unit:V-PER-M .
-
-unit:ExbiBYTE
-    qudt:isScalingOf unit:BYTE ;
-    qudt:prefix      prefix:Exbi .
-
-unit:MegaBYTE
-    qudt:isScalingOf unit:BYTE ;
-    qudt:prefix      prefix:Mega .
-
-unit:KiloGM-PER-MilliM
-    qudt:isScalingOf unit:GM-PER-M .
-
-unit:GM-PER-CentiM2
-    qudt:isScalingOf unit:GM-PER-M2 .
-
-unit:NUM-PER-HectoGM
-    qudt:isScalingOf unit:NUM-PER-GM .
-
-unit:N-CentiM
-    qudt:convertsTo  unit:N-M ;
-    qudt:isScalingOf unit:N-M .
-
-unit:MegaHZ-PER-K
-    qudt:convertsTo  unit:HZ-PER-K ;
-    qudt:isScalingOf unit:HZ-PER-K .
-
-unit:MegaJ
-    qudt:convertsTo  unit:J ;
-    qudt:isScalingOf unit:J ;
-    qudt:prefix      prefix:Mega .
-
-unit:AttoJ
-    qudt:convertsTo  unit:J ;
-    qudt:isScalingOf unit:J ;
-    qudt:prefix      prefix:Atto .
-
-unit:KiloGM-PER-DAY
-    qudt:isScalingOf unit:GM-PER-SEC .
-
-unit:MilliGM-PER-DAY
-    qudt:isScalingOf unit:GM-PER-SEC .
-
-unit:PicoGM-PER-GM
-    qudt:convertsTo  unit:GM-PER-GM ;
-    qudt:isScalingOf unit:GM-PER-GM .
-
-unit:MilliMOL-PER-M3
-    qudt:convertsTo  unit:MOL-PER-M3 ;
-    qudt:isScalingOf unit:MOL-PER-M3 .
-
-unit:KiloWB
-    qudt:isScalingOf unit:WB ;
-    qudt:prefix      prefix:Kilo .
-
-unit:DeciM3-PER-SEC
-    qudt:convertsTo  unit:M3-PER-SEC ;
-    qudt:isScalingOf unit:M3-PER-SEC .
-
-unit:MicroFARAD-PER-M
-    qudt:convertsTo  unit:FARAD-PER-M ;
-    qudt:isScalingOf unit:FARAD-PER-M .
-
-unit:NUM-PER-NanoL
-    qudt:isScalingOf unit:NUM-PER-L .
-
-unit:DeciM2
-    qudt:convertsTo  unit:M2 ;
-    qudt:isScalingOf unit:M2 ;
-    qudt:prefix      prefix:Deci .
-
-unit:MilliM-PER-YR
-    qudt:convertsTo  unit:M-PER-SEC ;
-    qudt:isScalingOf unit:M-PER-SEC .
-
-unit:MicroMHO
-    qudt:convertsTo  unit:MHO ;
-    qudt:isScalingOf unit:MHO ;
-    qudt:prefix      prefix:Micro .
-
-unit:C-PER-MilliM3
-    qudt:convertsTo  unit:C-PER-M3 ;
-    qudt:isScalingOf unit:C-PER-M3 .
-
-unit:PER-MilliM3
-    qudt:convertsTo  unit:PER-M3 ;
-    qudt:isScalingOf unit:PER-M3 .
-
-unit:ZettaC
-    qudt:convertsTo  unit:C ;
-    qudt:isScalingOf unit:C ;
-    qudt:prefix      prefix:Zetta .
-
-unit:MilliGM-PER-CentiM2
-    qudt:isScalingOf unit:GM-PER-M2 .
-
-unit:PetaJ
-    qudt:convertsTo  unit:J ;
-    qudt:isScalingOf unit:J ;
-    qudt:prefix      prefix:Peta .
-
-unit:HectoPA
-    qudt:convertsTo  unit:PA ;
-    qudt:isScalingOf unit:PA ;
-    qudt:prefix      prefix:Hecto .
-
-unit:ZeptoC
-    qudt:convertsTo  unit:C ;
-    qudt:isScalingOf unit:C ;
-    qudt:prefix      prefix:Zepto .
-
-unit:MilliL-PER-K
-    qudt:isScalingOf unit:L-PER-K .
-
-unit:A-PER-CentiM2
-    qudt:convertsTo  unit:A-PER-M2 ;
-    qudt:isScalingOf unit:A-PER-M2 .
-
-unit:N-PER-MilliM2
-    qudt:convertsTo  unit:N-PER-M2 ;
-    qudt:isScalingOf unit:N-PER-M2 .
-
-unit:J-PER-KiloGM
-    qudt:isScalingOf unit:J-PER-GM .
-
-unit:DeciM3-PER-HR
-    qudt:convertsTo  unit:M3-PER-SEC ;
-    qudt:isScalingOf unit:M3-PER-SEC .
-
-unit:MicroH-PER-OHM
-    qudt:convertsTo  unit:H-PER-OHM ;
-    qudt:isScalingOf unit:H-PER-OHM .
-
-unit:MilliJ
-    qudt:convertsTo  unit:J ;
-    qudt:isScalingOf unit:J ;
-    qudt:prefix      prefix:Milli .
-
-unit:MilliMOL-PER-M3-DAY
-    qudt:convertsTo  unit:MOL-PER-M3-SEC ;
-    qudt:isScalingOf unit:MOL-PER-M3-SEC .
-
-unit:KiloEV-PER-MicroM
-    qudt:isScalingOf unit:EV-PER-M .
-
-unit:N-PER-MilliM
-    qudt:convertsTo  unit:N-PER-M ;
-    qudt:isScalingOf unit:N-PER-M .
-
-unit:KiloGM-PER-MOL
-    qudt:isScalingOf unit:GM-PER-MOL .
-
-unit:MicroGM
-    qudt:isScalingOf unit:GM ;
-    qudt:prefix      prefix:Micro .
-
-unit:MicroV
-    qudt:convertsTo  unit:V ;
-    qudt:isScalingOf unit:V ;
-    qudt:prefix      prefix:Micro .
-
-unit:KiloTON_Metric
-    qudt:isScalingOf unit:TON_Metric ;
-    qudt:prefix      prefix:Kilo .
-
-unit:MegaBIT
-    qudt:isScalingOf unit:BIT ;
-    qudt:prefix      prefix:Mega .
-
-unit:FemtoJ
-    qudt:convertsTo  unit:J ;
-    qudt:isScalingOf unit:J ;
-    qudt:prefix      prefix:Femto .
-
-unit:ExaC
-    qudt:convertsTo  unit:C ;
-    qudt:isScalingOf unit:C ;
-    qudt:prefix      prefix:Exa .
-
-unit:DecaL
-    qudt:isScalingOf unit:L ;
-    qudt:prefix      prefix:Deca .
-
-unit:MilliBQ
-    qudt:isScalingOf unit:BQ ;
-    qudt:prefix      prefix:Milli .
-
-unit:PicoGM-PER-KiloGM
-    qudt:convertsTo  unit:GM-PER-GM ;
-    qudt:isScalingOf unit:GM-PER-GM .
-
-unit:MilliM4
-    qudt:convertsTo  unit:M4 ;
-    qudt:isScalingOf unit:M4 ;
-    qudt:prefix      prefix:Milli .
-
-unit:CentiN-M
-    qudt:convertsTo  unit:N-M ;
-    qudt:isScalingOf unit:N-M .
-
-unit:FemtoMOL
-    qudt:isScalingOf unit:MOL ;
-    qudt:prefix      prefix:Femto .
-
-unit:AttoJ-SEC
-    qudt:convertsTo  unit:J-SEC ;
-    qudt:isScalingOf unit:J-SEC .
-
-unit:MicroMOL
-    qudt:convertsTo  unit:MOL ;
-    qudt:isScalingOf unit:MOL ;
-    qudt:prefix      prefix:Micro .
-
-unit:KiloWB-PER-M
-    qudt:convertsTo  unit:WB-PER-M ;
-    qudt:isScalingOf unit:WB-PER-M .
-
-unit:MicroL-PER-L
-    qudt:convertsTo  unit:L-PER-L ;
-    qudt:isScalingOf unit:L-PER-L .
-
-unit:MegaJ-PER-M3
-    qudt:convertsTo  unit:J-PER-M3 ;
-    qudt:isScalingOf unit:J-PER-M3 .
-
-unit:NanoMOL
-    qudt:isScalingOf unit:MOL ;
-    qudt:prefix      prefix:Nano .
-
-unit:DeciBAR
-    qudt:isScalingOf unit:BAR ;
-    qudt:prefix      prefix:Deci .
-
-unit:S-PER-CentiM
-    qudt:convertsTo  unit:S-PER-M ;
-    qudt:isScalingOf unit:S-PER-M .
-
-unit:KiloJ-PER-KiloGM
-    qudt:isScalingOf unit:J-PER-GM .
-
-unit:MegaN-M
-    qudt:convertsTo  unit:N-M ;
-    qudt:isScalingOf unit:N-M .
-
-unit:KiloM-PER-DAY
-    qudt:convertsTo  unit:M-PER-SEC ;
-    qudt:isScalingOf unit:M-PER-SEC .
-
-unit:MegaGM-PER-M3
-    qudt:isScalingOf unit:GM-PER-M3 .
-
-unit:FemtoGM-PER-L
-    qudt:convertsTo  unit:GM-PER-L ;
-    qudt:isScalingOf unit:GM-PER-L .
-
-unit:MicroM2
-    qudt:convertsTo  unit:M2 ;
-    qudt:isScalingOf unit:M2 ;
-    qudt:prefix      prefix:Micro .
-
-unit:MilliRAD_R
-    qudt:isScalingOf unit:RAD_R ;
-    qudt:prefix      prefix:Milli .
-
-unit:WB-PER-MilliM
-    qudt:convertsTo  unit:WB-PER-M ;
-    qudt:isScalingOf unit:WB-PER-M .
-
-unit:PicoGM-PER-MilliL
-    qudt:convertsTo  unit:GM-PER-L ;
-    qudt:isScalingOf unit:GM-PER-L .
-
-unit:MilliMOL
-    qudt:convertsTo  unit:MOL ;
-    qudt:isScalingOf unit:MOL ;
-    qudt:prefix      prefix:Milli .
-
-unit:KiloL-PER-HR
-    qudt:isScalingOf unit:L-PER-SEC .
-
-unit:DecaPA
-    qudt:convertsTo  unit:PA ;
-    qudt:isScalingOf unit:PA ;
-    qudt:prefix      prefix:Deca .
-
-unit:MilliCi
-    qudt:isScalingOf unit:Ci ;
-    qudt:prefix      prefix:Milli .
-
-unit:PicoFARAD-PER-M
-    qudt:convertsTo  unit:FARAD-PER-M ;
-    qudt:isScalingOf unit:FARAD-PER-M .
-
-unit:KiloA-HR
-    qudt:convertsTo  unit:A-SEC ;
-    qudt:isScalingOf unit:A-SEC .
-
-unit:KiloHZ-M
-    qudt:convertsTo  unit:HZ-M ;
-    qudt:isScalingOf unit:HZ-M .
-
-unit:KiloV
-    qudt:convertsTo  unit:V ;
-    qudt:isScalingOf unit:V ;
-    qudt:prefix      prefix:Kilo .
-
-unit:GM-PER-CentiM3
-    qudt:isScalingOf unit:GM-PER-M3 .
-
-unit:MilliARCSEC
-    qudt:isScalingOf unit:ARCSEC ;
-    qudt:prefix      prefix:Milli .
-
-unit:KiloBAR
-    qudt:isScalingOf unit:BAR ;
-    qudt:prefix      prefix:Kilo .
-
-unit:V-PER-MilliM
-    qudt:convertsTo  unit:V-PER-M ;
-    qudt:isScalingOf unit:V-PER-M .
-
-unit:CentiM3-PER-MIN
-    qudt:convertsTo  unit:M3-PER-SEC ;
-    qudt:isScalingOf unit:M3-PER-SEC .
-
-unit:KiloPA
-    qudt:convertsTo  unit:PA ;
-    qudt:isScalingOf unit:PA ;
-    qudt:prefix      prefix:Kilo .
-
-unit:MicroPOISE
-    qudt:isScalingOf unit:POISE ;
-    qudt:prefix      prefix:Micro .
-
-unit:PicoA
-    qudt:convertsTo  unit:A ;
-    qudt:isScalingOf unit:A ;
-    qudt:prefix      prefix:Pico .
-
-unit:FemtoGM-PER-KiloGM
-    qudt:convertsTo  unit:GM-PER-GM ;
-    qudt:isScalingOf unit:GM-PER-GM .
-
-unit:MegaV
-    qudt:convertsTo  unit:V ;
-    qudt:isScalingOf unit:V ;
-    qudt:prefix      prefix:Mega .
-
-unit:TeraW
-    qudt:convertsTo  unit:W ;
-    qudt:isScalingOf unit:W ;
-    qudt:prefix      prefix:Tera .
-
-unit:MilliM-PER-DAY
-    qudt:convertsTo  unit:M-PER-SEC ;
-    qudt:isScalingOf unit:M-PER-SEC .
-
-unit:DeciM3
-    qudt:convertsTo  unit:M3 ;
-    qudt:isScalingOf unit:M3 ;
-    qudt:prefix      prefix:Deci .
-
-unit:MilliIN
-    qudt:isScalingOf unit:IN ;
-    qudt:prefix      prefix:Milli .
-
-unit:PicoW
-    qudt:convertsTo  unit:W ;
-    qudt:isScalingOf unit:W ;
-    qudt:prefix      prefix:Pico .
-
-unit:MicroFARAD-PER-KiloM
-    qudt:convertsTo  unit:FARAD-PER-M ;
-    qudt:isScalingOf unit:FARAD-PER-M .
-
-unit:A-PER-MilliM2
-    qudt:convertsTo  unit:A-PER-M2 ;
-    qudt:isScalingOf unit:A-PER-M2 .
-
-unit:CentiPOISE
-    qudt:isScalingOf unit:POISE ;
-    qudt:prefix      prefix:Centi .
-
-unit:NanoS-PER-CentiM
-    qudt:convertsTo  unit:S-PER-M ;
-    qudt:isScalingOf unit:S-PER-M .
-
-unit:MicroBQ-PER-L
-    qudt:isScalingOf unit:BQ-PER-L .
-
-unit:DeciM3-PER-MIN
-    qudt:convertsTo  unit:M3-PER-SEC ;
-    qudt:isScalingOf unit:M3-PER-SEC .
-
-unit:MilliBQ-PER-L
-    qudt:isScalingOf unit:BQ-PER-L .
-
-unit:KiloM3-PER-SEC2
-    qudt:convertsTo  unit:M3-PER-SEC2 ;
-    qudt:isScalingOf unit:M3-PER-SEC2 .
-
-unit:NanoH-PER-M
-    qudt:convertsTo  unit:H-PER-M ;
-    qudt:isScalingOf unit:H-PER-M .
-
-unit:GigaBYTE
-    qudt:isScalingOf unit:BYTE ;
-    qudt:prefix      prefix:Giga .
-
-unit:KiloCAL_TH-PER-SEC
-    qudt:isScalingOf unit:CAL_TH-PER-SEC .
-
-unit:MicroRAD
-    qudt:convertsTo  unit:RAD ;
-    qudt:isScalingOf unit:RAD ;
-    qudt:prefix      prefix:Micro .
-
-unit:MilliL-PER-L
-    qudt:convertsTo  unit:L-PER-L ;
-    qudt:isScalingOf unit:L-PER-L .
-
-unit:KiloCAL_IT
-    qudt:isScalingOf unit:CAL_IT ;
-    qudt:prefix      prefix:Kilo .
-
-unit:GM-PER-DeciM3
-    qudt:isScalingOf unit:GM-PER-M3 .
-
-unit:MilliL-PER-DAY
-    qudt:isScalingOf unit:L-PER-SEC .
-
-unit:KiloMOL-PER-M3
-    qudt:convertsTo  unit:MOL-PER-M3 ;
-    qudt:isScalingOf unit:MOL-PER-M3 .
-
-unit:MegaPA
-    qudt:convertsTo  unit:PA ;
-    qudt:isScalingOf unit:PA ;
-    qudt:prefix      prefix:Mega .
-
-unit:GigaW
-    qudt:convertsTo  unit:W ;
-    qudt:isScalingOf unit:W ;
-    qudt:prefix      prefix:Giga .
-
-unit:MicroA
-    qudt:convertsTo  unit:A ;
-    qudt:isScalingOf unit:A ;
-    qudt:prefix      prefix:Micro .
-
-unit:NanoA
-    qudt:convertsTo  unit:A ;
-    qudt:isScalingOf unit:A ;
-    qudt:prefix      prefix:Nano .
-
-unit:KiloGM-PER-SEC
-    qudt:isScalingOf unit:GM-PER-SEC .
-
-unit:MebiBYTE
-    qudt:isScalingOf unit:BYTE ;
-    qudt:prefix      prefix:Mebi .
-
-unit:MilliGM-PER-SEC
-    qudt:isScalingOf unit:GM-PER-SEC .
-
-unit:MicroL
-    qudt:isScalingOf unit:L ;
-    qudt:prefix      prefix:Micro .
-
-unit:NanoL
-    qudt:isScalingOf unit:L ;
-    qudt:prefix      prefix:Nano .
-
-unit:KiloYR
-    qudt:isScalingOf unit:YR ;
-    qudt:prefix      prefix:Kilo .
-
-unit:HectoGM
-    qudt:isScalingOf unit:GM ;
-    qudt:prefix      prefix:Hecto .
-
-unit:MilliRAD
-    qudt:convertsTo  unit:RAD ;
-    qudt:isScalingOf unit:RAD ;
-    qudt:prefix      prefix:Milli .
-
-unit:CentiM2-PER-SEC
-    qudt:convertsTo  unit:M2-PER-SEC ;
-    qudt:isScalingOf unit:M2-PER-SEC .
-
-unit:MilliV
-    qudt:convertsTo  unit:V ;
-    qudt:isScalingOf unit:V ;
-    qudt:prefix      prefix:Milli .
-
-unit:NanoW
-    qudt:convertsTo  unit:W ;
-    qudt:isScalingOf unit:W ;
-    qudt:prefix      prefix:Nano .
-
-unit:MilliA-PER-MilliM
-    qudt:convertsTo  unit:A-PER-M ;
-    qudt:isScalingOf unit:A-PER-M .
-
-unit:MicroW
-    qudt:convertsTo  unit:W ;
-    qudt:isScalingOf unit:W ;
-    qudt:prefix      prefix:Micro .
-
-unit:MicroSEC
-    qudt:convertsTo  unit:SEC ;
-    qudt:isScalingOf unit:SEC ;
-    qudt:prefix      prefix:Micro .
-
-unit:MegaHZ-M
-    qudt:convertsTo  unit:HZ-M ;
-    qudt:isScalingOf unit:HZ-M .
-
-unit:DecaM
-    qudt:convertsTo  unit:M ;
-    qudt:isScalingOf unit:M ;
-    qudt:prefix      prefix:Deca .
-
-unit:MilliL-PER-HR
-    qudt:isScalingOf unit:L-PER-SEC .
-
-unit:NanoSEC
-    qudt:convertsTo  unit:SEC ;
-    qudt:isScalingOf unit:SEC ;
-    qudt:prefix      prefix:Nano .
-
-unit:GigaPA
-    qudt:convertsTo  unit:PA ;
-    qudt:isScalingOf unit:PA ;
-    qudt:prefix      prefix:Giga .
-
-unit:MegaPA-L-PER-SEC
-    qudt:isScalingOf unit:PA-L-PER-SEC .
-
-unit:GigaHZ-M
-    qudt:convertsTo  unit:HZ-M ;
-    qudt:isScalingOf unit:HZ-M .
-
-unit:KiloV-A
-    qudt:convertsTo  unit:V-A ;
-    qudt:isScalingOf unit:V-A .
-
-unit:MilliWB
-    qudt:convertsTo  unit:WB ;
-    qudt:isScalingOf unit:WB ;
-    qudt:prefix      prefix:Milli .
-
-unit:MilliSV
-    qudt:convertsTo  unit:SV ;
-    qudt:isScalingOf unit:SV ;
-    qudt:prefix      prefix:Milli .
-
-unit:CentiM-PER-KiloYR
-    qudt:isScalingOf unit:M-PER-YR .
-
-unit:MicroN-M
-    qudt:convertsTo  unit:N-M ;
-    qudt:isScalingOf unit:N-M .
-
-unit:MilliSEC
-    qudt:convertsTo  unit:SEC ;
-    qudt:isScalingOf unit:SEC ;
-    qudt:prefix      prefix:Milli .
-
-unit:KiloC-PER-M2
-    qudt:convertsTo  unit:C-PER-M2 ;
-    qudt:isScalingOf unit:C-PER-M2 .
-
-unit:MicroM3
-    qudt:convertsTo  unit:M3 ;
-    qudt:isScalingOf unit:M3 ;
-    qudt:prefix      prefix:Micro .
-
-unit:MilliGRAY
-    qudt:convertsTo  unit:GRAY ;
-    qudt:isScalingOf unit:GRAY ;
-    qudt:prefix      prefix:Milli .
-
-unit:KibiBYTE
-    qudt:isScalingOf unit:BYTE ;
-    qudt:prefix      prefix:Kibi .
-
-unit:MegaEV-PER-CentiM
-    qudt:isScalingOf unit:EV-PER-M .
-
-unit:KiloA
-    qudt:convertsTo  unit:A ;
-    qudt:isScalingOf unit:A ;
-    qudt:prefix      prefix:Kilo .
-
-unit:MegaYR
-    qudt:isScalingOf unit:YR ;
-    qudt:prefix      prefix:Mega .
-
-unit:MilliPA-SEC
-    qudt:convertsTo  unit:PA-SEC ;
-    qudt:isScalingOf unit:PA-SEC .
-
-unit:TeraBYTE
-    qudt:isScalingOf unit:BYTE ;
-    qudt:prefix      prefix:Tera .
-
-unit:KiloTONNE
-    qudt:isScalingOf unit:TONNE ;
-    qudt:prefix      prefix:Kilo .
-
-unit:MilliN-M
-    qudt:convertsTo  unit:N-M ;
-    qudt:isScalingOf unit:N-M .
-
-unit:KiloL
-    qudt:isScalingOf unit:L ;
-    qudt:prefix      prefix:Kilo .
-
-unit:MegaJ-PER-K
-    qudt:convertsTo  unit:J-PER-K ;
-    qudt:isScalingOf unit:J-PER-K .
-
-unit:MicroH-PER-M
-    qudt:convertsTo  unit:H-PER-M ;
-    qudt:isScalingOf unit:H-PER-M .
-
-unit:KiloW
-    qudt:convertsTo  unit:W ;
-    qudt:isScalingOf unit:W ;
-    qudt:prefix      prefix:Kilo .
-
-unit:V-PER-CentiM
-    qudt:convertsTo  unit:V-PER-M ;
-    qudt:isScalingOf unit:V-PER-M .
-
-unit:MicroTORR
-    qudt:isScalingOf unit:TORR ;
-    qudt:prefix      prefix:Micro .
-
-unit:NanoGM-PER-M3
-    qudt:isScalingOf unit:GM-PER-M3 .
-
-unit:KiloCAL_TH
-    qudt:isScalingOf unit:CAL_TH ;
-    qudt:prefix      prefix:Kilo .
-
-unit:MicroG
-    qudt:isScalingOf unit:G ;
-    qudt:prefix      prefix:Micro .
-
-unit:MegaA
-    qudt:convertsTo  unit:A ;
-    qudt:isScalingOf unit:A ;
-    qudt:prefix      prefix:Mega .
-
-unit:KiloMOL-PER-SEC
-    qudt:convertsTo  unit:MOL-PER-SEC ;
-    qudt:isScalingOf unit:MOL-PER-SEC .
-
-unit:CentiM-PER-SEC2
-    qudt:convertsTo  unit:M-PER-SEC2 ;
-    qudt:isScalingOf unit:M-PER-SEC2 .
-
-unit:NanoFARAD
-    qudt:convertsTo  unit:FARAD ;
-    qudt:isScalingOf unit:FARAD ;
-    qudt:prefix      prefix:Nano .
-
-unit:CentiM3-PER-K
-    qudt:convertsTo  unit:M3-PER-K ;
-    qudt:isScalingOf unit:M3-PER-K .
-
-unit:MegaL
-    qudt:isScalingOf unit:L ;
-    qudt:prefix      prefix:Mega .
-
-unit:MegaS-PER-M
-    qudt:convertsTo  unit:S-PER-M ;
-    qudt:isScalingOf unit:S-PER-M .
-
-unit:HectoPA-PER-BAR
-    qudt:isScalingOf unit:PA-PER-BAR .
-
-unit:DecaGM
-    qudt:isScalingOf unit:GM ;
-    qudt:prefix      prefix:Deca .
-
-unit:MegaJ-PER-SEC
-    qudt:convertsTo  unit:J-PER-SEC ;
-    qudt:isScalingOf unit:J-PER-SEC .
-
-unit:KiloGM-PER-M2
-    qudt:isScalingOf unit:GM-PER-M2 .
-
-unit:MegaW
-    qudt:isScalingOf unit:W ;
-    qudt:prefix      prefix:Mega .
-
-unit:MicroGAL
-    qudt:isScalingOf unit:GAL ;
-    qudt:prefix      prefix:Micro .
-
-unit:ExaJ
-    qudt:convertsTo  unit:J ;
-    qudt:isScalingOf unit:J ;
-    qudt:prefix      prefix:Exa .
-
-unit:NanoGM
-    qudt:isScalingOf unit:GM ;
-    qudt:prefix      prefix:Nano .
-
-unit:PicoM
-    qudt:convertsTo  unit:M ;
-    qudt:isScalingOf unit:M ;
-    qudt:prefix      prefix:Pico .
-
-unit:MilliGM-PER-GM
-    qudt:convertsTo  unit:GM-PER-GM ;
-    qudt:isScalingOf unit:GM-PER-GM .
-
-unit:KiloOHM
-    qudt:convertsTo  unit:OHM ;
-    qudt:isScalingOf unit:OHM ;
-    qudt:prefix      prefix:Kilo .
-
-unit:KiloM-PER-SEC
-    qudt:convertsTo  unit:M-PER-SEC ;
-    qudt:isScalingOf unit:M-PER-SEC .
-
-unit:PicoPA-PER-KiloM
-    qudt:convertsTo  unit:PA-PER-M ;
-    qudt:isScalingOf unit:PA-PER-M .
-
-unit:KiloGAUSS
-    qudt:isScalingOf unit:GAUSS ;
-    qudt:prefix      prefix:Kilo .
-
-unit:FemtoMOL-PER-L
-    qudt:isScalingOf unit:MOL-PER-L .
-
-unit:CentiBAR
-    qudt:isScalingOf unit:BAR ;
-    qudt:prefix      prefix:Centi .
-
-unit:KiloW-HR
-    qudt:convertsTo  unit:W-SEC ;
-    qudt:isScalingOf unit:W-SEC .
-
-unit:KiloGM
-    qudt:isScalingOf unit:GM ;
-    qudt:prefix      prefix:Kilo .
-
-unit:MilliGAL
-    qudt:isScalingOf unit:GAL ;
-    qudt:prefix      prefix:Milli .
-
-unit:MilliGM-PER-DeciL
-    qudt:convertsTo  unit:GM-PER-L ;
-    qudt:isScalingOf unit:GM-PER-L .
-
-unit:DeciL
-    qudt:isScalingOf unit:L ;
-    qudt:prefix      prefix:Deci .
-
-unit:HectoL
-    qudt:isScalingOf unit:L ;
-    qudt:prefix      prefix:Hecto .
-
-unit:NUM-PER-MilliGM
-    qudt:isScalingOf unit:NUM-PER-GM .
-
-unit:KiloA-PER-M2
-    qudt:convertsTo  unit:A-PER-M2 ;
-    qudt:isScalingOf unit:A-PER-M2 .
-
-unit:GigaC-PER-M3
-    qudt:convertsTo  unit:C-PER-M3 ;
-    qudt:isScalingOf unit:C-PER-M3 .
-
-unit:MegaBAR
-    qudt:isScalingOf unit:BAR ;
-    qudt:prefix      prefix:Mega .
-
-unit:PicoMOL-PER-L
-    qudt:isScalingOf unit:MOL-PER-L .
-
-unit:NanoM2
-    qudt:convertsTo  unit:M2 ;
-    qudt:isScalingOf unit:M2 ;
-    qudt:prefix      prefix:Nano .
-
-unit:KiloR
-    qudt:isScalingOf unit:R ;
-    qudt:prefix      prefix:Kilo .
-
-unit:NanoMOL-PER-MicroMOL
-    qudt:convertsTo  unit:MOL-PER-MOL ;
-    qudt:isScalingOf unit:MOL-PER-MOL .
-
-unit:KiloBIT-PER-SEC
-    qudt:isScalingOf unit:BIT-PER-SEC .
-
-unit:MicroGRAY
-    qudt:convertsTo  unit:GRAY ;
-    qudt:isScalingOf unit:GRAY ;
-    qudt:prefix      prefix:Micro .
-
-unit:MilliA
-    qudt:convertsTo  unit:A ;
-    qudt:isScalingOf unit:A ;
-    qudt:prefix      prefix:Milli .
-
-unit:MilliGM-PER-M2
-    qudt:isScalingOf unit:GM-PER-M2 .
-
-unit:MilliFARAD
-    qudt:convertsTo  unit:FARAD ;
-    qudt:isScalingOf unit:FARAD ;
-    qudt:prefix      prefix:Milli .
-
-unit:PicoMOL
-    qudt:isScalingOf unit:MOL ;
-    qudt:prefix      prefix:Pico .
-
-unit:MilliL
-    qudt:isScalingOf unit:L ;
-    qudt:prefix      prefix:Milli .
-
-unit:MicroC-PER-M2
-    qudt:convertsTo  unit:C-PER-M2 ;
-    qudt:isScalingOf unit:C-PER-M2 .
-
-unit:KiloHZ
-    qudt:convertsTo  unit:HZ ;
-    qudt:isScalingOf unit:HZ ;
-    qudt:prefix      prefix:Kilo .
-
-unit:MicroM
-    qudt:convertsTo  unit:M ;
-    qudt:isScalingOf unit:M ;
-    qudt:prefix      prefix:Micro .
-
-unit:NanoM
-    qudt:convertsTo  unit:M ;
-    qudt:isScalingOf unit:M ;
-    qudt:prefix      prefix:Nano .
-
-unit:GM-PER-KiloGM
-    qudt:convertsTo  unit:GM-PER-GM ;
-    qudt:isScalingOf unit:GM-PER-GM .
-
-unit:MilliM-PER-SEC
-    qudt:convertsTo  unit:M-PER-SEC ;
-    qudt:isScalingOf unit:M-PER-SEC .
-
-unit:MilliW
-    qudt:isScalingOf unit:W ;
-    qudt:prefix      prefix:Milli .
-
-unit:KiloCAL_TH-PER-MIN
-    qudt:isScalingOf unit:CAL_TH-PER-SEC .
-
-unit:MilliC-PER-M2
-    qudt:convertsTo  unit:C-PER-M2 ;
-    qudt:isScalingOf unit:C-PER-M2 .
-
-unit:DecaC
-    qudt:convertsTo  unit:C ;
-    qudt:isScalingOf unit:C ;
-    qudt:prefix      prefix:Deca .
-
-unit:CentiPOISE-PER-BAR
-    qudt:isScalingOf unit:POISE-PER-BAR .
-
-unit:MicroMOL-PER-M2-HR
-    qudt:convertsTo  unit:MOL-PER-M2-SEC ;
-    qudt:isScalingOf unit:MOL-PER-M2-SEC .
-
-unit:PicoFARAD
-    qudt:convertsTo  unit:FARAD ;
-    qudt:isScalingOf unit:FARAD ;
-    qudt:prefix      prefix:Pico .
-
-unit:PicoH
-    qudt:convertsTo  unit:H ;
-    qudt:isScalingOf unit:H ;
-    qudt:prefix      prefix:Pico .
-
-unit:NanoMOL-PER-M2-DAY
-    qudt:convertsTo  unit:MOL-PER-M2-SEC ;
-    qudt:isScalingOf unit:MOL-PER-M2-SEC .
-
-unit:MegaGM
-    qudt:isScalingOf unit:GM ;
-    qudt:prefix      prefix:Mega .
-
-unit:MilliMOL-PER-M2-DAY
-    qudt:convertsTo  unit:MOL-PER-M2-SEC ;
-    qudt:isScalingOf unit:MOL-PER-M2-SEC .
-
-unit:KiloGM-PER-MIN
-    qudt:isScalingOf unit:GM-PER-SEC .
-
-unit:PicoS
-    qudt:isScalingOf unit:S ;
-    qudt:prefix      prefix:Pico .
-
-unit:MilliPA
-    qudt:convertsTo  unit:PA ;
-    qudt:isScalingOf unit:PA ;
-    qudt:prefix      prefix:Milli .
-
-unit:MicroMOL-PER-M2-SEC
-    qudt:convertsTo  unit:MOL-PER-M2-SEC ;
-    qudt:isScalingOf unit:MOL-PER-M2-SEC .
-
-unit:KiloGM-PER-CentiM2
-    qudt:isScalingOf unit:GM-PER-M2 .
-
-unit:KiloJ-PER-K
-    qudt:convertsTo  unit:J-PER-K ;
-    qudt:isScalingOf unit:J-PER-K .
-
-unit:MilliGM-PER-MIN
-    qudt:isScalingOf unit:GM-PER-SEC .
-
-unit:TeraOHM
-    qudt:convertsTo  unit:OHM ;
-    qudt:isScalingOf unit:OHM ;
-    qudt:prefix      prefix:Tera .
-
-unit:MilliTORR
-    qudt:isScalingOf unit:TORR ;
-    qudt:prefix      prefix:Milli .
-
-unit:MicroS-PER-M
-    qudt:convertsTo  unit:S-PER-M ;
-    qudt:isScalingOf unit:S-PER-M .
-
-unit:PicoGM-PER-L
-    qudt:convertsTo  unit:GM-PER-L ;
-    qudt:isScalingOf unit:GM-PER-L .
-
-unit:GM-PER-MilliL
-    qudt:convertsTo  unit:GM-PER-L ;
-    qudt:isScalingOf unit:GM-PER-L .
-
-unit:MicroGM-PER-GM
-    qudt:convertsTo  unit:GM-PER-GM ;
-    qudt:isScalingOf unit:GM-PER-GM .
-
-unit:W-PER-CentiM2
-    qudt:convertsTo  unit:W-PER-M2 ;
-    qudt:isScalingOf unit:W-PER-M2 .
-
-unit:NUM-PER-KiloM2
-    qudt:convertsTo  unit:NUM-PER-M2 ;
-    qudt:isScalingOf unit:NUM-PER-M2 .
-
-unit:N-PER-CentiM
-    qudt:convertsTo  unit:N-PER-M ;
-    qudt:isScalingOf unit:N-PER-M .
-
-unit:MOL-PER-DeciM3
-    qudt:convertsTo  unit:MOL-PER-M3 ;
-    qudt:isScalingOf unit:MOL-PER-M3 .
-
-unit:MicroBQ
-    qudt:convertsTo  unit:BQ ;
-    qudt:isScalingOf unit:BQ ;
-    qudt:prefix      prefix:Micro .
-
-unit:KiloC-PER-M3
-    qudt:convertsTo  unit:C-PER-M3 ;
-    qudt:isScalingOf unit:C-PER-M3 .
-
-unit:AttoFARAD
-    qudt:convertsTo  unit:FARAD ;
-    qudt:isScalingOf unit:FARAD ;
-    qudt:prefix      prefix:Atto .
-
-unit:MilliL-PER-SEC
-    qudt:isScalingOf unit:L-PER-SEC .
-
-unit:KiloS-PER-M
-    qudt:convertsTo  unit:S-PER-M ;
-    qudt:isScalingOf unit:S-PER-M .
-
-unit:MegaHZ
-    qudt:convertsTo  unit:HZ ;
-    qudt:isScalingOf unit:HZ ;
-    qudt:prefix      prefix:Mega .
-
-unit:MilliA-HR
-    qudt:convertsTo  unit:A-SEC ;
-    qudt:isScalingOf unit:A-SEC .
-
-unit:CentiM3-PER-M3
-    qudt:convertsTo  unit:M3-PER-M3 ;
-    qudt:isScalingOf unit:M3-PER-M3 .
-
-unit:KiloM
-    qudt:convertsTo  unit:M ;
-    qudt:isScalingOf unit:M ;
-    qudt:prefix      prefix:Kilo .
-
-unit:GibiBYTE
-    qudt:isScalingOf unit:BYTE ;
-    qudt:prefix      prefix:Gibi .
-
-unit:MegaW-HR
-    qudt:convertsTo  unit:W-SEC ;
-    qudt:isScalingOf unit:W-SEC .
-
-unit:DeciS-PER-M
-    qudt:convertsTo  unit:S-PER-M ;
-    qudt:isScalingOf unit:S-PER-M .
-
-unit:MilliG
-    qudt:isScalingOf unit:G ;
-    qudt:prefix      prefix:Milli .
-
-unit:MicroH
-    qudt:convertsTo  unit:H ;
-    qudt:isScalingOf unit:H ;
-    qudt:prefix      prefix:Micro .
-
-unit:NanoH
-    qudt:convertsTo  unit:H ;
-    qudt:isScalingOf unit:H ;
-    qudt:prefix      prefix:Nano .
-
-unit:MegaV-A
-    qudt:convertsTo  unit:V-A ;
-    qudt:isScalingOf unit:V-A .
-
-unit:MilliR
-    qudt:isScalingOf unit:R ;
-    qudt:prefix      prefix:Milli .
-
-unit:MegaC-PER-M2
-    qudt:convertsTo  unit:C-PER-M2 ;
-    qudt:isScalingOf unit:C-PER-M2 .
-
-unit:NanoS
-    qudt:isScalingOf unit:S ;
-    qudt:prefix      prefix:Nano .
-
-unit:TeraC
-    qudt:convertsTo  unit:C ;
-    qudt:isScalingOf unit:C ;
-    qudt:prefix      prefix:Tera .
-
-unit:MegaPA-M3-PER-SEC
-    qudt:convertsTo  unit:PA-M3-PER-SEC ;
-    qudt:isScalingOf unit:PA-M3-PER-SEC .
-
-unit:MicroS
-    qudt:convertsTo  unit:S ;
-    qudt:isScalingOf unit:S ;
-    qudt:prefix      prefix:Micro .
-
-unit:CentiGM
-    qudt:isScalingOf unit:GM ;
-    qudt:prefix      prefix:Centi .
-
-unit:YottaC
-    qudt:convertsTo  unit:C ;
-    qudt:isScalingOf unit:C ;
-    qudt:prefix      prefix:Yotta .
-
-unit:MilliM2-PER-SEC
-    qudt:convertsTo  unit:M2-PER-SEC ;
-    qudt:isScalingOf unit:M2-PER-SEC .
-
-unit:KiloLB_F
-    qudt:isScalingOf unit:LB_F ;
-    qudt:prefix      prefix:Kilo .
-
-unit:MilliGM-PER-KiloGM
-    qudt:convertsTo  unit:GM-PER-GM ;
-    qudt:isScalingOf unit:GM-PER-GM .
-
-unit:MicroCi
-    qudt:isScalingOf unit:Ci ;
-    qudt:prefix      prefix:Micro .
-
-unit:GigaHZ
-    qudt:convertsTo  unit:HZ ;
-    qudt:isScalingOf unit:HZ ;
-    qudt:prefix      prefix:Giga .
-
-unit:KiloGM-PER-M3
-    qudt:isScalingOf unit:GM-PER-M3 .
-
-unit:PicoC
-    qudt:convertsTo  unit:C ;
-    qudt:isScalingOf unit:C ;
-    qudt:prefix      prefix:Pico .
-
-unit:CentiM-PER-HR
-    qudt:convertsTo  unit:M-PER-SEC ;
-    qudt:isScalingOf unit:M-PER-SEC .
-
-unit:NUM-PER-MicroL
-    qudt:isScalingOf unit:NUM-PER-L .
-
-unit:MilliMOL-PER-L
-    qudt:isScalingOf unit:MOL-PER-L .
-
-unit:MicroS-PER-CentiM
-    qudt:convertsTo  unit:S-PER-M ;
-    qudt:isScalingOf unit:S-PER-M .
-
-unit:H-PER-KiloOHM
-    qudt:convertsTo  unit:H-PER-OHM ;
-    qudt:isScalingOf unit:H-PER-OHM .
-
-unit:HectoPA-L-PER-SEC
-    qudt:isScalingOf unit:PA-L-PER-SEC .
-
-unit:MilliBAR-PER-K
-    qudt:isScalingOf unit:BAR-PER-K .
-
-unit:KiloMOL-PER-MIN
-    qudt:convertsTo  unit:MOL-PER-SEC ;
-    qudt:isScalingOf unit:MOL-PER-SEC .
-
-unit:M2-PER-KiloGM
-    qudt:isScalingOf unit:M2-PER-GM .
-
-unit:DeciB
-    qudt:isScalingOf unit:B ;
-    qudt:prefix      prefix:Deci .
-
-unit:KiloGM-PER-KiloMOL
-    qudt:isScalingOf unit:GM-PER-MOL .
-
-unit:CentiM2
-    qudt:convertsTo  unit:M2 ;
-    qudt:isScalingOf unit:M2 ;
-    qudt:prefix      prefix:Centi .
-
-unit:KiloMOL-PER-HR
-    qudt:convertsTo  unit:MOL-PER-SEC ;
-    qudt:isScalingOf unit:MOL-PER-SEC .
-
-unit:DeciM
-    qudt:convertsTo  unit:M ;
-    qudt:isScalingOf unit:M ;
-    qudt:prefix      prefix:Deci .
-
-unit:HectoM
-    qudt:convertsTo  unit:M ;
-    qudt:isScalingOf unit:M ;
-    qudt:prefix      prefix:Hecto .
-
-unit:KiloM-PER-HR
-    qudt:convertsTo  unit:M-PER-SEC ;
-    qudt:isScalingOf unit:M-PER-SEC .
-
-unit:GigaC
-    qudt:convertsTo  unit:C ;
-    qudt:isScalingOf unit:C ;
-    qudt:prefix      prefix:Giga .
-
-unit:MicroIN
-    qudt:isScalingOf unit:IN ;
-    qudt:prefix      prefix:Micro .
-
-unit:MicroBAR
-    qudt:isScalingOf unit:BAR ;
-    qudt:prefix      prefix:Micro .
-
-unit:DecaM3
-    qudt:convertsTo  unit:M3 ;
-    qudt:isScalingOf unit:M3 ;
-    qudt:prefix      prefix:Deca .
-
-unit:FemtoGM
-    qudt:isScalingOf unit:GM ;
-    qudt:prefix      prefix:Femto .
-
-unit:HectoBAR
-    qudt:isScalingOf unit:BAR ;
-    qudt:prefix      prefix:Hecto .
-
-unit:MilliS-PER-M
-    qudt:convertsTo  unit:S-PER-M ;
-    qudt:isScalingOf unit:S-PER-M .
-
-unit:PicoSEC
-    qudt:convertsTo  unit:SEC ;
-    qudt:isScalingOf unit:SEC ;
-    qudt:prefix      prefix:Pico .
-
-unit:CentiL
-    qudt:isScalingOf unit:L ;
-    qudt:prefix      prefix:Centi .
-
-unit:KiloS
-    qudt:convertsTo  unit:S ;
-    qudt:isScalingOf unit:S ;
-    qudt:prefix      prefix:Kilo .
-
-unit:KiloPA-PER-K
-    qudt:isScalingOf unit:PA-PER-K .
-
-unit:A-PER-MilliM
-    qudt:convertsTo  unit:A-PER-M ;
-    qudt:isScalingOf unit:A-PER-M .
-
-unit:MilliGM-PER-M3
-    qudt:isScalingOf unit:GM-PER-M3 .
-
-unit:NanoC
-    qudt:convertsTo  unit:C ;
-    qudt:isScalingOf unit:C ;
-    qudt:prefix      prefix:Nano .
-
-unit:MicroC
-    qudt:convertsTo  unit:C ;
-    qudt:isScalingOf unit:C ;
-    qudt:prefix      prefix:Micro .
-
-unit:DeciTON_Metric
-    qudt:isScalingOf unit:TON_Metric ;
-    qudt:prefix      prefix:Deci .
-
-unit:MegaOHM
-    qudt:convertsTo  unit:OHM ;
-    qudt:isScalingOf unit:OHM ;
-    qudt:prefix      prefix:Mega .
-
-unit:MilliM
-    qudt:convertsTo  unit:M ;
-    qudt:isScalingOf unit:M ;
-    qudt:prefix      prefix:Milli .
-
-unit:MicroN
-    qudt:convertsTo  unit:N ;
-    qudt:isScalingOf unit:N ;
-    qudt:prefix      prefix:Micro .
-
-unit:MicroC-PER-M3
-    qudt:convertsTo  unit:C-PER-M3 ;
-    qudt:isScalingOf unit:C-PER-M3 .
-
-unit:MilliBAR
-    qudt:isScalingOf unit:BAR ;
-    qudt:prefix      prefix:Milli .
-
-unit:NanoS-PER-M
-    qudt:convertsTo  unit:S-PER-M ;
-    qudt:isScalingOf unit:S-PER-M .
-
-unit:KiloGM-PER-L
-    qudt:convertsTo  unit:GM-PER-L ;
-    qudt:isScalingOf unit:GM-PER-L .
-
-unit:NanoMOL-PER-CentiM3-HR
-    qudt:convertsTo  unit:MOL-PER-M3-SEC ;
-    qudt:isScalingOf unit:MOL-PER-M3-SEC .
-
-unit:MegaHZ-PER-T
-    qudt:convertsTo  unit:HZ-PER-T ;
-    qudt:isScalingOf unit:HZ-PER-T .
-
-unit:MegaA-PER-M2
-    qudt:convertsTo  unit:A-PER-M2 ;
-    qudt:isScalingOf unit:A-PER-M2 .
-
-unit:MilliC-PER-M3
-    qudt:convertsTo  unit:C-PER-M3 ;
-    qudt:isScalingOf unit:C-PER-M3 .
-
-unit:MegaS
-    qudt:isScalingOf unit:S ;
-    qudt:prefix      prefix:Mega .
-
-unit:PicoPA
-    qudt:isScalingOf unit:PA ;
-    qudt:prefix      prefix:Pico .
-
-unit:FemtoM
-    qudt:convertsTo  unit:M ;
-    qudt:isScalingOf unit:M ;
-    qudt:prefix      prefix:Femto .
-
-unit:J-PER-CentiM2
-    qudt:convertsTo  unit:J-PER-M2 ;
-    qudt:isScalingOf unit:J-PER-M2 .
-
-unit:MilliDEG_C
-    qudt:isScalingOf unit:DEG_C ;
-    qudt:prefix      prefix:Milli .
-
-unit:PER-MilliSEC
-    qudt:convertsTo  unit:PER-SEC ;
-    qudt:isScalingOf unit:PER-SEC .
-
-unit:W-PER-M2-NanoM
-    qudt:convertsTo  unit:W-PER-M2-M ;
-    qudt:isScalingOf unit:W-PER-M2-M .
-
-unit:KiloGM-PER-CentiM3
-    qudt:isScalingOf unit:GM-PER-M3 .
-
-unit:TebiBYTE
-    qudt:isScalingOf unit:BYTE ;
-    qudt:prefix      prefix:Tebi .
-
-unit:MilliH-PER-KiloOHM
-    qudt:convertsTo  unit:H-PER-OHM ;
-    qudt:isScalingOf unit:H-PER-OHM .
-
-unit:MilliM-PER-MIN
-    qudt:convertsTo  unit:M-PER-SEC ;
-    qudt:isScalingOf unit:M-PER-SEC .
-
-unit:NanoBQ-PER-L
-    qudt:isScalingOf unit:BQ-PER-L .
-
-unit:MegaLB_F
-    qudt:isScalingOf unit:LB_F ;
-    qudt:prefix      prefix:Mega .
-
-unit:GM-PER-MilliM
-    qudt:isScalingOf unit:GM-PER-M .
-
-unit:MicroM-PER-K
-    qudt:convertsTo  unit:M-PER-K ;
-    qudt:isScalingOf unit:M-PER-K .
-
-unit:MegaBIT-PER-SEC
-    qudt:isScalingOf unit:BIT-PER-SEC .
-
-unit:YoctoC
-    qudt:convertsTo  unit:C ;
-    qudt:isScalingOf unit:C ;
-    qudt:prefix      prefix:Yocto .
-
-unit:MegaTOE
-    qudt:isScalingOf unit:TOE ;
-    qudt:prefix      prefix:Mega .
-
-unit:MilliBAR-M3-PER-SEC
-    qudt:isScalingOf unit:BAR-M3-PER-SEC .
-
-unit:C-PER-CentiM2
-    qudt:convertsTo  unit:C-PER-M2 ;
-    qudt:isScalingOf unit:C-PER-M2 .
-
-unit:DeciS
-    qudt:isScalingOf unit:S ;
-    qudt:prefix      prefix:Deci .
-
-unit:KiloPA-PER-BAR
-    qudt:isScalingOf unit:PA-PER-BAR .
-
-unit:KiloC
-    qudt:convertsTo  unit:C ;
-    qudt:isScalingOf unit:C ;
-    qudt:prefix      prefix:Kilo .
-
-unit:MilliGM
-    qudt:isScalingOf unit:GM ;
-    qudt:prefix      prefix:Milli .
-
-unit:MicroSV
-    qudt:convertsTo  unit:SV ;
-    qudt:isScalingOf unit:SV ;
-    qudt:prefix      prefix:Micro .
-
-unit:KiloMOL
-    qudt:convertsTo  unit:MOL ;
-    qudt:isScalingOf unit:MOL ;
-    qudt:prefix      prefix:Kilo .
-
-unit:KiloN
-    qudt:convertsTo  unit:N ;
-    qudt:isScalingOf unit:N ;
-    qudt:prefix      prefix:Kilo .
-
-unit:CentiM3-PER-DAY
-    qudt:convertsTo  unit:M3-PER-SEC ;
-    qudt:isScalingOf unit:M3-PER-SEC .
-
-unit:MicroGM-PER-KiloGM
-    qudt:convertsTo  unit:GM-PER-GM ;
-    qudt:isScalingOf unit:GM-PER-GM .
-
-unit:MilliH
-    qudt:convertsTo  unit:H ;
-    qudt:isScalingOf unit:H ;
-    qudt:prefix      prefix:Milli .
-
-unit:MicroFARAD
-    qudt:convertsTo  unit:FARAD ;
-    qudt:isScalingOf unit:FARAD ;
-    qudt:prefix      prefix:Micro .
-
-unit:MilliV-PER-MIN
-    qudt:convertsTo  unit:V-PER-SEC ;
-    qudt:isScalingOf unit:V-PER-SEC .
-
-unit:NanoT
-    qudt:convertsTo  unit:T ;
-    qudt:isScalingOf unit:T ;
-    qudt:prefix      prefix:Nano .
-
-unit:MilliS
-    qudt:convertsTo  unit:S ;
-    qudt:isScalingOf unit:S ;
-    qudt:prefix      prefix:Milli .
-
-unit:KiloCAL_TH-PER-HR
-    qudt:isScalingOf unit:CAL_TH-PER-SEC .
-
-unit:MegaC
-    qudt:convertsTo  unit:C ;
-    qudt:isScalingOf unit:C ;
-    qudt:prefix      prefix:Mega .
-
-unit:AttoC
-    qudt:convertsTo  unit:C ;
-    qudt:isScalingOf unit:C ;
-    qudt:prefix      prefix:Atto .
-
-unit:MilliL-PER-MIN
-    qudt:isScalingOf unit:L-PER-SEC .
-
-unit:MicroGM-PER-M3
-    qudt:isScalingOf unit:GM-PER-M3 .
-
-unit:MicroATM
-    qudt:isScalingOf unit:ATM ;
-    qudt:prefix      prefix:Micro .
-
-unit:MegaC-PER-M3
-    qudt:convertsTo  unit:C-PER-M3 ;
-    qudt:isScalingOf unit:C-PER-M3 .
-
-unit:KiloEV
-    qudt:isScalingOf unit:EV ;
-    qudt:prefix      prefix:Kilo .
-
-unit:MegaPA-PER-BAR
-    qudt:isScalingOf unit:PA-PER-BAR .
-
-unit:DeciM3-PER-M3
-    qudt:convertsTo  unit:M3-PER-M3 ;
-    qudt:isScalingOf unit:M3-PER-M3 .
-
-unit:MicroT
-    qudt:convertsTo  unit:T ;
-    qudt:isScalingOf unit:T ;
-    qudt:prefix      prefix:Micro .
-
-unit:MilliMOL-PER-M2-SEC
-    qudt:convertsTo  unit:MOL-PER-M2-SEC ;
-    qudt:isScalingOf unit:MOL-PER-M2-SEC .
-
-unit:MegaN
-    qudt:convertsTo  unit:N ;
-    qudt:isScalingOf unit:N ;
-    qudt:prefix      prefix:Mega .
-
-unit:MilliM-PER-HR
-    qudt:convertsTo  unit:M-PER-SEC ;
-    qudt:isScalingOf unit:M-PER-SEC .
-
-unit:MilliM2
-    qudt:convertsTo  unit:M2 ;
-    qudt:isScalingOf unit:M2 ;
-    qudt:prefix      prefix:Milli .
-
-unit:PicoMOL-PER-M2-DAY
-    qudt:convertsTo  unit:MOL-PER-M2-SEC ;
-    qudt:isScalingOf unit:MOL-PER-M2-SEC .
-
-unit:MicroGM-PER-MilliL
-    qudt:convertsTo  unit:GM-PER-L ;
-    qudt:isScalingOf unit:GM-PER-L .
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:SEC
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  2 ;
+                       qudt:unit      unit:KiloGM
+                     ] .
+
+unit:PER-GM  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                qudt:unit      unit:GM
+                              ] .
+
+unit:MicroM-PER-N  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:N
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:MicroM
+                                    ] .
+
+unit:L-PER-L  qudt:factorUnit  [ qudt:exponent  1 ;
+                                 qudt:unit      unit:L
+                               ] ;
+              qudt:factorUnit  [ qudt:exponent  -1 ;
+                                 qudt:unit      unit:L
+                               ] .
+
+unit:LB-PER-HR  qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:LB
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  -1 ;
+                                   qudt:unit      unit:HR
+                                 ] .
+
+unit:LB-MOL-DEG_F  qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:MOL
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:LB
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:DEG_F
+                                    ] .
+
+unit:J-PER-GM  qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:J
+                                ] ;
+               qudt:factorUnit  [ qudt:exponent  -1 ;
+                                  qudt:unit      unit:GM
+                                ] .
+
+unit:KiloV-A-HR  qudt:factorUnit  [ qudt:exponent  1 ;
+                                    qudt:unit      unit:KiloV
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  1 ;
+                                    qudt:unit      unit:HR
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  1 ;
+                                    qudt:unit      unit:A
+                                  ] .
+
+unit:N-PER-MilliM  qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:N
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:MilliM
+                                    ] .
+
+unit:M3-PER-M3  qudt:factorUnit  [ qudt:exponent  3 ;
+                                   qudt:unit      unit:M
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  -3 ;
+                                   qudt:unit      unit:M
+                                 ] .
+
+unit:PicoGM-PER-GM  qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:PicoGM
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:GM
+                                     ] .
+
+unit:DEG_F-PER-SEC2  qudt:factorUnit  [ qudt:exponent  -2 ;
+                                        qudt:unit      unit:SEC
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:DEG_F
+                                      ] .
+
+unit:YD3-PER-HR  qudt:factorUnit  [ qudt:exponent  3 ;
+                                    qudt:unit      unit:YD
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  -1 ;
+                                    qudt:unit      unit:HR
+                                  ] .
+
+unit:LB_F-PER-FT  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:LB_F
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                     qudt:unit      unit:FT
+                                   ] .
 
 unit:MegaV-A_Reactive
-    qudt:convertsTo  unit:V-A_Reactive ;
-    qudt:isScalingOf unit:V-A_Reactive .
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MegaV
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:A_Reactive
+                     ] .
 
-unit:DeciM3-PER-DAY
-    qudt:convertsTo  unit:M3-PER-SEC ;
-    qudt:isScalingOf unit:M3-PER-SEC .
+unit:KiloGM-PER-CentiM3
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:KiloGM
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -3 ;
+                       qudt:unit      unit:CentiM
+                     ] .
 
-unit:KiloGM-PER-KiloGM
-    qudt:convertsTo  unit:GM-PER-GM ;
-    qudt:isScalingOf unit:GM-PER-GM .
+unit:PINT_US-PER-HR  qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:PINT_US
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:HR
+                                      ] .
 
-unit:MicroGM-PER-L
-    qudt:convertsTo  unit:GM-PER-L ;
-    qudt:isScalingOf unit:GM-PER-L .
+unit:PA-M3-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:SEC
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:PA
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  3 ;
+                                       qudt:unit      unit:M
+                                     ] .
 
-unit:HectoPA-PER-K
-    qudt:isScalingOf unit:PA-PER-K .
+unit:PA-PER-BAR  qudt:factorUnit  [ qudt:exponent  1 ;
+                                    qudt:unit      unit:PA
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  -1 ;
+                                    qudt:unit      unit:BAR
+                                  ] .
 
-unit:PetaC
-    qudt:convertsTo  unit:C ;
-    qudt:isScalingOf unit:C ;
-    qudt:prefix      prefix:Peta .
+unit:MOL-PER-DeciM3  qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:MOL
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -3 ;
+                                        qudt:unit      unit:DeciM
+                                      ] .
 
-unit:HectoPA-PER-HR
-    qudt:convertsTo  unit:PA-PER-SEC ;
-    qudt:isScalingOf unit:PA-PER-SEC .
+unit:KiloGM-PER-HR  qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:KiloGM
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:HR
+                                     ] .
 
-unit:MilliPA-SEC-PER-BAR
-    qudt:isScalingOf unit:PA-SEC-PER-BAR .
+unit:PERCENT-PER-HR  qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:PERCENT
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:HR
+                                      ] .
 
-unit:DeciC
-    qudt:convertsTo  unit:C ;
-    qudt:isScalingOf unit:C ;
-    qudt:prefix      prefix:Deci .
+unit:LB-PER-FT-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:SEC
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:LB
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:FT
+                                     ] .
 
-unit:KiloLB_F-PER-IN2
-    qudt:isScalingOf unit:LB_F-PER-IN2 .
+unit:PER-PSI  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                 qudt:unit      unit:PSI
+                               ] .
 
-unit:HectoC
-    qudt:convertsTo  unit:C ;
-    qudt:isScalingOf unit:C ;
-    qudt:prefix      prefix:Hecto .
+unit:BU_US_DRY-PER-MIN
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:MIN
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:BU_US_DRY
+                     ] .
 
-unit:MilliGM-PER-L
-    qudt:convertsTo  unit:GM-PER-L ;
-    qudt:isScalingOf unit:GM-PER-L .
+unit:W-PER-M2  qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:W
+                                ] ;
+               qudt:factorUnit  [ qudt:exponent  -2 ;
+                                  qudt:unit      unit:M
+                                ] .
 
-unit:CentiM3
-    qudt:convertsTo  unit:M3 ;
-    qudt:isScalingOf unit:M3 ;
-    qudt:prefix      prefix:Centi .
+unit:A-PER-DEG_C  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                     qudt:unit      unit:DEG_C
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:A
+                                   ] .
 
-unit:MilliBAR-PER-BAR
-    qudt:convertsTo  unit:BAR-PER-BAR ;
-    qudt:isScalingOf unit:BAR-PER-BAR .
+unit:ERG-PER-GM  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                    qudt:unit      unit:GM
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  1 ;
+                                    qudt:unit      unit:ERG
+                                  ] .
 
-unit:NanoGM-PER-MicroL
-    qudt:convertsTo  unit:GM-PER-L ;
-    qudt:isScalingOf unit:GM-PER-L .
+unit:C-M  qudt:factorUnit  [ qudt:exponent  1 ;
+                             qudt:unit      unit:M
+                           ] ;
+          qudt:factorUnit  [ qudt:exponent  1 ;
+                             qudt:unit      unit:C
+                           ] .
 
-unit:MicroMOL-PER-MOL
-    qudt:convertsTo  unit:MOL-PER-MOL ;
-    qudt:isScalingOf unit:MOL-PER-MOL .
+unit:FT-LA  qudt:factorUnit  [ qudt:exponent  1 ;
+                               qudt:unit      unit:LA
+                             ] ;
+            qudt:factorUnit  [ qudt:exponent  1 ;
+                               qudt:unit      unit:FT
+                             ] .
 
-unit:KiloGM_F
-    qudt:isScalingOf unit:GM_F ;
-    qudt:prefix      prefix:Kilo .
+unit:M3-PER-K  qudt:factorUnit  [ qudt:exponent  3 ;
+                                  qudt:unit      unit:M
+                                ] ;
+               qudt:factorUnit  [ qudt:exponent  -1 ;
+                                  qudt:unit      unit:K
+                                ] .
 
-unit:MicroMOL-PER-M2
-    qudt:convertsTo  unit:MOL-PER-M2 ;
-    qudt:isScalingOf unit:MOL-PER-M2 .
+unit:M2-PER-HZ  qudt:factorUnit  [ qudt:exponent  2 ;
+                                   qudt:unit      unit:M
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  -1 ;
+                                   qudt:unit      unit:HZ
+                                 ] .
 
-unit:MilliS-PER-CentiM
-    qudt:convertsTo  unit:S-PER-M ;
-    qudt:isScalingOf unit:S-PER-M .
+unit:WB-PER-MilliM  qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:WB
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:MilliM
+                                     ] .
 
-unit:A-PER-CentiM
-    qudt:convertsTo  unit:A-PER-M ;
-    qudt:isScalingOf unit:A-PER-M .
+unit:BTU_IT-PER-LB  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:LB
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:BTU_IT
+                                     ] .
 
-unit:GigaW-HR
-    qudt:convertsTo  unit:W-SEC ;
-    qudt:isScalingOf unit:W-SEC .
+unit:FT-LB_F-PER-FT2-SEC
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:SEC
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:LB_F
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:FT
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:FT
+                     ] .
 
-unit:CentiST
-    qudt:isScalingOf unit:ST ;
-    qudt:prefix      prefix:Centi .
+unit:KiloCAL-PER-CentiM2-MIN
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:MIN
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:KiloCAL
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:CentiM
+                     ] .
 
-unit:MegaEV
-    qudt:isScalingOf unit:EV ;
-    qudt:prefix      prefix:Mega .
+unit:W-PER-IN2  qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:W
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  -2 ;
+                                   qudt:unit      unit:IN
+                                 ] .
 
-unit:CentiM
-    qudt:prefix      prefix:Centi .
+unit:AC-FT  qudt:factorUnit  [ qudt:exponent  1 ;
+                               qudt:unit      unit:FT
+                             ] ;
+            qudt:factorUnit  [ qudt:exponent  1 ;
+                               qudt:unit      unit:AC
+                             ] .
 
-unit:NanoBQ
-    qudt:isScalingOf unit:BQ ;
-    qudt:prefix      prefix:Nano .
+unit:FARAD-PER-KiloM  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                         qudt:unit      unit:KiloM
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  1 ;
+                                         qudt:unit      unit:FARAD
+                                       ] .
 
-unit:MilliC
-    qudt:convertsTo  unit:C ;
-    qudt:isScalingOf unit:C ;
-    qudt:prefix      prefix:Milli .
+unit:M2-PER-HZ2  qudt:factorUnit  [ qudt:exponent  2 ;
+                                    qudt:unit      unit:M
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  -2 ;
+                                    qudt:unit      unit:HZ
+                                  ] .
 
-unit:MilliM-PER-K
-    qudt:convertsTo  unit:M-PER-K ;
-    qudt:isScalingOf unit:M-PER-K .
+unit:OZ_F-IN  qudt:factorUnit  [ qudt:exponent  1 ;
+                                 qudt:unit      unit:OZ_F
+                               ] ;
+              qudt:factorUnit  [ qudt:exponent  1 ;
+                                 qudt:unit      unit:IN
+                               ] .
+
+unit:V_Stat-CentiM  qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:V_Stat
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:CentiM
+                                     ] .
+
+unit:LB-PER-FT2  qudt:factorUnit  [ qudt:exponent  1 ;
+                                    qudt:unit      unit:LB
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  -2 ;
+                                    qudt:unit      unit:FT
+                                  ] .
+
+unit:TON_UK-PER-YD3  qudt:factorUnit  [ qudt:exponent  -3 ;
+                                        qudt:unit      unit:YD
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:TON_UK
+                                      ] .
 
 unit:KiloGM-PER-DeciM3
-    qudt:isScalingOf unit:GM-PER-M3 .
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:KiloGM
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -3 ;
+                       qudt:unit      unit:DeciM
+                     ] .
 
-unit:CentiM3-PER-MOL
-    qudt:convertsTo  unit:M3-PER-MOL ;
-    qudt:isScalingOf unit:M3-PER-MOL .
+unit:LB-DEG_F  qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:LB
+                                ] ;
+               qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:DEG_F
+                                ] .
 
-unit:MilliW-PER-CentiM2-MicroM-SR
-    qudt:convertsTo  unit:W-PER-M2-M-SR ;
-    qudt:isScalingOf unit:W-PER-M2-M-SR .
+unit:MOL-PER-L  qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:MOL
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  -1 ;
+                                   qudt:unit      unit:L
+                                 ] .
 
-unit:MicroOHM
-    qudt:convertsTo  unit:OHM ;
-    qudt:isScalingOf unit:OHM ;
-    qudt:prefix      prefix:Micro .
+unit:GM-PER-CentiM2-YR
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:YR
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:GM
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:CentiM
+                     ] .
 
-unit:KiloGM-PER-KiloM2
-    qudt:isScalingOf unit:GM-PER-M2 .
+unit:OZ-FT  qudt:factorUnit  [ qudt:exponent  1 ;
+                               qudt:unit      unit:OZ
+                             ] ;
+            qudt:factorUnit  [ qudt:exponent  1 ;
+                               qudt:unit      unit:FT
+                             ] .
 
-unit:MilliN
-    qudt:convertsTo  unit:N ;
-    qudt:isScalingOf unit:N ;
-    qudt:prefix      prefix:Milli .
+unit:M-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                   qudt:unit      unit:SEC
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:M
+                                 ] .
 
-unit:KiloGM-PER-M
-    qudt:isScalingOf unit:GM-PER-M .
+unit:SameDay  a       qudt:Unit ;
+              rdfs:comment  "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
 
-unit:KiloBQ
-    qudt:convertsTo  unit:BQ ;
-    qudt:isScalingOf unit:BQ ;
-    qudt:prefix      prefix:Kilo .
+unit:M-K  qudt:factorUnit  [ qudt:exponent  1 ;
+                             qudt:unit      unit:M
+                           ] ;
+          qudt:factorUnit  [ qudt:exponent  1 ;
+                             qudt:unit      unit:K
+                           ] .
 
-unit:TeraJ
-    qudt:convertsTo  unit:J ;
-    qudt:isScalingOf unit:J ;
-    qudt:prefix      prefix:Tera .
+unit:DEG-PER-HR  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                    qudt:unit      unit:HR
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  1 ;
+                                    qudt:unit      unit:DEG
+                                  ] .
 
-unit:FemtoC
-    qudt:convertsTo  unit:C ;
-    qudt:isScalingOf unit:C ;
-    qudt:prefix      prefix:Femto .
+unit:NUM-PER-M2  qudt:factorUnit  [ qudt:exponent  1 ;
+                                    qudt:unit      unit:NUM
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  -2 ;
+                                    qudt:unit      unit:M
+                                  ] .
 
-unit:MicroH-PER-KiloOHM
-    qudt:convertsTo  unit:H-PER-OHM ;
-    qudt:isScalingOf unit:H-PER-OHM .
+unit:IN3-PER-HR  qudt:factorUnit  [ qudt:exponent  3 ;
+                                    qudt:unit      unit:IN
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  -1 ;
+                                    qudt:unit      unit:HR
+                                  ] .
 
-unit:MilliMOL-PER-M2
-    qudt:convertsTo  unit:MOL-PER-M2 ;
-    qudt:isScalingOf unit:MOL-PER-M2 .
+unit:PA-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                    qudt:unit      unit:SEC
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  1 ;
+                                    qudt:unit      unit:PA
+                                  ] .
 
-unit:MilliV-PER-M
-    qudt:convertsTo  unit:V-PER-M ;
-    qudt:isScalingOf unit:V-PER-M .
+unit:KiloW-HR  qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:KiloW
+                                ] ;
+               qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:HR
+                                ] .
 
-unit:GigaEV
-    qudt:isScalingOf unit:EV ;
-    qudt:prefix      prefix:Giga .
+unit:CentiM3-PER-K  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:K
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  3 ;
+                                       qudt:unit      unit:CentiM
+                                     ] .
 
-unit:MilliOHM
-    qudt:convertsTo  unit:OHM ;
-    qudt:isScalingOf unit:OHM ;
-    qudt:prefix      prefix:Milli .
+unit:J-PER-M3-K  qudt:factorUnit  [ qudt:exponent  -3 ;
+                                    qudt:unit      unit:M
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  -1 ;
+                                    qudt:unit      unit:K
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  1 ;
+                                    qudt:unit      unit:J
+                                  ] .
 
-unit:DeciN-M
-    qudt:convertsTo  unit:N-M ;
-    qudt:isScalingOf unit:N-M .
+unit:MilliM-PER-DAY  qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:MilliM
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:DAY
+                                      ] .
 
-unit:MegaPA-PER-K
-    qudt:isScalingOf unit:PA-PER-K .
+unit:PA-L-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:SEC
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:PA
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:L
+                                    ] .
 
-unit:MegaV-PER-M
-    qudt:convertsTo  unit:V-PER-M ;
-    qudt:isScalingOf unit:V-PER-M .
+unit:M2-PER-SR-J  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                     qudt:unit      unit:SR
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  2 ;
+                                     qudt:unit      unit:M
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                     qudt:unit      unit:J
+                                   ] .
 
-unit:DeciTONNE
-    qudt:isScalingOf unit:TONNE ;
-    qudt:prefix      prefix:Deci .
+unit:MilliGM-PER-M2-DAY
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MilliGM
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:M
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:DAY
+                     ] .
 
-unit:C-PER-MilliM2
-    qudt:convertsTo  unit:C-PER-M2 ;
-    qudt:isScalingOf unit:C-PER-M2 .
+unit:MicroGM-PER-MilliL
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:MilliL
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MicroGM
+                     ] .
 
-unit:KiloLB_F-PER-FT
-    qudt:isScalingOf unit:LB_F-PER-FT .
+unit:MilliV-PER-MIN  qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:MilliV
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:MIN
+                                      ] .
 
-unit:DeciM3-PER-MOL
-    qudt:convertsTo  unit:M3-PER-MOL ;
-    qudt:isScalingOf unit:M3-PER-MOL .
+unit:DEG_C-PER-M  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                     qudt:unit      unit:M
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:DEG_C
+                                   ] .
+
+unit:MilliGM-PER-KiloGM
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MilliGM
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:KiloGM
+                     ] .
+
+unit:W-PER-M2-SR  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:W
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                     qudt:unit      unit:SR
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  -2 ;
+                                     qudt:unit      unit:M
+                                   ] .
+
+unit:NanoBQ-PER-L  qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:NanoBQ
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:L
+                                    ] .
+
+unit:DecaM3  qudt:factorUnit  [ qudt:exponent  3 ;
+                                qudt:unit      unit:DecaM
+                              ] .
+
+unit:TON_US-PER-YD3  qudt:factorUnit  [ qudt:exponent  -3 ;
+                                        qudt:unit      unit:YD
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:TON_US
+                                      ] .
+
+unit:MilliM2  qudt:factorUnit  [ qudt:exponent  2 ;
+                                 qudt:unit      unit:MilliM
+                               ] .
+
+unit:DeciBAR-PER-YR  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:YR
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:DeciBAR
+                                      ] .
+
+unit:RAD-PER-SEC2  qudt:factorUnit  [ qudt:exponent  -2 ;
+                                      qudt:unit      unit:SEC
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:RAD
+                                    ] .
+
+unit:DEG_F-HR  qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:HR
+                                ] ;
+               qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:DEG_F
+                                ] .
+
+unit:EV-PER-M  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                  qudt:unit      unit:M
+                                ] ;
+               qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:EV
+                                ] .
+
+unit:LUX-HR  qudt:factorUnit  [ qudt:exponent  1 ;
+                                qudt:unit      unit:LUX
+                              ] ;
+             qudt:factorUnit  [ qudt:exponent  1 ;
+                                qudt:unit      unit:HR
+                              ] .
+
+unit:KiloS-PER-M  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                     qudt:unit      unit:M
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:KiloS
+                                   ] .
+
+unit:PER-M-NanoM-SR  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:SR
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:NanoM
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:M
+                                      ] .
+
+unit:V-PER-M2  qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:V
+                                ] ;
+               qudt:factorUnit  [ qudt:exponent  -2 ;
+                                  qudt:unit      unit:M
+                                ] .
+
+unit:TON_LONG-PER-YD3
+    qudt:factorUnit  [ qudt:exponent  -3 ;
+                       qudt:unit      unit:YD
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:TON_LONG
+                     ] .
+
+unit:NanoGM-PER-MilliL
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:NanoGM
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:MilliL
+                     ] .
+
+unit:W-M2  qudt:factorUnit  [ qudt:exponent  1 ;
+                              qudt:unit      unit:W
+                            ] ;
+           qudt:factorUnit  [ qudt:exponent  2 ;
+                              qudt:unit      unit:M
+                            ] .
+
+unit:KiloM3-PER-SEC2  qudt:factorUnit  [ qudt:exponent  -2 ;
+                                         qudt:unit      unit:SEC
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  3 ;
+                                         qudt:unit      unit:KiloM
+                                       ] .
+
+unit:MOL-PER-M2-DAY  qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:MOL
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -2 ;
+                                        qudt:unit      unit:M
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:DAY
+                                      ] .
+
+unit:PPTH-PER-HR  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:PPTH
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                     qudt:unit      unit:HR
+                                   ] .
+
+unit:FRAME-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:SEC
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:FRAME
+                                     ] .
+
+unit:SEC-PER-RAD-M3  qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:SEC
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:RAD
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -3 ;
+                                        qudt:unit      unit:M
+                                      ] .
+
+unit:C_Stat-PER-CentiM2
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:CentiM
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:C_Stat
+                     ] .
+
+unit:MOL-PER-KiloGM  qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:MOL
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:KiloGM
+                                      ] .
+
+unit:C3-M-PER-J2  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:M
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  -2 ;
+                                     qudt:unit      unit:J
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  3 ;
+                                     qudt:unit      unit:C
+                                   ] .
+
+unit:GM-PER-MilliL  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:MilliL
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:GM
+                                     ] .
+
+unit:J-PER-T  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                 qudt:unit      unit:T
+                               ] ;
+              qudt:factorUnit  [ qudt:exponent  1 ;
+                                 qudt:unit      unit:J
+                               ] .
+
+unit:LB-PER-IN2  qudt:factorUnit  [ qudt:exponent  1 ;
+                                    qudt:unit      unit:LB
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  -2 ;
+                                    qudt:unit      unit:IN
+                                  ] .
+
+unit:PER-M2  qudt:factorUnit  [ qudt:exponent  -2 ;
+                                qudt:unit      unit:M
+                              ] .
+
+unit:OZ-PER-GAL  qudt:factorUnit  [ qudt:exponent  1 ;
+                                    qudt:unit      unit:OZ
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  -1 ;
+                                    qudt:unit      unit:GAL
+                                  ] .
+
+unit:KiloCAL_TH-PER-SEC
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:SEC
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:KiloCAL_TH
+                     ] .
+
+unit:OZ_VOL_UK-PER-HR
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:OZ_VOL_UK
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:HR
+                     ] .
+
+unit:J-PER-M2  qudt:factorUnit  [ qudt:exponent  -2 ;
+                                  qudt:unit      unit:M
+                                ] ;
+               qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:J
+                                ] .
+
+unit:OZ-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                    qudt:unit      unit:SEC
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  1 ;
+                                    qudt:unit      unit:OZ
+                                  ] .
+
+unit:KiloGM_F-M-PER-SEC
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:SEC
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:M
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:KiloGM_F
+                     ] .
+
+unit:MilliL-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:SEC
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:MilliL
+                                      ] .
+
+unit:MillionUSD-PER-YR
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:YR
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MillionUSD
+                     ] .
+
+unit:RAD-M2-PER-KiloGM
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:RAD
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  2 ;
+                       qudt:unit      unit:M
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:KiloGM
+                     ] .
+
+unit:LB-MOL  qudt:factorUnit  [ qudt:exponent  1 ;
+                                qudt:unit      unit:MOL
+                              ] ;
+             qudt:factorUnit  [ qudt:exponent  1 ;
+                                qudt:unit      unit:LB
+                              ] .
+
+unit:C-PER-KiloGM-SEC
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:SEC
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:KiloGM
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:C
+                     ] .
+
+unit:PicoMOL-PER-L  qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:PicoMOL
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:L
+                                     ] .
+
+unit:M3-PER-KiloGM  qudt:factorUnit  [ qudt:exponent  3 ;
+                                       qudt:unit      unit:M
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:KiloGM
+                                     ] .
+
+unit:V_Stat-PER-CentiM
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:V_Stat
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:CentiM
+                     ] .
+
+unit:K-M-PER-W  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                   qudt:unit      unit:W
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:M
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:K
+                                 ] .
+
+unit:KiloGM-PER-M-SEC
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:SEC
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:M
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:KiloGM
+                     ] .
+
+unit:CAL_TH-PER-SEC-CentiM-K
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:SEC
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:K
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:CentiM
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:CAL_TH
+                     ] .
+
+unit:MicroGM-PER-M3  qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:MicroGM
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -3 ;
+                                        qudt:unit      unit:M
+                                      ] .
+
+unit:NanoS-PER-M  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:NanoS
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                     qudt:unit      unit:M
+                                   ] .
+
+unit:KiloGM-PER-M-HR  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                         qudt:unit      unit:M
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  1 ;
+                                         qudt:unit      unit:KiloGM
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  -1 ;
+                                         qudt:unit      unit:HR
+                                       ] .
+
+unit:BTU_IT-IN-PER-FT2-HR-DEG_F
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:IN
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:HR
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:FT
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:DEG_F
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:BTU_IT
+                     ] .
+
+unit:M2-PER-HA  qudt:factorUnit  [ qudt:exponent  2 ;
+                                   qudt:unit      unit:M
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  -1 ;
+                                   qudt:unit      unit:HA
+                                 ] .
+
+unit:CentiM2-MIN  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:MIN
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  2 ;
+                                     qudt:unit      unit:CentiM
+                                   ] .
+
+unit:MilliGM-PER-CentiM2
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MilliGM
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:CentiM
+                     ] .
+
+unit:WB-M  qudt:factorUnit  [ qudt:exponent  1 ;
+                              qudt:unit      unit:WB
+                            ] ;
+           qudt:factorUnit  [ qudt:exponent  1 ;
+                              qudt:unit      unit:M
+                            ] .
+
+unit:PINT_UK-PER-HR  qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:PINT_UK
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:HR
+                                      ] .
+
+unit:MegaEV-PER-SpeedOfLight
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:SpeedOfLight
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MegaEV
+                     ] .
+
+unit:V-PER-M  qudt:factorUnit  [ qudt:exponent  1 ;
+                                 qudt:unit      unit:V
+                               ] ;
+              qudt:factorUnit  [ qudt:exponent  -1 ;
+                                 qudt:unit      unit:M
+                               ] .
+
+unit:KiloCAL-PER-GM  qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:KiloCAL
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:GM
+                                      ] .
+
+unit:CAL_IT-PER-GM  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:GM
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:CAL_IT
+                                     ] .
+
+unit:BTU_TH-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:SEC
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:BTU_TH
+                                      ] .
+
+unit:KiloGM_F-M  qudt:factorUnit  [ qudt:exponent  1 ;
+                                    qudt:unit      unit:M
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  1 ;
+                                    qudt:unit      unit:KiloGM_F
+                                  ] .
+
+unit:N-M  qudt:factorUnit  [ qudt:exponent  1 ;
+                             qudt:unit      unit:N
+                           ] ;
+          qudt:factorUnit  [ qudt:exponent  1 ;
+                             qudt:unit      unit:M
+                           ] .
+
+unit:MI-PER-MIN  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                    qudt:unit      unit:MIN
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  1 ;
+                                    qudt:unit      unit:MI
+                                  ] .
+
+unit:CentiM-PER-SEC2  qudt:factorUnit  [ qudt:exponent  -2 ;
+                                         qudt:unit      unit:SEC
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  1 ;
+                                         qudt:unit      unit:CentiM
+                                       ] .
+
+unit:MilliGM-PER-M3-DAY
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MilliGM
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -3 ;
+                       qudt:unit      unit:M
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:DAY
+                     ] .
+
+unit:DEG_F-PER-MIN  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:MIN
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:DEG_F
+                                     ] .
+
+unit:MilliMOL-PER-M2-DAY
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MilliMOL
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:M
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:DAY
+                     ] .
+
+unit:K-PER-T  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                 qudt:unit      unit:T
+                               ] ;
+              qudt:factorUnit  [ qudt:exponent  1 ;
+                                 qudt:unit      unit:K
+                               ] .
+
+unit:OZ-PER-YD3  qudt:factorUnit  [ qudt:exponent  -3 ;
+                                    qudt:unit      unit:YD
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  1 ;
+                                    qudt:unit      unit:OZ
+                                  ] .
+
+unit:TON_US-PER-HR  qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:TON_US
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:HR
+                                     ] .
+
+unit:AT-PER-M  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                  qudt:unit      unit:M
+                                ] ;
+               qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:AT
+                                ] .
+
+unit:A_Ab-PER-CentiM2
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:CentiM
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:A_Ab
+                     ] .
+
+unit:QT_UK-PER-MIN  qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:QT_UK
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:MIN
+                                     ] .
+
+unit:V-A_Reactive  qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:V
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:A_Reactive
+                                    ] .
+
+unit:M2-PER-SR  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                   qudt:unit      unit:SR
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  2 ;
+                                   qudt:unit      unit:M
+                                 ] .
+
+unit:C4-M4-PER-J3  qudt:factorUnit  [ qudt:exponent  4 ;
+                                      qudt:unit      unit:M
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  -3 ;
+                                      qudt:unit      unit:J
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  4 ;
+                                      qudt:unit      unit:C
+                                    ] .
+
+unit:HZ-PER-T  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                  qudt:unit      unit:T
+                                ] ;
+               qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:HZ
+                                ] .
+
+unit:KiloGM-PER-SEC-M2
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:SEC
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:M
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:KiloGM
+                     ] .
+
+unit:SEC-PER-M  qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:SEC
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  -1 ;
+                                   qudt:unit      unit:M
+                                 ] .
+
+unit:M3-PER-SEC2  qudt:factorUnit  [ qudt:exponent  -2 ;
+                                     qudt:unit      unit:SEC
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  3 ;
+                                     qudt:unit      unit:M
+                                   ] .
+
+unit:BAR-M3-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:SEC
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  3 ;
+                                        qudt:unit      unit:M
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:BAR
+                                      ] .
+
+unit:BU_US_DRY-PER-SEC
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:SEC
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:BU_US_DRY
+                     ] .
+
+unit:GM-PER-L  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                  qudt:unit      unit:L
+                                ] ;
+               qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:GM
+                                ] .
+
+unit:LB_F-PER-FT2  qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:LB_F
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  -2 ;
+                                      qudt:unit      unit:FT
+                                    ] .
+
+unit:N-PER-CentiM  qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:N
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:CentiM
+                                    ] .
+
+unit:KiloCAL-PER-CentiM2-SEC
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:SEC
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:KiloCAL
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:CentiM
+                     ] .
+
+unit:KiloGM-SEC2  qudt:factorUnit  [ qudt:exponent  2 ;
+                                     qudt:unit      unit:SEC
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:KiloGM
+                                   ] .
+
+unit:OZ_VOL_US-PER-SEC
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:SEC
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:OZ_VOL_US
+                     ] .
+
+unit:MicroL-PER-L  qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:MicroL
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:L
+                                    ] .
+
+unit:N-PER-M2  qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:N
+                                ] ;
+               qudt:factorUnit  [ qudt:exponent  -2 ;
+                                  qudt:unit      unit:M
+                                ] .
+
+unit:DEG-PER-MIN  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                     qudt:unit      unit:MIN
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:DEG
+                                   ] .
+
+unit:PSI-IN3-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                         qudt:unit      unit:SEC
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  1 ;
+                                         qudt:unit      unit:PSI
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  3 ;
+                                         qudt:unit      unit:IN
+                                       ] .
+
+unit:DEG_R-PER-HR  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:HR
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:DEG_R
+                                    ] .
+
+unit:DeciM3-PER-HR  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:HR
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  3 ;
+                                       qudt:unit      unit:DeciM
+                                     ] .
+
+unit:HART-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:SEC
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:HART
+                                    ] .
+
+unit:W-PER-M  qudt:factorUnit  [ qudt:exponent  1 ;
+                                 qudt:unit      unit:W
+                               ] ;
+              qudt:factorUnit  [ qudt:exponent  -1 ;
+                                 qudt:unit      unit:M
+                               ] .
+
+unit:SLUG-PER-MIN  qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:SLUG
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:MIN
+                                    ] .
+
+unit:QT_US-PER-MIN  qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:QT_US
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:MIN
+                                     ] .
+
+unit:PER-MIN  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                 qudt:unit      unit:MIN
+                               ] .
+
+unit:FT-LB_F  qudt:factorUnit  [ qudt:exponent  1 ;
+                                 qudt:unit      unit:LB_F
+                               ] ;
+              qudt:factorUnit  [ qudt:exponent  1 ;
+                                 qudt:unit      unit:FT
+                               ] .
+
+unit:M2-PER-N  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                  qudt:unit      unit:N
+                                ] ;
+               qudt:factorUnit  [ qudt:exponent  2 ;
+                                  qudt:unit      unit:M
+                                ] .
+
+unit:KiloGM-MilliM2  qudt:factorUnit  [ qudt:exponent  2 ;
+                                        qudt:unit      unit:MilliM
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:KiloGM
+                                      ] .
+
+unit:CentiPOISE-PER-BAR
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:CentiPOISE
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:BAR
+                     ] .
+
+unit:PER-MOL  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                 qudt:unit      unit:MOL
+                               ] .
+
+unit:FT3-PER-MIN  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                     qudt:unit      unit:MIN
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  3 ;
+                                     qudt:unit      unit:FT
+                                   ] .
+
+unit:TON_Metric-PER-MIN
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:TON_Metric
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:MIN
+                     ] .
+
+unit:MilliL-PER-M2-DAY
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MilliL
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:M
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:DAY
+                     ] .
+
+unit:KiloV-A  qudt:factorUnit  [ qudt:exponent  1 ;
+                                 qudt:unit      unit:KiloV
+                               ] ;
+              qudt:factorUnit  [ qudt:exponent  1 ;
+                                 qudt:unit      unit:A
+                               ] .
+
+unit:BU_UK-PER-DAY  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:DAY
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:BU_UK
+                                     ] .
+
+unit:MegaHZ-M  qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:MegaHZ
+                                ] ;
+               qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:M
+                                ] .
+
+unit:NanoMOL-PER-L-DAY
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:NanoMOL
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:L
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:DAY
+                     ] .
+
+unit:NUM-PER-NanoL  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:NanoL
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:NUM
+                                     ] .
+
+unit:J-PER-KiloGM-K-M3
+    qudt:factorUnit  [ qudt:exponent  -3 ;
+                       qudt:unit      unit:M
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:KiloGM
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:K
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:J
+                     ] .
+
+unit:CAL_IT-PER-GM-DEG_C
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:GM
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:DEG_C
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:CAL_IT
+                     ] .
+
+unit:MilliL-PER-KiloGM
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MilliL
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:KiloGM
+                     ] .
+
+unit:OZ-PER-FT2  qudt:factorUnit  [ qudt:exponent  1 ;
+                                    qudt:unit      unit:OZ
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  -2 ;
+                                    qudt:unit      unit:FT
+                                  ] .
+
+unit:MilliGM-PER-HR  qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:MilliGM
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:HR
+                                      ] .
+
+unit:BTU_IT-PER-HR  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:HR
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:BTU_IT
+                                     ] .
+
+unit:MilliBQ-PER-GM  qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:MilliBQ
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:GM
+                                      ] .
+
+unit:A_Stat-PER-CentiM2
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:CentiM
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:A_Stat
+                     ] .
+
+unit:PA-PER-HR  qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:PA
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  -1 ;
+                                   qudt:unit      unit:HR
+                                 ] .
+
+unit:CentiMOL-PER-KiloGM
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:KiloGM
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:CentiMOL
+                     ] .
+
+unit:FT3-PER-HR  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                    qudt:unit      unit:HR
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  3 ;
+                                    qudt:unit      unit:FT
+                                  ] .
+
+unit:PER-M-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                   qudt:unit      unit:SEC
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  -1 ;
+                                   qudt:unit      unit:M
+                                 ] .
+
+unit:J-PER-T2  qudt:factorUnit  [ qudt:exponent  -2 ;
+                                  qudt:unit      unit:T
+                                ] ;
+               qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:J
+                                ] .
+
+unit:MicroFARAD-PER-M
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MicroFARAD
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:M
+                     ] .
+
+unit:BU_US_DRY-PER-HR
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:HR
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:BU_US_DRY
+                     ] .
+
+unit:OZ-PER-HR  qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:OZ
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  -1 ;
+                                   qudt:unit      unit:HR
+                                 ] .
+
+unit:GM-PER-GM  qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:GM
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  -1 ;
+                                   qudt:unit      unit:GM
+                                 ] .
+
+unit:PER-T-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                   qudt:unit      unit:T
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  -1 ;
+                                   qudt:unit      unit:SEC
+                                 ] .
+
+unit:KiloC-PER-M3  qudt:factorUnit  [ qudt:exponent  -3 ;
+                                      qudt:unit      unit:M
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:KiloC
+                                    ] .
+
+unit:W-PER-M-K  qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:W
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  -1 ;
+                                   qudt:unit      unit:M
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  -1 ;
+                                   qudt:unit      unit:K
+                                 ] .
+
+unit:TONNE-PER-M3  qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:TONNE
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  -3 ;
+                                      qudt:unit      unit:M
+                                    ] .
+
+unit:V_Ab-PER-CentiM  qudt:factorUnit  [ qudt:exponent  1 ;
+                                         qudt:unit      unit:V_Ab
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  -1 ;
+                                         qudt:unit      unit:CentiM
+                                       ] .
+
+unit:LB-PER-FT  qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:LB
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  -1 ;
+                                   qudt:unit      unit:FT
+                                 ] .
+
+unit:FT-PDL  qudt:factorUnit  [ qudt:exponent  1 ;
+                                qudt:unit      unit:PDL
+                              ] ;
+             qudt:factorUnit  [ qudt:exponent  1 ;
+                                qudt:unit      unit:FT
+                              ] .
+
+unit:J-PER-MOL  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                   qudt:unit      unit:MOL
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:J
+                                 ] .
+
+unit:OZ_VOL_UK-PER-DAY
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:OZ_VOL_UK
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:DAY
+                     ] .
+
+unit:MilliH-PER-KiloOHM
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MilliH
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:KiloOHM
+                     ] .
+
+unit:BTU_IT-PER-SEC-FT2-DEG_R
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:SEC
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:FT
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:DEG_R
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:BTU_IT
+                     ] .
+
+unit:LB-PER-M3  qudt:factorUnit  [ qudt:exponent  -3 ;
+                                   qudt:unit      unit:M
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:LB
+                                 ] .
+
+unit:KiloGM-PER-M  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:M
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:KiloGM
+                                    ] .
+
+unit:MicroC-PER-M2  qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:MicroC
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -2 ;
+                                       qudt:unit      unit:M
+                                     ] .
+
+unit:LB_F-PER-IN2  qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:LB_F
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  -2 ;
+                                      qudt:unit      unit:IN
+                                    ] .
+
+unit:L-PER-HR  qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:L
+                                ] ;
+               qudt:factorUnit  [ qudt:exponent  -1 ;
+                                  qudt:unit      unit:HR
+                                ] .
+
+unit:CentiM3  qudt:factorUnit  [ qudt:exponent  3 ;
+                                 qudt:unit      unit:CentiM
+                               ] .
+
+unit:CentiM3-PER-DAY  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                         qudt:unit      unit:DAY
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  3 ;
+                                         qudt:unit      unit:CentiM
+                                       ] .
+
+unit:KiloCAL_IT-PER-HR-M-DEG_C
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:M
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:KiloCAL_IT
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:HR
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:DEG_C
+                     ] .
+
+unit:A-M2-PER-J-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:SEC
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  2 ;
+                                        qudt:unit      unit:M
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:J
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:A
+                                      ] .
+
+unit:C-M2-PER-V  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                    qudt:unit      unit:V
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  2 ;
+                                    qudt:unit      unit:M
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  1 ;
+                                    qudt:unit      unit:C
+                                  ] .
+
+unit:PER-M3-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                    qudt:unit      unit:SEC
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  -3 ;
+                                    qudt:unit      unit:M
+                                  ] .
+
+unit:H-PER-M  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                 qudt:unit      unit:M
+                               ] ;
+              qudt:factorUnit  [ qudt:exponent  1 ;
+                                 qudt:unit      unit:H
+                               ] .
+
+unit:K-PA-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:SEC
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:PA
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:K
+                                    ] .
+
+unit:MicroGM-PER-L  qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:MicroGM
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:L
+                                     ] .
+
+unit:PK_UK-PER-MIN  qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:PK_UK
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:MIN
+                                     ] .
+
+unit:PicoS-PER-M  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:PicoS
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                     qudt:unit      unit:M
+                                   ] .
+
+unit:KiloGM-M2  qudt:factorUnit  [ qudt:exponent  2 ;
+                                   qudt:unit      unit:M
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:KiloGM
+                                 ] .
+
+unit:KiloGM-PER-M3  qudt:factorUnit  [ qudt:exponent  -3 ;
+                                       qudt:unit      unit:M
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:KiloGM
+                                     ] .
+
+unit:MicroM2  qudt:factorUnit  [ qudt:exponent  2 ;
+                                 qudt:unit      unit:MicroM
+                               ] .
+
+unit:MegaEV-FemtoM  qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:MegaEV
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:FemtoM
+                                     ] .
+
+unit:MilliA-PER-MilliM
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:MilliM
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MilliA
+                     ] .
+
+unit:DEG_F-HR-PER-BTU_IT
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:HR
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:DEG_F
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:BTU_IT
+                     ] .
+
+unit:HP-PER-V  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                  qudt:unit      unit:V
+                                ] ;
+               qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:HP
+                                ] .
+
+unit:MegaPA-PER-K  qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:MegaPA
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:K
+                                    ] .
+
+unit:GI_UK-PER-DAY  qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:GI_UK
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:DAY
+                                     ] .
+
+unit:OZ_VOL_US-PER-DAY
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:OZ_VOL_US
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:DAY
+                     ] .
+
+unit:FT2-PER-HR  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                    qudt:unit      unit:HR
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  2 ;
+                                    qudt:unit      unit:FT
+                                  ] .
+
+unit:M-PER-SEC2  qudt:factorUnit  [ qudt:exponent  -2 ;
+                                    qudt:unit      unit:SEC
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  1 ;
+                                    qudt:unit      unit:M
+                                  ] .
+
+unit:MI_N-PER-HR  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:MI_N
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                     qudt:unit      unit:HR
+                                   ] .
+
+unit:DYN-SEC-PER-CentiM
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:SEC
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:DYN
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:CentiM
+                     ] .
+
+unit:A-PER-M2  qudt:factorUnit  [ qudt:exponent  -2 ;
+                                  qudt:unit      unit:M
+                                ] ;
+               qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:A
+                                ] .
+
+unit:FT3  qudt:factorUnit  [ qudt:exponent  3 ;
+                             qudt:unit      unit:FT
+                           ] .
+
+unit:TON_Metric-PER-M3
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:TON_Metric
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -3 ;
+                       qudt:unit      unit:M
+                     ] .
+
+unit:FARAD-PER-M  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                     qudt:unit      unit:M
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:FARAD
+                                   ] .
+
+unit:BTU_IT-PER-LB_F-DEG_F
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:LB_F
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:DEG_F
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:BTU_IT
+                     ] .
+
+unit:BBL_UK_PET-PER-MIN
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:MIN
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:BBL_UK_PET
+                     ] .
+
+unit:MegaPA-M3-PER-SEC
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:SEC
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MegaPA
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  3 ;
+                       qudt:unit      unit:M
+                     ] .
+
+unit:PER-SEC-SR  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                    qudt:unit      unit:SR
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  -1 ;
+                                    qudt:unit      unit:SEC
+                                  ] .
+
+unit:CentiM2-SEC  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:SEC
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  2 ;
+                                     qudt:unit      unit:CentiM
+                                   ] .
 
 unit:MilliW-PER-M2-NanoM-SR
-    qudt:convertsTo  unit:W-PER-M2-M-SR ;
-    qudt:isScalingOf unit:W-PER-M2-M-SR .
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:SR
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:NanoM
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MilliW
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:M
+                     ] .
 
-unit:CentiM-PER-SEC
-    qudt:convertsTo  unit:M-PER-SEC ;
-    qudt:isScalingOf unit:M-PER-SEC .
+unit:PDL-PER-FT2  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:PDL
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  -2 ;
+                                     qudt:unit      unit:FT
+                                   ] .
 
-unit:KiloBYTE
-    qudt:isScalingOf unit:BYTE ;
-    qudt:prefix      prefix:Kilo .
+unit:H-PER-OHM  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                   qudt:unit      unit:OHM
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:H
+                                 ] .
+
+unit:NanoMOL-PER-L-HR
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:NanoMOL
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:L
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:HR
+                     ] .
+
+unit:PA-M-PER-SEC2  qudt:factorUnit  [ qudt:exponent  -2 ;
+                                       qudt:unit      unit:SEC
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:PA
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:M
+                                     ] .
+
+unit:KiloWB-PER-M  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:M
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:KiloWB
+                                    ] .
+
+unit:BTU_IT-PER-LB-MOL
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:MOL
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:LB
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:BTU_IT
+                     ] .
+
+unit:A-PER-CentiM2  qudt:factorUnit  [ qudt:exponent  -2 ;
+                                       qudt:unit      unit:CentiM
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:A
+                                     ] .
+
+unit:N-SEC-PER-M3  qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:SEC
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:N
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  -3 ;
+                                      qudt:unit      unit:M
+                                    ] .
+
+unit:NUM-PER-HR  qudt:factorUnit  [ qudt:exponent  1 ;
+                                    qudt:unit      unit:NUM
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  -1 ;
+                                    qudt:unit      unit:HR
+                                  ] .
+
+unit:K-PER-HR  qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:K
+                                ] ;
+               qudt:factorUnit  [ qudt:exponent  -1 ;
+                                  qudt:unit      unit:HR
+                                ] .
+
+unit:GI_US-PER-DAY  qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:GI_US
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:DAY
+                                     ] .
+
+unit:PicoW-PER-CentiM2-L
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:PicoW
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:L
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:CentiM
+                     ] .
+
+unit:BAR-L-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:SEC
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:L
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:BAR
+                                     ] .
+
+unit:TONNE-PER-HA  qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:TONNE
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:HA
+                                    ] .
+
+unit:DEG_F-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:SEC
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:DEG_F
+                                     ] .
+
+unit:C_Ab-PER-CentiM2
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:CentiM
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:C_Ab
+                     ] .
+
+unit:C-M2  qudt:factorUnit  [ qudt:exponent  2 ;
+                              qudt:unit      unit:M
+                            ] ;
+           qudt:factorUnit  [ qudt:exponent  1 ;
+                              qudt:unit      unit:C
+                            ] .
+
+unit:LB-PER-DAY  qudt:factorUnit  [ qudt:exponent  1 ;
+                                    qudt:unit      unit:LB
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  -1 ;
+                                    qudt:unit      unit:DAY
+                                  ] .
+
+unit:MilliC-PER-KiloGM
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MilliC
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:KiloGM
+                     ] .
+
+unit:BU_UK-PER-HR  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:HR
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:BU_UK
+                                    ] .
+
+unit:C-PER-CentiM2  qudt:factorUnit  [ qudt:exponent  -2 ;
+                                       qudt:unit      unit:CentiM
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:C
+                                     ] .
+
+unit:SLUG-PER-HR  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:SLUG
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                     qudt:unit      unit:HR
+                                   ] .
+
+unit:PINT_UK-PER-DAY  qudt:factorUnit  [ qudt:exponent  1 ;
+                                         qudt:unit      unit:PINT_UK
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  -1 ;
+                                         qudt:unit      unit:DAY
+                                       ] .
+
+unit:DYN-CentiM  qudt:factorUnit  [ qudt:exponent  1 ;
+                                    qudt:unit      unit:DYN
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  1 ;
+                                    qudt:unit      unit:CentiM
+                                  ] .
+
+unit:PER-BAR  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                 qudt:unit      unit:BAR
+                               ] .
+
+unit:HectoPA-PER-HR  qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:HectoPA
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:HR
+                                      ] .
+
+unit:BTU_TH-IN-PER-FT2-HR-DEG_F
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:IN
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:HR
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:FT
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:DEG_F
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:BTU_TH
+                     ] .
+
+unit:KiloPA-PER-MilliM
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:MilliM
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:KiloPA
+                     ] .
+
+unit:MicroGAL-PER-M  qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:MicroGAL
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:M
+                                      ] .
+
+unit:L-PER-MIN  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                   qudt:unit      unit:MIN
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:L
+                                 ] .
+
+unit:W-SEC  qudt:factorUnit  [ qudt:exponent  1 ;
+                               qudt:unit      unit:W
+                             ] ;
+            qudt:factorUnit  [ qudt:exponent  1 ;
+                               qudt:unit      unit:SEC
+                             ] .
+
+unit:LM-SEC  qudt:factorUnit  [ qudt:exponent  1 ;
+                                qudt:unit      unit:SEC
+                              ] ;
+             qudt:factorUnit  [ qudt:exponent  1 ;
+                                qudt:unit      unit:LM
+                              ] .
+
+unit:L-PER-MOL  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                   qudt:unit      unit:MOL
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:L
+                                 ] .
+
+unit:DEG_C-PER-K  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                     qudt:unit      unit:K
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:DEG_C
+                                   ] .
+
+unit:QT_UK-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:SEC
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:QT_UK
+                                     ] .
+
+unit:W-HR  qudt:factorUnit  [ qudt:exponent  1 ;
+                              qudt:unit      unit:W
+                            ] ;
+           qudt:factorUnit  [ qudt:exponent  1 ;
+                              qudt:unit      unit:HR
+                            ] .
+
+unit:MilliBQ-PER-M2-DAY
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MilliBQ
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:M
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:DAY
+                     ] .
+
+unit:EV-PER-K  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                  qudt:unit      unit:K
+                                ] ;
+               qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:EV
+                                ] .
+
+unit:J-SEC-PER-MOL  qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:SEC
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:MOL
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:J
+                                     ] .
+
+unit:KiloGM-PER-MIN  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:MIN
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:KiloGM
+                                      ] .
+
+unit:KiloGM-PER-HA  qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:KiloGM
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:HA
+                                     ] .
+
+unit:MilliBQ-PER-KiloGM
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MilliBQ
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:KiloGM
+                     ] .
+
+unit:PER-MilliSEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:MilliSEC
+                                    ] .
+
+unit:KiloGM-PER-MOL  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:MOL
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:KiloGM
+                                      ] .
+
+unit:MicroV-PER-M  qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:MicroV
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:M
+                                    ] .
+
+unit:GM-PER-M2  qudt:factorUnit  [ qudt:exponent  -2 ;
+                                   qudt:unit      unit:M
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:GM
+                                 ] .
+
+unit:K-M  qudt:factorUnit  [ qudt:exponent  1 ;
+                             qudt:unit      unit:M
+                           ] ;
+          qudt:factorUnit  [ qudt:exponent  1 ;
+                             qudt:unit      unit:K
+                           ] .
+
+unit:TONNE-PER-DAY  qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:TONNE
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:DAY
+                                     ] .
+
+unit:IN3  qudt:factorUnit  [ qudt:exponent  3 ;
+                             qudt:unit      unit:IN
+                           ] .
+
+unit:QT_US-PER-HR  qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:QT_US
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:HR
+                                    ] .
+
+unit:IN3-PER-MIN  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                     qudt:unit      unit:MIN
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  3 ;
+                                     qudt:unit      unit:IN
+                                   ] .
+
+unit:V-SEC-PER-M  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:V
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:SEC
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                     qudt:unit      unit:M
+                                   ] .
+
+unit:M-PER-FARAD  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:M
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                     qudt:unit      unit:FARAD
+                                   ] .
+
+unit:FT-PER-SEC2  qudt:factorUnit  [ qudt:exponent  -2 ;
+                                     qudt:unit      unit:SEC
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:FT
+                                   ] .
+
+unit:POISE-PER-BAR  qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:POISE
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:BAR
+                                     ] .
+
+unit:CD-PER-M2  qudt:factorUnit  [ qudt:exponent  -2 ;
+                                   qudt:unit      unit:M
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:CD
+                                 ] .
+
+unit:KiloGM-PER-SEC2  qudt:factorUnit  [ qudt:exponent  -2 ;
+                                         qudt:unit      unit:SEC
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  1 ;
+                                         qudt:unit      unit:KiloGM
+                                       ] .
+
+unit:PicoPA-PER-KiloM
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:PicoPA
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:KiloM
+                     ] .
+
+unit:IN-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                    qudt:unit      unit:SEC
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  1 ;
+                                    qudt:unit      unit:IN
+                                  ] .
+
+unit:PINT_US-PER-DAY  qudt:factorUnit  [ qudt:exponent  1 ;
+                                         qudt:unit      unit:PINT_US
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  -1 ;
+                                         qudt:unit      unit:DAY
+                                       ] .
+
+unit:PER-HR  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                qudt:unit      unit:HR
+                              ] .
+
+unit:DEG_R-PER-MIN  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:MIN
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:DEG_R
+                                     ] .
+
+unit:M2-K  qudt:factorUnit  [ qudt:exponent  2 ;
+                              qudt:unit      unit:M
+                            ] ;
+           qudt:factorUnit  [ qudt:exponent  1 ;
+                              qudt:unit      unit:K
+                            ] .
+
+unit:TON_Metric-PER-HA
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:TON_Metric
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:HA
+                     ] .
+
+unit:MegaV-A_Reactive-HR
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MegaV
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:HR
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:A_Reactive
+                     ] .
+
+unit:J-PER-HR  qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:J
+                                ] ;
+               qudt:factorUnit  [ qudt:exponent  -1 ;
+                                  qudt:unit      unit:HR
+                                ] .
+
+unit:DEG-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                     qudt:unit      unit:SEC
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:DEG
+                                   ] .
+
+unit:J-M-PER-MOL  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                     qudt:unit      unit:MOL
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:M
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:J
+                                   ] .
+
+unit:FT-PER-MIN  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                    qudt:unit      unit:MIN
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  1 ;
+                                    qudt:unit      unit:FT
+                                  ] .
+
+unit:DeciM3-PER-MIN  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:MIN
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  3 ;
+                                        qudt:unit      unit:DeciM
+                                      ] .
+
+unit:SLUG-PER-SEC  qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:SLUG
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:SEC
+                                    ] .
+
+unit:QT_US-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:SEC
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:QT_US
+                                     ] .
+
+unit:PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                 qudt:unit      unit:SEC
+                               ] .
+
+unit:DeciM3-PER-MOL  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:MOL
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  3 ;
+                                        qudt:unit      unit:DeciM
+                                      ] .
+
+unit:LB_F-SEC-PER-FT2
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:SEC
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:LB_F
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:FT
+                     ] .
+
+unit:T-SEC  qudt:factorUnit  [ qudt:exponent  1 ;
+                               qudt:unit      unit:T
+                             ] ;
+            qudt:factorUnit  [ qudt:exponent  1 ;
+                               qudt:unit      unit:SEC
+                             ] .
+
+unit:GM-PER-CentiM2  qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:GM
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -2 ;
+                                        qudt:unit      unit:CentiM
+                                      ] .
+
+unit:YD3-PER-MIN  qudt:factorUnit  [ qudt:exponent  3 ;
+                                     qudt:unit      unit:YD
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                     qudt:unit      unit:MIN
+                                   ] .
+
+unit:FT3-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                     qudt:unit      unit:SEC
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  3 ;
+                                     qudt:unit      unit:FT
+                                   ] .
+
+unit:N-M-SEC  qudt:factorUnit  [ qudt:exponent  1 ;
+                                 qudt:unit      unit:SEC
+                               ] ;
+              qudt:factorUnit  [ qudt:exponent  1 ;
+                                 qudt:unit      unit:N
+                               ] ;
+              qudt:factorUnit  [ qudt:exponent  1 ;
+                                 qudt:unit      unit:M
+                               ] .
+
+unit:MicroFARAD-PER-KiloM
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MicroFARAD
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:KiloM
+                     ] .
+
+unit:TON_Metric-PER-SEC
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:TON_Metric
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:SEC
+                     ] .
+
+unit:BTU_IT-PER-MIN  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:MIN
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:BTU_IT
+                                      ] .
+
+unit:M2-HZ4  qudt:factorUnit  [ qudt:exponent  2 ;
+                                qudt:unit      unit:M
+                              ] ;
+             qudt:factorUnit  [ qudt:exponent  4 ;
+                                qudt:unit      unit:HZ
+                              ] .
+
+unit:MegaJ-PER-KiloGM
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MegaJ
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:KiloGM
+                     ] .
+
+unit:CAL_TH-PER-SEC-CentiM2-K
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:SEC
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:K
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:CentiM
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:CAL_TH
+                     ] .
+
+unit:TON_UK-PER-DAY  qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:TON_UK
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:DAY
+                                      ] .
+
+unit:J-PER-M  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                 qudt:unit      unit:M
+                               ] ;
+              qudt:factorUnit  [ qudt:exponent  1 ;
+                                 qudt:unit      unit:J
+                               ] .
+
+unit:LB-FT2  qudt:factorUnit  [ qudt:exponent  1 ;
+                                qudt:unit      unit:LB
+                              ] ;
+             qudt:factorUnit  [ qudt:exponent  2 ;
+                                qudt:unit      unit:FT
+                              ] .
+
+unit:M3-PER-DAY  qudt:factorUnit  [ qudt:exponent  3 ;
+                                    qudt:unit      unit:M
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  -1 ;
+                                    qudt:unit      unit:DAY
+                                  ] .
+
+unit:LB-PER-GAL_UK  qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:LB
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:GAL_UK
+                                     ] .
+
+unit:DEATHS-PER-1000000I-YR
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:YR
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:DEATHS
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:1000000I
+                     ] .
+
+unit:KiloGM_F-PER-M  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:M
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:KiloGM_F
+                                      ] .
+
+unit:MegaV-A-HR  qudt:factorUnit  [ qudt:exponent  1 ;
+                                    qudt:unit      unit:MegaV
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  1 ;
+                                    qudt:unit      unit:HR
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  1 ;
+                                    qudt:unit      unit:A
+                                  ] .
+
+unit:DeciM3  qudt:factorUnit  [ qudt:exponent  3 ;
+                                qudt:unit      unit:DeciM
+                              ] .
+
+unit:PER-M-SR  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                  qudt:unit      unit:SR
+                                ] ;
+               qudt:factorUnit  [ qudt:exponent  -1 ;
+                                  qudt:unit      unit:M
+                                ] .
+
+unit:KiloGM_F-PER-CentiM2
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:KiloGM_F
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:CentiM
+                     ] .
+
+unit:NUM-PER-KiloM2  qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:NUM
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -2 ;
+                                        qudt:unit      unit:KiloM
+                                      ] .
+
+unit:K-PER-W  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                 qudt:unit      unit:W
+                               ] ;
+              qudt:factorUnit  [ qudt:exponent  1 ;
+                                 qudt:unit      unit:K
+                               ] .
+
+unit:J-SEC  qudt:factorUnit  [ qudt:exponent  1 ;
+                               qudt:unit      unit:SEC
+                             ] ;
+            qudt:factorUnit  [ qudt:exponent  1 ;
+                               qudt:unit      unit:J
+                             ] .
+
+unit:V-PER-K  qudt:factorUnit  [ qudt:exponent  1 ;
+                                 qudt:unit      unit:V
+                               ] ;
+              qudt:factorUnit  [ qudt:exponent  -1 ;
+                                 qudt:unit      unit:K
+                               ] .
+
+unit:J-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                   qudt:unit      unit:SEC
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:J
+                                 ] .
+
+unit:DeciN-M  qudt:factorUnit  [ qudt:exponent  1 ;
+                                 qudt:unit      unit:M
+                               ] ;
+              qudt:factorUnit  [ qudt:exponent  1 ;
+                                 qudt:unit      unit:DeciN
+                               ] .
+
+unit:MI_N-PER-MIN  qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:MI_N
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:MIN
+                                    ] .
+
+unit:H_Stat-PER-CentiM
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:H_Stat
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:CentiM
+                     ] .
+
+unit:TON_US-PER-DAY  qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:TON_US
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:DAY
+                                      ] .
+
+unit:NanoGM-PER-M3  qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:NanoGM
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -3 ;
+                                       qudt:unit      unit:M
+                                     ] .
+
+unit:MegaV-PER-M  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:MegaV
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                     qudt:unit      unit:M
+                                   ] .
+
+unit:BTU_IT-PER-DEG_R
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:DEG_R
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:BTU_IT
+                     ] .
+
+unit:GM-PER-DeciM3  qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:GM
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -3 ;
+                                       qudt:unit      unit:DeciM
+                                     ] .
+
+unit:PER-L  qudt:factorUnit  [ qudt:exponent  -1 ;
+                               qudt:unit      unit:L
+                             ] .
+
+unit:MilliGAL-PER-MO  qudt:factorUnit  [ qudt:exponent  1 ;
+                                         qudt:unit      unit:MilliGAL
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  -1 ;
+                                         qudt:unit      unit:MO
+                                       ] .
+
+unit:PER-YD3  qudt:factorUnit  [ qudt:exponent  -3 ;
+                                 qudt:unit      unit:YD
+                               ] .
+
+unit:BTU_IT-PER-HR-FT2-DEG_R
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:HR
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:FT
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:DEG_R
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:BTU_IT
+                     ] .
+
+unit:EV-PER-ANGSTROM  qudt:factorUnit  [ qudt:exponent  1 ;
+                                         qudt:unit      unit:EV
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  -1 ;
+                                         qudt:unit      unit:ANGSTROM
+                                       ] .
+
+unit:NUM-PER-YR  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                    qudt:unit      unit:YR
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  1 ;
+                                    qudt:unit      unit:NUM
+                                  ] .
+
+unit:BBL_US-PER-DAY  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:DAY
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:BBL_US
+                                      ] .
+
+unit:N-SEC-PER-RAD  qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:SEC
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:RAD
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:N
+                                     ] .
+
+unit:BEAT-PER-MIN  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:MIN
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:BEAT
+                                    ] .
+
+unit:LB_F-FT  qudt:factorUnit  [ qudt:exponent  1 ;
+                                 qudt:unit      unit:LB_F
+                               ] ;
+              qudt:factorUnit  [ qudt:exponent  1 ;
+                                 qudt:unit      unit:FT
+                               ] .
+
+unit:PK_UK-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:SEC
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:PK_UK
+                                     ] .
+
+unit:PER-M-NanoM  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                     qudt:unit      unit:NanoM
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                     qudt:unit      unit:M
+                                   ] .
+
+unit:NanoH-PER-M  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:NanoH
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                     qudt:unit      unit:M
+                                   ] .
+
+unit:ERG-PER-GM-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:SEC
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:GM
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:ERG
+                                      ] .
+
+unit:LB_F-SEC-PER-IN2
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:SEC
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:LB_F
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:IN
+                     ] .
+
+unit:FT-PER-DEG_F  qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:FT
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:DEG_F
+                                    ] .
+
+unit:PicoGM-PER-MilliL
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:PicoGM
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:MilliL
+                     ] .
+
+unit:K-PER-M  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                 qudt:unit      unit:M
+                               ] ;
+              qudt:factorUnit  [ qudt:exponent  1 ;
+                                 qudt:unit      unit:K
+                               ] .
+
+unit:LB-IN2  qudt:factorUnit  [ qudt:exponent  1 ;
+                                qudt:unit      unit:LB
+                              ] ;
+             qudt:factorUnit  [ qudt:exponent  2 ;
+                                qudt:unit      unit:IN
+                              ] .
+
+unit:MilliA-PER-IN  qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:MilliA
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:IN
+                                     ] .
+
+unit:KiloCAL-PER-CentiM-SEC-DEG_C
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:SEC
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:KiloCAL
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:DEG_C
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:CentiM
+                     ] .
+
+unit:FT2-DEG_F  qudt:factorUnit  [ qudt:exponent  2 ;
+                                   qudt:unit      unit:FT
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:DEG_F
+                                 ] .
+
+unit:FemtoMOL-PER-L  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:L
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:FemtoMOL
+                                      ] .
+
+unit:J-M2  qudt:factorUnit  [ qudt:exponent  2 ;
+                              qudt:unit      unit:M
+                            ] ;
+           qudt:factorUnit  [ qudt:exponent  1 ;
+                              qudt:unit      unit:J
+                            ] .
+
+unit:PER-T-M  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                 qudt:unit      unit:T
+                               ] ;
+              qudt:factorUnit  [ qudt:exponent  -1 ;
+                                 qudt:unit      unit:M
+                               ] .
+
+unit:MilliC-PER-M2  qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:MilliC
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -2 ;
+                                       qudt:unit      unit:M
+                                     ] .
+
+unit:N-SEC  qudt:factorUnit  [ qudt:exponent  1 ;
+                               qudt:unit      unit:SEC
+                             ] ;
+            qudt:factorUnit  [ qudt:exponent  1 ;
+                               qudt:unit      unit:N
+                             ] .
+
+unit:BBL_UK_PET-PER-SEC
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:SEC
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:BBL_UK_PET
+                     ] .
+
+unit:MicroN-M  qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:MicroN
+                                ] ;
+               qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:M
+                                ] .
+
+unit:MI-PER-HR  qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:MI
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  -1 ;
+                                   qudt:unit      unit:HR
+                                 ] .
+
+unit:DeciM3-PER-M3  qudt:factorUnit  [ qudt:exponent  -3 ;
+                                       qudt:unit      unit:M
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  3 ;
+                                       qudt:unit      unit:DeciM
+                                     ] .
+
+unit:BTU_IT-IN-PER-FT2-SEC-DEG_F
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:SEC
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:IN
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:FT
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:DEG_F
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:BTU_IT
+                     ] .
+
+unit:S-M2-PER-MOL  qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:S
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:MOL
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  2 ;
+                                      qudt:unit      unit:M
+                                    ] .
+
+unit:MicroGM-PER-KiloGM
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MicroGM
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:KiloGM
+                     ] .
+
+unit:KiloV-A_Reactive-HR
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:KiloV
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:HR
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:A_Reactive
+                     ] .
+
+unit:MilliGM-PER-L  qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:MilliGM
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:L
+                                     ] .
+
+unit:GM-PER-MIN  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                    qudt:unit      unit:MIN
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  1 ;
+                                    qudt:unit      unit:GM
+                                  ] .
+
+unit:MicroH-PER-M  qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:MicroH
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:M
+                                    ] .
+
+unit:GRAIN-PER-GAL_US
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:GRAIN
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:GAL_US
+                     ] .
+
+unit:KiloLB_F-PER-IN2
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:KiloLB_F
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:IN
+                     ] .
+
+unit:V-A_Reactive-HR  qudt:factorUnit  [ qudt:exponent  1 ;
+                                         qudt:unit      unit:V
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  1 ;
+                                         qudt:unit      unit:HR
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  1 ;
+                                         qudt:unit      unit:A_Reactive
+                                       ] .
+
+unit:FT2-PER-BTU_IT-IN
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:IN
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  2 ;
+                       qudt:unit      unit:FT
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:BTU_IT
+                     ] .
+
+unit:GM-PER-MOL  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                    qudt:unit      unit:MOL
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  1 ;
+                                    qudt:unit      unit:GM
+                                  ] .
+
+unit:MegaJ-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:SEC
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:MegaJ
+                                     ] .
+
+unit:W-PER-K  qudt:factorUnit  [ qudt:exponent  1 ;
+                                 qudt:unit      unit:W
+                               ] ;
+              qudt:factorUnit  [ qudt:exponent  -1 ;
+                                 qudt:unit      unit:K
+                               ] .
+
+unit:M4  qudt:factorUnit  [ qudt:exponent  4 ;
+                            qudt:unit      unit:M
+                          ] .
+
+unit:MicroBQ-PER-L  qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:MicroBQ
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:L
+                                     ] .
+
+unit:C_Stat-PER-MOL  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:MOL
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:C_Stat
+                                      ] .
+
+unit:V-M  qudt:factorUnit  [ qudt:exponent  1 ;
+                             qudt:unit      unit:V
+                           ] ;
+          qudt:factorUnit  [ qudt:exponent  1 ;
+                             qudt:unit      unit:M
+                           ] .
+
+unit:MilliMOL-PER-GM  qudt:factorUnit  [ qudt:exponent  1 ;
+                                         qudt:unit      unit:MilliMOL
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  -1 ;
+                                         qudt:unit      unit:GM
+                                       ] .
+
+unit:N-PER-RAD  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                   qudt:unit      unit:RAD
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:N
+                                 ] .
+
+unit:PER-YR  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                qudt:unit      unit:YR
+                              ] .
+
+unit:MilliGM-PER-M3  qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:MilliGM
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -3 ;
+                                        qudt:unit      unit:M
+                                      ] .
+
+unit:MilliM-PER-HR  qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:MilliM
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:HR
+                                     ] .
 
 unit:PicoMOL-PER-M3-SEC
-    qudt:convertsTo  unit:MOL-PER-M3-SEC ;
-    qudt:isScalingOf unit:MOL-PER-M3-SEC .
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:SEC
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:PicoMOL
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -3 ;
+                       qudt:unit      unit:M
+                     ] .
+
+unit:NanoGM-PER-KiloGM
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:NanoGM
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:KiloGM
+                     ] .
+
+unit:QT_UK-PER-HR  qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:QT_UK
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:HR
+                                    ] .
+
+unit:GigaHZ-M  qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:M
+                                ] ;
+               qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:GigaHZ
+                                ] .
+
+unit:SLUG-PER-FT2  qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:SLUG
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  -2 ;
+                                      qudt:unit      unit:FT
+                                    ] .
+
+unit:A_Ab-CentiM2  qudt:factorUnit  [ qudt:exponent  2 ;
+                                      qudt:unit      unit:CentiM
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:A_Ab
+                                    ] .
+
+unit:PER-M2-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                    qudt:unit      unit:SEC
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  -2 ;
+                                    qudt:unit      unit:M
+                                  ] .
+
+unit:MilliGM-PER-MIN  qudt:factorUnit  [ qudt:exponent  1 ;
+                                         qudt:unit      unit:MilliGM
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  -1 ;
+                                         qudt:unit      unit:MIN
+                                       ] .
+
+unit:GM-PER-M2-DAY  qudt:factorUnit  [ qudt:exponent  -2 ;
+                                       qudt:unit      unit:M
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:GM
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:DAY
+                                     ] .
+
+unit:C-PER-M2  qudt:factorUnit  [ qudt:exponent  -2 ;
+                                  qudt:unit      unit:M
+                                ] ;
+               qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:C
+                                ] .
+
+unit:K-SEC  qudt:factorUnit  [ qudt:exponent  1 ;
+                               qudt:unit      unit:SEC
+                             ] ;
+            qudt:factorUnit  [ qudt:exponent  1 ;
+                               qudt:unit      unit:K
+                             ] .
+
+unit:C2-M-PER-J  qudt:factorUnit  [ qudt:exponent  1 ;
+                                    qudt:unit      unit:M
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  -1 ;
+                                    qudt:unit      unit:J
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  2 ;
+                                    qudt:unit      unit:C
+                                  ] .
+
+unit:L-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                   qudt:unit      unit:SEC
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:L
+                                 ] .
+
+unit:GM-PER-KiloGM  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:KiloGM
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:GM
+                                     ] .
+
+unit:PicoW-PER-M2  qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:PicoW
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  -2 ;
+                                      qudt:unit      unit:M
+                                    ] .
+
+unit:REV-PER-MIN  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:REV
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                     qudt:unit      unit:MIN
+                                   ] .
+
+unit:PSI-M3-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:SEC
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:PSI
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  3 ;
+                                        qudt:unit      unit:M
+                                      ] .
+
+unit:YD2  qudt:factorUnit  [ qudt:exponent  2 ;
+                             qudt:unit      unit:YD
+                           ] .
+
+unit:BTU_TH-IN-PER-FT2-SEC-DEG_F
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:SEC
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:IN
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:FT
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:DEG_F
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:BTU_TH
+                     ] .
+
+unit:KiloPA-M2-PER-GM
+    qudt:factorUnit  [ qudt:exponent  2 ;
+                       qudt:unit      unit:M
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:KiloPA
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:GM
+                     ] .
+
+unit:OZ-PER-DAY  qudt:factorUnit  [ qudt:exponent  1 ;
+                                    qudt:unit      unit:OZ
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  -1 ;
+                                    qudt:unit      unit:DAY
+                                  ] .
+
+unit:CentiN-M  qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:M
+                                ] ;
+               qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:CentiN
+                                ] .
+
+unit:KiloGM-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:SEC
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:KiloGM
+                                      ] .
+
+unit:MilliL-PER-DAY  qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:MilliL
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:DAY
+                                      ] .
+
+unit:KiloMOL-PER-KiloGM
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:KiloMOL
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:KiloGM
+                     ] .
+
+unit:M-PER-HR  qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:M
+                                ] ;
+               qudt:factorUnit  [ qudt:exponent  -1 ;
+                                  qudt:unit      unit:HR
+                                ] .
+
+unit:IN3-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                     qudt:unit      unit:SEC
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  3 ;
+                                     qudt:unit      unit:IN
+                                   ] .
+
+unit:DEG_F-PER-K  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                     qudt:unit      unit:K
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:DEG_F
+                                   ] .
+
+unit:MicroGM-PER-L-HR
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MicroGM
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:L
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:HR
+                     ] .
+
+unit:PicoA-PER-MicroMOL-L
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:PicoA
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:MicroMOL
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:L
+                     ] .
+
+unit:DEG_R-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:SEC
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:DEG_R
+                                     ] .
+
+unit:A-SEC  qudt:factorUnit  [ qudt:exponent  1 ;
+                               qudt:unit      unit:SEC
+                             ] ;
+            qudt:factorUnit  [ qudt:exponent  1 ;
+                               qudt:unit      unit:A
+                             ] .
+
+unit:ERG-PER-CentiM2-SEC
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:SEC
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:ERG
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:CentiM
+                     ] .
+
+unit:MilliL-PER-HR  qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:MilliL
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:HR
+                                     ] .
+
+unit:W-PER-M2-PA  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:W
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                     qudt:unit      unit:PA
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  -2 ;
+                                     qudt:unit      unit:M
+                                   ] .
+
+unit:NanoMOL-PER-M2-DAY
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:NanoMOL
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:M
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:DAY
+                     ] .
+
+unit:FT-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                    qudt:unit      unit:SEC
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  1 ;
+                                    qudt:unit      unit:FT
+                                  ] .
+
+unit:DeciM3-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:SEC
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  3 ;
+                                        qudt:unit      unit:DeciM
+                                      ] .
+
+unit:W-PER-M3  qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:W
+                                ] ;
+               qudt:factorUnit  [ qudt:exponent  -3 ;
+                                  qudt:unit      unit:M
+                                ] .
+
+unit:PicoFARAD-PER-M  qudt:factorUnit  [ qudt:exponent  1 ;
+                                         qudt:unit      unit:PicoFARAD
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  -1 ;
+                                         qudt:unit      unit:M
+                                       ] .
+
+unit:KN-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                    qudt:unit      unit:SEC
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  1 ;
+                                    qudt:unit      unit:KN
+                                  ] .
+
+unit:MilliN-PER-M  qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:MilliN
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:M
+                                    ] .
+
+unit:NanoMOL-PER-KiloGM
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:NanoMOL
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:KiloGM
+                     ] .
+
+unit:REV-PER-SEC2  qudt:factorUnit  [ qudt:exponent  -2 ;
+                                      qudt:unit      unit:SEC
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:REV
+                                    ] .
+
+unit:YD3-PER-SEC  qudt:factorUnit  [ qudt:exponent  3 ;
+                                     qudt:unit      unit:YD
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                     qudt:unit      unit:SEC
+                                   ] .
+
+unit:PER-WB  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                qudt:unit      unit:WB
+                              ] .
+
+unit:BTU_IT-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:SEC
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:BTU_IT
+                                      ] .
+
+unit:DEG_F-PER-HR  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:HR
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:DEG_F
+                                    ] .
+
+unit:CentiM-PER-HR  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:HR
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:CentiM
+                                     ] .
+
+unit:PK_UK-PER-HR  qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:PK_UK
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:HR
+                                    ] .
+
+unit:LB-PER-FT3  qudt:factorUnit  [ qudt:exponent  1 ;
+                                    qudt:unit      unit:LB
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  -3 ;
+                                    qudt:unit      unit:FT
+                                  ] .
+
+unit:MegaBIT-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                         qudt:unit      unit:SEC
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  1 ;
+                                         qudt:unit      unit:MegaBIT
+                                       ] .
+
+unit:MilliL-PER-CentiM2-MIN
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MilliL
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:MIN
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:CentiM
+                     ] .
+
+unit:OHM-M  qudt:factorUnit  [ qudt:exponent  1 ;
+                               qudt:unit      unit:OHM
+                             ] ;
+            qudt:factorUnit  [ qudt:exponent  1 ;
+                               qudt:unit      unit:M
+                             ] .
+
+unit:CentiM-SEC-DEG_C
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:SEC
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:DEG_C
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:CentiM
+                     ] .
+
+unit:PA-SEC-PER-BAR  qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:SEC
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:PA
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:BAR
+                                      ] .
+
+unit:CD-PER-IN2  qudt:factorUnit  [ qudt:exponent  -2 ;
+                                    qudt:unit      unit:IN
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  1 ;
+                                    qudt:unit      unit:CD
+                                  ] .
+
+unit:MicroM3-PER-M3  qudt:factorUnit  [ qudt:exponent  3 ;
+                                        qudt:unit      unit:MicroM
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -3 ;
+                                        qudt:unit      unit:M
+                                      ] .
+
+unit:CAL_TH-PER-G  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:G
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:CAL_TH
+                                    ] .
+
+unit:MOL-PER-M2  qudt:factorUnit  [ qudt:exponent  1 ;
+                                    qudt:unit      unit:MOL
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  -2 ;
+                                    qudt:unit      unit:M
+                                  ] .
+
+unit:NUM-PER-M3  qudt:factorUnit  [ qudt:exponent  1 ;
+                                    qudt:unit      unit:NUM
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  -3 ;
+                                    qudt:unit      unit:M
+                                  ] .
+
+unit:M2-PER-V-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:V
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:SEC
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  2 ;
+                                      qudt:unit      unit:M
+                                    ] .
+
+unit:MOL-PER-M2-SEC-SR
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:SR
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:SEC
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MOL
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:M
+                     ] .
+
+unit:N-CentiM  qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:N
+                                ] ;
+               qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:CentiM
+                                ] .
+
+unit:KiloV-PER-M  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                     qudt:unit      unit:M
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:KiloV
+                                   ] .
+
+unit:W-M-PER-M2-SR  qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:W
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:SR
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:M
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -2 ;
+                                       qudt:unit      unit:M
+                                     ] .
+
+unit:PK_US_DRY-PER-MIN
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:PK_US_DRY
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:MIN
+                     ] .
+
+unit:DEG_F-HR-FT2-PER-BTU_TH
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:HR
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  2 ;
+                       qudt:unit      unit:FT
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:DEG_F
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:BTU_TH
+                     ] .
+
+unit:MegaV-A  qudt:factorUnit  [ qudt:exponent  1 ;
+                                 qudt:unit      unit:MegaV
+                               ] ;
+              qudt:factorUnit  [ qudt:exponent  1 ;
+                                 qudt:unit      unit:A
+                               ] .
+
+unit:LB_F-PER-IN2-SEC
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:SEC
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:LB_F
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:IN
+                     ] .
+
+unit:SLUG-PER-FT  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:SLUG
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                     qudt:unit      unit:FT
+                                   ] .
+
+unit:BU_US_DRY-PER-DAY
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:DAY
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:BU_US_DRY
+                     ] .
+
+unit:KiloPA-PER-K  qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:KiloPA
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:K
+                                    ] .
+
+unit:MilliM3  qudt:factorUnit  [ qudt:exponent  3 ;
+                                 qudt:unit      unit:MilliM
+                               ] .
+
+unit:MilliMOL-PER-M2  qudt:factorUnit  [ qudt:exponent  1 ;
+                                         qudt:unit      unit:MilliMOL
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  -2 ;
+                                         qudt:unit      unit:M
+                                       ] .
+
+unit:OHM-M2-PER-M  qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:OHM
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  2 ;
+                                      qudt:unit      unit:M
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:M
+                                    ] .
+
+unit:M2-PER-SEC2  qudt:factorUnit  [ qudt:exponent  -2 ;
+                                     qudt:unit      unit:SEC
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  2 ;
+                                     qudt:unit      unit:M
+                                   ] .
+
+unit:PicoMOL-PER-L-DAY
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:PicoMOL
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:L
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:DAY
+                     ] .
+
+unit:PERCENT-PER-M  qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:PERCENT
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:M
+                                     ] .
+
+unit:M2-PER-MOL  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                    qudt:unit      unit:MOL
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  2 ;
+                                    qudt:unit      unit:M
+                                  ] .
+
+unit:KiloBYTE-PER-SEC
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:SEC
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:KiloBYTE
+                     ] .
+
+unit:MilliM-PER-YR  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:YR
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:MilliM
+                                     ] .
+
+unit:KiloCAL-PER-MOL-DEG_C
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:MOL
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:KiloCAL
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:DEG_C
+                     ] .
+
+unit:CentiM-PER-K  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:K
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:CentiM
+                                    ] .
+
+unit:CASES-PER-1000I-YR
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:YR
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:CASES
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:1000I
+                     ] .
+
+unit:OERSTED-CentiM  qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:OERSTED
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:CentiM
+                                      ] .
+
+unit:MOL-DEG_C  qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:MOL
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:DEG_C
+                                 ] .
+
+unit:PA-M-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:SEC
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:PA
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:M
+                                    ] .
+
+unit:YD3-PER-DEG_F  qudt:factorUnit  [ qudt:exponent  3 ;
+                                       qudt:unit      unit:YD
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:DEG_F
+                                     ] .
+
+unit:NUM-PER-M2-DAY  qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:NUM
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -2 ;
+                                        qudt:unit      unit:M
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:DAY
+                                      ] .
+
+unit:PER-GigaEV2  qudt:factorUnit  [ qudt:exponent  -2 ;
+                                     qudt:unit      unit:GigaEV
+                                   ] .
+
+unit:GM-PER-HR  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                   qudt:unit      unit:HR
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:GM
+                                 ] .
+
+unit:W-PER-M2-NanoM-SR
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:W
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:SR
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:NanoM
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:M
+                     ] .
+
+unit:NUM-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                     qudt:unit      unit:SEC
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:NUM
+                                   ] .
+
+unit:HectoPA-PER-K  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:K
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:HectoPA
+                                     ] .
+
+unit:MilliBAR-PER-K  qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:MilliBAR
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:K
+                                      ] .
+
+unit:GM-PER-MilliM  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:MilliM
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:GM
+                                     ] .
+
+unit:LB-PER-IN3  qudt:factorUnit  [ qudt:exponent  1 ;
+                                    qudt:unit      unit:LB
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  -3 ;
+                                    qudt:unit      unit:IN
+                                  ] .
+
+unit:CAL_IT-PER-SEC-CentiM2-K
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:SEC
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:K
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:CentiM
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:CAL_IT
+                     ] .
+
+unit:V-PER-SEC  qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:V
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  -1 ;
+                                   qudt:unit      unit:SEC
+                                 ] .
+
+unit:LB-PER-GAL_US  qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:LB
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:GAL_US
+                                     ] .
+
+unit:PER-M3  qudt:factorUnit  [ qudt:exponent  -3 ;
+                                qudt:unit      unit:M
+                              ] .
+
+unit:CentiM2-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                         qudt:unit      unit:SEC
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  2 ;
+                                         qudt:unit      unit:CentiM
+                                       ] .
+
+unit:J-PER-M3  qudt:factorUnit  [ qudt:exponent  -3 ;
+                                  qudt:unit      unit:M
+                                ] ;
+               qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:J
+                                ] .
+
+unit:NUM-PER-L  qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:NUM
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  -1 ;
+                                   qudt:unit      unit:L
+                                 ] .
+
+unit:V2-PER-K2  qudt:factorUnit  [ qudt:exponent  2 ;
+                                   qudt:unit      unit:V
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  -2 ;
+                                   qudt:unit      unit:K
+                                 ] .
+
+unit:DYN-PER-CentiM2  qudt:factorUnit  [ qudt:exponent  1 ;
+                                         qudt:unit      unit:DYN
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  -2 ;
+                                         qudt:unit      unit:CentiM
+                                       ] .
+
+unit:MilliPA-SEC-PER-BAR
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:SEC
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MilliPA
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:BAR
+                     ] .
+
+unit:M-KiloGM  qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:M
+                                ] ;
+               qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:KiloGM
+                                ] .
+
+unit:BTU_IT-IN  qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:IN
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:BTU_IT
+                                 ] .
+
+unit:M-PER-YR  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                  qudt:unit      unit:YR
+                                ] ;
+               qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:M
+                                ] .
+
+unit:GM-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                    qudt:unit      unit:SEC
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  1 ;
+                                    qudt:unit      unit:GM
+                                  ] .
+
+unit:M2-HZ  qudt:factorUnit  [ qudt:exponent  2 ;
+                               qudt:unit      unit:M
+                             ] ;
+            qudt:factorUnit  [ qudt:exponent  1 ;
+                               qudt:unit      unit:HZ
+                             ] .
+
+unit:A-PER-MilliM2  qudt:factorUnit  [ qudt:exponent  -2 ;
+                                       qudt:unit      unit:MilliM
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:A
+                                     ] .
+
+unit:MegaW-HR  qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:MegaW
+                                ] ;
+               qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:HR
+                                ] .
+
+unit:KiloLB_F-FT-PER-LB
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:LB
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:KiloLB_F
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:FT
+                     ] .
+
+unit:NUM-PER-HA  qudt:factorUnit  [ qudt:exponent  1 ;
+                                    qudt:unit      unit:NUM
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  -1 ;
+                                    qudt:unit      unit:HA
+                                  ] .
+
+unit:MicroH-PER-KiloOHM
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MicroH
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:KiloOHM
+                     ] .
+
+unit:N-M-PER-RAD  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                     qudt:unit      unit:RAD
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:N
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:M
+                                   ] .
+
+unit:MegaJ-PER-M2  qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:MegaJ
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  -2 ;
+                                      qudt:unit      unit:M
+                                    ] .
+
+unit:M2-HZ2  qudt:factorUnit  [ qudt:exponent  2 ;
+                                qudt:unit      unit:M
+                              ] ;
+             qudt:factorUnit  [ qudt:exponent  2 ;
+                                qudt:unit      unit:HZ
+                              ] .
+
+unit:MegaEV-PER-CentiM
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MegaEV
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:CentiM
+                     ] .
+
+unit:PA2-PER-SEC2  qudt:factorUnit  [ qudt:exponent  -2 ;
+                                      qudt:unit      unit:SEC
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  2 ;
+                                      qudt:unit      unit:PA
+                                    ] .
+
+unit:MI2  qudt:factorUnit  [ qudt:exponent  2 ;
+                             qudt:unit      unit:MI
+                           ] .
+
+unit:MilliGM-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                         qudt:unit      unit:SEC
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  1 ;
+                                         qudt:unit      unit:MilliGM
+                                       ] .
+
+unit:J-PER-K  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                 qudt:unit      unit:K
+                               ] ;
+              qudt:factorUnit  [ qudt:exponent  1 ;
+                                 qudt:unit      unit:J
+                               ] .
+
+unit:C-PER-MilliM2  qudt:factorUnit  [ qudt:exponent  -2 ;
+                                       qudt:unit      unit:MilliM
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:C
+                                     ] .
+
+unit:BTU_IT-PER-FT2  qudt:factorUnit  [ qudt:exponent  -2 ;
+                                        qudt:unit      unit:FT
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:BTU_IT
+                                      ] .
+
+unit:FT-LB_F-SEC  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:SEC
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:LB_F
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:FT
+                                   ] .
+
+unit:W-PER-SR  qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:W
+                                ] ;
+               qudt:factorUnit  [ qudt:exponent  -1 ;
+                                  qudt:unit      unit:SR
+                                ] .
+
+unit:REV-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                     qudt:unit      unit:SEC
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:REV
+                                   ] .
+
+unit:NanoMOL-PER-MicroGM-HR
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:NanoMOL
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:MicroGM
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:HR
+                     ] .
+
+unit:PicoGM-PER-L  qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:PicoGM
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:L
+                                    ] .
+
+unit:NAT-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                     qudt:unit      unit:SEC
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:NAT
+                                   ] .
+
+unit:NanoMOL-PER-MicroMOL
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:NanoMOL
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:MicroMOL
+                     ] .
+
+unit:MilliBQ-PER-L  qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:MilliBQ
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:L
+                                     ] .
+
+unit:LB_F-PER-IN  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:LB_F
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                     qudt:unit      unit:IN
+                                   ] .
+
+unit:H-PER-KiloOHM  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:KiloOHM
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:H
+                                     ] .
+
+unit:USDollar-SameDay
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:USDollar
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:SameDay
+                     ] .
+
+unit:CAL_IT-PER-GM-K  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                         qudt:unit      unit:K
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  -1 ;
+                                         qudt:unit      unit:GM
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  1 ;
+                                         qudt:unit      unit:CAL_IT
+                                       ] .
+
+unit:MilliL-PER-K  qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:MilliL
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:K
+                                    ] .
+
+unit:GAL_UK-PER-MIN  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:MIN
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:GAL_UK
+                                      ] .
+
+unit:KiloGM-K  qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:KiloGM
+                                ] ;
+               qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:K
+                                ] .
+
+unit:DEG_C2-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:SEC
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  2 ;
+                                        qudt:unit      unit:DEG_C
+                                      ] .
+
+unit:PER-ANGSTROM  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:ANGSTROM
+                                    ] .
+
+unit:FemtoMOL-PER-KiloGM
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:KiloGM
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:FemtoMOL
+                     ] .
+
+unit:J-PER-CentiM2  qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:J
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -2 ;
+                                       qudt:unit      unit:CentiM
+                                     ] .
+
+unit:MilliPA-SEC  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:SEC
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:MilliPA
+                                   ] .
+
+unit:LM-PER-W  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                  qudt:unit      unit:W
+                                ] ;
+               qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:LM
+                                ] .
+
+unit:KiloV-A_Reactive
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:KiloV
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:A_Reactive
+                     ] .
+
+unit:MilliGM-PER-DeciL
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MilliGM
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:DeciL
+                     ] .
+
+unit:GM-PER-M  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                  qudt:unit      unit:M
+                                ] ;
+               qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:GM
+                                ] .
+
+unit:BTU_TH-FT-PER-HR-FT2-DEG_F
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:HR
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:FT
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:FT
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:DEG_F
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:BTU_TH
+                     ] .
+
+unit:BQ-PER-L  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                  qudt:unit      unit:L
+                                ] ;
+               qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:BQ
+                                ] .
+
+unit:DEG_C-PER-HR  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:HR
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:DEG_C
+                                    ] .
+
+unit:SHANNON-PER-SEC  qudt:factorUnit  [ qudt:exponent  1 ;
+                                         qudt:unit      unit:SHANNON
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  -1 ;
+                                         qudt:unit      unit:SEC
+                                       ] .
+
+unit:DeciN  a         qudt:Unit ;
+            rdfs:comment  "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
+
+unit:K-PER-K  qudt:factorUnit  [ qudt:exponent  1 ;
+                                 qudt:unit      unit:K
+                               ] ;
+              qudt:factorUnit  [ qudt:exponent  -1 ;
+                                 qudt:unit      unit:K
+                               ] .
+
+unit:N-PER-M3  qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:N
+                                ] ;
+               qudt:factorUnit  [ qudt:exponent  -3 ;
+                                  qudt:unit      unit:M
+                                ] .
+
+unit:BQ-PER-M2  qudt:factorUnit  [ qudt:exponent  -2 ;
+                                   qudt:unit      unit:M
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:BQ
+                                 ] .
+
+unit:MegaC-PER-M2  qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:MegaC
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  -2 ;
+                                      qudt:unit      unit:M
+                                    ] .
+
+unit:OZ-IN  qudt:factorUnit  [ qudt:exponent  1 ;
+                               qudt:unit      unit:OZ
+                             ] ;
+            qudt:factorUnit  [ qudt:exponent  1 ;
+                               qudt:unit      unit:IN
+                             ] .
+
+unit:KiloGM-PER-M-SEC2
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:SEC
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:M
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:KiloGM
+                     ] .
+
+unit:MOL-K  qudt:factorUnit  [ qudt:exponent  1 ;
+                               qudt:unit      unit:MOL
+                             ] ;
+            qudt:factorUnit  [ qudt:exponent  1 ;
+                               qudt:unit      unit:K
+                             ] .
+
+unit:MilliL-PER-CentiM2-SEC
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:SEC
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MilliL
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:CentiM
+                     ] .
+
+unit:MegaHZ-PER-T  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:T
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:MegaHZ
+                                    ] .
+
+unit:GAL_US-PER-MIN  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:MIN
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:GAL_US
+                                      ] .
+
+unit:BTU_IT-PER-DEG_F
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:DEG_F
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:BTU_IT
+                     ] .
+
+unit:M2-PER-GM  qudt:factorUnit  [ qudt:exponent  2 ;
+                                   qudt:unit      unit:M
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  -1 ;
+                                   qudt:unit      unit:GM
+                                 ] .
+
+unit:REV-PER-HR  qudt:factorUnit  [ qudt:exponent  1 ;
+                                    qudt:unit      unit:REV
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  -1 ;
+                                    qudt:unit      unit:HR
+                                  ] .
+
+unit:PA-SEC-PER-M  qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:SEC
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:PA
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:M
+                                    ] .
+
+unit:KiloGM_F-PER-MilliM2
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:MilliM
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:KiloGM_F
+                     ] .
+
+unit:CAL_TH-PER-CentiM-SEC-DEG_C
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:SEC
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:DEG_C
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:CentiM
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:CAL_TH
+                     ] .
+
+unit:FT3-PER-DEG_F  qudt:factorUnit  [ qudt:exponent  3 ;
+                                       qudt:unit      unit:FT
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:DEG_F
+                                     ] .
+
+unit:N-PER-CentiM2  qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:N
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -2 ;
+                                       qudt:unit      unit:CentiM
+                                     ] .
+
+unit:BTU_IT-PER-MOL-DEG_F
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:MOL
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:DEG_F
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:BTU_IT
+                     ] .
+
+unit:QT_UK-PER-DAY  qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:QT_UK
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:DAY
+                                     ] .
+
+unit:HZ-PER-K  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                  qudt:unit      unit:K
+                                ] ;
+               qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:HZ
+                                ] .
+
+unit:PK_US_DRY-PER-SEC
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:SEC
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:PK_US_DRY
+                     ] .
+
+unit:PER-SR  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                qudt:unit      unit:SR
+                              ] .
+
+unit:M2  qudt:factorUnit  [ qudt:exponent  2 ;
+                            qudt:unit      unit:M
+                          ] .
+
+unit:MicroBQ-PER-KiloGM
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MicroBQ
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:KiloGM
+                     ] .
+
+unit:NanoGM-PER-DAY  qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:NanoGM
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:DAY
+                                      ] .
+
+unit:MilliM-PER-K  qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:MilliM
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:K
+                                    ] .
+
+unit:M2-PER-J  qudt:factorUnit  [ qudt:exponent  2 ;
+                                  qudt:unit      unit:M
+                                ] ;
+               qudt:factorUnit  [ qudt:exponent  -1 ;
+                                  qudt:unit      unit:J
+                                ] .
+
+unit:CAL_TH-PER-GM-K  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                         qudt:unit      unit:K
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  -1 ;
+                                         qudt:unit      unit:GM
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  1 ;
+                                         qudt:unit      unit:CAL_TH
+                                       ] .
+
+unit:S-PER-CentiM  qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:S
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:CentiM
+                                    ] .
+
+unit:KiloM-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:SEC
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:KiloM
+                                     ] .
+
+unit:NanoM2  qudt:factorUnit  [ qudt:exponent  2 ;
+                                qudt:unit      unit:NanoM
+                              ] .
+
+unit:K-M-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                     qudt:unit      unit:SEC
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:M
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:K
+                                   ] .
+
+unit:M2-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                    qudt:unit      unit:SEC
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  2 ;
+                                    qudt:unit      unit:M
+                                  ] .
+
+unit:DEG_C-WK  qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:WK
+                                ] ;
+               qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:DEG_C
+                                ] .
+
+unit:PER-MO  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                qudt:unit      unit:MO
+                              ] .
+
+unit:WB-PER-M  qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:WB
+                                ] ;
+               qudt:factorUnit  [ qudt:exponent  -1 ;
+                                  qudt:unit      unit:M
+                                ] .
+
+unit:PER-M-K  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                 qudt:unit      unit:M
+                               ] ;
+              qudt:factorUnit  [ qudt:exponent  -1 ;
+                                 qudt:unit      unit:K
+                               ] .
+
+unit:CAL_IT-PER-SEC-CentiM-K
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:SEC
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:K
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:CentiM
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:CAL_IT
+                     ] .
+
+unit:MilliGM-PER-M3-HR
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MilliGM
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -3 ;
+                       qudt:unit      unit:M
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:HR
+                     ] .
+
+unit:N-M-SEC-PER-RAD  qudt:factorUnit  [ qudt:exponent  1 ;
+                                         qudt:unit      unit:SEC
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  -1 ;
+                                         qudt:unit      unit:RAD
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  1 ;
+                                         qudt:unit      unit:N
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  1 ;
+                                         qudt:unit      unit:M
+                                       ] .
+
+unit:PA-PER-M  qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:PA
+                                ] ;
+               qudt:factorUnit  [ qudt:exponent  -1 ;
+                                  qudt:unit      unit:M
+                                ] .
+
+unit:SLUG-PER-DAY  qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:SLUG
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:DAY
+                                    ] .
+
+unit:QT_US-PER-DAY  qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:QT_US
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:DAY
+                                     ] .
+
+unit:MicroC-PER-M3  qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:MicroC
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -3 ;
+                                       qudt:unit      unit:M
+                                     ] .
+
+unit:PER-DAY  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                 qudt:unit      unit:DAY
+                               ] .
+
+unit:BTU_TH-PER-FT3  qudt:factorUnit  [ qudt:exponent  -3 ;
+                                        qudt:unit      unit:FT
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:BTU_TH
+                                      ] .
+
+unit:MicroGM-PER-M2-DAY
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MicroGM
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:M
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:DAY
+                     ] .
+
+unit:BTU_TH-PER-LB-DEG_F
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:LB
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:DEG_F
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:BTU_TH
+                     ] .
+
+unit:MilliM2-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                         qudt:unit      unit:SEC
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  2 ;
+                                         qudt:unit      unit:MilliM
+                                       ] .
+
+unit:BQ-PER-KiloGM  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:KiloGM
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:BQ
+                                     ] .
+
+unit:FT3-PER-DAY  qudt:factorUnit  [ qudt:exponent  3 ;
+                                     qudt:unit      unit:FT
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                     qudt:unit      unit:DAY
+                                   ] .
+
+unit:L-PER-K  qudt:factorUnit  [ qudt:exponent  1 ;
+                                 qudt:unit      unit:L
+                               ] ;
+              qudt:factorUnit  [ qudt:exponent  -1 ;
+                                 qudt:unit      unit:K
+                               ] .
+
+unit:M2-PER-HZ-DEG  qudt:factorUnit  [ qudt:exponent  2 ;
+                                       qudt:unit      unit:M
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:HZ
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:DEG
+                                     ] .
+
+unit:TON_Metric-PER-DAY
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:TON_Metric
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:DAY
+                     ] .
+
+unit:V_Ab-SEC  qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:V_Ab
+                                ] ;
+               qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:SEC
+                                ] .
+
+unit:CentiM-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:SEC
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:CentiM
+                                      ] .
+
+unit:N-M-PER-M  qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:N
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:M
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  -1 ;
+                                   qudt:unit      unit:M
+                                 ] .
+
+unit:V-A  qudt:factorUnit  [ qudt:exponent  1 ;
+                             qudt:unit      unit:V
+                           ] ;
+          qudt:factorUnit  [ qudt:exponent  1 ;
+                             qudt:unit      unit:A
+                           ] .
+
+unit:PicoMOL-PER-M2-DAY
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:PicoMOL
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:M
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:DAY
+                     ] .
+
+unit:MicroM3  qudt:factorUnit  [ qudt:exponent  3 ;
+                                 qudt:unit      unit:MicroM
+                               ] .
+
+unit:M2-K-PER-W  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                    qudt:unit      unit:W
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  2 ;
+                                    qudt:unit      unit:M
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  1 ;
+                                    qudt:unit      unit:K
+                                  ] .
+
+unit:KiloGM-PER-M3-SEC
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:SEC
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -3 ;
+                       qudt:unit      unit:M
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:KiloGM
+                     ] .
+
+unit:MilliBAR-PER-BAR
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MilliBAR
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:BAR
+                     ] .
+
+unit:MilliL-PER-M3  qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:MilliL
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -3 ;
+                                       qudt:unit      unit:M
+                                     ] .
+
+unit:CentiM3-PER-HR  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:HR
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  3 ;
+                                        qudt:unit      unit:CentiM
+                                      ] .
+
+unit:M2-SR  qudt:factorUnit  [ qudt:exponent  1 ;
+                               qudt:unit      unit:SR
+                             ] ;
+            qudt:factorUnit  [ qudt:exponent  2 ;
+                               qudt:unit      unit:M
+                             ] .
+
+unit:PicoMOL-PER-KiloGM
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:PicoMOL
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:KiloGM
+                     ] .
+
+unit:KiloGM-PER-CentiM2
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:KiloGM
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:CentiM
+                     ] .
+
+unit:MilliM-PER-MIN  qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:MilliM
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:MIN
+                                      ] .
+
+unit:GRAY-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:SEC
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:GRAY
+                                    ] .
+
+unit:OZ-PER-IN3  qudt:factorUnit  [ qudt:exponent  1 ;
+                                    qudt:unit      unit:OZ
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  -3 ;
+                                    qudt:unit      unit:IN
+                                  ] .
+
+unit:BTU_IT-PER-SEC-FT-DEG_R
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:SEC
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:FT
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:DEG_R
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:BTU_IT
+                     ] .
+
+unit:MicroGM-PER-GM  qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:MicroGM
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:GM
+                                      ] .
+
+unit:J-PER-KiloGM-K-PA
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:PA
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:KiloGM
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:K
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:J
+                     ] .
+
+unit:GAL_US-PER-HR  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:HR
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:GAL_US
+                                     ] .
+
+unit:NanoMOL-PER-MicroMOL-DAY
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:NanoMOL
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:MicroMOL
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:DAY
+                     ] .
+
+unit:IN-PER-SEC2  qudt:factorUnit  [ qudt:exponent  -2 ;
+                                     qudt:unit      unit:SEC
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:IN
+                                   ] .
+
+unit:CAL_TH-PER-MIN  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:MIN
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:CAL_TH
+                                      ] .
+
+unit:KiloCAL_TH-PER-HR
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:KiloCAL_TH
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:HR
+                     ] .
+
+unit:MicroMOL-PER-L-HR
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MicroMOL
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:L
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:HR
+                     ] .
+
+unit:PERCENT-PER-DAY  qudt:factorUnit  [ qudt:exponent  1 ;
+                                         qudt:unit      unit:PERCENT
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  -1 ;
+                                         qudt:unit      unit:DAY
+                                       ] .
+
+unit:DEG_C-CentiM  qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:DEG_C
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:CentiM
+                                    ] .
+
+unit:MOL-PER-HR  qudt:factorUnit  [ qudt:exponent  1 ;
+                                    qudt:unit      unit:MOL
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  -1 ;
+                                    qudt:unit      unit:HR
+                                  ] .
+
+unit:FT2-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                     qudt:unit      unit:SEC
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  2 ;
+                                     qudt:unit      unit:FT
+                                   ] .
+
+unit:MOL-PER-M2-SEC-M
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:SEC
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MOL
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:M
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:M
+                     ] .
+
+unit:MegaA-PER-M2  qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:MegaA
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  -2 ;
+                                      qudt:unit      unit:M
+                                    ] .
+
+unit:DEG_C-PER-MIN  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:MIN
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:DEG_C
+                                     ] .
+
+unit:DEG_C-PER-YR  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:YR
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:DEG_C
+                                    ] .
+
+unit:PK_UK-PER-DAY  qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:PK_UK
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:DAY
+                                     ] .
+
+unit:TON_SHORT-PER-YD3
+    qudt:factorUnit  [ qudt:exponent  -3 ;
+                       qudt:unit      unit:YD
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:TON_SHORT
+                     ] .
+
+unit:IN-PER-DEG_F  qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:IN
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:DEG_F
+                                    ] .
+
+unit:HP-PER-M  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                  qudt:unit      unit:M
+                                ] ;
+               qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:HP
+                                ] .
+
+unit:GM-MilliM  qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:MilliM
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:GM
+                                 ] .
+
+unit:PicoMOL-PER-L-HR
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:PicoMOL
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:L
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:HR
+                     ] .
+
+unit:PA-SEC  qudt:factorUnit  [ qudt:exponent  1 ;
+                                qudt:unit      unit:SEC
+                              ] ;
+             qudt:factorUnit  [ qudt:exponent  1 ;
+                                qudt:unit      unit:PA
+                              ] .
+
+unit:M4-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                    qudt:unit      unit:SEC
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  4 ;
+                                    qudt:unit      unit:M
+                                  ] .
+
+unit:BBL_US_PET-PER-SEC
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:SEC
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:BBL_US_PET
+                     ] .
+
+unit:C-PER-CentiM3  qudt:factorUnit  [ qudt:exponent  -3 ;
+                                       qudt:unit      unit:CentiM
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:C
+                                     ] .
+
+unit:J-PER-KiloGM-K  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:KiloGM
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:K
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:J
+                                      ] .
+
+unit:MilliRAD_R-PER-HR
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MilliRAD_R
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:HR
+                     ] .
+
+unit:NanoGM-PER-L  qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:NanoGM
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:L
+                                    ] .
+
+unit:MilliS-PER-M  qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:MilliS
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:M
+                                    ] .
+
+unit:PicoGM-PER-KiloGM
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:PicoGM
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:KiloGM
+                     ] .
+
+unit:DYN-SEC-PER-CentiM3
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:SEC
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:DYN
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -3 ;
+                       qudt:unit      unit:CentiM
+                     ] .
+
+unit:BAR-PER-BAR  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:BAR
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                     qudt:unit      unit:BAR
+                                   ] .
+
+unit:W-HR-PER-M3  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:W
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  -3 ;
+                                     qudt:unit      unit:M
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:HR
+                                   ] .
+
+unit:PSI-L-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:SEC
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:PSI
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:L
+                                     ] .
+
+unit:ERG-PER-G  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                   qudt:unit      unit:G
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:ERG
+                                 ] .
+
+unit:LB_F-PER-LB  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:LB_F
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                     qudt:unit      unit:LB
+                                   ] .
+
+unit:BBL_UK_PET-PER-DAY
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:DAY
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:BBL_UK_PET
+                     ] .
+
+unit:N-M2-PER-KiloGM2
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:N
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  2 ;
+                       qudt:unit      unit:M
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:KiloGM
+                     ] .
+
+unit:GAL_UK-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:SEC
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:GAL_UK
+                                      ] .
+
+unit:MicroH-PER-OHM  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:OHM
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:MicroH
+                                      ] .
+
+unit:J-PER-KiloGM  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:KiloGM
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:J
+                                    ] .
+
+unit:GM-PER-M3  qudt:factorUnit  [ qudt:exponent  -3 ;
+                                   qudt:unit      unit:M
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:GM
+                                 ] .
+
+unit:IN4  qudt:factorUnit  [ qudt:exponent  4 ;
+                             qudt:unit      unit:IN
+                           ] .
+
+unit:NUM-PER-HectoGM  qudt:factorUnit  [ qudt:exponent  1 ;
+                                         qudt:unit      unit:NUM
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  -1 ;
+                                         qudt:unit      unit:HectoGM
+                                       ] .
+
+unit:SEC-FT2  qudt:factorUnit  [ qudt:exponent  1 ;
+                                 qudt:unit      unit:SEC
+                               ] ;
+              qudt:factorUnit  [ qudt:exponent  2 ;
+                                 qudt:unit      unit:FT
+                               ] .
+
+unit:KiloN-M  qudt:factorUnit  [ qudt:exponent  1 ;
+                                 qudt:unit      unit:M
+                               ] ;
+              qudt:factorUnit  [ qudt:exponent  1 ;
+                                 qudt:unit      unit:KiloN
+                               ] .
+
+unit:FT2-SEC-DEG_F  qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:SEC
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  2 ;
+                                       qudt:unit      unit:FT
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:DEG_F
+                                     ] .
+
+unit:MegaPA-L-PER-SEC
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:SEC
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MegaPA
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:L
+                     ] .
+
+unit:A-PER-J  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                 qudt:unit      unit:J
+                               ] ;
+              qudt:factorUnit  [ qudt:exponent  1 ;
+                                 qudt:unit      unit:A
+                               ] .
+
+unit:PER-CentiM  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                    qudt:unit      unit:CentiM
+                                  ] .
+
+unit:RAD-M2-PER-MOL  qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:RAD
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:MOL
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  2 ;
+                                        qudt:unit      unit:M
+                                      ] .
+
+unit:MDOLLAR-PER-FLIGHT
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MDOLLAR
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:FLIGHT
+                     ] .
+
+unit:ERG-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                     qudt:unit      unit:SEC
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:ERG
+                                   ] .
+
+unit:IU-PER-L  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                  qudt:unit      unit:L
+                                ] ;
+               qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:IU
+                                ] .
+
+unit:W-M2-PER-SR  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:W
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                     qudt:unit      unit:SR
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  2 ;
+                                     qudt:unit      unit:M
+                                   ] .
+
+unit:N-SEC-PER-M  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:SEC
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:N
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                     qudt:unit      unit:M
+                                   ] .
+
+unit:GM-PER-CentiM3  qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:GM
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -3 ;
+                                        qudt:unit      unit:CentiM
+                                      ] .
+
+unit:GAL_US-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:SEC
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:GAL_US
+                                      ] .
+
+unit:L-PER-DAY  qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:L
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  -1 ;
+                                   qudt:unit      unit:DAY
+                                 ] .
+
+unit:DEG-PER-M  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                   qudt:unit      unit:M
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:DEG
+                                 ] .
+
+unit:HZ-M  qudt:factorUnit  [ qudt:exponent  1 ;
+                              qudt:unit      unit:M
+                            ] ;
+           qudt:factorUnit  [ qudt:exponent  1 ;
+                              qudt:unit      unit:HZ
+                            ] .
+
+unit:KiloCAL-PER-MIN  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                         qudt:unit      unit:MIN
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  1 ;
+                                         qudt:unit      unit:KiloCAL
+                                       ] .
+
+unit:KiloGM-PER-DAY  qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:KiloGM
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:DAY
+                                      ] .
+
+unit:MilliM3-PER-M3  qudt:factorUnit  [ qudt:exponent  3 ;
+                                        qudt:unit      unit:MilliM
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -3 ;
+                                        qudt:unit      unit:M
+                                      ] .
+
+unit:KiloCAL-PER-MOL  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                         qudt:unit      unit:MOL
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  1 ;
+                                         qudt:unit      unit:KiloCAL
+                                       ] .
+
+unit:PER-CentiM3  qudt:factorUnit  [ qudt:exponent  -3 ;
+                                     qudt:unit      unit:CentiM
+                                   ] .
+
+unit:DEG-PER-SEC2  qudt:factorUnit  [ qudt:exponent  -2 ;
+                                      qudt:unit      unit:SEC
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:DEG
+                                    ] .
+
+unit:RAD-PER-M  qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:RAD
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  -1 ;
+                                   qudt:unit      unit:M
+                                 ] .
+
+unit:MilliA-HR  qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:MilliA
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:HR
+                                 ] .
+
+unit:HR-FT2  qudt:factorUnit  [ qudt:exponent  1 ;
+                                qudt:unit      unit:HR
+                              ] ;
+             qudt:factorUnit  [ qudt:exponent  2 ;
+                                qudt:unit      unit:FT
+                              ] .
+
+unit:KiloBIT-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                         qudt:unit      unit:SEC
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  1 ;
+                                         qudt:unit      unit:KiloBIT
+                                       ] .
+
+unit:FT-LB_F-PER-M2  qudt:factorUnit  [ qudt:exponent  -2 ;
+                                        qudt:unit      unit:M
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:LB_F
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:FT
+                                      ] .
+
+unit:MicroMOL-PER-L  qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:MicroMOL
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:L
+                                      ] .
+
+unit:NUM-PER-CentiM-KiloYR
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:NUM
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:KiloYR
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:CentiM
+                     ] .
+
+unit:LB-PER-IN  qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:LB
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  -1 ;
+                                   qudt:unit      unit:IN
+                                 ] .
+
+unit:KiloGM-M-PER-SEC
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:SEC
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:M
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:KiloGM
+                     ] .
+
+unit:MegaGM-PER-M3  qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:MegaGM
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -3 ;
+                                       qudt:unit      unit:M
+                                     ] .
+
+unit:MicroMOL-PER-M2-HR
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MicroMOL
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:M
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:HR
+                     ] .
+
+unit:PER-MicroMOL-L  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:MicroMOL
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:L
+                                      ] .
+
+unit:MegaJ-PER-K  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:MegaJ
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                     qudt:unit      unit:K
+                                   ] .
+
+unit:MOL-PER-GM-HR  qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:MOL
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:HR
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:GM
+                                     ] .
+
+unit:PER-SEC-M2-SR  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:SR
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:SEC
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -2 ;
+                                       qudt:unit      unit:M
+                                     ] .
+
+unit:KiloHZ-M  qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:M
+                                ] ;
+               qudt:factorUnit  [ qudt:exponent  1 ;
+                                  qudt:unit      unit:KiloHZ
+                                ] .
+
+unit:GAL_UK-PER-HR  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:HR
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:GAL_UK
+                                     ] .
+
+unit:DeciM3-PER-DAY  qudt:factorUnit  [ qudt:exponent  3 ;
+                                        qudt:unit      unit:DeciM
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:DAY
+                                      ] .
+
+unit:NanoS-PER-CentiM
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:NanoS
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:CentiM
+                     ] .
+
+unit:PER-M  qudt:factorUnit  [ qudt:exponent  -1 ;
+                               qudt:unit      unit:M
+                             ] .
+
+unit:PA-M  qudt:factorUnit  [ qudt:exponent  1 ;
+                              qudt:unit      unit:PA
+                            ] ;
+           qudt:factorUnit  [ qudt:exponent  1 ;
+                              qudt:unit      unit:M
+                            ] .
+
+unit:YD3-PER-DAY  qudt:factorUnit  [ qudt:exponent  3 ;
+                                     qudt:unit      unit:YD
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                     qudt:unit      unit:DAY
+                                   ] .
+
+unit:PERCENT-PER-WK  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:WK
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:PERCENT
+                                      ] .
+
+unit:CentiM2-PER-CentiM3
+    qudt:factorUnit  [ qudt:exponent  2 ;
+                       qudt:unit      unit:CentiM
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -3 ;
+                       qudt:unit      unit:CentiM
+                     ] .
+
+unit:BREATH-PER-MIN  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:MIN
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:BREATH
+                                      ] .
+
+unit:N-PER-M  qudt:factorUnit  [ qudt:exponent  1 ;
+                                 qudt:unit      unit:N
+                               ] ;
+              qudt:factorUnit  [ qudt:exponent  -1 ;
+                                 qudt:unit      unit:M
+                               ] .
+
+unit:OZ-PER-YD2  qudt:factorUnit  [ qudt:exponent  -2 ;
+                                    qudt:unit      unit:YD
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  1 ;
+                                    qudt:unit      unit:OZ
+                                  ] .
+
+unit:BU_UK-PER-MIN  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:MIN
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:BU_UK
+                                     ] .
+
+unit:PER-KiloV-A-HR  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:KiloV
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:HR
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:A
+                                      ] .
+
+unit:AttoJ-SEC  qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:SEC
+                                 ] ;
+                qudt:factorUnit  [ qudt:exponent  1 ;
+                                   qudt:unit      unit:AttoJ
+                                 ] .
+
+unit:PER-SEC-M2  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                    qudt:unit      unit:SEC
+                                  ] ;
+                 qudt:factorUnit  [ qudt:exponent  -2 ;
+                                    qudt:unit      unit:M
+                                  ] .
+
+unit:MilliMOL-PER-L  qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:MilliMOL
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:L
+                                      ] .
+
+unit:MegaPA-PER-BAR  qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:MegaPA
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:BAR
+                                      ] .
+
+unit:CentiM-PER-KiloYR
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:KiloYR
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:CentiM
+                     ] .
+
+unit:PER-H  qudt:factorUnit  [ qudt:exponent  -1 ;
+                               qudt:unit      unit:H
+                             ] .
+
+unit:SLUG-PER-FT-SEC  qudt:factorUnit  [ qudt:exponent  1 ;
+                                         qudt:unit      unit:SLUG
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  -1 ;
+                                         qudt:unit      unit:SEC
+                                       ] ;
+                      qudt:factorUnit  [ qudt:exponent  -1 ;
+                                         qudt:unit      unit:FT
+                                       ] .
+
+unit:A-PER-CentiM  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                      qudt:unit      unit:CentiM
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:A
+                                    ] .
+
+unit:MilliM-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:SEC
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:MilliM
+                                      ] .
+
+unit:MilliGM-PER-M2-SEC
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:SEC
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MilliGM
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:M
+                     ] .
+
+unit:MicroM-PER-L-DAY
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MicroM
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:L
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:DAY
+                     ] .
+
+unit:MicroGM-PER-M3-HR
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:MicroGM
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -3 ;
+                       qudt:unit      unit:M
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:HR
+                     ] .
+
+unit:NanoGM-PER-MicroL
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:NanoGM
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:MicroL
+                     ] .
+
+unit:MilliC-PER-M3  qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:MilliC
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -3 ;
+                                       qudt:unit      unit:M
+                                     ] .
+
+unit:GigaC-PER-M3  qudt:factorUnit  [ qudt:exponent  -3 ;
+                                      qudt:unit      unit:M
+                                    ] ;
+                   qudt:factorUnit  [ qudt:exponent  1 ;
+                                      qudt:unit      unit:GigaC
+                                    ] .
+
+unit:BTU_IT-PER-LB-DEG_R
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:LB
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:DEG_R
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:BTU_IT
+                     ] .
+
+unit:RAD-PER-MIN  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:RAD
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                     qudt:unit      unit:MIN
+                                   ] .
+
+unit:BTU_TH-FT-PER-FT2-HR-DEG_F
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:HR
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:FT
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:FT
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:DEG_F
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:BTU_TH
+                     ] .
+
+unit:BTU_IT-PER-SEC-FT2
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:SEC
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -2 ;
+                       qudt:unit      unit:FT
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:BTU_IT
+                     ] .
+
+unit:MicroM3-PER-MilliL
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:MilliL
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  3 ;
+                       qudt:unit      unit:MicroM
+                     ] .
+
+unit:PSI-PER-PSI  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:PSI
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                     qudt:unit      unit:PSI
+                                   ] .
+
+unit:W-PER-M2-K4  qudt:factorUnit  [ qudt:exponent  1 ;
+                                     qudt:unit      unit:W
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  -2 ;
+                                     qudt:unit      unit:M
+                                   ] ;
+                  qudt:factorUnit  [ qudt:exponent  -4 ;
+                                     qudt:unit      unit:K
+                                   ] .
+
+unit:MilliGM-PER-M  qudt:factorUnit  [ qudt:exponent  1 ;
+                                       qudt:unit      unit:MilliGM
+                                     ] ;
+                    qudt:factorUnit  [ qudt:exponent  -1 ;
+                                       qudt:unit      unit:M
+                                     ] .
+
+unit:CAL_TH-PER-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:SEC
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:CAL_TH
+                                      ] .
+
+unit:OZ_VOL_UK-PER-MIN
+    qudt:factorUnit  [ qudt:exponent  1 ;
+                       qudt:unit      unit:OZ_VOL_UK
+                     ] ;
+    qudt:factorUnit  [ qudt:exponent  -1 ;
+                       qudt:unit      unit:MIN
+                     ] .
+
+unit:CentiN  a        qudt:Unit ;
+             rdfs:comment  "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
+
+unit:MOL-PER-M2-SEC  qudt:factorUnit  [ qudt:exponent  -1 ;
+                                        qudt:unit      unit:SEC
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  1 ;
+                                        qudt:unit      unit:MOL
+                                      ] ;
+                     qudt:factorUnit  [ qudt:exponent  -2 ;
+                                        qudt:unit      unit:M
+                                      ] .
+
+
+unit:PicoMOL-PER-M3-SEC
+    qudt:convertsTo   unit:MOL-PER-M3-SEC ;
+    qudt:isScalingOf  unit:MOL-PER-M3-SEC .
+
+unit:PebiBYTE  qudt:isScalingOf  unit:BYTE ;
+               qudt:prefix       prefix:Pebi .
+
+unit:GM-PER-KiloM  qudt:isScalingOf  unit:GM-PER-M .
+
+unit:CentiM3-PER-HR  qudt:convertsTo  unit:M3-PER-SEC ;
+                     qudt:isScalingOf  unit:M3-PER-SEC .
+
+unit:PicoGM  qudt:isScalingOf  unit:GM ;
+             qudt:prefix       prefix:Pico .
+
+unit:KiloCi  qudt:isScalingOf  unit:Ci ;
+             qudt:prefix       prefix:Kilo .
+
+unit:MilliM3-PER-M3  qudt:convertsTo  unit:M3-PER-M3 ;
+                     qudt:isScalingOf  unit:M3-PER-M3 .
+
+unit:KiloSEC  qudt:convertsTo  unit:SEC ;
+              qudt:isScalingOf  unit:SEC ;
+              qudt:prefix       prefix:Kilo .
+
+unit:MicroPA  qudt:convertsTo  unit:PA ;
+              qudt:isScalingOf  unit:PA ;
+              qudt:prefix       prefix:Micro .
+
+unit:KiloJ-PER-MOL  qudt:convertsTo  unit:J-PER-MOL ;
+                    qudt:isScalingOf  unit:J-PER-MOL .
+
+unit:C-PER-CentiM3  qudt:convertsTo  unit:C-PER-M3 ;
+                    qudt:isScalingOf  unit:C-PER-M3 .
+
+unit:GigaJ  qudt:convertsTo  unit:J ;
+            qudt:isScalingOf  unit:J ;
+            qudt:prefix       prefix:Giga .
+
+unit:TeraW-HR  qudt:convertsTo  unit:W-SEC ;
+               qudt:isScalingOf  unit:W-SEC .
+
+unit:PER-CentiM3  qudt:convertsTo  unit:PER-M3 ;
+                  qudt:isScalingOf  unit:PER-M3 .
+
+unit:MegaBQ  qudt:convertsTo  unit:BQ ;
+             qudt:isScalingOf  unit:BQ ;
+             qudt:prefix       prefix:Mega .
+
+unit:V-PER-MicroSEC  qudt:convertsTo  unit:V-PER-SEC ;
+                     qudt:isScalingOf  unit:V-PER-SEC .
+
+unit:FARAD-PER-KiloM  qudt:convertsTo  unit:FARAD-PER-M ;
+                      qudt:isScalingOf  unit:FARAD-PER-M .
+
+unit:KiloN-M  qudt:convertsTo  unit:N-M ;
+              qudt:isScalingOf  unit:N-M .
+
+unit:MilliBAR-L-PER-SEC
+    qudt:isScalingOf  unit:BAR-L-PER-SEC .
+
+unit:MicroJ  qudt:convertsTo  unit:J ;
+             qudt:isScalingOf  unit:J ;
+             qudt:prefix       prefix:Micro .
+
+unit:CentiM-PER-K  qudt:convertsTo  unit:M-PER-K ;
+                   qudt:isScalingOf  unit:M-PER-K .
+
+unit:KiloGM-PER-HR  qudt:isScalingOf  unit:GM-PER-SEC .
+
+unit:MilliT  qudt:convertsTo  unit:T ;
+             qudt:isScalingOf  unit:T ;
+             qudt:prefix       prefix:Milli .
+
+unit:MilliN-PER-M  qudt:convertsTo  unit:N-PER-M ;
+                   qudt:isScalingOf  unit:N-PER-M .
+
+unit:PER-CentiM  qudt:convertsTo  unit:PER-M ;
+                 qudt:isScalingOf  unit:PER-M .
+
+unit:N-PER-CentiM2  qudt:convertsTo  unit:N-PER-M2 ;
+                    qudt:isScalingOf  unit:N-PER-M2 .
+
+unit:PetaBYTE  qudt:isScalingOf  unit:BYTE ;
+               qudt:prefix       prefix:Peta .
+
+unit:MicroMOL-PER-L  qudt:isScalingOf  unit:MOL-PER-L .
+
+unit:DecaARE  qudt:isScalingOf  unit:ARE ;
+              qudt:prefix       prefix:Deca .
+
+unit:KiloPA-PER-MilliM
+    qudt:convertsTo   unit:PA-PER-M ;
+    qudt:isScalingOf  unit:PA-PER-M .
+
+unit:NanoGM-PER-KiloGM
+    qudt:convertsTo   unit:GM-PER-GM ;
+    qudt:isScalingOf  unit:GM-PER-GM .
+
+unit:PicoW-PER-M2  qudt:convertsTo  unit:W-PER-M2 ;
+                   qudt:isScalingOf  unit:W-PER-M2 .
+
+unit:KiloV-A_Reactive
+    qudt:convertsTo   unit:V-A_Reactive ;
+    qudt:isScalingOf  unit:V-A_Reactive .
+
+unit:NanoFARAD-PER-M  qudt:convertsTo  unit:FARAD-PER-M ;
+                      qudt:isScalingOf  unit:FARAD-PER-M .
+
+unit:GigaBQ  qudt:convertsTo  unit:BQ ;
+             qudt:isScalingOf  unit:BQ ;
+             qudt:prefix       prefix:Giga .
+
+unit:ExaBYTE  qudt:isScalingOf  unit:BYTE ;
+              qudt:prefix       prefix:Exa .
+
+unit:MilliM3  qudt:convertsTo  unit:M3 ;
+              qudt:isScalingOf  unit:M3 ;
+              qudt:prefix       prefix:Milli .
+
+unit:KiloA-PER-M  qudt:convertsTo  unit:A-PER-M ;
+                  qudt:isScalingOf  unit:A-PER-M .
+
+unit:MegaJ-PER-M2  qudt:convertsTo  unit:J-PER-M2 ;
+                   qudt:isScalingOf  unit:J-PER-M2 .
+
+unit:GigaOHM  qudt:convertsTo  unit:OHM ;
+              qudt:isScalingOf  unit:OHM ;
+              qudt:prefix       prefix:Giga .
+
+unit:MilliMOL-PER-MOL
+    qudt:convertsTo   unit:MOL-PER-MOL ;
+    qudt:isScalingOf  unit:MOL-PER-MOL .
+
+unit:L-PER-MicroMOL  qudt:isScalingOf  unit:L-PER-MOL .
+
+unit:MicroW-PER-M2  qudt:convertsTo  unit:W-PER-M2 ;
+                    qudt:isScalingOf  unit:W-PER-M2 .
+
+unit:MicroMOL-PER-SEC
+    qudt:convertsTo   unit:MOL-PER-SEC ;
+    qudt:isScalingOf  unit:MOL-PER-SEC .
+
+unit:HectoPA-M3-PER-SEC
+    qudt:convertsTo   unit:PA-M3-PER-SEC ;
+    qudt:isScalingOf  unit:PA-M3-PER-SEC .
+
+unit:MilliW-PER-M2-NanoM
+    qudt:convertsTo   unit:W-PER-M2-M ;
+    qudt:isScalingOf  unit:W-PER-M2-M .
+
+unit:PicoS-PER-M  qudt:convertsTo  unit:S-PER-M ;
+                  qudt:isScalingOf  unit:S-PER-M .
+
+unit:MilliGM-PER-M  qudt:isScalingOf  unit:GM-PER-M .
+
+unit:MicroV-PER-M  qudt:convertsTo  unit:V-PER-M ;
+                   qudt:isScalingOf  unit:V-PER-M .
+
+unit:TeraHZ  qudt:convertsTo  unit:HZ ;
+             qudt:isScalingOf  unit:HZ ;
+             qudt:prefix       prefix:Tera .
+
+unit:NanoGM-PER-L  qudt:convertsTo  unit:GM-PER-L ;
+                   qudt:isScalingOf  unit:GM-PER-L .
+
+unit:NanoGM-PER-MilliL
+    qudt:convertsTo   unit:GM-PER-L ;
+    qudt:isScalingOf  unit:GM-PER-L .
+
+unit:MilliW-PER-M2  qudt:convertsTo  unit:W-PER-M2 ;
+                    qudt:isScalingOf  unit:W-PER-M2 .
+
+unit:NanoGM-PER-DAY  qudt:isScalingOf  unit:GM-PER-SEC .
+
+unit:W-PER-M2-NanoM-SR
+    qudt:convertsTo   unit:W-PER-M2-M-SR ;
+    qudt:isScalingOf  unit:W-PER-M2-M-SR .
+
+unit:MegaJ-PER-KiloGM
+    qudt:isScalingOf  unit:J-PER-GM .
+
+unit:MilliGM-PER-HR  qudt:isScalingOf  unit:GM-PER-SEC .
+
+unit:CentiC  qudt:convertsTo  unit:C ;
+             qudt:isScalingOf  unit:C ;
+             qudt:prefix       prefix:Centi .
+
+unit:PicoMOL-PER-M3  qudt:convertsTo  unit:MOL-PER-M3 ;
+                     qudt:isScalingOf  unit:MOL-PER-M3 .
+
+unit:DeciGM  qudt:isScalingOf  unit:GM ;
+             qudt:prefix       prefix:Deci .
+
+unit:CentiM3-PER-SEC  qudt:convertsTo  unit:M3-PER-SEC ;
+                      qudt:isScalingOf  unit:M3-PER-SEC .
+
+unit:MilliH-PER-OHM  qudt:convertsTo  unit:H-PER-OHM ;
+                     qudt:isScalingOf  unit:H-PER-OHM .
+
+unit:MicroMOL-PER-M2-DAY
+    qudt:convertsTo   unit:MOL-PER-M2-SEC ;
+    qudt:isScalingOf  unit:MOL-PER-M2-SEC .
+
+unit:MicroM3-PER-M3  qudt:convertsTo  unit:M3-PER-M3 ;
+                     qudt:isScalingOf  unit:M3-PER-M3 .
+
+unit:KiloJ  qudt:convertsTo  unit:J ;
+            qudt:isScalingOf  unit:J ;
+            qudt:prefix       prefix:Kilo .
+
+unit:CentiN  qudt:isScalingOf  unit:N ;
+             qudt:prefix       prefix:Centi .
+
+unit:KiloV-PER-M  qudt:convertsTo  unit:V-PER-M ;
+                  qudt:isScalingOf  unit:V-PER-M .
+
+unit:ExbiBYTE  qudt:isScalingOf  unit:BYTE ;
+               qudt:prefix       prefix:Exbi .
+
+unit:MegaBYTE  qudt:isScalingOf  unit:BYTE ;
+               qudt:prefix       prefix:Mega .
+
+unit:KiloGM-PER-MilliM
+    qudt:isScalingOf  unit:GM-PER-M .
+
+unit:GM-PER-CentiM2  qudt:isScalingOf  unit:GM-PER-M2 .
+
+unit:NUM-PER-HectoGM  qudt:isScalingOf  unit:NUM-PER-GM .
+
+unit:N-CentiM  qudt:convertsTo  unit:N-M ;
+               qudt:isScalingOf  unit:N-M .
+
+unit:MegaHZ-PER-K  qudt:convertsTo  unit:HZ-PER-K ;
+                   qudt:isScalingOf  unit:HZ-PER-K .
+
+unit:MegaJ  qudt:convertsTo  unit:J ;
+            qudt:isScalingOf  unit:J ;
+            qudt:prefix       prefix:Mega .
+
+unit:AttoJ  qudt:convertsTo  unit:J ;
+            qudt:isScalingOf  unit:J ;
+            qudt:prefix       prefix:Atto .
+
+unit:KiloGM-PER-DAY  qudt:isScalingOf  unit:GM-PER-SEC .
+
+unit:MilliGM-PER-DAY  qudt:isScalingOf  unit:GM-PER-SEC .
+
+unit:PicoGM-PER-GM  qudt:convertsTo  unit:GM-PER-GM ;
+                    qudt:isScalingOf  unit:GM-PER-GM .
+
+unit:MilliMOL-PER-M3  qudt:convertsTo  unit:MOL-PER-M3 ;
+                      qudt:isScalingOf  unit:MOL-PER-M3 .
+
+unit:DeciM3-PER-SEC  qudt:convertsTo  unit:M3-PER-SEC ;
+                     qudt:isScalingOf  unit:M3-PER-SEC .
+
+unit:MicroFARAD-PER-M
+    qudt:convertsTo   unit:FARAD-PER-M ;
+    qudt:isScalingOf  unit:FARAD-PER-M .
+
+unit:NUM-PER-NanoL  qudt:isScalingOf  unit:NUM-PER-L .
+
+unit:DeciM2  qudt:convertsTo  unit:M2 ;
+             qudt:isScalingOf  unit:M2 ;
+             qudt:prefix       prefix:Deci .
+
+unit:MilliM-PER-YR  qudt:convertsTo  unit:M-PER-SEC ;
+                    qudt:isScalingOf  unit:M-PER-SEC .
+
+unit:MicroMHO  qudt:convertsTo  unit:MHO ;
+               qudt:isScalingOf  unit:MHO ;
+               qudt:prefix       prefix:Micro .
+
+unit:C-PER-MilliM3  qudt:convertsTo  unit:C-PER-M3 ;
+                    qudt:isScalingOf  unit:C-PER-M3 .
+
+unit:PER-MilliM3  qudt:convertsTo  unit:PER-M3 ;
+                  qudt:isScalingOf  unit:PER-M3 .
+
+unit:ZettaC  qudt:convertsTo  unit:C ;
+             qudt:isScalingOf  unit:C ;
+             qudt:prefix       prefix:Zetta .
+
+unit:MilliGM-PER-CentiM2
+    qudt:isScalingOf  unit:GM-PER-M2 .
+
+unit:PetaJ  qudt:convertsTo  unit:J ;
+            qudt:isScalingOf  unit:J ;
+            qudt:prefix       prefix:Peta .
+
+unit:HectoPA  qudt:convertsTo  unit:PA ;
+              qudt:isScalingOf  unit:PA ;
+              qudt:prefix       prefix:Hecto .
+
+unit:ZeptoC  qudt:convertsTo  unit:C ;
+             qudt:isScalingOf  unit:C ;
+             qudt:prefix       prefix:Zepto .
+
+unit:MilliL-PER-K  qudt:isScalingOf  unit:L-PER-K .
+
+unit:A-PER-CentiM2  qudt:convertsTo  unit:A-PER-M2 ;
+                    qudt:isScalingOf  unit:A-PER-M2 .
+
+unit:N-PER-MilliM2  qudt:convertsTo  unit:N-PER-M2 ;
+                    qudt:isScalingOf  unit:N-PER-M2 .
+
+unit:J-PER-KiloGM  qudt:isScalingOf  unit:J-PER-GM .
+
+unit:DeciM3-PER-HR  qudt:convertsTo  unit:M3-PER-SEC ;
+                    qudt:isScalingOf  unit:M3-PER-SEC .
+
+unit:MicroH-PER-OHM  qudt:convertsTo  unit:H-PER-OHM ;
+                     qudt:isScalingOf  unit:H-PER-OHM .
+
+unit:MilliJ  qudt:convertsTo  unit:J ;
+             qudt:isScalingOf  unit:J ;
+             qudt:prefix       prefix:Milli .
+
+unit:MilliMOL-PER-M3-DAY
+    qudt:convertsTo   unit:MOL-PER-M3-SEC ;
+    qudt:isScalingOf  unit:MOL-PER-M3-SEC .
+
+unit:KiloEV-PER-MicroM
+    qudt:isScalingOf  unit:EV-PER-M .
+
+unit:N-PER-MilliM  qudt:convertsTo  unit:N-PER-M ;
+                   qudt:isScalingOf  unit:N-PER-M .
+
+unit:KiloGM-PER-MOL  qudt:isScalingOf  unit:GM-PER-MOL .
+
+unit:MicroGM  qudt:isScalingOf  unit:GM ;
+              qudt:prefix       prefix:Micro .
+
+unit:MicroV  qudt:convertsTo  unit:V ;
+             qudt:isScalingOf  unit:V ;
+             qudt:prefix       prefix:Micro .
+
+unit:KiloTON_Metric  qudt:isScalingOf  unit:TON_Metric ;
+                     qudt:prefix       prefix:Kilo .
+
+unit:FemtoJ  qudt:convertsTo  unit:J ;
+             qudt:isScalingOf  unit:J ;
+             qudt:prefix       prefix:Femto .
+
+unit:ExaC  qudt:convertsTo  unit:C ;
+           qudt:isScalingOf  unit:C ;
+           qudt:prefix       prefix:Exa .
+
+unit:DecaL  qudt:isScalingOf  unit:L ;
+            qudt:prefix       prefix:Deca .
+
+unit:PicoGM-PER-KiloGM
+    qudt:convertsTo   unit:GM-PER-GM ;
+    qudt:isScalingOf  unit:GM-PER-GM .
+
+unit:MilliM4  qudt:convertsTo  unit:M4 ;
+              qudt:isScalingOf  unit:M4 ;
+              qudt:prefix       prefix:Milli .
+
+unit:CentiN-M  qudt:convertsTo  unit:N-M ;
+               qudt:isScalingOf  unit:N-M .
+
+unit:AttoJ-SEC  qudt:convertsTo  unit:J-SEC ;
+                qudt:isScalingOf  unit:J-SEC .
+
+unit:MicroMOL  qudt:convertsTo  unit:MOL ;
+               qudt:isScalingOf  unit:MOL ;
+               qudt:prefix       prefix:Micro .
+
+unit:KiloWB-PER-M  qudt:convertsTo  unit:WB-PER-M ;
+                   qudt:isScalingOf  unit:WB-PER-M .
+
+unit:MicroL-PER-L  qudt:convertsTo  unit:L-PER-L ;
+                   qudt:isScalingOf  unit:L-PER-L .
+
+unit:MegaJ-PER-M3  qudt:convertsTo  unit:J-PER-M3 ;
+                   qudt:isScalingOf  unit:J-PER-M3 .
+
+unit:DeciBAR  qudt:isScalingOf  unit:BAR ;
+              qudt:prefix       prefix:Deci .
+
+unit:S-PER-CentiM  qudt:convertsTo  unit:S-PER-M ;
+                   qudt:isScalingOf  unit:S-PER-M .
+
+unit:KiloJ-PER-KiloGM
+    qudt:isScalingOf  unit:J-PER-GM .
+
+unit:MegaN-M  qudt:convertsTo  unit:N-M ;
+              qudt:isScalingOf  unit:N-M .
+
+unit:KiloM-PER-DAY  qudt:convertsTo  unit:M-PER-SEC ;
+                    qudt:isScalingOf  unit:M-PER-SEC .
+
+unit:MegaGM-PER-M3  qudt:isScalingOf  unit:GM-PER-M3 .
+
+unit:FemtoGM-PER-L  qudt:convertsTo  unit:GM-PER-L ;
+                    qudt:isScalingOf  unit:GM-PER-L .
+
+unit:MicroM2  qudt:convertsTo  unit:M2 ;
+              qudt:isScalingOf  unit:M2 ;
+              qudt:prefix       prefix:Micro .
+
+unit:WB-PER-MilliM  qudt:convertsTo  unit:WB-PER-M ;
+                    qudt:isScalingOf  unit:WB-PER-M .
+
+unit:PicoGM-PER-MilliL
+    qudt:convertsTo   unit:GM-PER-L ;
+    qudt:isScalingOf  unit:GM-PER-L .
+
+unit:KiloL-PER-HR  qudt:isScalingOf  unit:L-PER-SEC .
+
+unit:MilliMOL  qudt:convertsTo  unit:MOL ;
+               qudt:isScalingOf  unit:MOL ;
+               qudt:prefix       prefix:Milli .
+
+unit:DecaPA  qudt:convertsTo  unit:PA ;
+             qudt:isScalingOf  unit:PA ;
+             qudt:prefix       prefix:Deca .
+
+unit:MilliCi  qudt:isScalingOf  unit:Ci ;
+              qudt:prefix       prefix:Milli .
+
+unit:PicoFARAD-PER-M  qudt:convertsTo  unit:FARAD-PER-M ;
+                      qudt:isScalingOf  unit:FARAD-PER-M .
+
+unit:KiloA-HR  qudt:convertsTo  unit:A-SEC ;
+               qudt:isScalingOf  unit:A-SEC .
+
+unit:KiloHZ-M  qudt:convertsTo  unit:HZ-M ;
+               qudt:isScalingOf  unit:HZ-M .
+
+unit:KiloV  qudt:convertsTo  unit:V ;
+            qudt:isScalingOf  unit:V ;
+            qudt:prefix       prefix:Kilo .
+
+unit:GM-PER-CentiM3  qudt:isScalingOf  unit:GM-PER-M3 .
+
+unit:MilliARCSEC  qudt:isScalingOf  unit:ARCSEC ;
+                  qudt:prefix       prefix:Milli .
+
+unit:KiloBAR  qudt:isScalingOf  unit:BAR ;
+              qudt:prefix       prefix:Kilo .
+
+unit:V-PER-MilliM  qudt:convertsTo  unit:V-PER-M ;
+                   qudt:isScalingOf  unit:V-PER-M .
+
+unit:CentiM3-PER-MIN  qudt:convertsTo  unit:M3-PER-SEC ;
+                      qudt:isScalingOf  unit:M3-PER-SEC .
+
+unit:KiloPA  qudt:convertsTo  unit:PA ;
+             qudt:isScalingOf  unit:PA ;
+             qudt:prefix       prefix:Kilo .
+
+unit:MicroPOISE  qudt:isScalingOf  unit:POISE ;
+                 qudt:prefix       prefix:Micro .
+
+unit:PicoA  qudt:convertsTo  unit:A ;
+            qudt:isScalingOf  unit:A ;
+            qudt:prefix       prefix:Pico .
+
+unit:FemtoGM-PER-KiloGM
+    qudt:convertsTo   unit:GM-PER-GM ;
+    qudt:isScalingOf  unit:GM-PER-GM .
+
+unit:MegaV  qudt:convertsTo  unit:V ;
+            qudt:isScalingOf  unit:V ;
+            qudt:prefix       prefix:Mega .
+
+unit:TeraW  qudt:convertsTo  unit:W ;
+            qudt:isScalingOf  unit:W ;
+            qudt:prefix       prefix:Tera .
+
+unit:MilliM-PER-DAY  qudt:convertsTo  unit:M-PER-SEC ;
+                     qudt:isScalingOf  unit:M-PER-SEC .
+
+unit:DeciM3  qudt:convertsTo  unit:M3 ;
+             qudt:isScalingOf  unit:M3 ;
+             qudt:prefix       prefix:Deci .
+
+unit:MilliIN  qudt:isScalingOf  unit:IN ;
+              qudt:prefix       prefix:Milli .
+
+unit:PicoW  qudt:convertsTo  unit:W ;
+            qudt:isScalingOf  unit:W ;
+            qudt:prefix       prefix:Pico .
+
+unit:MicroFARAD-PER-KiloM
+    qudt:convertsTo   unit:FARAD-PER-M ;
+    qudt:isScalingOf  unit:FARAD-PER-M .
+
+unit:A-PER-MilliM2  qudt:convertsTo  unit:A-PER-M2 ;
+                    qudt:isScalingOf  unit:A-PER-M2 .
+
+unit:CentiPOISE  qudt:isScalingOf  unit:POISE ;
+                 qudt:prefix       prefix:Centi .
+
+unit:NanoS-PER-CentiM
+    qudt:convertsTo   unit:S-PER-M ;
+    qudt:isScalingOf  unit:S-PER-M .
+
+unit:MicroBQ-PER-L  qudt:isScalingOf  unit:BQ-PER-L .
+
+unit:DeciM3-PER-MIN  qudt:convertsTo  unit:M3-PER-SEC ;
+                     qudt:isScalingOf  unit:M3-PER-SEC .
+
+unit:MilliBQ-PER-L  qudt:isScalingOf  unit:BQ-PER-L .
+
+unit:KiloM3-PER-SEC2  qudt:convertsTo  unit:M3-PER-SEC2 ;
+                      qudt:isScalingOf  unit:M3-PER-SEC2 .
+
+unit:NanoH-PER-M  qudt:convertsTo  unit:H-PER-M ;
+                  qudt:isScalingOf  unit:H-PER-M .
+
+unit:GigaBYTE  qudt:isScalingOf  unit:BYTE ;
+               qudt:prefix       prefix:Giga .
+
+unit:KiloCAL_TH-PER-SEC
+    qudt:isScalingOf  unit:CAL_TH-PER-SEC .
+
+unit:MicroRAD  qudt:convertsTo  unit:RAD ;
+               qudt:isScalingOf  unit:RAD ;
+               qudt:prefix       prefix:Micro .
+
+unit:MilliL-PER-L  qudt:convertsTo  unit:L-PER-L ;
+                   qudt:isScalingOf  unit:L-PER-L .
+
+unit:KiloCAL_IT  qudt:isScalingOf  unit:CAL_IT ;
+                 qudt:prefix       prefix:Kilo .
+
+unit:GM-PER-DeciM3  qudt:isScalingOf  unit:GM-PER-M3 .
+
+unit:MilliL-PER-DAY  qudt:isScalingOf  unit:L-PER-SEC .
+
+unit:KiloMOL-PER-M3  qudt:convertsTo  unit:MOL-PER-M3 ;
+                     qudt:isScalingOf  unit:MOL-PER-M3 .
+
+unit:MegaPA  qudt:convertsTo  unit:PA ;
+             qudt:isScalingOf  unit:PA ;
+             qudt:prefix       prefix:Mega .
+
+unit:GigaW  qudt:convertsTo  unit:W ;
+            qudt:isScalingOf  unit:W ;
+            qudt:prefix       prefix:Giga .
+
+unit:MicroA  qudt:convertsTo  unit:A ;
+             qudt:isScalingOf  unit:A ;
+             qudt:prefix       prefix:Micro .
+
+unit:NanoA  qudt:convertsTo  unit:A ;
+            qudt:isScalingOf  unit:A ;
+            qudt:prefix       prefix:Nano .
+
+unit:KiloGM-PER-SEC  qudt:isScalingOf  unit:GM-PER-SEC .
+
+unit:MebiBYTE  qudt:isScalingOf  unit:BYTE ;
+               qudt:prefix       prefix:Mebi .
+
+unit:MilliGM-PER-SEC  qudt:isScalingOf  unit:GM-PER-SEC .
+
+unit:MicroL  qudt:isScalingOf  unit:L ;
+             qudt:prefix       prefix:Micro .
+
+unit:HectoGM  qudt:isScalingOf  unit:GM ;
+              qudt:prefix       prefix:Hecto .
+
+unit:MilliRAD  qudt:convertsTo  unit:RAD ;
+               qudt:isScalingOf  unit:RAD ;
+               qudt:prefix       prefix:Milli .
+
+unit:CentiM2-PER-SEC  qudt:convertsTo  unit:M2-PER-SEC ;
+                      qudt:isScalingOf  unit:M2-PER-SEC .
+
+unit:MilliV  qudt:convertsTo  unit:V ;
+             qudt:isScalingOf  unit:V ;
+             qudt:prefix       prefix:Milli .
+
+unit:NanoW  qudt:convertsTo  unit:W ;
+            qudt:isScalingOf  unit:W ;
+            qudt:prefix       prefix:Nano .
+
+unit:MilliA-PER-MilliM
+    qudt:convertsTo   unit:A-PER-M ;
+    qudt:isScalingOf  unit:A-PER-M .
+
+unit:MicroW  qudt:convertsTo  unit:W ;
+             qudt:isScalingOf  unit:W ;
+             qudt:prefix       prefix:Micro .
+
+unit:MicroSEC  qudt:convertsTo  unit:SEC ;
+               qudt:isScalingOf  unit:SEC ;
+               qudt:prefix       prefix:Micro .
+
+unit:MegaHZ-M  qudt:convertsTo  unit:HZ-M ;
+               qudt:isScalingOf  unit:HZ-M .
+
+unit:DecaM  qudt:convertsTo  unit:M ;
+            qudt:isScalingOf  unit:M ;
+            qudt:prefix       prefix:Deca .
+
+unit:MilliL-PER-HR  qudt:isScalingOf  unit:L-PER-SEC .
+
+unit:NanoSEC  qudt:convertsTo  unit:SEC ;
+              qudt:isScalingOf  unit:SEC ;
+              qudt:prefix       prefix:Nano .
+
+unit:GigaPA  qudt:convertsTo  unit:PA ;
+             qudt:isScalingOf  unit:PA ;
+             qudt:prefix       prefix:Giga .
+
+unit:MegaPA-L-PER-SEC
+    qudt:isScalingOf  unit:PA-L-PER-SEC .
+
+unit:GigaHZ-M  qudt:convertsTo  unit:HZ-M ;
+               qudt:isScalingOf  unit:HZ-M .
+
+unit:KiloV-A  qudt:convertsTo  unit:V-A ;
+              qudt:isScalingOf  unit:V-A .
+
+unit:MilliWB  qudt:convertsTo  unit:WB ;
+              qudt:isScalingOf  unit:WB ;
+              qudt:prefix       prefix:Milli .
+
+unit:MilliSV  qudt:convertsTo  unit:SV ;
+              qudt:isScalingOf  unit:SV ;
+              qudt:prefix       prefix:Milli .
+
+unit:CentiM-PER-KiloYR
+    qudt:isScalingOf  unit:M-PER-YR .
+
+unit:MicroN-M  qudt:convertsTo  unit:N-M ;
+               qudt:isScalingOf  unit:N-M .
+
+unit:MilliSEC  qudt:convertsTo  unit:SEC ;
+               qudt:isScalingOf  unit:SEC ;
+               qudt:prefix       prefix:Milli .
+
+unit:KiloC-PER-M2  qudt:convertsTo  unit:C-PER-M2 ;
+                   qudt:isScalingOf  unit:C-PER-M2 .
+
+unit:MicroM3  qudt:convertsTo  unit:M3 ;
+              qudt:isScalingOf  unit:M3 ;
+              qudt:prefix       prefix:Micro .
+
+unit:MilliGRAY  qudt:convertsTo  unit:GRAY ;
+                qudt:isScalingOf  unit:GRAY ;
+                qudt:prefix       prefix:Milli .
+
+unit:KibiBYTE  qudt:isScalingOf  unit:BYTE ;
+               qudt:prefix       prefix:Kibi .
+
+unit:MegaEV-PER-CentiM
+    qudt:isScalingOf  unit:EV-PER-M .
+
+unit:KiloA  qudt:convertsTo  unit:A ;
+            qudt:isScalingOf  unit:A ;
+            qudt:prefix       prefix:Kilo .
+
+unit:MegaYR  qudt:isScalingOf  unit:YR ;
+             qudt:prefix       prefix:Mega .
+
+unit:MilliPA-SEC  qudt:convertsTo  unit:PA-SEC ;
+                  qudt:isScalingOf  unit:PA-SEC .
+
+unit:TeraBYTE  qudt:isScalingOf  unit:BYTE ;
+               qudt:prefix       prefix:Tera .
+
+unit:KiloTONNE  qudt:isScalingOf  unit:TONNE ;
+                qudt:prefix       prefix:Kilo .
+
+unit:MilliN-M  qudt:convertsTo  unit:N-M ;
+               qudt:isScalingOf  unit:N-M .
+
+unit:KiloL  qudt:isScalingOf  unit:L ;
+            qudt:prefix       prefix:Kilo .
+
+unit:MegaJ-PER-K  qudt:convertsTo  unit:J-PER-K ;
+                  qudt:isScalingOf  unit:J-PER-K .
+
+unit:MicroH-PER-M  qudt:convertsTo  unit:H-PER-M ;
+                   qudt:isScalingOf  unit:H-PER-M .
+
+unit:KiloW  qudt:convertsTo  unit:W ;
+            qudt:isScalingOf  unit:W ;
+            qudt:prefix       prefix:Kilo .
+
+unit:V-PER-CentiM  qudt:convertsTo  unit:V-PER-M ;
+                   qudt:isScalingOf  unit:V-PER-M .
+
+unit:MicroTORR  qudt:isScalingOf  unit:TORR ;
+                qudt:prefix       prefix:Micro .
+
+unit:NanoGM-PER-M3  qudt:isScalingOf  unit:GM-PER-M3 .
+
+unit:KiloCAL_TH  qudt:isScalingOf  unit:CAL_TH ;
+                 qudt:prefix       prefix:Kilo .
+
+unit:MicroG  qudt:isScalingOf  unit:G ;
+             qudt:prefix       prefix:Micro .
+
+unit:MegaA  qudt:convertsTo  unit:A ;
+            qudt:isScalingOf  unit:A ;
+            qudt:prefix       prefix:Mega .
+
+unit:KiloMOL-PER-SEC  qudt:convertsTo  unit:MOL-PER-SEC ;
+                      qudt:isScalingOf  unit:MOL-PER-SEC .
+
+unit:CentiM-PER-SEC2  qudt:convertsTo  unit:M-PER-SEC2 ;
+                      qudt:isScalingOf  unit:M-PER-SEC2 .
+
+unit:NanoFARAD  qudt:convertsTo  unit:FARAD ;
+                qudt:isScalingOf  unit:FARAD ;
+                qudt:prefix       prefix:Nano .
+
+unit:CentiM3-PER-K  qudt:convertsTo  unit:M3-PER-K ;
+                    qudt:isScalingOf  unit:M3-PER-K .
+
+unit:MegaL  qudt:isScalingOf  unit:L ;
+            qudt:prefix       prefix:Mega .
+
+unit:MegaS-PER-M  qudt:convertsTo  unit:S-PER-M ;
+                  qudt:isScalingOf  unit:S-PER-M .
+
+unit:HectoPA-PER-BAR  qudt:isScalingOf  unit:PA-PER-BAR .
+
+unit:DecaGM  qudt:isScalingOf  unit:GM ;
+             qudt:prefix       prefix:Deca .
+
+unit:MegaJ-PER-SEC  qudt:convertsTo  unit:J-PER-SEC ;
+                    qudt:isScalingOf  unit:J-PER-SEC .
+
+unit:KiloGM-PER-M2  qudt:isScalingOf  unit:GM-PER-M2 .
+
+unit:MegaW  qudt:isScalingOf  unit:W ;
+            qudt:prefix       prefix:Mega .
+
+unit:ExaJ  qudt:convertsTo  unit:J ;
+           qudt:isScalingOf  unit:J ;
+           qudt:prefix       prefix:Exa .
+
+unit:NanoGM  qudt:isScalingOf  unit:GM ;
+             qudt:prefix       prefix:Nano .
+
+unit:PicoM  qudt:convertsTo  unit:M ;
+            qudt:isScalingOf  unit:M ;
+            qudt:prefix       prefix:Pico .
+
+unit:MilliGM-PER-GM  qudt:convertsTo  unit:GM-PER-GM ;
+                     qudt:isScalingOf  unit:GM-PER-GM .
+
+unit:KiloOHM  qudt:convertsTo  unit:OHM ;
+              qudt:isScalingOf  unit:OHM ;
+              qudt:prefix       prefix:Kilo .
+
+unit:KiloM-PER-SEC  qudt:convertsTo  unit:M-PER-SEC ;
+                    qudt:isScalingOf  unit:M-PER-SEC .
+
+unit:PicoPA-PER-KiloM
+    qudt:convertsTo   unit:PA-PER-M ;
+    qudt:isScalingOf  unit:PA-PER-M .
+
+unit:KiloGAUSS  qudt:isScalingOf  unit:GAUSS ;
+                qudt:prefix       prefix:Kilo .
+
+unit:FemtoMOL-PER-L  qudt:isScalingOf  unit:MOL-PER-L .
+
+unit:CentiBAR  qudt:isScalingOf  unit:BAR ;
+               qudt:prefix       prefix:Centi .
+
+unit:KiloW-HR  qudt:convertsTo  unit:W-SEC ;
+               qudt:isScalingOf  unit:W-SEC .
+
+unit:KiloGM  qudt:isScalingOf  unit:GM ;
+             qudt:prefix       prefix:Kilo .
+
+unit:MilliGM-PER-DeciL
+    qudt:convertsTo   unit:GM-PER-L ;
+    qudt:isScalingOf  unit:GM-PER-L .
+
+unit:DeciL  qudt:isScalingOf  unit:L ;
+            qudt:prefix       prefix:Deci .
+
+unit:HectoL  qudt:isScalingOf  unit:L ;
+             qudt:prefix       prefix:Hecto .
+
+unit:NUM-PER-MilliGM  qudt:isScalingOf  unit:NUM-PER-GM .
+
+unit:KiloA-PER-M2  qudt:convertsTo  unit:A-PER-M2 ;
+                   qudt:isScalingOf  unit:A-PER-M2 .
+
+unit:GigaC-PER-M3  qudt:convertsTo  unit:C-PER-M3 ;
+                   qudt:isScalingOf  unit:C-PER-M3 .
+
+unit:MegaBAR  qudt:isScalingOf  unit:BAR ;
+              qudt:prefix       prefix:Mega .
+
+unit:PicoMOL-PER-L  qudt:isScalingOf  unit:MOL-PER-L .
+
+unit:NanoM2  qudt:convertsTo  unit:M2 ;
+             qudt:isScalingOf  unit:M2 ;
+             qudt:prefix       prefix:Nano .
+
+unit:KiloR  qudt:isScalingOf  unit:R ;
+            qudt:prefix       prefix:Kilo .
+
+unit:NanoMOL-PER-MicroMOL
+    qudt:convertsTo   unit:MOL-PER-MOL ;
+    qudt:isScalingOf  unit:MOL-PER-MOL .
+
+unit:KiloBIT-PER-SEC  qudt:isScalingOf  unit:BIT-PER-SEC .
+
+unit:MicroGRAY  qudt:convertsTo  unit:GRAY ;
+                qudt:isScalingOf  unit:GRAY ;
+                qudt:prefix       prefix:Micro .
+
+unit:MilliA  qudt:convertsTo  unit:A ;
+             qudt:isScalingOf  unit:A ;
+             qudt:prefix       prefix:Milli .
+
+unit:MilliGM-PER-M2  qudt:isScalingOf  unit:GM-PER-M2 .
+
+unit:MilliFARAD  qudt:convertsTo  unit:FARAD ;
+                 qudt:isScalingOf  unit:FARAD ;
+                 qudt:prefix       prefix:Milli .
+
+unit:MilliL  qudt:isScalingOf  unit:L ;
+             qudt:prefix       prefix:Milli .
+
+unit:MicroC-PER-M2  qudt:convertsTo  unit:C-PER-M2 ;
+                    qudt:isScalingOf  unit:C-PER-M2 .
+
+unit:KiloHZ  qudt:convertsTo  unit:HZ ;
+             qudt:isScalingOf  unit:HZ ;
+             qudt:prefix       prefix:Kilo .
+
+unit:MicroM  qudt:convertsTo  unit:M ;
+             qudt:isScalingOf  unit:M ;
+             qudt:prefix       prefix:Micro .
+
+unit:NanoM  qudt:convertsTo  unit:M ;
+            qudt:isScalingOf  unit:M ;
+            qudt:prefix       prefix:Nano .
+
+unit:GM-PER-KiloGM  qudt:convertsTo  unit:GM-PER-GM ;
+                    qudt:isScalingOf  unit:GM-PER-GM .
+
+unit:MilliM-PER-SEC  qudt:convertsTo  unit:M-PER-SEC ;
+                     qudt:isScalingOf  unit:M-PER-SEC .
+
+unit:MilliW  qudt:isScalingOf  unit:W ;
+             qudt:prefix       prefix:Milli .
+
+unit:KiloCAL_TH-PER-MIN
+    qudt:isScalingOf  unit:CAL_TH-PER-SEC .
+
+unit:MilliC-PER-M2  qudt:convertsTo  unit:C-PER-M2 ;
+                    qudt:isScalingOf  unit:C-PER-M2 .
+
+unit:DecaC  qudt:convertsTo  unit:C ;
+            qudt:isScalingOf  unit:C ;
+            qudt:prefix       prefix:Deca .
+
+unit:CentiPOISE-PER-BAR
+    qudt:isScalingOf  unit:POISE-PER-BAR .
+
+unit:MicroMOL-PER-M2-HR
+    qudt:convertsTo   unit:MOL-PER-M2-SEC ;
+    qudt:isScalingOf  unit:MOL-PER-M2-SEC .
+
+unit:PicoFARAD  qudt:convertsTo  unit:FARAD ;
+                qudt:isScalingOf  unit:FARAD ;
+                qudt:prefix       prefix:Pico .
+
+unit:PicoH  qudt:convertsTo  unit:H ;
+            qudt:isScalingOf  unit:H ;
+            qudt:prefix       prefix:Pico .
+
+unit:NanoMOL-PER-M2-DAY
+    qudt:convertsTo   unit:MOL-PER-M2-SEC ;
+    qudt:isScalingOf  unit:MOL-PER-M2-SEC .
+
+unit:MegaGM  qudt:isScalingOf  unit:GM ;
+             qudt:prefix       prefix:Mega .
+
+unit:MilliMOL-PER-M2-DAY
+    qudt:convertsTo   unit:MOL-PER-M2-SEC ;
+    qudt:isScalingOf  unit:MOL-PER-M2-SEC .
+
+unit:KiloGM-PER-MIN  qudt:isScalingOf  unit:GM-PER-SEC .
+
+unit:MilliPA  qudt:convertsTo  unit:PA ;
+              qudt:isScalingOf  unit:PA ;
+              qudt:prefix       prefix:Milli .
+
+unit:KiloGM-PER-CentiM2
+    qudt:isScalingOf  unit:GM-PER-M2 .
+
+unit:MicroMOL-PER-M2-SEC
+    qudt:convertsTo   unit:MOL-PER-M2-SEC ;
+    qudt:isScalingOf  unit:MOL-PER-M2-SEC .
+
+unit:KiloJ-PER-K  qudt:convertsTo  unit:J-PER-K ;
+                  qudt:isScalingOf  unit:J-PER-K .
+
+unit:MilliGM-PER-MIN  qudt:isScalingOf  unit:GM-PER-SEC .
+
+unit:TeraOHM  qudt:convertsTo  unit:OHM ;
+              qudt:isScalingOf  unit:OHM ;
+              qudt:prefix       prefix:Tera .
+
+unit:MilliTORR  qudt:isScalingOf  unit:TORR ;
+                qudt:prefix       prefix:Milli .
+
+unit:MicroS-PER-M  qudt:convertsTo  unit:S-PER-M ;
+                   qudt:isScalingOf  unit:S-PER-M .
+
+unit:PicoGM-PER-L  qudt:convertsTo  unit:GM-PER-L ;
+                   qudt:isScalingOf  unit:GM-PER-L .
+
+unit:GM-PER-MilliL  qudt:convertsTo  unit:GM-PER-L ;
+                    qudt:isScalingOf  unit:GM-PER-L .
+
+unit:MicroGM-PER-GM  qudt:convertsTo  unit:GM-PER-GM ;
+                     qudt:isScalingOf  unit:GM-PER-GM .
+
+unit:W-PER-CentiM2  qudt:convertsTo  unit:W-PER-M2 ;
+                    qudt:isScalingOf  unit:W-PER-M2 .
+
+unit:NUM-PER-KiloM2  qudt:convertsTo  unit:NUM-PER-M2 ;
+                     qudt:isScalingOf  unit:NUM-PER-M2 .
+
+unit:N-PER-CentiM  qudt:convertsTo  unit:N-PER-M ;
+                   qudt:isScalingOf  unit:N-PER-M .
+
+unit:MOL-PER-DeciM3  qudt:convertsTo  unit:MOL-PER-M3 ;
+                     qudt:isScalingOf  unit:MOL-PER-M3 .
+
+unit:MicroBQ  qudt:convertsTo  unit:BQ ;
+              qudt:isScalingOf  unit:BQ ;
+              qudt:prefix       prefix:Micro .
+
+unit:KiloC-PER-M3  qudt:convertsTo  unit:C-PER-M3 ;
+                   qudt:isScalingOf  unit:C-PER-M3 .
+
+unit:AttoFARAD  qudt:convertsTo  unit:FARAD ;
+                qudt:isScalingOf  unit:FARAD ;
+                qudt:prefix       prefix:Atto .
+
+unit:MilliL-PER-SEC  qudt:isScalingOf  unit:L-PER-SEC .
+
+unit:KiloS-PER-M  qudt:convertsTo  unit:S-PER-M ;
+                  qudt:isScalingOf  unit:S-PER-M .
+
+unit:MegaHZ  qudt:convertsTo  unit:HZ ;
+             qudt:isScalingOf  unit:HZ ;
+             qudt:prefix       prefix:Mega .
+
+unit:MilliA-HR  qudt:convertsTo  unit:A-SEC ;
+                qudt:isScalingOf  unit:A-SEC .
+
+unit:CentiM3-PER-M3  qudt:convertsTo  unit:M3-PER-M3 ;
+                     qudt:isScalingOf  unit:M3-PER-M3 .
+
+unit:KiloM  qudt:convertsTo  unit:M ;
+            qudt:isScalingOf  unit:M ;
+            qudt:prefix       prefix:Kilo .
+
+unit:GibiBYTE  qudt:isScalingOf  unit:BYTE ;
+               qudt:prefix       prefix:Gibi .
+
+unit:MegaW-HR  qudt:convertsTo  unit:W-SEC ;
+               qudt:isScalingOf  unit:W-SEC .
+
+unit:DeciS-PER-M  qudt:convertsTo  unit:S-PER-M ;
+                  qudt:isScalingOf  unit:S-PER-M .
+
+unit:MilliG  qudt:isScalingOf  unit:G ;
+             qudt:prefix       prefix:Milli .
+
+unit:MicroH  qudt:convertsTo  unit:H ;
+             qudt:isScalingOf  unit:H ;
+             qudt:prefix       prefix:Micro .
+
+unit:NanoH  qudt:convertsTo  unit:H ;
+            qudt:isScalingOf  unit:H ;
+            qudt:prefix       prefix:Nano .
+
+unit:MegaV-A  qudt:convertsTo  unit:V-A ;
+              qudt:isScalingOf  unit:V-A .
+
+unit:MilliR  qudt:isScalingOf  unit:R ;
+             qudt:prefix       prefix:Milli .
+
+unit:MegaC-PER-M2  qudt:convertsTo  unit:C-PER-M2 ;
+                   qudt:isScalingOf  unit:C-PER-M2 .
+
+unit:TeraC  qudt:convertsTo  unit:C ;
+            qudt:isScalingOf  unit:C ;
+            qudt:prefix       prefix:Tera .
+
+unit:MegaPA-M3-PER-SEC
+    qudt:convertsTo   unit:PA-M3-PER-SEC ;
+    qudt:isScalingOf  unit:PA-M3-PER-SEC .
+
+unit:MicroS  qudt:convertsTo  unit:S ;
+             qudt:isScalingOf  unit:S ;
+             qudt:prefix       prefix:Micro .
+
+unit:CentiGM  qudt:isScalingOf  unit:GM ;
+              qudt:prefix       prefix:Centi .
+
+unit:YottaC  qudt:convertsTo  unit:C ;
+             qudt:isScalingOf  unit:C ;
+             qudt:prefix       prefix:Yotta .
+
+unit:MilliM2-PER-SEC  qudt:convertsTo  unit:M2-PER-SEC ;
+                      qudt:isScalingOf  unit:M2-PER-SEC .
+
+unit:MilliGM-PER-KiloGM
+    qudt:convertsTo   unit:GM-PER-GM ;
+    qudt:isScalingOf  unit:GM-PER-GM .
+
+unit:MicroCi  qudt:isScalingOf  unit:Ci ;
+              qudt:prefix       prefix:Micro .
+
+unit:GigaHZ  qudt:convertsTo  unit:HZ ;
+             qudt:isScalingOf  unit:HZ ;
+             qudt:prefix       prefix:Giga .
+
+unit:KiloGM-PER-M3  qudt:isScalingOf  unit:GM-PER-M3 .
+
+unit:PicoC  qudt:convertsTo  unit:C ;
+            qudt:isScalingOf  unit:C ;
+            qudt:prefix       prefix:Pico .
+
+unit:CentiM-PER-HR  qudt:convertsTo  unit:M-PER-SEC ;
+                    qudt:isScalingOf  unit:M-PER-SEC .
+
+unit:NUM-PER-MicroL  qudt:isScalingOf  unit:NUM-PER-L .
+
+unit:MilliMOL-PER-L  qudt:isScalingOf  unit:MOL-PER-L .
+
+unit:MicroS-PER-CentiM
+    qudt:convertsTo   unit:S-PER-M ;
+    qudt:isScalingOf  unit:S-PER-M .
+
+unit:H-PER-KiloOHM  qudt:convertsTo  unit:H-PER-OHM ;
+                    qudt:isScalingOf  unit:H-PER-OHM .
+
+unit:HectoPA-L-PER-SEC
+    qudt:isScalingOf  unit:PA-L-PER-SEC .
+
+unit:MilliBAR-PER-K  qudt:isScalingOf  unit:BAR-PER-K .
+
+unit:KiloMOL-PER-MIN  qudt:convertsTo  unit:MOL-PER-SEC ;
+                      qudt:isScalingOf  unit:MOL-PER-SEC .
+
+unit:M2-PER-KiloGM  qudt:isScalingOf  unit:M2-PER-GM .
+
+unit:DeciB  qudt:isScalingOf  unit:B ;
+            qudt:prefix       prefix:Deci .
+
+unit:KiloGM-PER-KiloMOL
+    qudt:isScalingOf  unit:GM-PER-MOL .
+
+unit:CentiM2  qudt:convertsTo  unit:M2 ;
+              qudt:isScalingOf  unit:M2 ;
+              qudt:prefix       prefix:Centi .
+
+unit:KiloMOL-PER-HR  qudt:convertsTo  unit:MOL-PER-SEC ;
+                     qudt:isScalingOf  unit:MOL-PER-SEC .
+
+unit:DeciM  qudt:convertsTo  unit:M ;
+            qudt:isScalingOf  unit:M ;
+            qudt:prefix       prefix:Deci .
+
+unit:HectoM  qudt:convertsTo  unit:M ;
+             qudt:isScalingOf  unit:M ;
+             qudt:prefix       prefix:Hecto .
+
+unit:KiloM-PER-HR  qudt:convertsTo  unit:M-PER-SEC ;
+                   qudt:isScalingOf  unit:M-PER-SEC .
+
+unit:GigaC  qudt:convertsTo  unit:C ;
+            qudt:isScalingOf  unit:C ;
+            qudt:prefix       prefix:Giga .
+
+unit:MicroIN  qudt:isScalingOf  unit:IN ;
+              qudt:prefix       prefix:Micro .
+
+unit:MicroBAR  qudt:isScalingOf  unit:BAR ;
+               qudt:prefix       prefix:Micro .
+
+unit:DecaM3  qudt:convertsTo  unit:M3 ;
+             qudt:isScalingOf  unit:M3 ;
+             qudt:prefix       prefix:Deca .
+
+unit:HectoBAR  qudt:isScalingOf  unit:BAR ;
+               qudt:prefix       prefix:Hecto .
+
+unit:MilliS-PER-M  qudt:convertsTo  unit:S-PER-M ;
+                   qudt:isScalingOf  unit:S-PER-M .
+
+unit:PicoSEC  qudt:convertsTo  unit:SEC ;
+              qudt:isScalingOf  unit:SEC ;
+              qudt:prefix       prefix:Pico .
+
+unit:CentiL  qudt:isScalingOf  unit:L ;
+             qudt:prefix       prefix:Centi .
+
+unit:KiloS  qudt:convertsTo  unit:S ;
+            qudt:isScalingOf  unit:S ;
+            qudt:prefix       prefix:Kilo .
+
+unit:KiloPA-PER-K  qudt:isScalingOf  unit:PA-PER-K .
+
+unit:A-PER-MilliM  qudt:convertsTo  unit:A-PER-M ;
+                   qudt:isScalingOf  unit:A-PER-M .
+
+unit:MilliGM-PER-M3  qudt:isScalingOf  unit:GM-PER-M3 .
+
+unit:NanoC  qudt:convertsTo  unit:C ;
+            qudt:isScalingOf  unit:C ;
+            qudt:prefix       prefix:Nano .
+
+unit:MicroC  qudt:convertsTo  unit:C ;
+             qudt:isScalingOf  unit:C ;
+             qudt:prefix       prefix:Micro .
+
+unit:DeciTON_Metric  qudt:isScalingOf  unit:TON_Metric ;
+                     qudt:prefix       prefix:Deci .
+
+unit:MegaOHM  qudt:convertsTo  unit:OHM ;
+              qudt:isScalingOf  unit:OHM ;
+              qudt:prefix       prefix:Mega .
+
+unit:MilliM  qudt:convertsTo  unit:M ;
+             qudt:isScalingOf  unit:M ;
+             qudt:prefix       prefix:Milli .
+
+unit:MicroN  qudt:convertsTo  unit:N ;
+             qudt:isScalingOf  unit:N ;
+             qudt:prefix       prefix:Micro .
+
+unit:MicroC-PER-M3  qudt:convertsTo  unit:C-PER-M3 ;
+                    qudt:isScalingOf  unit:C-PER-M3 .
+
+unit:MilliBAR  qudt:isScalingOf  unit:BAR ;
+               qudt:prefix       prefix:Milli .
+
+unit:NanoS-PER-M  qudt:convertsTo  unit:S-PER-M ;
+                  qudt:isScalingOf  unit:S-PER-M .
+
+unit:KiloGM-PER-L  qudt:convertsTo  unit:GM-PER-L ;
+                   qudt:isScalingOf  unit:GM-PER-L .
+
+unit:NanoMOL-PER-CentiM3-HR
+    qudt:convertsTo   unit:MOL-PER-M3-SEC ;
+    qudt:isScalingOf  unit:MOL-PER-M3-SEC .
+
+unit:MegaHZ-PER-T  qudt:convertsTo  unit:HZ-PER-T ;
+                   qudt:isScalingOf  unit:HZ-PER-T .
+
+unit:MegaA-PER-M2  qudt:convertsTo  unit:A-PER-M2 ;
+                   qudt:isScalingOf  unit:A-PER-M2 .
+
+unit:MilliC-PER-M3  qudt:convertsTo  unit:C-PER-M3 ;
+                    qudt:isScalingOf  unit:C-PER-M3 .
+
+unit:FemtoM  qudt:convertsTo  unit:M ;
+             qudt:isScalingOf  unit:M ;
+             qudt:prefix       prefix:Femto .
+
+unit:J-PER-CentiM2  qudt:convertsTo  unit:J-PER-M2 ;
+                    qudt:isScalingOf  unit:J-PER-M2 .
+
+unit:MilliDEG_C  qudt:isScalingOf  unit:DEG_C ;
+                 qudt:prefix       prefix:Milli .
+
+unit:PER-MilliSEC  qudt:convertsTo  unit:PER-SEC ;
+                   qudt:isScalingOf  unit:PER-SEC .
+
+unit:W-PER-M2-NanoM  qudt:convertsTo  unit:W-PER-M2-M ;
+                     qudt:isScalingOf  unit:W-PER-M2-M .
+
+unit:KiloGM-PER-CentiM3
+    qudt:isScalingOf  unit:GM-PER-M3 .
+
+unit:TebiBYTE  qudt:isScalingOf  unit:BYTE ;
+               qudt:prefix       prefix:Tebi .
+
+unit:MilliH-PER-KiloOHM
+    qudt:convertsTo   unit:H-PER-OHM ;
+    qudt:isScalingOf  unit:H-PER-OHM .
+
+unit:MilliM-PER-MIN  qudt:convertsTo  unit:M-PER-SEC ;
+                     qudt:isScalingOf  unit:M-PER-SEC .
+
+unit:NanoBQ-PER-L  qudt:isScalingOf  unit:BQ-PER-L .
+
+unit:MegaLB_F  qudt:isScalingOf  unit:LB_F ;
+               qudt:prefix       prefix:Mega .
+
+unit:GM-PER-MilliM  qudt:isScalingOf  unit:GM-PER-M .
+
+unit:MicroM-PER-K  qudt:convertsTo  unit:M-PER-K ;
+                   qudt:isScalingOf  unit:M-PER-K .
+
+unit:MegaBIT-PER-SEC  qudt:isScalingOf  unit:BIT-PER-SEC .
+
+unit:YoctoC  qudt:convertsTo  unit:C ;
+             qudt:isScalingOf  unit:C ;
+             qudt:prefix       prefix:Yocto .
+
+unit:MegaTOE  qudt:isScalingOf  unit:TOE ;
+              qudt:prefix       prefix:Mega .
+
+unit:MilliBAR-M3-PER-SEC
+    qudt:isScalingOf  unit:BAR-M3-PER-SEC .
+
+unit:C-PER-CentiM2  qudt:convertsTo  unit:C-PER-M2 ;
+                    qudt:isScalingOf  unit:C-PER-M2 .
+
+unit:KiloPA-PER-BAR  qudt:isScalingOf  unit:PA-PER-BAR .
+
+unit:KiloC  qudt:convertsTo  unit:C ;
+            qudt:isScalingOf  unit:C ;
+            qudt:prefix       prefix:Kilo .
+
+unit:MilliGM  qudt:isScalingOf  unit:GM ;
+              qudt:prefix       prefix:Milli .
+
+unit:MicroSV  qudt:convertsTo  unit:SV ;
+              qudt:isScalingOf  unit:SV ;
+              qudt:prefix       prefix:Micro .
+
+unit:KiloMOL  qudt:convertsTo  unit:MOL ;
+              qudt:isScalingOf  unit:MOL ;
+              qudt:prefix       prefix:Kilo .
+
+unit:KiloN  qudt:convertsTo  unit:N ;
+            qudt:isScalingOf  unit:N ;
+            qudt:prefix       prefix:Kilo .
+
+unit:CentiM3-PER-DAY  qudt:convertsTo  unit:M3-PER-SEC ;
+                      qudt:isScalingOf  unit:M3-PER-SEC .
+
+unit:MicroGM-PER-KiloGM
+    qudt:convertsTo   unit:GM-PER-GM ;
+    qudt:isScalingOf  unit:GM-PER-GM .
+
+unit:MilliH  qudt:convertsTo  unit:H ;
+             qudt:isScalingOf  unit:H ;
+             qudt:prefix       prefix:Milli .
+
+unit:MicroFARAD  qudt:convertsTo  unit:FARAD ;
+                 qudt:isScalingOf  unit:FARAD ;
+                 qudt:prefix       prefix:Micro .
+
+unit:MilliV-PER-MIN  qudt:convertsTo  unit:V-PER-SEC ;
+                     qudt:isScalingOf  unit:V-PER-SEC .
+
+unit:NanoT  qudt:convertsTo  unit:T ;
+            qudt:isScalingOf  unit:T ;
+            qudt:prefix       prefix:Nano .
+
+unit:MilliS  qudt:convertsTo  unit:S ;
+             qudt:isScalingOf  unit:S ;
+             qudt:prefix       prefix:Milli .
+
+unit:KiloCAL_TH-PER-HR
+    qudt:isScalingOf  unit:CAL_TH-PER-SEC .
+
+unit:MegaC  qudt:convertsTo  unit:C ;
+            qudt:isScalingOf  unit:C ;
+            qudt:prefix       prefix:Mega .
+
+unit:AttoC  qudt:convertsTo  unit:C ;
+            qudt:isScalingOf  unit:C ;
+            qudt:prefix       prefix:Atto .
+
+unit:MilliL-PER-MIN  qudt:isScalingOf  unit:L-PER-SEC .
+
+unit:MicroGM-PER-M3  qudt:isScalingOf  unit:GM-PER-M3 .
+
+unit:MicroATM  qudt:isScalingOf  unit:ATM ;
+               qudt:prefix       prefix:Micro .
+
+unit:MegaC-PER-M3  qudt:convertsTo  unit:C-PER-M3 ;
+                   qudt:isScalingOf  unit:C-PER-M3 .
+
+unit:KiloEV  qudt:isScalingOf  unit:EV ;
+             qudt:prefix       prefix:Kilo .
+
+unit:MegaPA-PER-BAR  qudt:isScalingOf  unit:PA-PER-BAR .
+
+unit:DeciM3-PER-M3  qudt:convertsTo  unit:M3-PER-M3 ;
+                    qudt:isScalingOf  unit:M3-PER-M3 .
+
+unit:MicroT  qudt:convertsTo  unit:T ;
+             qudt:isScalingOf  unit:T ;
+             qudt:prefix       prefix:Micro .
+
+unit:MilliMOL-PER-M2-SEC
+    qudt:convertsTo   unit:MOL-PER-M2-SEC ;
+    qudt:isScalingOf  unit:MOL-PER-M2-SEC .
+
+unit:MegaN  qudt:convertsTo  unit:N ;
+            qudt:isScalingOf  unit:N ;
+            qudt:prefix       prefix:Mega .
+
+unit:MilliM-PER-HR  qudt:convertsTo  unit:M-PER-SEC ;
+                    qudt:isScalingOf  unit:M-PER-SEC .
+
+unit:MilliM2  qudt:convertsTo  unit:M2 ;
+              qudt:isScalingOf  unit:M2 ;
+              qudt:prefix       prefix:Milli .
+
+unit:PicoMOL-PER-M2-DAY
+    qudt:convertsTo   unit:MOL-PER-M2-SEC ;
+    qudt:isScalingOf  unit:MOL-PER-M2-SEC .
+
+unit:MicroGM-PER-MilliL
+    qudt:convertsTo   unit:GM-PER-L ;
+    qudt:isScalingOf  unit:GM-PER-L .
+
+unit:MegaV-A_Reactive
+    qudt:convertsTo   unit:V-A_Reactive ;
+    qudt:isScalingOf  unit:V-A_Reactive .
+
+unit:DeciM3-PER-DAY  qudt:convertsTo  unit:M3-PER-SEC ;
+                     qudt:isScalingOf  unit:M3-PER-SEC .
+
+unit:KiloGM-PER-KiloGM
+    qudt:convertsTo   unit:GM-PER-GM ;
+    qudt:isScalingOf  unit:GM-PER-GM .
+
+unit:MicroGM-PER-L  qudt:convertsTo  unit:GM-PER-L ;
+                    qudt:isScalingOf  unit:GM-PER-L .
+
+unit:HectoPA-PER-K  qudt:isScalingOf  unit:PA-PER-K .
+
+unit:PetaC  qudt:convertsTo  unit:C ;
+            qudt:isScalingOf  unit:C ;
+            qudt:prefix       prefix:Peta .
+
+unit:HectoPA-PER-HR  qudt:convertsTo  unit:PA-PER-SEC ;
+                     qudt:isScalingOf  unit:PA-PER-SEC .
+
+unit:MilliPA-SEC-PER-BAR
+    qudt:isScalingOf  unit:PA-SEC-PER-BAR .
+
+unit:DeciC  qudt:convertsTo  unit:C ;
+            qudt:isScalingOf  unit:C ;
+            qudt:prefix       prefix:Deci .
+
+unit:KiloLB_F-PER-IN2
+    qudt:isScalingOf  unit:LB_F-PER-IN2 .
+
+unit:HectoC  qudt:convertsTo  unit:C ;
+             qudt:isScalingOf  unit:C ;
+             qudt:prefix       prefix:Hecto .
+
+unit:MilliGM-PER-L  qudt:convertsTo  unit:GM-PER-L ;
+                    qudt:isScalingOf  unit:GM-PER-L .
+
+unit:CentiM3  qudt:convertsTo  unit:M3 ;
+              qudt:isScalingOf  unit:M3 ;
+              qudt:prefix       prefix:Centi .
+
+unit:MilliBAR-PER-BAR
+    qudt:convertsTo   unit:BAR-PER-BAR ;
+    qudt:isScalingOf  unit:BAR-PER-BAR .
+
+unit:DeciN  qudt:isScalingOf  unit:N ;
+            qudt:prefix       prefix:Deci .
+
+unit:NanoGM-PER-MicroL
+    qudt:convertsTo   unit:GM-PER-L ;
+    qudt:isScalingOf  unit:GM-PER-L .
+
+unit:MicroMOL-PER-MOL
+    qudt:convertsTo   unit:MOL-PER-MOL ;
+    qudt:isScalingOf  unit:MOL-PER-MOL .
+
+unit:MicroMOL-PER-M2  qudt:convertsTo  unit:MOL-PER-M2 ;
+                      qudt:isScalingOf  unit:MOL-PER-M2 .
+
+unit:MilliS-PER-CentiM
+    qudt:convertsTo   unit:S-PER-M ;
+    qudt:isScalingOf  unit:S-PER-M .
+
+unit:A-PER-CentiM  qudt:convertsTo  unit:A-PER-M ;
+                   qudt:isScalingOf  unit:A-PER-M .
+
+unit:GigaW-HR  qudt:convertsTo  unit:W-SEC ;
+               qudt:isScalingOf  unit:W-SEC .
+
+unit:CentiST  qudt:isScalingOf  unit:ST ;
+              qudt:prefix       prefix:Centi .
+
+unit:MegaEV  qudt:isScalingOf  unit:EV ;
+             qudt:prefix       prefix:Mega .
+
+unit:CentiM  qudt:convertsTo  unit:M ;
+             qudt:isScalingOf  unit:M ;
+             qudt:prefix       prefix:Centi .
+
+unit:MilliC  qudt:convertsTo  unit:C ;
+             qudt:isScalingOf  unit:C ;
+             qudt:prefix       prefix:Milli .
+
+unit:MilliM-PER-K  qudt:convertsTo  unit:M-PER-K ;
+                   qudt:isScalingOf  unit:M-PER-K .
+
+unit:KiloGM-PER-DeciM3
+    qudt:isScalingOf  unit:GM-PER-M3 .
+
+unit:CentiM3-PER-MOL  qudt:convertsTo  unit:M3-PER-MOL ;
+                      qudt:isScalingOf  unit:M3-PER-MOL .
+
+unit:MilliW-PER-CentiM2-MicroM-SR
+    qudt:convertsTo   unit:W-PER-M2-M-SR ;
+    qudt:isScalingOf  unit:W-PER-M2-M-SR .
+
+unit:MicroOHM  qudt:convertsTo  unit:OHM ;
+               qudt:isScalingOf  unit:OHM ;
+               qudt:prefix       prefix:Micro .
+
+unit:KiloGM-PER-KiloM2
+    qudt:isScalingOf  unit:GM-PER-M2 .
+
+unit:MilliN  qudt:convertsTo  unit:N ;
+             qudt:isScalingOf  unit:N ;
+             qudt:prefix       prefix:Milli .
+
+unit:KiloGM-PER-M  qudt:isScalingOf  unit:GM-PER-M .
+
+unit:KiloBQ  qudt:convertsTo  unit:BQ ;
+             qudt:isScalingOf  unit:BQ ;
+             qudt:prefix       prefix:Kilo .
+
+unit:TeraJ  qudt:convertsTo  unit:J ;
+            qudt:isScalingOf  unit:J ;
+            qudt:prefix       prefix:Tera .
+
+unit:FemtoC  qudt:convertsTo  unit:C ;
+             qudt:isScalingOf  unit:C ;
+             qudt:prefix       prefix:Femto .
+
+unit:MicroH-PER-KiloOHM
+    qudt:convertsTo   unit:H-PER-OHM ;
+    qudt:isScalingOf  unit:H-PER-OHM .
+
+unit:MilliMOL-PER-M2  qudt:convertsTo  unit:MOL-PER-M2 ;
+                      qudt:isScalingOf  unit:MOL-PER-M2 .
+
+unit:MilliV-PER-M  qudt:convertsTo  unit:V-PER-M ;
+                   qudt:isScalingOf  unit:V-PER-M .
+
+unit:GigaEV  qudt:isScalingOf  unit:EV ;
+             qudt:prefix       prefix:Giga .
+
+unit:MilliOHM  qudt:convertsTo  unit:OHM ;
+               qudt:isScalingOf  unit:OHM ;
+               qudt:prefix       prefix:Milli .
+
+unit:DeciN-M  qudt:convertsTo  unit:N-M ;
+              qudt:isScalingOf  unit:N-M .
+
+unit:MegaPA-PER-K  qudt:isScalingOf  unit:PA-PER-K .
+
+unit:MegaV-PER-M  qudt:convertsTo  unit:V-PER-M ;
+                  qudt:isScalingOf  unit:V-PER-M .
+
+unit:DeciTONNE  qudt:isScalingOf  unit:TONNE ;
+                qudt:prefix       prefix:Deci .
+
+unit:C-PER-MilliM2  qudt:convertsTo  unit:C-PER-M2 ;
+                    qudt:isScalingOf  unit:C-PER-M2 .
+
+unit:KiloLB_F-PER-FT  qudt:isScalingOf  unit:LB_F-PER-FT .
+
+unit:DeciM3-PER-MOL  qudt:convertsTo  unit:M3-PER-MOL ;
+                     qudt:isScalingOf  unit:M3-PER-MOL .
+
+unit:MilliW-PER-M2-NanoM-SR
+    qudt:convertsTo   unit:W-PER-M2-M-SR ;
+    qudt:isScalingOf  unit:W-PER-M2-M-SR .
+
+unit:CentiM-PER-SEC  qudt:convertsTo  unit:M-PER-SEC ;
+                     qudt:isScalingOf  unit:M-PER-SEC .
+
+unit:KiloBYTE  qudt:isScalingOf  unit:BYTE ;
+               qudt:prefix       prefix:Kilo .
 
 
 ## additional factors for the SI units with special names

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -3042,7 +3042,6 @@ unit:CentiGM
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Mass ;
   qudt:iec61360Code "0112/2///62720#UAB077" ;
-  qudt:isScalingOf unit:KiloGM ;
   qudt:plainTextDescription "0,000 01-fold of the SI base unit kilogram" ;
   qudt:prefix prefix:Centi ;
   qudt:ucumCode "cg"^^qudt:UCUMcs ;
@@ -4473,7 +4472,6 @@ unit:DecaGM
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Mass ;
   qudt:iec61360Code "0112/2///62720#UAB075" ;
-  qudt:isScalingOf unit:KiloGM ;
   qudt:plainTextDescription "0,01-fold of the SI base unit kilogram" ;
   qudt:prefix prefix:Deca ;
   qudt:ucumCode "dag"^^qudt:UCUMcs ;
@@ -4623,7 +4621,6 @@ unit:DeciGM
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Mass ;
   qudt:iec61360Code "0112/2///62720#UAB076" ;
-  qudt:isScalingOf unit:KiloGM ;
   qudt:plainTextDescription "0.0001-fold of the SI base unit kilogram" ;
   qudt:prefix prefix:Deci ;
   qudt:ucumCode "dg"^^qudt:UCUMcs ;
@@ -6586,7 +6583,6 @@ unit:GM
   qudt:hasQuantityKind quantitykind:Mass ;
   qudt:iec61360Code "0112/2///62720#UAA465" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Gram?oldid=493995797"^^xsd:anyURI ;
-  qudt:isScalingOf unit:KiloGM ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/gram> ;
   qudt:symbol "g" ;
   qudt:ucumCode "g"^^qudt:UCUMcs ;
@@ -7733,7 +7729,6 @@ unit:HectoGM
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Mass ;
   qudt:iec61360Code "0112/2///62720#UAB079" ;
-  qudt:isScalingOf unit:KiloGM ;
   qudt:plainTextDescription "0.1-fold of the SI base unit kilogram" ;
   qudt:prefix prefix:Hecto ;
   qudt:ucumCode "hg"^^qudt:UCUMcs ;
@@ -13198,7 +13193,6 @@ unit:MegaGM
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Mass ;
   qudt:iec61360Code "0112/2///62720#UAA228" ;
-  qudt:isScalingOf unit:KiloGM ;
   qudt:plainTextDescription "1 000-fold of the SI base unit kilogram" ;
   qudt:prefix prefix:Mega ;
   qudt:ucumCode "Mg"^^qudt:UCUMcs ;
@@ -13855,7 +13849,6 @@ unit:MicroGM
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Mass ;
   qudt:iec61360Code "0112/2///62720#UAA082" ;
-  qudt:isScalingOf unit:KiloGM ;
   qudt:plainTextDescription "0.000000001-fold of the SI base unit kilogram" ;
   qudt:prefix prefix:Micro ;
   qudt:ucumCode "ug"^^qudt:UCUMcs ;
@@ -14916,7 +14909,6 @@ unit:MilliGM
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Mass ;
   qudt:iec61360Code "0112/2///62720#UAA815" ;
-  qudt:isScalingOf unit:KiloGM ;
   qudt:plainTextDescription "0.000001-fold of the SI base unit kilogram" ;
   qudt:prefix prefix:Milli ;
   qudt:ucumCode "mg"^^qudt:UCUMcs ;
@@ -16857,7 +16849,6 @@ unit:NanoGM
   qudt:conversionMultiplier 0.000000000001 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Mass ;
-  qudt:isScalingOf unit:KiloGM ;
   qudt:prefix prefix:Nano ;
   qudt:ucumCode "ng"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -19492,7 +19483,6 @@ unit:PicoGM
   qudt:conversionMultiplier 0.15 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Mass ;
-  qudt:isScalingOf unit:KiloGM ;
   qudt:prefix prefix:Pico ;
   qudt:ucumCode "pg"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -31704,3 +31704,133 @@ unit:PicoMOL-PER-M3-SEC
     qudt:isScalingOf unit:MOL-PER-M3-SEC .
 
 
+## additional factors for the SI units with special names
+
+unit:HZ
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] .
+
+unit:RAD
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:M ] .
+
+unit:SR
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 2;
+                      qudt:unit     unit:M ] .
+
+unit:N
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloGM ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:SEC ] .
+
+
+unit:PA
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit unit:N ] ;
+    qudt:factorUnit [ qudt:exponent -2;
+                      qudt:unit unit:M ].
+
+
+unit:J
+    qudt:factorUnit [qudt:exponent 1 ;
+                     qudt:unit unit:N ] ;
+    qudt:factorUnit [qudt:exponent 1 ;
+                     qudt:unit unit:M ] .
+
+unit:W
+    qudt:factorUnit [qudt:exponent 1 ;
+                     qudt:unit unit:J ] ;
+    qudt:factorUnit [qudt:exponent -1 ;
+                     qudt:unit unit:SEC ] .
+
+unit:C
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit unit:A ] .
+
+unit:V
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit unit:W ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit unit:A ] .
+
+unit:F
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit unit:C ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit unit:V ] .
+
+unit:OHM
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit unit:V ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit unit:A ] .
+
+unit:S
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit unit:A ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit unit:V ] .
+
+unit:WB
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit unit:J] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit unit:A ] .
+unit:T
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit unit:WB ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit unit:M ] .
+
+unit:H
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit unit:WB ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit unit:A ] .
+
+unit:DEG_C
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit unit:K ] .
+
+unit:LM
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit unit:CD ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit unit:SR ] .
+
+unit:LUX
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit unit:LM ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit unit:M ] .
+
+unit:BQ
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit unit:SEC ] .
+
+unit:GRAY
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit unit:J ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit unit:KiloGM ] .
+
+unit:SV
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit unit:J ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit unit:KiloGM ] .
+
+unit:KAT
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit unit:MOL ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit unit:SEC ] .

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -23444,3 +23444,8263 @@ THE UCUM TABLE (IN ALL FORMATS), UCUM DEFINITIONS, AND SPECIFICATION ARE PROVIDE
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "All Units Ontology Version 2.1.15" ;
 .
+unit:FT-PER-HR
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:FT ] .
+
+unit:W-SEC-PER-M2
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:W ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] .
+
+unit:N-PER-C
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:N ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:C ] .
+
+unit:MicroMOL-PER-M2
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MicroMOL ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] .
+
+unit:CentiM3-PER-MIN
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MIN ] ;
+    qudt:factorUnit [ qudt:exponent 3 ;
+                      qudt:unit     unit:CentiM ] .
+
+unit:J-M2-PER-KiloGM
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:KiloGM ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:J ] .
+
+unit:BAR-PER-K
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:K ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BAR ] .
+
+unit:CentiM3-PER-MOL
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MOL ] ;
+    qudt:factorUnit [ qudt:exponent 3 ;
+                      qudt:unit     unit:CentiM ] .
+
+unit:SLUG-PER-FT3
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:SLUG ] ;
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:FT ] .
+
+unit:DEG_C-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:DEG_C ] .
+
+unit:PER-FT3
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:FT ] .
+
+unit:KiloGM_F-M-PER-CentiM2
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloGM_F ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:CentiM ] .
+
+unit:KiloEV-PER-MicroM
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MicroM ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloEV ] .
+
+unit:CAL_TH-PER-GM-DEG_C
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:GM ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DEG_C ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:CAL_TH ] .
+
+unit:BTU_IT-PER-FT2-HR-DEG_F
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:FT ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DEG_F ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BTU_IT ] .
+
+unit:N-M-SEC-PER-M
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:N ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] .
+
+unit:OZ-PER-GAL_UK
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:OZ ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:GAL_UK ] .
+
+unit:C-PER-M3
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:C ] .
+
+unit:FT-LB_F-PER-MIN
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MIN ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:LB_F ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:FT ] .
+
+unit:MOL-PER-KiloGM-PA
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:PA ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MOL ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:KiloGM ] .
+
+unit:KiloGM-PER-M2-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloGM ] .
+
+unit:GI_UK-PER-MIN
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MIN ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:GI_UK ] .
+
+unit:BIT-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BIT ] .
+
+unit:KiloMOL-PER-HR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloMOL ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] .
+
+unit:YD3
+    qudt:factorUnit [ qudt:exponent 3 ;
+                      qudt:unit     unit:YD ] .
+
+unit:A-PER-M2-K2
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:K ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:A ] .
+
+unit:OZ_VOL_US-PER-MIN
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:OZ_VOL_US ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MIN ] .
+
+unit:PER-J-M3
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:J ] .
+
+unit:W-PER-M2-M
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:W ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] .
+
+unit:PicoMOL-PER-M-W-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:W ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:PicoMOL ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] .
+
+unit:V-PER-MicroSEC
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:V ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MicroSEC ] .
+
+unit:PA-SEC-PER-M3
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:PA ] ;
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:M ] .
+
+unit:L-PER-KiloGM
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:L ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:KiloGM ] .
+
+unit:KiloC-PER-M2
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloC ] .
+
+unit:KiloMOL-PER-MIN
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MIN ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloMOL ] .
+
+unit:A-M2
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:A ] .
+
+unit:BTU_TH-PER-LB
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:LB ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BTU_TH ] .
+
+unit:KiloWB
+    a            qudt:Unit ;
+    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
+
+unit:GM-PER-DAY
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:GM ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DAY ] .
+
+unit:MilliV-PER-M
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliV ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] .
+
+unit:A-PER-RAD
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:RAD ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:A ] .
+
+unit:KiloCAL-PER-GM-DEG_C
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloCAL ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:GM ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DEG_C ] .
+
+unit:KiloGM_F-PER-M2
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloGM_F ] .
+
+unit:PA-PER-K
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:PA ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:K ] .
+
+unit:KiloGM-PER-L
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:L ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloGM ] .
+
+unit:CentiM2
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:CentiM ] .
+
+unit:M3-PER-HR
+    qudt:factorUnit [ qudt:exponent 3 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] .
+
+unit:NUM-PER-MilliGM
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:NUM ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MilliGM ] .
+
+unit:MicroM-PER-K
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MicroM ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:K ] .
+
+unit:GI_US-PER-MIN
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MIN ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:GI_US ] .
+
+unit:CentiM3-PER-M3
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 3 ;
+                      qudt:unit     unit:CentiM ] .
+
+unit:KiloM-PER-HR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloM ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] .
+
+unit:LB-PER-FT-HR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:LB ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:FT ] .
+
+unit:GM-PER-KiloM
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:KiloM ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:GM ] .
+
+unit:MilliGM-PER-M3-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliGM ] ;
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:M ] .
+
+unit:MilliGM-PER-DAY
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliGM ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DAY ] .
+
+unit:KiloGM-PER-M2
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloGM ] .
+
+unit:K-M2-PER-KiloGM-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:KiloGM ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:K ] .
+
+unit:MilliMOL-PER-M2-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliMOL ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] .
+
+unit:PER-PlanckMass2
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:PlanckMass ] .
+
+unit:LB-PER-MIN
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MIN ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:LB ] .
+
+unit:PER-IN3
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:IN ] .
+
+unit:PINT_UK-PER-MIN
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:PINT_UK ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MIN ] .
+
+unit:BTU_IT-PER-FT2-SEC-DEG_F
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:FT ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DEG_F ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BTU_IT ] .
+
+unit:MilliRAD_R
+    a            qudt:Unit ;
+    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
+
+unit:BBL_US_PET-PER-HR
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BBL_US_PET ] .
+
+unit:C-PER-MOL
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MOL ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:C ] .
+
+unit:N-PER-MilliM2
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:N ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:MilliM ] .
+
+unit:MilliMOL-PER-MOL
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliMOL ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MOL ] .
+
+unit:GI_US-PER-HR
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:GI_US ] .
+
+unit:M-K-PER-W
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:W ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:K ] .
+
+unit:J-PER-MOL-K
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MOL ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:K ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:J ] .
+
+unit:NanoMOL-PER-CentiM3-HR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:NanoMOL ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] ;
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:CentiM ] .
+
+unit:GM_Nitrogen-PER-M2-DAY
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:GM_Nitrogen ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DAY ] .
+
+unit:FT2
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:FT ] .
+
+unit:KiloCAL-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloCAL ] .
+
+unit:MicroMOL-PER-MOL
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MicroMOL ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MOL ] .
+
+unit:MOL-PER-M3-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MOL ] ;
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:M ] .
+
+unit:KiloJ-PER-KiloGM
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloJ ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:KiloGM ] .
+
+unit:W-PER-KiloGM
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:W ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:KiloGM ] .
+
+unit:FT2-HR-DEG_F
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:HR ] ;
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:FT ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:DEG_F ] .
+
+unit:MOL-PER-M3
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MOL ] ;
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:M ] .
+
+unit:A-PER-MilliM
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MilliM ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:A ] .
+
+unit:MicroW-PER-M2
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MicroW ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] .
+
+unit:EV-PER-T
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:T ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:EV ] .
+
+unit:TONNE-PER-MIN
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:TONNE ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MIN ] .
+
+unit:KiloJ-PER-K
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloJ ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:K ] .
+
+unit:M3-PER-KiloGM-SEC2
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 3 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:KiloGM ] .
+
+unit:FLIGHT
+    a            qudt:Unit ;
+    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
+
+unit:FRAME
+    a            qudt:Unit ;
+    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
+
+unit:L-PER-MicroMOL
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MicroMOL ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:L ] .
+
+unit:BTU_IT-FT-PER-FT2-HR-DEG_F
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:FT ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:FT ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DEG_F ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BTU_IT ] .
+
+unit:BBL_UK_PET-PER-HR
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BBL_UK_PET ] .
+
+unit:N-M-PER-A
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:N ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:A ] .
+
+unit:PINT_US-PER-MIN
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:PINT_US ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MIN ] .
+
+unit:HectoPA-M3-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 3 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:HectoPA ] .
+
+unit:K-PER-MIN
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MIN ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:K ] .
+
+unit:M3-PER-C
+    qudt:factorUnit [ qudt:exponent 3 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:C ] .
+
+unit:NUM-PER-MicroL
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:NUM ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MicroL ] .
+
+unit:KiloLB_F-FT-PER-A
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloLB_F ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:FT ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:A ] .
+
+unit:M2-PER-GM_DRY
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:GM_DRY ] .
+
+unit:MilliM4
+    qudt:factorUnit [ qudt:exponent 4 ;
+                      qudt:unit     unit:MilliM ] .
+
+unit:MilliMOL-PER-M3
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliMOL ] ;
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:M ] .
+
+unit:KiloGM-PER-KiloGM
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloGM ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:KiloGM ] .
+
+unit:KiloL-PER-HR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloL ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] .
+
+unit:DYN-PER-CentiM
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:DYN ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:CentiM ] .
+
+unit:GM_F-PER-CentiM2
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:GM_F ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:CentiM ] .
+
+unit:BTU_IT-PER-HR-FT2
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:FT ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BTU_IT ] .
+
+unit:SAMPLE-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:SAMPLE ] .
+
+unit:BU_UK-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BU_UK ] .
+
+unit:MilliGM-PER-M2-HR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliGM ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] .
+
+unit:M3-PER-MIN
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MIN ] ;
+    qudt:factorUnit [ qudt:exponent 3 ;
+                      qudt:unit     unit:M ] .
+
+unit:MOL-PER-MIN
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MOL ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MIN ] .
+
+unit:C-PER-KiloGM
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:KiloGM ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:C ] .
+
+unit:M3-PER-MOL
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MOL ] ;
+    qudt:factorUnit [ qudt:exponent 3 ;
+                      qudt:unit     unit:M ] .
+
+unit:MOL-PER-MOL
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MOL ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MOL ] .
+
+unit:W-PER-CentiM2
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:W ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:CentiM ] .
+
+unit:A-PER-M
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:A ] .
+
+unit:PK_US_DRY-PER-HR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:PK_US_DRY ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] .
+
+unit:KiloA-PER-M2
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloA ] .
+
+unit:IN2
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:IN ] .
+
+unit:MilliW-PER-CentiM2-MicroM-SR
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SR ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliW ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MicroM ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:CentiM ] .
+
+unit:MicroS-PER-CentiM
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MicroS ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:CentiM ] .
+
+unit:J-PER-M4
+    qudt:factorUnit [ qudt:exponent -4 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:J ] .
+
+unit:NUM-PER-M
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:NUM ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] .
+
+unit:PK_US_DRY-PER-DAY
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:PK_US_DRY ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DAY ] .
+
+unit:DEG_C-KiloGM-PER-M2
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloGM ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:DEG_C ] .
+
+unit:RAD-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:RAD ] .
+
+unit:CAL_TH-PER-GM
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:GM ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:CAL_TH ] .
+
+unit:MicroS-PER-M
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MicroS ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] .
+
+unit:OZ_VOL_UK-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:OZ_VOL_UK ] .
+
+unit:MilliMOL-PER-KiloGM
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliMOL ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:KiloGM ] .
+
+unit:FT3-PER-MIN-FT2
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MIN ] ;
+    qudt:factorUnit [ qudt:exponent 3 ;
+                      qudt:unit     unit:FT ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:FT ] .
+
+unit:V-PER-CentiM
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:V ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:CentiM ] .
+
+unit:MilliGM-PER-GM
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliGM ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:GM ] .
+
+unit:KiloM-PER-DAY
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloM ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DAY ] .
+
+unit:M-PER-K
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:K ] .
+
+unit:FT2-HR-DEG_F-PER-BTU_IT
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:HR ] ;
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:FT ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:DEG_F ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:BTU_IT ] .
+
+unit:CentiM3-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 3 ;
+                      qudt:unit     unit:CentiM ] .
+
+unit:W-PER-M2-NanoM
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:W ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:NanoM ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] .
+
+unit:BTU_IT-IN-PER-HR-FT2-DEG_F
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:IN ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:FT ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DEG_F ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BTU_IT ] .
+
+unit:CentiMOL
+    a            qudt:Unit ;
+    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
+
+unit:BBL_US-PER-MIN
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MIN ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BBL_US ] .
+
+unit:MegaJ-PER-M3
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MegaJ ] ;
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:M ] .
+
+unit:M2-HZ3
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 3 ;
+                      qudt:unit     unit:HZ ] .
+
+unit:MicroMOL-PER-M2-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MicroMOL ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] .
+
+unit:MI3
+    qudt:factorUnit [ qudt:exponent 3 ;
+                      qudt:unit     unit:MI ] .
+
+unit:C-PER-MilliM3
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:MilliM ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:C ] .
+
+unit:FemtoGM-PER-KiloGM
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:KiloGM ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:FemtoGM ] .
+
+unit:BTU_IT-PER-FT3
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:FT ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BTU_IT ] .
+
+unit:FT-LB_F-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:LB_F ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:FT ] .
+
+unit:FT-LB_F-PER-HR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:LB_F ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:FT ] .
+
+unit:M2-PER-KiloGM
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:KiloGM ] .
+
+unit:KiloGM-CentiM2
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloGM ] ;
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:CentiM ] .
+
+unit:PER-MILLE-PER-PSI
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:PSI ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MILLE ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MILLE ] .
+
+unit:GI_UK-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:GI_UK ] .
+
+unit:DEATHS-PER-1000I-YR
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:YR ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:DEATHS ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:1000I ] .
+
+unit:DeciM2
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:DeciM ] .
+
+unit:M-PER-MIN
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MIN ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:M ] .
+
+unit:DEG_F-HR-FT2-PER-BTU_IT
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:HR ] ;
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:FT ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:DEG_F ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:BTU_IT ] .
+
+unit:BTU_IT-PER-LB_F
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:LB_F ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BTU_IT ] .
+
+unit:SEC2
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:SEC ] .
+
+unit:N-PER-KiloGM
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:N ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:KiloGM ] .
+
+unit:MilliBAR-L-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliBAR ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:L ] .
+
+unit:N-M-PER-M2
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:N ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] .
+
+unit:GM-PER-DEG_C
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:GM ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DEG_C ] .
+
+unit:KiloPA-PER-BAR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloPA ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:BAR ] .
+
+unit:PA-PER-MIN
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:PA ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MIN ] .
+
+unit:1000I
+    a            qudt:Unit ;
+    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
+
+unit:KiloMOL-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloMOL ] .
+
+unit:GI_UK-PER-HR
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:GI_UK ] .
+
+unit:HectoPA-PER-BAR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:HectoPA ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:BAR ] .
+
+unit:MicroSV-PER-HR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MicroSV ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] .
+
+unit:KIP_F-PER-IN2
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KIP_F ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:IN ] .
+
+unit:MilliL-PER-L
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliL ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:L ] .
+
+unit:DeciL-PER-GM
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:GM ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:DeciL ] .
+
+unit:BQ-SEC-PER-M3
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BQ ] .
+
+unit:TON_SHORT-PER-HR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:TON_SHORT ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] .
+
+unit:KiloCAL-PER-CentiM2
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloCAL ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:CentiM ] .
+
+unit:AT-PER-IN
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:IN ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:AT ] .
+
+unit:PER-K
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:K ] .
+
+unit:PER-PA
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:PA ] .
+
+unit:KiloLB_F-PER-FT
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloLB_F ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:FT ] .
+
+unit:PSI-YD3-PER-SEC
+    qudt:factorUnit [ qudt:exponent 3 ;
+                      qudt:unit     unit:YD ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:PSI ] .
+
+unit:HZ-PER-V
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:V ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:HZ ] .
+
+unit:KiloGM-PER-KiloM2
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:KiloM ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloGM ] .
+
+unit:GI_US-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:GI_US ] .
+
+unit:MilliH-PER-OHM
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:OHM ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliH ] .
+
+unit:NanoFARAD-PER-M
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:NanoFARAD ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] .
+
+unit:LB_F-PER-IN2-DEG_F
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:LB_F ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:IN ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DEG_F ] .
+
+unit:MegaS-PER-M
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MegaS ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] .
+
+unit:KiloGM-PER-MilliM
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MilliM ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloGM ] .
+
+unit:LB-PER-GAL
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:LB ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:GAL ] .
+
+unit:DEG2
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:DEG ] .
+
+unit:YD-PER-DEG_F
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:YD ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DEG_F ] .
+
+unit:BTU_TH-PER-HR
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BTU_TH ] .
+
+unit:ERG-PER-CentiM
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:ERG ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:CentiM ] .
+
+unit:LB-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:LB ] .
+
+unit:DeciS-PER-M
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:DeciS ] .
+
+unit:M2-HR-DEG_C-PER-KiloCAL_IT
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:KiloCAL_IT ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:HR ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:DEG_C ] .
+
+unit:PINT_UK-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:PINT_UK ] .
+
+unit:MilliW-PER-M2-NanoM
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:NanoM ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliW ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] .
+
+unit:OZ-PER-GAL_US
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:OZ ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:GAL_US ] .
+
+unit:RAD-PER-HR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:RAD ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] .
+
+unit:PER-SEC2
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:SEC ] .
+
+unit:BQ-PER-M3
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BQ ] .
+
+unit:MilliMOL-PER-M3-DAY
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliMOL ] ;
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DAY ] .
+
+unit:MegaC-PER-M3
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MegaC ] ;
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:M ] .
+
+unit:KiloCAL_TH-PER-MIN
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MIN ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloCAL_TH ] .
+
+unit:MicroMOL-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MicroMOL ] .
+
+unit:PA2-SEC
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:PA ] .
+
+unit:MilliBAR-M3-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliBAR ] ;
+    qudt:factorUnit [ qudt:exponent 3 ;
+                      qudt:unit     unit:M ] .
+
+unit:NUM-PER-GM
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:NUM ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:GM ] .
+
+unit:PER-MilliM3
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:MilliM ] .
+
+unit:OZ-PER-MIN
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:OZ ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MIN ] .
+
+unit:MilliL-PER-MIN
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliL ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MIN ] .
+
+unit:MicroM-PER-MilliL
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MilliL ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MicroM ] .
+
+unit:KiloA-PER-M
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloA ] .
+
+unit:N-M2-PER-A
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:N ] ;
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:A ] .
+
+unit:MilliS-PER-CentiM
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliS ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:CentiM ] .
+
+unit:HectoPA-L-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:L ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:HectoPA ] .
+
+unit:TONNE-PER-SEC
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:TONNE ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] .
+
+unit:MicroMOL-PER-M2-DAY
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MicroMOL ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DAY ] .
+
+unit:MOL-PER-M2-SEC-M-SR
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SR ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MOL ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] .
+
+unit:C-PER-M
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:C ] .
+
+unit:PER-PA-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:PA ] .
+
+unit:MicroMOL-PER-MicroMOL-DAY
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MicroMOL ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MicroMOL ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DAY ] .
+
+unit:S-PER-M
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:S ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] .
+
+unit:MicroMOL-PER-KiloGM
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MicroMOL ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:KiloGM ] .
+
+unit:GAL_UK-PER-DAY
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:GAL_UK ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DAY ] .
+
+unit:N-PER-A
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:N ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:A ] .
+
+unit:M3
+    qudt:factorUnit [ qudt:exponent 3 ;
+                      qudt:unit     unit:M ] .
+
+unit:V-PER-IN
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:V ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:IN ] .
+
+unit:PicoMOL-PER-M3
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:PicoMOL ] ;
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:M ] .
+
+unit:PINT_US-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:PINT_US ] .
+
+unit:K-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:K ] .
+
+unit:M2-PER-K
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:K ] .
+
+unit:BTU_IT-IN-PER-SEC-FT2-DEG_F
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:IN ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:FT ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DEG_F ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BTU_IT ] .
+
+unit:FARAD_Ab-PER-CentiM
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:FARAD_Ab ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:CentiM ] .
+
+unit:MilliGM-PER-M2
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliGM ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] .
+
+unit:KiloJ-PER-KiloGM-K
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloJ ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:KiloGM ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:K ] .
+
+unit:K2
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:K ] .
+
+unit:GM_Carbon-PER-M2-DAY
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:GM_Carbon ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DAY ] .
+
+unit:W-PER-FT2
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:W ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:FT ] .
+
+unit:MicroGAL
+    a            qudt:Unit ;
+    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
+
+unit:ERG-PER-CentiM3
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:ERG ] ;
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:CentiM ] .
+
+unit:KiloJ-PER-MOL
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MOL ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloJ ] .
+
+unit:V-PER-MilliM
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:V ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MilliM ] .
+
+unit:KiloMOL-PER-M3
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloMOL ] .
+
+unit:FemtoGM-PER-L
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:L ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:FemtoGM ] .
+
+unit:OZ_VOL_US-PER-HR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:OZ_VOL_US ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] .
+
+unit:MegaHZ-PER-K
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MegaHZ ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:K ] .
+
+unit:LB-PER-YD3
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:YD ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:LB ] .
+
+unit:BTU_IT-PER-LB_F-DEG_R
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:LB_F ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DEG_R ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BTU_IT ] .
+
+unit:BTU_TH-PER-MIN
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MIN ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BTU_TH ] .
+
+unit:KiloGM-PER-KiloMOL
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:KiloMOL ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloGM ] .
+
+unit:KiloGM-M2-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloGM ] .
+
+unit:MilliW-PER-M2
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliW ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] .
+
+unit:IN2-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:IN ] .
+
+unit:W-PER-M2-M-SR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:W ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SR ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] .
+
+unit:FT-LB_F-PER-FT2
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:LB_F ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:FT ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:FT ] .
+
+unit:J-PER-CentiM2-DAY
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:J ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DAY ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:CentiM ] .
+
+unit:W-PER-M2-K
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:W ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:K ] .
+
+unit:N-M-PER-KiloGM
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:N ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:KiloGM ] .
+
+unit:PER-WK
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:WK ] .
+
+unit:M3-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 3 ;
+                      qudt:unit     unit:M ] .
+
+unit:BTU_IT-PER-LB-DEG_F
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:LB ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DEG_F ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BTU_IT ] .
+
+unit:MOL-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MOL ] .
+
+unit:GAL_US-PER-DAY
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:GAL_US ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DAY ] .
+
+unit:M2-SEC-PER-RAD
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:RAD ] ;
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:M ] .
+
+unit:GRAIN-PER-GAL
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:GRAIN ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:GAL ] .
+
+unit:KiloGM2-PER-SEC2
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:KiloGM ] .
+
+unit:PER-GM
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:GM ] .
+
+unit:MicroM-PER-N
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:N ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MicroM ] .
+
+unit:L-PER-L
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:L ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:L ] .
+
+unit:LB-PER-HR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:LB ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] .
+
+unit:J-PER-GM
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:J ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:GM ] .
+
+unit:SAMPLE
+    a            qudt:Unit ;
+    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
+
+unit:N-PER-MilliM
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:N ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MilliM ] .
+
+unit:M3-PER-M3
+    qudt:factorUnit [ qudt:exponent 3 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:M ] .
+
+unit:PicoGM-PER-GM
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:PicoGM ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:GM ] .
+
+unit:DEG_F-PER-SEC2
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:DEG_F ] .
+
+unit:YD3-PER-HR
+    qudt:factorUnit [ qudt:exponent 3 ;
+                      qudt:unit     unit:YD ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] .
+
+unit:LB_F-PER-FT
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:LB_F ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:FT ] .
+
+unit:PicoPA
+    a            qudt:Unit ;
+    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
+
+unit:1000000I
+    a            qudt:Unit ;
+    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
+
+unit:KiloGM-PER-CentiM3
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloGM ] ;
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:CentiM ] .
+
+unit:PINT_US-PER-HR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:PINT_US ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] .
+
+unit:PA-M3-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:PA ] ;
+    qudt:factorUnit [ qudt:exponent 3 ;
+                      qudt:unit     unit:M ] .
+
+unit:PA-PER-BAR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:PA ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:BAR ] .
+
+unit:MOL-PER-DeciM3
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MOL ] ;
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:DeciM ] .
+
+unit:KiloGM-PER-HR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloGM ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] .
+
+unit:PERCENT-PER-HR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:PERCENT ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] .
+
+unit:LB-PER-FT-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:LB ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:FT ] .
+
+unit:PER-PSI
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:PSI ] .
+
+unit:BU_US_DRY-PER-MIN
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MIN ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BU_US_DRY ] .
+
+unit:W-PER-M2
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:W ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] .
+
+unit:A-PER-DEG_C
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DEG_C ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:A ] .
+
+unit:ERG-PER-GM
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:GM ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:ERG ] .
+
+unit:M3-PER-K
+    qudt:factorUnit [ qudt:exponent 3 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:K ] .
+
+unit:M2-PER-HZ
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HZ ] .
+
+unit:WB-PER-MilliM
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:WB ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MilliM ] .
+
+unit:BTU_IT-PER-LB
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:LB ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BTU_IT ] .
+
+unit:FT-LB_F-PER-FT2-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:LB_F ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:FT ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:FT ] .
+
+unit:KiloCAL-PER-CentiM2-MIN
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MIN ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloCAL ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:CentiM ] .
+
+unit:W-PER-IN2
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:W ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:IN ] .
+
+unit:FARAD-PER-KiloM
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:KiloM ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:FARAD ] .
+
+unit:M2-PER-HZ2
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:HZ ] .
+
+unit:LB-PER-FT2
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:LB ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:FT ] .
+
+unit:TON_UK-PER-YD3
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:YD ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:TON_UK ] .
+
+unit:KiloGM-PER-DeciM3
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloGM ] ;
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:DeciM ] .
+
+unit:MDOLLAR
+    a            qudt:Unit ;
+    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
+
+unit:MOL-PER-L
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MOL ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:L ] .
+
+unit:GM-PER-CentiM2-YR
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:YR ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:GM ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:CentiM ] .
+
+unit:M-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:M ] .
+
+unit:DEG-PER-HR
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:DEG ] .
+
+unit:NUM-PER-M2
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:NUM ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] .
+
+unit:IN3-PER-HR
+    qudt:factorUnit [ qudt:exponent 3 ;
+                      qudt:unit     unit:IN ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] .
+
+unit:PA-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:PA ] .
+
+unit:CentiM3-PER-K
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:K ] ;
+    qudt:factorUnit [ qudt:exponent 3 ;
+                      qudt:unit     unit:CentiM ] .
+
+unit:J-PER-M3-K
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:K ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:J ] .
+
+unit:MilliM-PER-DAY
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliM ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DAY ] .
+
+unit:M2-PER-SR-J
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SR ] ;
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:J ] .
+
+unit:PA-L-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:PA ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:L ] .
+
+unit:MilliGM-PER-M2-DAY
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliGM ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DAY ] .
+
+unit:MicroGM-PER-MilliL
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MilliL ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MicroGM ] .
+
+unit:MilliV-PER-MIN
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliV ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MIN ] .
+
+unit:DEG_C-PER-M
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:DEG_C ] .
+
+unit:MilliGM-PER-KiloGM
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliGM ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:KiloGM ] .
+
+unit:W-PER-M2-SR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:W ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SR ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] .
+
+unit:DecaM3
+    qudt:factorUnit [ qudt:exponent 3 ;
+                      qudt:unit     unit:DecaM ] .
+
+unit:NanoBQ-PER-L
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:NanoBQ ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:L ] .
+
+unit:TON_US-PER-YD3
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:YD ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:TON_US ] .
+
+unit:MilliM2
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:MilliM ] .
+
+unit:DeciBAR-PER-YR
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:YR ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:DeciBAR ] .
+
+unit:RAD-PER-SEC2
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:RAD ] .
+
+unit:EV-PER-M
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:EV ] .
+
+unit:KiloS-PER-M
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloS ] .
+
+unit:PER-M-NanoM-SR
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SR ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:NanoM ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] .
+
+unit:V-PER-M2
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:V ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] .
+
+unit:TON_LONG-PER-YD3
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:YD ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:TON_LONG ] .
+
+unit:NanoGM-PER-MilliL
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:NanoGM ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MilliL ] .
+
+unit:MilliBQ
+    a            qudt:Unit ;
+    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
+
+unit:W-M2
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:W ] ;
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:M ] .
+
+unit:KiloM3-PER-SEC2
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 3 ;
+                      qudt:unit     unit:KiloM ] .
+
+unit:MOL-PER-M2-DAY
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MOL ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DAY ] .
+
+unit:KiloLB_F
+    a            qudt:Unit ;
+    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
+
+unit:PPTH-PER-HR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:PPTH ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] .
+
+unit:FRAME-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:FRAME ] .
+
+unit:SEC-PER-RAD-M3
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:RAD ] ;
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:M ] .
+
+unit:C_Stat-PER-CentiM2
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:CentiM ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:C_Stat ] .
+
+unit:MOL-PER-KiloGM
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MOL ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:KiloGM ] .
+
+unit:SpeedOfLight
+    a            qudt:Unit ;
+    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
+
+unit:C3-M-PER-J2
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:J ] ;
+    qudt:factorUnit [ qudt:exponent 3 ;
+                      qudt:unit     unit:C ] .
+
+unit:GM-PER-MilliL
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MilliL ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:GM ] .
+
+unit:J-PER-T
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:T ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:J ] .
+
+unit:LB-PER-IN2
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:LB ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:IN ] .
+
+unit:PER-M2
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] .
+
+unit:OZ-PER-GAL
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:OZ ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:GAL ] .
+
+unit:KiloCAL_TH-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloCAL_TH ] .
+
+unit:OZ_VOL_UK-PER-HR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:OZ_VOL_UK ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] .
+
+unit:J-PER-M2
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:J ] .
+
+unit:MILLE
+    a            qudt:Unit ;
+    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
+
+unit:OZ-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:OZ ] .
+
+unit:KiloGM_F-M-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloGM_F ] .
+
+unit:MilliL-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliL ] .
+
+unit:MillionUSD-PER-YR
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:YR ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MillionUSD ] .
+
+unit:RAD-M2-PER-KiloGM
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:RAD ] ;
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:KiloGM ] .
+
+unit:C-PER-KiloGM-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:KiloGM ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:C ] .
+
+unit:PicoMOL-PER-L
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:PicoMOL ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:L ] .
+
+unit:V_Stat-PER-CentiM
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:V_Stat ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:CentiM ] .
+
+unit:M3-PER-KiloGM
+    qudt:factorUnit [ qudt:exponent 3 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:KiloGM ] .
+
+unit:K-M-PER-W
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:W ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:K ] .
+
+unit:KiloGM-PER-M-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloGM ] .
+
+unit:CAL_TH-PER-SEC-CentiM-K
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:K ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:CentiM ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:CAL_TH ] .
+
+unit:MicroGM-PER-M3
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MicroGM ] ;
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:M ] .
+
+unit:NanoS-PER-M
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:NanoS ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] .
+
+unit:KiloGM-PER-M-HR
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloGM ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] .
+
+unit:BTU_IT-IN-PER-FT2-HR-DEG_F
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:IN ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:FT ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DEG_F ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BTU_IT ] .
+
+unit:M2-PER-HA
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HA ] .
+
+unit:CentiM2-MIN
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MIN ] ;
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:CentiM ] .
+
+unit:MilliGM-PER-CentiM2
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliGM ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:CentiM ] .
+
+unit:PINT_UK-PER-HR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:PINT_UK ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] .
+
+unit:MegaEV-PER-SpeedOfLight
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SpeedOfLight ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MegaEV ] .
+
+unit:V-PER-M
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:V ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] .
+
+unit:CAL_IT-PER-GM
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:GM ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:CAL_IT ] .
+
+unit:KiloCAL-PER-GM
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloCAL ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:GM ] .
+
+unit:BTU_TH-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BTU_TH ] .
+
+unit:MI-PER-MIN
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MIN ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MI ] .
+
+unit:CentiM-PER-SEC2
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:CentiM ] .
+
+unit:MilliGM-PER-M3-DAY
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliGM ] ;
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DAY ] .
+
+unit:DEG_F-PER-MIN
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MIN ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:DEG_F ] .
+
+unit:MilliMOL-PER-M2-DAY
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliMOL ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DAY ] .
+
+unit:K-PER-T
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:T ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:K ] .
+
+unit:OZ-PER-YD3
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:YD ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:OZ ] .
+
+unit:TON_US-PER-HR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:TON_US ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] .
+
+unit:AT-PER-M
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:AT ] .
+
+unit:A_Ab-PER-CentiM2
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:CentiM ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:A_Ab ] .
+
+unit:QT_UK-PER-MIN
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:QT_UK ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MIN ] .
+
+unit:M2-PER-SR
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SR ] ;
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:M ] .
+
+unit:C4-M4-PER-J3
+    qudt:factorUnit [ qudt:exponent 4 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:J ] ;
+    qudt:factorUnit [ qudt:exponent 4 ;
+                      qudt:unit     unit:C ] .
+
+unit:HZ-PER-T
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:T ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:HZ ] .
+
+unit:KiloGM-PER-SEC-M2
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloGM ] .
+
+unit:M3-PER-SEC2
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 3 ;
+                      qudt:unit     unit:M ] .
+
+unit:BAR-M3-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 3 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BAR ] .
+
+unit:SEC-PER-M
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] .
+
+unit:BU_US_DRY-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BU_US_DRY ] .
+
+unit:GM-PER-L
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:L ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:GM ] .
+
+unit:LB_F-PER-FT2
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:LB_F ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:FT ] .
+
+unit:N-PER-CentiM
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:N ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:CentiM ] .
+
+unit:KiloCAL-PER-CentiM2-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloCAL ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:CentiM ] .
+
+unit:KiloGM-SEC2
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloGM ] .
+
+unit:OZ_VOL_US-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:OZ_VOL_US ] .
+
+unit:MicroL-PER-L
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MicroL ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:L ] .
+
+unit:N-PER-M2
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:N ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] .
+
+unit:DEG-PER-MIN
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MIN ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:DEG ] .
+
+unit:PSI-IN3-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:PSI ] ;
+    qudt:factorUnit [ qudt:exponent 3 ;
+                      qudt:unit     unit:IN ] .
+
+unit:DEG_R-PER-HR
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:DEG_R ] .
+
+unit:DeciM3-PER-HR
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] ;
+    qudt:factorUnit [ qudt:exponent 3 ;
+                      qudt:unit     unit:DeciM ] .
+
+unit:HART-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:HART ] .
+
+unit:W-PER-M
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:W ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] .
+
+unit:SLUG-PER-MIN
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:SLUG ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MIN ] .
+
+unit:QT_US-PER-MIN
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:QT_US ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MIN ] .
+
+unit:PER-MIN
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MIN ] .
+
+unit:M2-PER-N
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:N ] ;
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:M ] .
+
+unit:KiloGM-MilliM2
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:MilliM ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloGM ] .
+
+unit:CentiPOISE-PER-BAR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:CentiPOISE ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:BAR ] .
+
+unit:PER-MOL
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MOL ] .
+
+unit:FT3-PER-MIN
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MIN ] ;
+    qudt:factorUnit [ qudt:exponent 3 ;
+                      qudt:unit     unit:FT ] .
+
+unit:BU_US_DRY
+    a            qudt:Unit ;
+    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
+
+unit:TON_Metric-PER-MIN
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:TON_Metric ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MIN ] .
+
+unit:MilliL-PER-M2-DAY
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliL ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DAY ] .
+
+unit:BU_UK-PER-DAY
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DAY ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BU_UK ] .
+
+unit:NanoMOL-PER-L-DAY
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:NanoMOL ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:L ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DAY ] .
+
+unit:NUM-PER-NanoL
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:NanoL ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:NUM ] .
+
+unit:J-PER-KiloGM-K-M3
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:KiloGM ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:K ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:J ] .
+
+unit:CAL_IT-PER-GM-DEG_C
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:GM ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DEG_C ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:CAL_IT ] .
+
+unit:MilliL-PER-KiloGM
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliL ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:KiloGM ] .
+
+unit:OZ-PER-FT2
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:OZ ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:FT ] .
+
+unit:MilliGM-PER-HR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliGM ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] .
+
+unit:BTU_IT-PER-HR
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BTU_IT ] .
+
+unit:MegaS
+    a            qudt:Unit ;
+    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
+
+unit:MilliBQ-PER-GM
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliBQ ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:GM ] .
+
+unit:A_Stat-PER-CentiM2
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:CentiM ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:A_Stat ] .
+
+unit:PA-PER-HR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:PA ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] .
+
+unit:CentiMOL-PER-KiloGM
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:KiloGM ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:CentiMOL ] .
+
+unit:BEAT
+    a            qudt:Unit ;
+    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
+
+unit:FT3-PER-HR
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] ;
+    qudt:factorUnit [ qudt:exponent 3 ;
+                      qudt:unit     unit:FT ] .
+
+unit:PER-M-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] .
+
+unit:J-PER-T2
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:T ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:J ] .
+
+unit:MicroFARAD-PER-M
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MicroFARAD ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] .
+
+unit:BU_US_DRY-PER-HR
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BU_US_DRY ] .
+
+unit:OZ-PER-HR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:OZ ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] .
+
+unit:GM-PER-GM
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:GM ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:GM ] .
+
+unit:PER-T-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:T ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] .
+
+unit:KiloC-PER-M3
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloC ] .
+
+unit:W-PER-M-K
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:W ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:K ] .
+
+unit:TONNE-PER-M3
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:TONNE ] ;
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:M ] .
+
+unit:V_Ab-PER-CentiM
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:V_Ab ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:CentiM ] .
+
+unit:LB-PER-FT
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:LB ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:FT ] .
+
+unit:J-PER-MOL
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MOL ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:J ] .
+
+unit:OZ_VOL_UK-PER-DAY
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:OZ_VOL_UK ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DAY ] .
+
+unit:MilliH-PER-KiloOHM
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliH ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:KiloOHM ] .
+
+unit:BTU_IT-PER-SEC-FT2-DEG_R
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:FT ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DEG_R ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BTU_IT ] .
+
+unit:LB-PER-M3
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:LB ] .
+
+unit:KiloGM-PER-M
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloGM ] .
+
+unit:MicroC-PER-M2
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MicroC ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] .
+
+unit:LB_F-PER-IN2
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:LB_F ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:IN ] .
+
+unit:L-PER-HR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:L ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] .
+
+unit:CentiM3
+    qudt:factorUnit [ qudt:exponent 3 ;
+                      qudt:unit     unit:CentiM ] .
+
+unit:CentiM3-PER-DAY
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DAY ] ;
+    qudt:factorUnit [ qudt:exponent 3 ;
+                      qudt:unit     unit:CentiM ] .
+
+unit:KiloCAL_IT-PER-HR-M-DEG_C
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloCAL_IT ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DEG_C ] .
+
+unit:A-M2-PER-J-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:J ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:A ] .
+
+unit:C-M2-PER-V
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:V ] ;
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:C ] .
+
+unit:PER-M3-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:M ] .
+
+unit:H-PER-M
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:H ] .
+
+unit:K-PA-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:PA ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:K ] .
+
+unit:MicroGM-PER-L
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MicroGM ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:L ] .
+
+unit:PK_UK-PER-MIN
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:PK_UK ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MIN ] .
+
+unit:PicoS-PER-M
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:PicoS ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] .
+
+unit:KiloGM-M2
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloGM ] .
+
+unit:KiloGM-PER-M3
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloGM ] .
+
+unit:MicroM2
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:MicroM ] .
+
+unit:MilliA-PER-MilliM
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MilliM ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliA ] .
+
+unit:DEG_F-HR-PER-BTU_IT
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:HR ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:DEG_F ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:BTU_IT ] .
+
+unit:HP-PER-V
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:V ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:HP ] .
+
+unit:MegaPA-PER-K
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MegaPA ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:K ] .
+
+unit:GI_UK-PER-DAY
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:GI_UK ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DAY ] .
+
+unit:OZ_VOL_US-PER-DAY
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:OZ_VOL_US ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DAY ] .
+
+unit:FT2-PER-HR
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] ;
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:FT ] .
+
+unit:M-PER-SEC2
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:M ] .
+
+unit:MI_N-PER-HR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MI_N ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] .
+
+unit:DYN-SEC-PER-CentiM
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:DYN ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:CentiM ] .
+
+unit:A-PER-M2
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:A ] .
+
+unit:FT3
+    qudt:factorUnit [ qudt:exponent 3 ;
+                      qudt:unit     unit:FT ] .
+
+unit:TON_Metric-PER-M3
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:TON_Metric ] ;
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:M ] .
+
+unit:FARAD-PER-M
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:FARAD ] .
+
+unit:BTU_IT-PER-LB_F-DEG_F
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:LB_F ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DEG_F ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BTU_IT ] .
+
+unit:BBL_UK_PET-PER-MIN
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MIN ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BBL_UK_PET ] .
+
+unit:MegaPA-M3-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MegaPA ] ;
+    qudt:factorUnit [ qudt:exponent 3 ;
+                      qudt:unit     unit:M ] .
+
+unit:PER-SEC-SR
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SR ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] .
+
+unit:CentiM2-SEC
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:CentiM ] .
+
+unit:MilliW-PER-M2-NanoM-SR
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SR ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:NanoM ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliW ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] .
+
+unit:PDL-PER-FT2
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:PDL ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:FT ] .
+
+unit:H-PER-OHM
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:OHM ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:H ] .
+
+unit:NanoMOL-PER-L-HR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:NanoMOL ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:L ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] .
+
+unit:PA-M-PER-SEC2
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:PA ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:M ] .
+
+unit:KiloWB-PER-M
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloWB ] .
+
+unit:BTU_IT-PER-LB-MOL
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MOL ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:LB ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BTU_IT ] .
+
+unit:A-PER-CentiM2
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:CentiM ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:A ] .
+
+unit:N-SEC-PER-M3
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:N ] ;
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:M ] .
+
+unit:NUM-PER-HR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:NUM ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] .
+
+unit:K-PER-HR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:K ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] .
+
+unit:GI_US-PER-DAY
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:GI_US ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DAY ] .
+
+unit:PicoW-PER-CentiM2-L
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:PicoW ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:L ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:CentiM ] .
+
+unit:TONNE-PER-HA
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:TONNE ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HA ] .
+
+unit:BAR-L-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:L ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BAR ] .
+
+unit:DEG_F-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:DEG_F ] .
+
+unit:C_Ab-PER-CentiM2
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:CentiM ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:C_Ab ] .
+
+unit:C-M2
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:C ] .
+
+unit:LB-PER-DAY
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:LB ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DAY ] .
+
+unit:MilliC-PER-KiloGM
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliC ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:KiloGM ] .
+
+unit:BU_UK-PER-HR
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BU_UK ] .
+
+unit:C-PER-CentiM2
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:CentiM ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:C ] .
+
+unit:SLUG-PER-HR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:SLUG ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] .
+
+unit:PINT_UK-PER-DAY
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:PINT_UK ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DAY ] .
+
+unit:PER-BAR
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:BAR ] .
+
+unit:HectoPA-PER-HR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:HectoPA ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] .
+
+unit:BTU_TH-IN-PER-FT2-HR-DEG_F
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:IN ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:FT ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DEG_F ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BTU_TH ] .
+
+unit:KiloPA-PER-MilliM
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MilliM ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloPA ] .
+
+unit:MicroGAL-PER-M
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MicroGAL ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] .
+
+unit:L-PER-MIN
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MIN ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:L ] .
+
+unit:L-PER-MOL
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MOL ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:L ] .
+
+unit:DEG_C-PER-K
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:K ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:DEG_C ] .
+
+unit:QT_UK-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:QT_UK ] .
+
+unit:MilliBQ-PER-M2-DAY
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliBQ ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DAY ] .
+
+unit:EV-PER-K
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:K ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:EV ] .
+
+unit:J-SEC-PER-MOL
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MOL ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:J ] .
+
+unit:KiloGM-PER-MIN
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MIN ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloGM ] .
+
+unit:KiloGM-PER-HA
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloGM ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HA ] .
+
+unit:MilliBQ-PER-KiloGM
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliBQ ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:KiloGM ] .
+
+unit:KiloGM-PER-MOL
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MOL ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloGM ] .
+
+unit:PER-MilliSEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MilliSEC ] .
+
+unit:MicroV-PER-M
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MicroV ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] .
+
+unit:GM-PER-M2
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:GM ] .
+
+unit:TONNE-PER-DAY
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:TONNE ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DAY ] .
+
+unit:IN3
+    qudt:factorUnit [ qudt:exponent 3 ;
+                      qudt:unit     unit:IN ] .
+
+unit:QT_US-PER-HR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:QT_US ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] .
+
+unit:IN3-PER-MIN
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MIN ] ;
+    qudt:factorUnit [ qudt:exponent 3 ;
+                      qudt:unit     unit:IN ] .
+
+unit:V-SEC-PER-M
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:V ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] .
+
+unit:M-PER-FARAD
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:FARAD ] .
+
+unit:FT-PER-SEC2
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:FT ] .
+
+unit:POISE-PER-BAR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:POISE ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:BAR ] .
+
+unit:CD-PER-M2
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:CD ] .
+
+unit:KiloGM-PER-SEC2
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloGM ] .
+
+unit:IN-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:IN ] .
+
+unit:PicoPA-PER-KiloM
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:PicoPA ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:KiloM ] .
+
+unit:PINT_US-PER-DAY
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:PINT_US ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DAY ] .
+
+unit:PER-HR
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] .
+
+unit:DEG_R-PER-MIN
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MIN ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:DEG_R ] .
+
+unit:M2-K
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:K ] .
+
+unit:TON_Metric-PER-HA
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:TON_Metric ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HA ] .
+
+unit:J-PER-HR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:J ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] .
+
+unit:DEG-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:DEG ] .
+
+unit:J-M-PER-MOL
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MOL ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:J ] .
+
+unit:FT-PER-MIN
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MIN ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:FT ] .
+
+unit:DeciM3-PER-MIN
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MIN ] ;
+    qudt:factorUnit [ qudt:exponent 3 ;
+                      qudt:unit     unit:DeciM ] .
+
+unit:SLUG-PER-SEC
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:SLUG ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] .
+
+unit:QT_US-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:QT_US ] .
+
+unit:PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] .
+
+unit:DeciM3-PER-MOL
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MOL ] ;
+    qudt:factorUnit [ qudt:exponent 3 ;
+                      qudt:unit     unit:DeciM ] .
+
+unit:LB_F-SEC-PER-FT2
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:LB_F ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:FT ] .
+
+unit:GM-PER-CentiM2
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:GM ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:CentiM ] .
+
+unit:YD3-PER-MIN
+    qudt:factorUnit [ qudt:exponent 3 ;
+                      qudt:unit     unit:YD ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MIN ] .
+
+unit:FT3-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 3 ;
+                      qudt:unit     unit:FT ] .
+
+unit:MicroFARAD-PER-KiloM
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MicroFARAD ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:KiloM ] .
+
+unit:TON_Metric-PER-SEC
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:TON_Metric ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] .
+
+unit:M2-HZ4
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 4 ;
+                      qudt:unit     unit:HZ ] .
+
+unit:BTU_IT-PER-MIN
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MIN ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BTU_IT ] .
+
+unit:MegaJ-PER-KiloGM
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MegaJ ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:KiloGM ] .
+
+unit:CAL_TH-PER-SEC-CentiM2-K
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:K ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:CentiM ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:CAL_TH ] .
+
+unit:TON_UK-PER-DAY
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:TON_UK ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DAY ] .
+
+unit:BBL_US_PET
+    a            qudt:Unit ;
+    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
+
+unit:J-PER-M
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:J ] .
+
+unit:LB-FT2
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:LB ] ;
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:FT ] .
+
+unit:M3-PER-DAY
+    qudt:factorUnit [ qudt:exponent 3 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DAY ] .
+
+unit:LB-PER-GAL_UK
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:LB ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:GAL_UK ] .
+
+unit:DEATHS-PER-1000000I-YR
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:YR ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:DEATHS ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:1000000I ] .
+
+unit:KiloGM_F-PER-M
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloGM_F ] .
+
+unit:DeciM3
+    qudt:factorUnit [ qudt:exponent 3 ;
+                      qudt:unit     unit:DeciM ] .
+
+unit:PER-M-SR
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SR ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] .
+
+unit:GM_DRY
+    a            qudt:Unit ;
+    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
+
+unit:KiloGM_F-PER-CentiM2
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloGM_F ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:CentiM ] .
+
+unit:NUM-PER-KiloM2
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:NUM ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:KiloM ] .
+
+unit:K-PER-W
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:W ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:K ] .
+
+unit:V-PER-K
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:V ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:K ] .
+
+unit:J-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:J ] .
+
+unit:MI_N-PER-MIN
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MI_N ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MIN ] .
+
+unit:H_Stat-PER-CentiM
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:H_Stat ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:CentiM ] .
+
+unit:TON_US-PER-DAY
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:TON_US ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DAY ] .
+
+unit:MegaV-PER-M
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MegaV ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] .
+
+unit:NanoGM-PER-M3
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:NanoGM ] ;
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:M ] .
+
+unit:BTU_IT-PER-DEG_R
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DEG_R ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BTU_IT ] .
+
+unit:GM-PER-DeciM3
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:GM ] ;
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:DeciM ] .
+
+unit:PER-L
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:L ] .
+
+unit:MilliGAL-PER-MO
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliGAL ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MO ] .
+
+unit:BTU_IT-PER-HR-FT2-DEG_R
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:FT ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DEG_R ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BTU_IT ] .
+
+unit:PER-YD3
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:YD ] .
+
+unit:EV-PER-ANGSTROM
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:EV ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:ANGSTROM ] .
+
+unit:NUM-PER-YR
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:YR ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:NUM ] .
+
+unit:BBL_US-PER-DAY
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DAY ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BBL_US ] .
+
+unit:N-SEC-PER-RAD
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:RAD ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:N ] .
+
+unit:BEAT-PER-MIN
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MIN ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BEAT ] .
+
+unit:PK_UK-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:PK_UK ] .
+
+unit:PER-M-NanoM
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:NanoM ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] .
+
+unit:NanoH-PER-M
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:NanoH ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] .
+
+unit:ERG-PER-GM-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:GM ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:ERG ] .
+
+unit:LB_F-SEC-PER-IN2
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:LB_F ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:IN ] .
+
+unit:FT-PER-DEG_F
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:FT ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DEG_F ] .
+
+unit:PicoGM-PER-MilliL
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:PicoGM ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MilliL ] .
+
+unit:K-PER-M
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:K ] .
+
+unit:LB-IN2
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:LB ] ;
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:IN ] .
+
+unit:MilliA-PER-IN
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliA ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:IN ] .
+
+unit:KiloCAL-PER-CentiM-SEC-DEG_C
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloCAL ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DEG_C ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:CentiM ] .
+
+unit:FT2-DEG_F
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:FT ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:DEG_F ] .
+
+unit:FemtoMOL-PER-L
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:L ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:FemtoMOL ] .
+
+unit:J-M2
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:J ] .
+
+unit:PER-T-M
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:T ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] .
+
+unit:MilliC-PER-M2
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliC ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] .
+
+unit:BBL_UK_PET-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BBL_UK_PET ] .
+
+unit:MI-PER-HR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MI ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] .
+
+unit:DeciM3-PER-M3
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 3 ;
+                      qudt:unit     unit:DeciM ] .
+
+unit:BTU_IT-IN-PER-FT2-SEC-DEG_F
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:IN ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:FT ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DEG_F ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BTU_IT ] .
+
+unit:S-M2-PER-MOL
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:S ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MOL ] ;
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:M ] .
+
+unit:MicroGM-PER-KiloGM
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MicroGM ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:KiloGM ] .
+
+unit:MilliGM-PER-L
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliGM ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:L ] .
+
+unit:GM-PER-MIN
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MIN ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:GM ] .
+
+unit:PicoS
+    a            qudt:Unit ;
+    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
+
+unit:MicroH-PER-M
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MicroH ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] .
+
+unit:GRAIN-PER-GAL_US
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:GRAIN ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:GAL_US ] .
+
+unit:KiloLB_F-PER-IN2
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloLB_F ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:IN ] .
+
+unit:FT2-PER-BTU_IT-IN
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:IN ] ;
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:FT ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:BTU_IT ] .
+
+unit:GM-PER-MOL
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MOL ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:GM ] .
+
+unit:MegaJ-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MegaJ ] .
+
+unit:W-PER-K
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:W ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:K ] .
+
+unit:M4
+    qudt:factorUnit [ qudt:exponent 4 ;
+                      qudt:unit     unit:M ] .
+
+unit:MicroBQ-PER-L
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MicroBQ ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:L ] .
+
+unit:C_Stat-PER-MOL
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MOL ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:C_Stat ] .
+
+unit:PER-YR
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:YR ] .
+
+unit:MilliMOL-PER-GM
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliMOL ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:GM ] .
+
+unit:N-PER-RAD
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:RAD ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:N ] .
+
+unit:MilliGM-PER-M3
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliGM ] ;
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:M ] .
+
+unit:MilliM-PER-HR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliM ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] .
+
+unit:PicoMOL-PER-M3-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:PicoMOL ] ;
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:M ] .
+
+unit:NanoGM-PER-KiloGM
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:NanoGM ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:KiloGM ] .
+
+unit:QT_UK-PER-HR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:QT_UK ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] .
+
+unit:SLUG-PER-FT2
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:SLUG ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:FT ] .
+
+unit:A_Ab-CentiM2
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:CentiM ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:A_Ab ] .
+
+unit:PER-M2-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] .
+
+unit:MilliGM-PER-MIN
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliGM ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MIN ] .
+
+unit:GM-PER-M2-DAY
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:GM ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DAY ] .
+
+unit:C-PER-M2
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:C ] .
+
+unit:C2-M-PER-J
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:J ] ;
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:C ] .
+
+unit:FemtoMOL
+    a            qudt:Unit ;
+    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
+
+unit:L-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:L ] .
+
+unit:GM-PER-KiloGM
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:KiloGM ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:GM ] .
+
+unit:PicoW-PER-M2
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:PicoW ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] .
+
+unit:REV-PER-MIN
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:REV ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MIN ] .
+
+unit:PSI-M3-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:PSI ] ;
+    qudt:factorUnit [ qudt:exponent 3 ;
+                      qudt:unit     unit:M ] .
+
+unit:YD2
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:YD ] .
+
+unit:BTU_TH-IN-PER-FT2-SEC-DEG_F
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:IN ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:FT ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DEG_F ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BTU_TH ] .
+
+unit:KiloPA-M2-PER-GM
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloPA ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:GM ] .
+
+unit:OZ-PER-DAY
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:OZ ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DAY ] .
+
+unit:KiloGM-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloGM ] .
+
+unit:MilliL-PER-DAY
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliL ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DAY ] .
+
+unit:KiloMOL-PER-KiloGM
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloMOL ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:KiloGM ] .
+
+unit:M-PER-HR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] .
+
+unit:IN3-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 3 ;
+                      qudt:unit     unit:IN ] .
+
+unit:DEG_F-PER-K
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:K ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:DEG_F ] .
+
+unit:MicroGM-PER-L-HR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MicroGM ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:L ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] .
+
+unit:PicoA-PER-MicroMOL-L
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:PicoA ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MicroMOL ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:L ] .
+
+unit:DEG_R-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:DEG_R ] .
+
+unit:ERG-PER-CentiM2-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:ERG ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:CentiM ] .
+
+unit:MilliL-PER-HR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliL ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] .
+
+unit:W-PER-M2-PA
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:W ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:PA ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] .
+
+unit:FT-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:FT ] .
+
+unit:NanoMOL-PER-M2-DAY
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:NanoMOL ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DAY ] .
+
+unit:DeciM3-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 3 ;
+                      qudt:unit     unit:DeciM ] .
+
+unit:W-PER-M3
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:W ] ;
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:M ] .
+
+unit:PicoFARAD-PER-M
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:PicoFARAD ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] .
+
+unit:KN-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KN ] .
+
+unit:MilliN-PER-M
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliN ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] .
+
+unit:NanoMOL-PER-KiloGM
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:NanoMOL ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:KiloGM ] .
+
+unit:REV-PER-SEC2
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:REV ] .
+
+unit:YD3-PER-SEC
+    qudt:factorUnit [ qudt:exponent 3 ;
+                      qudt:unit     unit:YD ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] .
+
+unit:PER-WB
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:WB ] .
+
+unit:BTU_IT-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BTU_IT ] .
+
+unit:DEG_F-PER-HR
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:DEG_F ] .
+
+unit:CentiM-PER-HR
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:CentiM ] .
+
+unit:PK_UK-PER-HR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:PK_UK ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] .
+
+unit:LB-PER-FT3
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:LB ] ;
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:FT ] .
+
+unit:MegaBIT-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MegaBIT ] .
+
+unit:MilliL-PER-CentiM2-MIN
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliL ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MIN ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:CentiM ] .
+
+unit:PA-SEC-PER-BAR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:PA ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:BAR ] .
+
+unit:CD-PER-IN2
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:IN ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:CD ] .
+
+unit:MicroM3-PER-M3
+    qudt:factorUnit [ qudt:exponent 3 ;
+                      qudt:unit     unit:MicroM ] ;
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:M ] .
+
+unit:CAL_TH-PER-G
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:G ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:CAL_TH ] .
+
+unit:MOL-PER-M2
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MOL ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] .
+
+unit:NUM-PER-M3
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:NUM ] ;
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:M ] .
+
+unit:M2-PER-V-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:V ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:M ] .
+
+unit:MOL-PER-M2-SEC-SR
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SR ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MOL ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] .
+
+unit:KiloV-PER-M
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloV ] .
+
+unit:W-M-PER-M2-SR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:W ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SR ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] .
+
+unit:PK_US_DRY-PER-MIN
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:PK_US_DRY ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MIN ] .
+
+unit:DEG_F-HR-FT2-PER-BTU_TH
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:HR ] ;
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:FT ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:DEG_F ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:BTU_TH ] .
+
+unit:LB_F-PER-IN2-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:LB_F ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:IN ] .
+
+unit:SLUG-PER-FT
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:SLUG ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:FT ] .
+
+unit:NanoMOL
+    a            qudt:Unit ;
+    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
+
+unit:BU_US_DRY-PER-DAY
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DAY ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BU_US_DRY ] .
+
+unit:KiloPA-PER-K
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloPA ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:K ] .
+
+unit:MilliM3
+    qudt:factorUnit [ qudt:exponent 3 ;
+                      qudt:unit     unit:MilliM ] .
+
+unit:MilliMOL-PER-M2
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliMOL ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] .
+
+unit:OHM-M2-PER-M
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:OHM ] ;
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] .
+
+unit:M2-PER-SEC2
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:M ] .
+
+unit:PicoMOL-PER-L-DAY
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:PicoMOL ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:L ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DAY ] .
+
+unit:PERCENT-PER-M
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:PERCENT ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] .
+
+unit:KiloBIT
+    a            qudt:Unit ;
+    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
+
+unit:M2-PER-MOL
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MOL ] ;
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:M ] .
+
+unit:KiloBYTE-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloBYTE ] .
+
+unit:MilliM-PER-YR
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:YR ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliM ] .
+
+unit:KiloCAL-PER-MOL-DEG_C
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MOL ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloCAL ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DEG_C ] .
+
+unit:CentiM-PER-K
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:K ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:CentiM ] .
+
+unit:CASES-PER-1000I-YR
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:YR ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:CASES ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:1000I ] .
+
+unit:PA-M-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:PA ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:M ] .
+
+unit:YD3-PER-DEG_F
+    qudt:factorUnit [ qudt:exponent 3 ;
+                      qudt:unit     unit:YD ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DEG_F ] .
+
+unit:NUM-PER-M2-DAY
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:NUM ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DAY ] .
+
+unit:PER-GigaEV2
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:GigaEV ] .
+
+unit:GM-PER-HR
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:GM ] .
+
+unit:W-PER-M2-NanoM-SR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:W ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SR ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:NanoM ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] .
+
+unit:NUM-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:NUM ] .
+
+unit:HectoPA-PER-K
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:K ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:HectoPA ] .
+
+unit:MilliBAR-PER-K
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliBAR ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:K ] .
+
+unit:GM-PER-MilliM
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MilliM ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:GM ] .
+
+unit:LB-PER-IN3
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:LB ] ;
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:IN ] .
+
+unit:CAL_IT-PER-SEC-CentiM2-K
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:K ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:CentiM ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:CAL_IT ] .
+
+unit:V-PER-SEC
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:V ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] .
+
+unit:LB-PER-GAL_US
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:LB ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:GAL_US ] .
+
+unit:PER-M3
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:M ] .
+
+unit:CentiM2-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:CentiM ] .
+
+unit:J-PER-M3
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:J ] .
+
+unit:NUM-PER-L
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:NUM ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:L ] .
+
+unit:V2-PER-K2
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:V ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:K ] .
+
+unit:DYN-PER-CentiM2
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:DYN ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:CentiM ] .
+
+unit:MilliPA-SEC-PER-BAR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliPA ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:BAR ] .
+
+unit:M-PER-YR
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:YR ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:M ] .
+
+unit:GM-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:GM ] .
+
+unit:NanoS
+    a            qudt:Unit ;
+    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
+
+unit:M2-HZ
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:HZ ] .
+
+unit:A-PER-MilliM2
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:MilliM ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:A ] .
+
+unit:KiloLB_F-FT-PER-LB
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:LB ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloLB_F ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:FT ] .
+
+unit:NUM-PER-HA
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:NUM ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HA ] .
+
+unit:BREATH
+    a            qudt:Unit ;
+    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
+
+unit:GM_F
+    a            qudt:Unit ;
+    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
+
+unit:MicroH-PER-KiloOHM
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MicroH ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:KiloOHM ] .
+
+unit:N-M-PER-RAD
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:RAD ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:N ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:M ] .
+
+unit:MegaJ-PER-M2
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MegaJ ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] .
+
+unit:M2-HZ2
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:HZ ] .
+
+unit:MegaEV-PER-CentiM
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MegaEV ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:CentiM ] .
+
+unit:PA2-PER-SEC2
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:PA ] .
+
+unit:MI2
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:MI ] .
+
+unit:MilliGM-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliGM ] .
+
+unit:J-PER-K
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:K ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:J ] .
+
+unit:C-PER-MilliM2
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:MilliM ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:C ] .
+
+unit:BTU_IT-PER-FT2
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:FT ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BTU_IT ] .
+
+unit:PicoMOL
+    a            qudt:Unit ;
+    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
+
+unit:W-PER-SR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:W ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SR ] .
+
+unit:DEATHS
+    a            qudt:Unit ;
+    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
+
+unit:REV-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:REV ] .
+
+unit:NanoMOL-PER-MicroGM-HR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:NanoMOL ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MicroGM ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] .
+
+unit:PicoGM-PER-L
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:PicoGM ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:L ] .
+
+unit:NAT-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:NAT ] .
+
+unit:NanoMOL-PER-MicroMOL
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:NanoMOL ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MicroMOL ] .
+
+unit:MilliBQ-PER-L
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliBQ ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:L ] .
+
+unit:LB_F-PER-IN
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:LB_F ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:IN ] .
+
+unit:H-PER-KiloOHM
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:KiloOHM ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:H ] .
+
+unit:CAL_IT-PER-GM-K
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:K ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:GM ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:CAL_IT ] .
+
+unit:MilliL-PER-K
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliL ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:K ] .
+
+unit:GAL_UK-PER-MIN
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MIN ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:GAL_UK ] .
+
+unit:DeciS
+    a            qudt:Unit ;
+    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
+
+unit:DEG_C2-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:DEG_C ] .
+
+unit:PER-ANGSTROM
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:ANGSTROM ] .
+
+unit:FemtoMOL-PER-KiloGM
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:KiloGM ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:FemtoMOL ] .
+
+unit:J-PER-CentiM2
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:J ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:CentiM ] .
+
+unit:LM-PER-W
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:W ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:LM ] .
+
+unit:MilliGM-PER-DeciL
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliGM ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DeciL ] .
+
+unit:GM-PER-M
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:GM ] .
+
+unit:BTU_TH-FT-PER-HR-FT2-DEG_F
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:FT ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:FT ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DEG_F ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BTU_TH ] .
+
+unit:BQ-PER-L
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:L ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BQ ] .
+
+unit:DEG_C-PER-HR
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:DEG_C ] .
+
+unit:SHANNON-PER-SEC
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:SHANNON ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] .
+
+unit:K-PER-K
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:K ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:K ] .
+
+unit:N-PER-M3
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:N ] ;
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:M ] .
+
+unit:BQ-PER-M2
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BQ ] .
+
+unit:MegaC-PER-M2
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MegaC ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] .
+
+unit:KiloGM-PER-M-SEC2
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloGM ] .
+
+unit:MilliL-PER-CentiM2-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliL ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:CentiM ] .
+
+unit:MegaHZ-PER-T
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:T ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MegaHZ ] .
+
+unit:GAL_US-PER-MIN
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MIN ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:GAL_US ] .
+
+unit:BTU_IT-PER-DEG_F
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DEG_F ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BTU_IT ] .
+
+unit:M2-PER-GM
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:GM ] .
+
+unit:REV-PER-HR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:REV ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] .
+
+unit:PA-SEC-PER-M
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:PA ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] .
+
+unit:KiloGM_F-PER-MilliM2
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:MilliM ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloGM_F ] .
+
+unit:CAL_TH-PER-CentiM-SEC-DEG_C
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DEG_C ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:CentiM ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:CAL_TH ] .
+
+unit:FT3-PER-DEG_F
+    qudt:factorUnit [ qudt:exponent 3 ;
+                      qudt:unit     unit:FT ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DEG_F ] .
+
+unit:N-PER-CentiM2
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:N ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:CentiM ] .
+
+unit:BTU_IT-PER-MOL-DEG_F
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MOL ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DEG_F ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BTU_IT ] .
+
+unit:QT_UK-PER-DAY
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:QT_UK ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DAY ] .
+
+unit:HZ-PER-K
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:K ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:HZ ] .
+
+unit:PK_US_DRY-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:PK_US_DRY ] .
+
+unit:PER-SR
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SR ] .
+
+unit:M2
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:M ] .
+
+unit:MicroBQ-PER-KiloGM
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MicroBQ ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:KiloGM ] .
+
+unit:NanoGM-PER-DAY
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:NanoGM ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DAY ] .
+
+unit:MilliM-PER-K
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliM ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:K ] .
+
+unit:M2-PER-J
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:J ] .
+
+unit:CAL_TH-PER-GM-K
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:K ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:GM ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:CAL_TH ] .
+
+unit:S-PER-CentiM
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:S ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:CentiM ] .
+
+unit:KiloM-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloM ] .
+
+unit:NanoM2
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:NanoM ] .
+
+unit:K-M-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:K ] .
+
+unit:M2-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:M ] .
+
+unit:PER-MO
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MO ] .
+
+unit:WB-PER-M
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:WB ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] .
+
+unit:PER-M-K
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:K ] .
+
+unit:NanoBQ
+    a            qudt:Unit ;
+    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
+
+unit:CAL_IT-PER-SEC-CentiM-K
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:K ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:CentiM ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:CAL_IT ] .
+
+unit:MilliGM-PER-M3-HR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliGM ] ;
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] .
+
+unit:N-M-SEC-PER-RAD
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:RAD ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:N ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:M ] .
+
+unit:PA-PER-M
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:PA ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] .
+
+unit:SLUG-PER-DAY
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:SLUG ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DAY ] .
+
+unit:QT_US-PER-DAY
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:QT_US ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DAY ] .
+
+unit:MicroC-PER-M3
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MicroC ] ;
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:M ] .
+
+unit:GM_Carbon
+    a            qudt:Unit ;
+    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
+
+unit:PER-DAY
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DAY ] .
+
+unit:BTU_TH-PER-FT3
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:FT ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BTU_TH ] .
+
+unit:MicroGM-PER-M2-DAY
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MicroGM ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DAY ] .
+
+unit:BTU_TH-PER-LB-DEG_F
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:LB ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DEG_F ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BTU_TH ] .
+
+unit:MilliM2-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:MilliM ] .
+
+unit:BQ-PER-KiloGM
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:KiloGM ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BQ ] .
+
+unit:FT3-PER-DAY
+    qudt:factorUnit [ qudt:exponent 3 ;
+                      qudt:unit     unit:FT ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DAY ] .
+
+unit:L-PER-K
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:L ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:K ] .
+
+unit:M2-PER-HZ-DEG
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HZ ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DEG ] .
+
+unit:TON_Metric-PER-DAY
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:TON_Metric ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DAY ] .
+
+unit:CentiM-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:CentiM ] .
+
+unit:N-M-PER-M
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:N ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] .
+
+unit:PicoMOL-PER-M2-DAY
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:PicoMOL ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DAY ] .
+
+unit:MicroM3
+    qudt:factorUnit [ qudt:exponent 3 ;
+                      qudt:unit     unit:MicroM ] .
+
+unit:M2-K-PER-W
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:W ] ;
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:K ] .
+
+unit:KiloGM-PER-M3-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloGM ] .
+
+unit:MilliBAR-PER-BAR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliBAR ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:BAR ] .
+
+unit:MilliL-PER-M3
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliL ] ;
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:M ] .
+
+unit:GM_Nitrogen
+    a            qudt:Unit ;
+    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
+
+unit:CentiM3-PER-HR
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] ;
+    qudt:factorUnit [ qudt:exponent 3 ;
+                      qudt:unit     unit:CentiM ] .
+
+unit:M2-SR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:SR ] ;
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:M ] .
+
+unit:PicoMOL-PER-KiloGM
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:PicoMOL ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:KiloGM ] .
+
+unit:KiloGM-PER-CentiM2
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloGM ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:CentiM ] .
+
+unit:MilliM-PER-MIN
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliM ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MIN ] .
+
+unit:GRAY-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:GRAY ] .
+
+unit:OZ-PER-IN3
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:OZ ] ;
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:IN ] .
+
+unit:BTU_IT-PER-SEC-FT-DEG_R
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:FT ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DEG_R ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BTU_IT ] .
+
+unit:MicroGM-PER-GM
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MicroGM ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:GM ] .
+
+unit:J-PER-KiloGM-K-PA
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:PA ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:KiloGM ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:K ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:J ] .
+
+unit:GAL_US-PER-HR
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:GAL_US ] .
+
+unit:NanoMOL-PER-MicroMOL-DAY
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:NanoMOL ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MicroMOL ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DAY ] .
+
+unit:IN-PER-SEC2
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:IN ] .
+
+unit:CAL_TH-PER-MIN
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MIN ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:CAL_TH ] .
+
+unit:KiloCAL_TH-PER-HR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloCAL_TH ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] .
+
+unit:MicroMOL-PER-L-HR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MicroMOL ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:L ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] .
+
+unit:PERCENT-PER-DAY
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:PERCENT ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DAY ] .
+
+unit:MOL-PER-HR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MOL ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] .
+
+unit:FT2-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:FT ] .
+
+unit:MOL-PER-M2-SEC-M
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MOL ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] .
+
+unit:MegaA-PER-M2
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MegaA ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] .
+
+unit:DEG_C-PER-MIN
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MIN ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:DEG_C ] .
+
+unit:DEG_C-PER-YR
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:YR ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:DEG_C ] .
+
+unit:PK_UK-PER-DAY
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:PK_UK ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DAY ] .
+
+unit:TON_SHORT-PER-YD3
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:YD ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:TON_SHORT ] .
+
+unit:IN-PER-DEG_F
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:IN ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DEG_F ] .
+
+unit:HP-PER-M
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:HP ] .
+
+unit:PicoMOL-PER-L-HR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:PicoMOL ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:L ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] .
+
+unit:M4-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 4 ;
+                      qudt:unit     unit:M ] .
+
+unit:BBL_US_PET-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BBL_US_PET ] .
+
+unit:C-PER-CentiM3
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:CentiM ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:C ] .
+
+unit:J-PER-KiloGM-K
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:KiloGM ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:K ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:J ] .
+
+unit:MilliRAD_R-PER-HR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliRAD_R ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] .
+
+unit:NanoGM-PER-L
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:NanoGM ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:L ] .
+
+unit:MilliS-PER-M
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliS ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] .
+
+unit:PicoGM-PER-KiloGM
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:PicoGM ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:KiloGM ] .
+
+unit:DYN-SEC-PER-CentiM3
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:DYN ] ;
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:CentiM ] .
+
+unit:BAR-PER-BAR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BAR ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:BAR ] .
+
+unit:W-HR-PER-M3
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:W ] ;
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:HR ] .
+
+unit:PSI-L-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:PSI ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:L ] .
+
+unit:ERG-PER-G
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:G ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:ERG ] .
+
+unit:LB_F-PER-LB
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:LB_F ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:LB ] .
+
+unit:BBL_UK_PET-PER-DAY
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DAY ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BBL_UK_PET ] .
+
+unit:N-M2-PER-KiloGM2
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:N ] ;
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:KiloGM ] .
+
+unit:GAL_UK-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:GAL_UK ] .
+
+unit:MicroH-PER-OHM
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:OHM ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MicroH ] .
+
+unit:J-PER-KiloGM
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:KiloGM ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:J ] .
+
+unit:GM-PER-M3
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:GM ] .
+
+unit:IN4
+    qudt:factorUnit [ qudt:exponent 4 ;
+                      qudt:unit     unit:IN ] .
+
+unit:SEC-FT2
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:FT ] .
+
+unit:NUM-PER-HectoGM
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:NUM ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HectoGM ] .
+
+unit:FT2-SEC-DEG_F
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:FT ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:DEG_F ] .
+
+unit:MegaPA-L-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MegaPA ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:L ] .
+
+unit:A-PER-J
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:J ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:A ] .
+
+unit:PER-CentiM
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:CentiM ] .
+
+unit:RAD-M2-PER-MOL
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:RAD ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MOL ] ;
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:M ] .
+
+unit:MDOLLAR-PER-FLIGHT
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MDOLLAR ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:FLIGHT ] .
+
+unit:ERG-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:ERG ] .
+
+unit:IU-PER-L
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:L ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:IU ] .
+
+unit:W-M2-PER-SR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:W ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SR ] ;
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:M ] .
+
+unit:GM-PER-CentiM3
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:GM ] ;
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:CentiM ] .
+
+unit:N-SEC-PER-M
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:N ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] .
+
+unit:GAL_US-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:GAL_US ] .
+
+unit:L-PER-DAY
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:L ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DAY ] .
+
+unit:DEG-PER-M
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:DEG ] .
+
+unit:KiloCAL-PER-MIN
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MIN ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloCAL ] .
+
+unit:KiloGM-PER-DAY
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloGM ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DAY ] .
+
+unit:MilliM3-PER-M3
+    qudt:factorUnit [ qudt:exponent 3 ;
+                      qudt:unit     unit:MilliM ] ;
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:M ] .
+
+unit:KiloCAL-PER-MOL
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MOL ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloCAL ] .
+
+unit:PER-CentiM3
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:CentiM ] .
+
+unit:DEG-PER-SEC2
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:DEG ] .
+
+unit:RAD-PER-M
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:RAD ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] .
+
+unit:HR-FT2
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:HR ] ;
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:FT ] .
+
+unit:KiloBIT-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloBIT ] .
+
+unit:FT-LB_F-PER-M2
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:LB_F ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:FT ] .
+
+unit:MicroMOL-PER-L
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MicroMOL ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:L ] .
+
+unit:NUM-PER-CentiM-KiloYR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:NUM ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:KiloYR ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:CentiM ] .
+
+unit:LB-PER-IN
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:LB ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:IN ] .
+
+unit:CASES
+    a            qudt:Unit ;
+    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
+
+unit:KiloGM-M-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:KiloGM ] .
+
+unit:NanoL
+    a            qudt:Unit ;
+    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
+
+unit:MegaGM-PER-M3
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MegaGM ] ;
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:M ] .
+
+unit:MicroMOL-PER-M2-HR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MicroMOL ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] .
+
+unit:PER-MicroMOL-L
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MicroMOL ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:L ] .
+
+unit:MegaJ-PER-K
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MegaJ ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:K ] .
+
+unit:MOL-PER-GM-HR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MOL ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:GM ] .
+
+unit:PER-SEC-M2-SR
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SR ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] .
+
+unit:DeciM3-PER-DAY
+    qudt:factorUnit [ qudt:exponent 3 ;
+                      qudt:unit     unit:DeciM ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DAY ] .
+
+unit:GAL_UK-PER-HR
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:GAL_UK ] .
+
+unit:NanoS-PER-CentiM
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:NanoS ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:CentiM ] .
+
+unit:PER-M
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] .
+
+unit:FemtoGM
+    a            qudt:Unit ;
+    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
+
+unit:YD3-PER-DAY
+    qudt:factorUnit [ qudt:exponent 3 ;
+                      qudt:unit     unit:YD ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DAY ] .
+
+unit:PERCENT-PER-WK
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:WK ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:PERCENT ] .
+
+unit:CentiM2-PER-CentiM3
+    qudt:factorUnit [ qudt:exponent 2 ;
+                      qudt:unit     unit:CentiM ] ;
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:CentiM ] .
+
+unit:BREATH-PER-MIN
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MIN ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BREATH ] .
+
+unit:N-PER-M
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:N ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] .
+
+unit:OZ-PER-YD2
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:YD ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:OZ ] .
+
+unit:BU_UK-PER-MIN
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MIN ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BU_UK ] .
+
+unit:PER-KiloV-A-HR
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:KiloV ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:A ] .
+
+unit:PER-SEC-M2
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] .
+
+unit:MilliMOL-PER-L
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliMOL ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:L ] .
+
+unit:GAL
+    a            qudt:Unit ;
+    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
+
+unit:MegaPA-PER-BAR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MegaPA ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:BAR ] .
+
+unit:PER-H
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:H ] .
+
+unit:CentiM-PER-KiloYR
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:KiloYR ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:CentiM ] .
+
+unit:MegaBIT
+    a            qudt:Unit ;
+    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
+
+unit:SLUG-PER-FT-SEC
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:SLUG ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:FT ] .
+
+unit:A-PER-CentiM
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:CentiM ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:A ] .
+
+unit:MilliM-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliM ] .
+
+unit:KiloYR
+    a            qudt:Unit ;
+    rdfs:comment "This unit was added while generating qudt:factorUnit information as a missing factor unit"@en .
+
+unit:MilliGM-PER-M2-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliGM ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] .
+
+unit:MicroM-PER-L-DAY
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MicroM ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:L ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DAY ] .
+
+unit:MicroGM-PER-M3-HR
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MicroGM ] ;
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] .
+
+unit:NanoGM-PER-MicroL
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:NanoGM ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MicroL ] .
+
+unit:MilliC-PER-M3
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliC ] ;
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:M ] .
+
+unit:GigaC-PER-M3
+    qudt:factorUnit [ qudt:exponent -3 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:GigaC ] .
+
+unit:RAD-PER-MIN
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:RAD ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MIN ] .
+
+unit:BTU_IT-PER-LB-DEG_R
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:LB ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DEG_R ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BTU_IT ] .
+
+unit:BTU_TH-FT-PER-FT2-HR-DEG_F
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:HR ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:FT ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:FT ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:DEG_F ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BTU_TH ] .
+
+unit:BTU_IT-PER-SEC-FT2
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:FT ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:BTU_IT ] .
+
+unit:MicroM3-PER-MilliL
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MilliL ] ;
+    qudt:factorUnit [ qudt:exponent 3 ;
+                      qudt:unit     unit:MicroM ] .
+
+unit:PSI-PER-PSI
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:PSI ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:PSI ] .
+
+unit:W-PER-M2-K4
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:W ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] ;
+    qudt:factorUnit [ qudt:exponent -4 ;
+                      qudt:unit     unit:K ] .
+
+unit:MilliGM-PER-M
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MilliGM ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:M ] .
+
+unit:CAL_TH-PER-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:CAL_TH ] .
+
+unit:OZ_VOL_UK-PER-MIN
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:OZ_VOL_UK ] ;
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:MIN ] .
+
+unit:MOL-PER-M2-SEC
+    qudt:factorUnit [ qudt:exponent -1 ;
+                      qudt:unit     unit:SEC ] ;
+    qudt:factorUnit [ qudt:exponent 1 ;
+                      qudt:unit     unit:MOL ] ;
+    qudt:factorUnit [ qudt:exponent -2 ;
+                      qudt:unit     unit:M ] .
+
+unit:KiloBIT
+    qudt:isScalingOf unit:BIT ;
+    qudt:prefix      prefix:Kilo .
+
+unit:PebiBYTE
+    qudt:isScalingOf unit:BYTE ;
+    qudt:prefix      prefix:Pebi .
+
+unit:GM-PER-KiloM
+    qudt:isScalingOf unit:GM-PER-M .
+
+unit:CentiM3-PER-HR
+    qudt:convertsTo  unit:M3-PER-SEC ;
+    qudt:isScalingOf unit:M3-PER-SEC .
+
+unit:PicoGM
+    qudt:isScalingOf unit:GM ;
+    qudt:prefix      prefix:Pico .
+
+unit:KiloCi
+    qudt:isScalingOf unit:Ci ;
+    qudt:prefix      prefix:Kilo .
+
+unit:MilliM3-PER-M3
+    qudt:convertsTo  unit:M3-PER-M3 ;
+    qudt:isScalingOf unit:M3-PER-M3 .
+
+unit:KiloSEC
+    qudt:convertsTo  unit:SEC ;
+    qudt:isScalingOf unit:SEC ;
+    qudt:prefix      prefix:Kilo .
+
+unit:MicroPA
+    qudt:convertsTo  unit:PA ;
+    qudt:isScalingOf unit:PA ;
+    qudt:prefix      prefix:Micro .
+
+unit:KiloJ-PER-MOL
+    qudt:convertsTo  unit:J-PER-MOL ;
+    qudt:isScalingOf unit:J-PER-MOL .
+
+unit:C-PER-CentiM3
+    qudt:convertsTo  unit:C-PER-M3 ;
+    qudt:isScalingOf unit:C-PER-M3 .
+
+unit:GigaJ
+    qudt:convertsTo  unit:J ;
+    qudt:isScalingOf unit:J ;
+    qudt:prefix      prefix:Giga .
+
+unit:TeraW-HR
+    qudt:convertsTo  unit:W-SEC ;
+    qudt:isScalingOf unit:W-SEC .
+
+unit:PER-CentiM3
+    qudt:convertsTo  unit:PER-M3 ;
+    qudt:isScalingOf unit:PER-M3 .
+
+unit:MegaBQ
+    qudt:convertsTo  unit:BQ ;
+    qudt:isScalingOf unit:BQ ;
+    qudt:prefix      prefix:Mega .
+
+unit:V-PER-MicroSEC
+    qudt:convertsTo  unit:V-PER-SEC ;
+    qudt:isScalingOf unit:V-PER-SEC .
+
+unit:FARAD-PER-KiloM
+    qudt:convertsTo  unit:FARAD-PER-M ;
+    qudt:isScalingOf unit:FARAD-PER-M .
+
+unit:KiloN-M
+    qudt:convertsTo  unit:N-M ;
+    qudt:isScalingOf unit:N-M .
+
+unit:MilliBAR-L-PER-SEC
+    qudt:isScalingOf unit:BAR-L-PER-SEC .
+
+unit:MicroJ
+    qudt:convertsTo  unit:J ;
+    qudt:isScalingOf unit:J ;
+    qudt:prefix      prefix:Micro .
+
+unit:CentiM-PER-K
+    qudt:convertsTo  unit:M-PER-K ;
+    qudt:isScalingOf unit:M-PER-K .
+
+unit:KiloGM-PER-HR
+    qudt:isScalingOf unit:GM-PER-SEC .
+
+unit:MilliT
+    qudt:convertsTo  unit:T ;
+    qudt:isScalingOf unit:T ;
+    qudt:prefix      prefix:Milli .
+
+unit:MilliN-PER-M
+    qudt:convertsTo  unit:N-PER-M ;
+    qudt:isScalingOf unit:N-PER-M .
+
+unit:PER-CentiM
+    qudt:convertsTo  unit:PER-M ;
+    qudt:isScalingOf unit:PER-M .
+
+unit:N-PER-CentiM2
+    qudt:convertsTo  unit:N-PER-M2 ;
+    qudt:isScalingOf unit:N-PER-M2 .
+
+unit:PetaBYTE
+    qudt:isScalingOf unit:BYTE ;
+    qudt:prefix      prefix:Peta .
+
+unit:MicroMOL-PER-L
+    qudt:isScalingOf unit:MOL-PER-L .
+
+unit:DecaARE
+    qudt:isScalingOf unit:ARE ;
+    qudt:prefix      prefix:Deca .
+
+unit:KiloPA-PER-MilliM
+    qudt:convertsTo  unit:PA-PER-M ;
+    qudt:isScalingOf unit:PA-PER-M .
+
+unit:NanoGM-PER-KiloGM
+    qudt:convertsTo  unit:GM-PER-GM ;
+    qudt:isScalingOf unit:GM-PER-GM .
+
+unit:CentiMOL
+    qudt:isScalingOf unit:MOL ;
+    qudt:prefix      prefix:Centi .
+
+unit:PicoW-PER-M2
+    qudt:convertsTo  unit:W-PER-M2 ;
+    qudt:isScalingOf unit:W-PER-M2 .
+
+unit:KiloV-A_Reactive
+    qudt:convertsTo  unit:V-A_Reactive ;
+    qudt:isScalingOf unit:V-A_Reactive .
+
+unit:NanoFARAD-PER-M
+    qudt:convertsTo  unit:FARAD-PER-M ;
+    qudt:isScalingOf unit:FARAD-PER-M .
+
+unit:GigaBQ
+    qudt:convertsTo  unit:BQ ;
+    qudt:isScalingOf unit:BQ ;
+    qudt:prefix      prefix:Giga .
+
+unit:ExaBYTE
+    qudt:isScalingOf unit:BYTE ;
+    qudt:prefix      prefix:Exa .
+
+unit:MilliM3
+    qudt:convertsTo  unit:M3 ;
+    qudt:isScalingOf unit:M3 ;
+    qudt:prefix      prefix:Milli .
+
+unit:KiloA-PER-M
+    qudt:convertsTo  unit:A-PER-M ;
+    qudt:isScalingOf unit:A-PER-M .
+
+unit:MegaJ-PER-M2
+    qudt:convertsTo  unit:J-PER-M2 ;
+    qudt:isScalingOf unit:J-PER-M2 .
+
+unit:GigaOHM
+    qudt:convertsTo  unit:OHM ;
+    qudt:isScalingOf unit:OHM ;
+    qudt:prefix      prefix:Giga .
+
+unit:MilliMOL-PER-MOL
+    qudt:convertsTo  unit:MOL-PER-MOL ;
+    qudt:isScalingOf unit:MOL-PER-MOL .
+
+unit:L-PER-MicroMOL
+    qudt:isScalingOf unit:L-PER-MOL .
+
+unit:MicroW-PER-M2
+    qudt:convertsTo  unit:W-PER-M2 ;
+    qudt:isScalingOf unit:W-PER-M2 .
+
+unit:MicroMOL-PER-SEC
+    qudt:convertsTo  unit:MOL-PER-SEC ;
+    qudt:isScalingOf unit:MOL-PER-SEC .
+
+unit:HectoPA-M3-PER-SEC
+    qudt:convertsTo  unit:PA-M3-PER-SEC ;
+    qudt:isScalingOf unit:PA-M3-PER-SEC .
+
+unit:MilliW-PER-M2-NanoM
+    qudt:convertsTo  unit:W-PER-M2-M ;
+    qudt:isScalingOf unit:W-PER-M2-M .
+
+unit:PicoS-PER-M
+    qudt:convertsTo  unit:S-PER-M ;
+    qudt:isScalingOf unit:S-PER-M .
+
+unit:MilliGM-PER-M
+    qudt:isScalingOf unit:GM-PER-M .
+
+unit:MicroV-PER-M
+    qudt:convertsTo  unit:V-PER-M ;
+    qudt:isScalingOf unit:V-PER-M .
+
+unit:TeraHZ
+    qudt:convertsTo  unit:HZ ;
+    qudt:isScalingOf unit:HZ ;
+    qudt:prefix      prefix:Tera .
+
+unit:NanoGM-PER-L
+    qudt:convertsTo  unit:GM-PER-L ;
+    qudt:isScalingOf unit:GM-PER-L .
+
+unit:NanoGM-PER-MilliL
+    qudt:convertsTo  unit:GM-PER-L ;
+    qudt:isScalingOf unit:GM-PER-L .
+
+unit:MilliW-PER-M2
+    qudt:convertsTo  unit:W-PER-M2 ;
+    qudt:isScalingOf unit:W-PER-M2 .
+
+unit:NanoGM-PER-DAY
+    qudt:isScalingOf unit:GM-PER-SEC .
+
+unit:W-PER-M2-NanoM-SR
+    qudt:convertsTo  unit:W-PER-M2-M-SR ;
+    qudt:isScalingOf unit:W-PER-M2-M-SR .
+
+unit:MegaJ-PER-KiloGM
+    qudt:isScalingOf unit:J-PER-GM .
+
+unit:MilliGM-PER-HR
+    qudt:isScalingOf unit:GM-PER-SEC .
+
+unit:CentiC
+    qudt:convertsTo  unit:C ;
+    qudt:isScalingOf unit:C ;
+    qudt:prefix      prefix:Centi .
+
+unit:PicoMOL-PER-M3
+    qudt:convertsTo  unit:MOL-PER-M3 ;
+    qudt:isScalingOf unit:MOL-PER-M3 .
+
+unit:DeciGM
+    qudt:isScalingOf unit:GM ;
+    qudt:prefix      prefix:Deci .
+
+unit:CentiM3-PER-SEC
+    qudt:convertsTo  unit:M3-PER-SEC ;
+    qudt:isScalingOf unit:M3-PER-SEC .
+
+unit:MicroMOL-PER-M2-DAY
+    qudt:convertsTo  unit:MOL-PER-M2-SEC ;
+    qudt:isScalingOf unit:MOL-PER-M2-SEC .
+
+unit:MilliH-PER-OHM
+    qudt:convertsTo  unit:H-PER-OHM ;
+    qudt:isScalingOf unit:H-PER-OHM .
+
+unit:MicroM3-PER-M3
+    qudt:convertsTo  unit:M3-PER-M3 ;
+    qudt:isScalingOf unit:M3-PER-M3 .
+
+unit:KiloJ
+    qudt:convertsTo  unit:J ;
+    qudt:isScalingOf unit:J ;
+    qudt:prefix      prefix:Kilo .
+
+unit:KiloV-PER-M
+    qudt:convertsTo  unit:V-PER-M ;
+    qudt:isScalingOf unit:V-PER-M .
+
+unit:ExbiBYTE
+    qudt:isScalingOf unit:BYTE ;
+    qudt:prefix      prefix:Exbi .
+
+unit:MegaBYTE
+    qudt:isScalingOf unit:BYTE ;
+    qudt:prefix      prefix:Mega .
+
+unit:KiloGM-PER-MilliM
+    qudt:isScalingOf unit:GM-PER-M .
+
+unit:GM-PER-CentiM2
+    qudt:isScalingOf unit:GM-PER-M2 .
+
+unit:NUM-PER-HectoGM
+    qudt:isScalingOf unit:NUM-PER-GM .
+
+unit:N-CentiM
+    qudt:convertsTo  unit:N-M ;
+    qudt:isScalingOf unit:N-M .
+
+unit:MegaHZ-PER-K
+    qudt:convertsTo  unit:HZ-PER-K ;
+    qudt:isScalingOf unit:HZ-PER-K .
+
+unit:MegaJ
+    qudt:convertsTo  unit:J ;
+    qudt:isScalingOf unit:J ;
+    qudt:prefix      prefix:Mega .
+
+unit:AttoJ
+    qudt:convertsTo  unit:J ;
+    qudt:isScalingOf unit:J ;
+    qudt:prefix      prefix:Atto .
+
+unit:KiloGM-PER-DAY
+    qudt:isScalingOf unit:GM-PER-SEC .
+
+unit:MilliGM-PER-DAY
+    qudt:isScalingOf unit:GM-PER-SEC .
+
+unit:PicoGM-PER-GM
+    qudt:convertsTo  unit:GM-PER-GM ;
+    qudt:isScalingOf unit:GM-PER-GM .
+
+unit:MilliMOL-PER-M3
+    qudt:convertsTo  unit:MOL-PER-M3 ;
+    qudt:isScalingOf unit:MOL-PER-M3 .
+
+unit:KiloWB
+    qudt:isScalingOf unit:WB ;
+    qudt:prefix      prefix:Kilo .
+
+unit:DeciM3-PER-SEC
+    qudt:convertsTo  unit:M3-PER-SEC ;
+    qudt:isScalingOf unit:M3-PER-SEC .
+
+unit:MicroFARAD-PER-M
+    qudt:convertsTo  unit:FARAD-PER-M ;
+    qudt:isScalingOf unit:FARAD-PER-M .
+
+unit:NUM-PER-NanoL
+    qudt:isScalingOf unit:NUM-PER-L .
+
+unit:DeciM2
+    qudt:convertsTo  unit:M2 ;
+    qudt:isScalingOf unit:M2 ;
+    qudt:prefix      prefix:Deci .
+
+unit:MilliM-PER-YR
+    qudt:convertsTo  unit:M-PER-SEC ;
+    qudt:isScalingOf unit:M-PER-SEC .
+
+unit:MicroMHO
+    qudt:convertsTo  unit:MHO ;
+    qudt:isScalingOf unit:MHO ;
+    qudt:prefix      prefix:Micro .
+
+unit:C-PER-MilliM3
+    qudt:convertsTo  unit:C-PER-M3 ;
+    qudt:isScalingOf unit:C-PER-M3 .
+
+unit:PER-MilliM3
+    qudt:convertsTo  unit:PER-M3 ;
+    qudt:isScalingOf unit:PER-M3 .
+
+unit:ZettaC
+    qudt:convertsTo  unit:C ;
+    qudt:isScalingOf unit:C ;
+    qudt:prefix      prefix:Zetta .
+
+unit:MilliGM-PER-CentiM2
+    qudt:isScalingOf unit:GM-PER-M2 .
+
+unit:PetaJ
+    qudt:convertsTo  unit:J ;
+    qudt:isScalingOf unit:J ;
+    qudt:prefix      prefix:Peta .
+
+unit:HectoPA
+    qudt:convertsTo  unit:PA ;
+    qudt:isScalingOf unit:PA ;
+    qudt:prefix      prefix:Hecto .
+
+unit:ZeptoC
+    qudt:convertsTo  unit:C ;
+    qudt:isScalingOf unit:C ;
+    qudt:prefix      prefix:Zepto .
+
+unit:MilliL-PER-K
+    qudt:isScalingOf unit:L-PER-K .
+
+unit:A-PER-CentiM2
+    qudt:convertsTo  unit:A-PER-M2 ;
+    qudt:isScalingOf unit:A-PER-M2 .
+
+unit:N-PER-MilliM2
+    qudt:convertsTo  unit:N-PER-M2 ;
+    qudt:isScalingOf unit:N-PER-M2 .
+
+unit:J-PER-KiloGM
+    qudt:isScalingOf unit:J-PER-GM .
+
+unit:DeciM3-PER-HR
+    qudt:convertsTo  unit:M3-PER-SEC ;
+    qudt:isScalingOf unit:M3-PER-SEC .
+
+unit:MicroH-PER-OHM
+    qudt:convertsTo  unit:H-PER-OHM ;
+    qudt:isScalingOf unit:H-PER-OHM .
+
+unit:MilliJ
+    qudt:convertsTo  unit:J ;
+    qudt:isScalingOf unit:J ;
+    qudt:prefix      prefix:Milli .
+
+unit:MilliMOL-PER-M3-DAY
+    qudt:convertsTo  unit:MOL-PER-M3-SEC ;
+    qudt:isScalingOf unit:MOL-PER-M3-SEC .
+
+unit:KiloEV-PER-MicroM
+    qudt:isScalingOf unit:EV-PER-M .
+
+unit:N-PER-MilliM
+    qudt:convertsTo  unit:N-PER-M ;
+    qudt:isScalingOf unit:N-PER-M .
+
+unit:KiloGM-PER-MOL
+    qudt:isScalingOf unit:GM-PER-MOL .
+
+unit:MicroGM
+    qudt:isScalingOf unit:GM ;
+    qudt:prefix      prefix:Micro .
+
+unit:MicroV
+    qudt:convertsTo  unit:V ;
+    qudt:isScalingOf unit:V ;
+    qudt:prefix      prefix:Micro .
+
+unit:KiloTON_Metric
+    qudt:isScalingOf unit:TON_Metric ;
+    qudt:prefix      prefix:Kilo .
+
+unit:MegaBIT
+    qudt:isScalingOf unit:BIT ;
+    qudt:prefix      prefix:Mega .
+
+unit:FemtoJ
+    qudt:convertsTo  unit:J ;
+    qudt:isScalingOf unit:J ;
+    qudt:prefix      prefix:Femto .
+
+unit:ExaC
+    qudt:convertsTo  unit:C ;
+    qudt:isScalingOf unit:C ;
+    qudt:prefix      prefix:Exa .
+
+unit:DecaL
+    qudt:isScalingOf unit:L ;
+    qudt:prefix      prefix:Deca .
+
+unit:MilliBQ
+    qudt:isScalingOf unit:BQ ;
+    qudt:prefix      prefix:Milli .
+
+unit:PicoGM-PER-KiloGM
+    qudt:convertsTo  unit:GM-PER-GM ;
+    qudt:isScalingOf unit:GM-PER-GM .
+
+unit:MilliM4
+    qudt:convertsTo  unit:M4 ;
+    qudt:isScalingOf unit:M4 ;
+    qudt:prefix      prefix:Milli .
+
+unit:CentiN-M
+    qudt:convertsTo  unit:N-M ;
+    qudt:isScalingOf unit:N-M .
+
+unit:FemtoMOL
+    qudt:isScalingOf unit:MOL ;
+    qudt:prefix      prefix:Femto .
+
+unit:AttoJ-SEC
+    qudt:convertsTo  unit:J-SEC ;
+    qudt:isScalingOf unit:J-SEC .
+
+unit:MicroMOL
+    qudt:convertsTo  unit:MOL ;
+    qudt:isScalingOf unit:MOL ;
+    qudt:prefix      prefix:Micro .
+
+unit:KiloWB-PER-M
+    qudt:convertsTo  unit:WB-PER-M ;
+    qudt:isScalingOf unit:WB-PER-M .
+
+unit:MicroL-PER-L
+    qudt:convertsTo  unit:L-PER-L ;
+    qudt:isScalingOf unit:L-PER-L .
+
+unit:MegaJ-PER-M3
+    qudt:convertsTo  unit:J-PER-M3 ;
+    qudt:isScalingOf unit:J-PER-M3 .
+
+unit:NanoMOL
+    qudt:isScalingOf unit:MOL ;
+    qudt:prefix      prefix:Nano .
+
+unit:DeciBAR
+    qudt:isScalingOf unit:BAR ;
+    qudt:prefix      prefix:Deci .
+
+unit:S-PER-CentiM
+    qudt:convertsTo  unit:S-PER-M ;
+    qudt:isScalingOf unit:S-PER-M .
+
+unit:KiloJ-PER-KiloGM
+    qudt:isScalingOf unit:J-PER-GM .
+
+unit:MegaN-M
+    qudt:convertsTo  unit:N-M ;
+    qudt:isScalingOf unit:N-M .
+
+unit:KiloM-PER-DAY
+    qudt:convertsTo  unit:M-PER-SEC ;
+    qudt:isScalingOf unit:M-PER-SEC .
+
+unit:MegaGM-PER-M3
+    qudt:isScalingOf unit:GM-PER-M3 .
+
+unit:FemtoGM-PER-L
+    qudt:convertsTo  unit:GM-PER-L ;
+    qudt:isScalingOf unit:GM-PER-L .
+
+unit:MicroM2
+    qudt:convertsTo  unit:M2 ;
+    qudt:isScalingOf unit:M2 ;
+    qudt:prefix      prefix:Micro .
+
+unit:MilliRAD_R
+    qudt:isScalingOf unit:RAD_R ;
+    qudt:prefix      prefix:Milli .
+
+unit:WB-PER-MilliM
+    qudt:convertsTo  unit:WB-PER-M ;
+    qudt:isScalingOf unit:WB-PER-M .
+
+unit:PicoGM-PER-MilliL
+    qudt:convertsTo  unit:GM-PER-L ;
+    qudt:isScalingOf unit:GM-PER-L .
+
+unit:MilliMOL
+    qudt:convertsTo  unit:MOL ;
+    qudt:isScalingOf unit:MOL ;
+    qudt:prefix      prefix:Milli .
+
+unit:KiloL-PER-HR
+    qudt:isScalingOf unit:L-PER-SEC .
+
+unit:DecaPA
+    qudt:convertsTo  unit:PA ;
+    qudt:isScalingOf unit:PA ;
+    qudt:prefix      prefix:Deca .
+
+unit:MilliCi
+    qudt:isScalingOf unit:Ci ;
+    qudt:prefix      prefix:Milli .
+
+unit:PicoFARAD-PER-M
+    qudt:convertsTo  unit:FARAD-PER-M ;
+    qudt:isScalingOf unit:FARAD-PER-M .
+
+unit:KiloA-HR
+    qudt:convertsTo  unit:A-SEC ;
+    qudt:isScalingOf unit:A-SEC .
+
+unit:KiloHZ-M
+    qudt:convertsTo  unit:HZ-M ;
+    qudt:isScalingOf unit:HZ-M .
+
+unit:KiloV
+    qudt:convertsTo  unit:V ;
+    qudt:isScalingOf unit:V ;
+    qudt:prefix      prefix:Kilo .
+
+unit:GM-PER-CentiM3
+    qudt:isScalingOf unit:GM-PER-M3 .
+
+unit:MilliARCSEC
+    qudt:isScalingOf unit:ARCSEC ;
+    qudt:prefix      prefix:Milli .
+
+unit:KiloBAR
+    qudt:isScalingOf unit:BAR ;
+    qudt:prefix      prefix:Kilo .
+
+unit:V-PER-MilliM
+    qudt:convertsTo  unit:V-PER-M ;
+    qudt:isScalingOf unit:V-PER-M .
+
+unit:CentiM3-PER-MIN
+    qudt:convertsTo  unit:M3-PER-SEC ;
+    qudt:isScalingOf unit:M3-PER-SEC .
+
+unit:KiloPA
+    qudt:convertsTo  unit:PA ;
+    qudt:isScalingOf unit:PA ;
+    qudt:prefix      prefix:Kilo .
+
+unit:MicroPOISE
+    qudt:isScalingOf unit:POISE ;
+    qudt:prefix      prefix:Micro .
+
+unit:PicoA
+    qudt:convertsTo  unit:A ;
+    qudt:isScalingOf unit:A ;
+    qudt:prefix      prefix:Pico .
+
+unit:FemtoGM-PER-KiloGM
+    qudt:convertsTo  unit:GM-PER-GM ;
+    qudt:isScalingOf unit:GM-PER-GM .
+
+unit:MegaV
+    qudt:convertsTo  unit:V ;
+    qudt:isScalingOf unit:V ;
+    qudt:prefix      prefix:Mega .
+
+unit:TeraW
+    qudt:convertsTo  unit:W ;
+    qudt:isScalingOf unit:W ;
+    qudt:prefix      prefix:Tera .
+
+unit:MilliM-PER-DAY
+    qudt:convertsTo  unit:M-PER-SEC ;
+    qudt:isScalingOf unit:M-PER-SEC .
+
+unit:DeciM3
+    qudt:convertsTo  unit:M3 ;
+    qudt:isScalingOf unit:M3 ;
+    qudt:prefix      prefix:Deci .
+
+unit:MilliIN
+    qudt:isScalingOf unit:IN ;
+    qudt:prefix      prefix:Milli .
+
+unit:PicoW
+    qudt:convertsTo  unit:W ;
+    qudt:isScalingOf unit:W ;
+    qudt:prefix      prefix:Pico .
+
+unit:MicroFARAD-PER-KiloM
+    qudt:convertsTo  unit:FARAD-PER-M ;
+    qudt:isScalingOf unit:FARAD-PER-M .
+
+unit:A-PER-MilliM2
+    qudt:convertsTo  unit:A-PER-M2 ;
+    qudt:isScalingOf unit:A-PER-M2 .
+
+unit:CentiPOISE
+    qudt:isScalingOf unit:POISE ;
+    qudt:prefix      prefix:Centi .
+
+unit:NanoS-PER-CentiM
+    qudt:convertsTo  unit:S-PER-M ;
+    qudt:isScalingOf unit:S-PER-M .
+
+unit:MicroBQ-PER-L
+    qudt:isScalingOf unit:BQ-PER-L .
+
+unit:DeciM3-PER-MIN
+    qudt:convertsTo  unit:M3-PER-SEC ;
+    qudt:isScalingOf unit:M3-PER-SEC .
+
+unit:MilliBQ-PER-L
+    qudt:isScalingOf unit:BQ-PER-L .
+
+unit:KiloM3-PER-SEC2
+    qudt:convertsTo  unit:M3-PER-SEC2 ;
+    qudt:isScalingOf unit:M3-PER-SEC2 .
+
+unit:NanoH-PER-M
+    qudt:convertsTo  unit:H-PER-M ;
+    qudt:isScalingOf unit:H-PER-M .
+
+unit:GigaBYTE
+    qudt:isScalingOf unit:BYTE ;
+    qudt:prefix      prefix:Giga .
+
+unit:KiloCAL_TH-PER-SEC
+    qudt:isScalingOf unit:CAL_TH-PER-SEC .
+
+unit:MicroRAD
+    qudt:convertsTo  unit:RAD ;
+    qudt:isScalingOf unit:RAD ;
+    qudt:prefix      prefix:Micro .
+
+unit:MilliL-PER-L
+    qudt:convertsTo  unit:L-PER-L ;
+    qudt:isScalingOf unit:L-PER-L .
+
+unit:KiloCAL_IT
+    qudt:isScalingOf unit:CAL_IT ;
+    qudt:prefix      prefix:Kilo .
+
+unit:GM-PER-DeciM3
+    qudt:isScalingOf unit:GM-PER-M3 .
+
+unit:MilliL-PER-DAY
+    qudt:isScalingOf unit:L-PER-SEC .
+
+unit:KiloMOL-PER-M3
+    qudt:convertsTo  unit:MOL-PER-M3 ;
+    qudt:isScalingOf unit:MOL-PER-M3 .
+
+unit:MegaPA
+    qudt:convertsTo  unit:PA ;
+    qudt:isScalingOf unit:PA ;
+    qudt:prefix      prefix:Mega .
+
+unit:GigaW
+    qudt:convertsTo  unit:W ;
+    qudt:isScalingOf unit:W ;
+    qudt:prefix      prefix:Giga .
+
+unit:MicroA
+    qudt:convertsTo  unit:A ;
+    qudt:isScalingOf unit:A ;
+    qudt:prefix      prefix:Micro .
+
+unit:NanoA
+    qudt:convertsTo  unit:A ;
+    qudt:isScalingOf unit:A ;
+    qudt:prefix      prefix:Nano .
+
+unit:KiloGM-PER-SEC
+    qudt:isScalingOf unit:GM-PER-SEC .
+
+unit:MebiBYTE
+    qudt:isScalingOf unit:BYTE ;
+    qudt:prefix      prefix:Mebi .
+
+unit:MilliGM-PER-SEC
+    qudt:isScalingOf unit:GM-PER-SEC .
+
+unit:MicroL
+    qudt:isScalingOf unit:L ;
+    qudt:prefix      prefix:Micro .
+
+unit:NanoL
+    qudt:isScalingOf unit:L ;
+    qudt:prefix      prefix:Nano .
+
+unit:KiloYR
+    qudt:isScalingOf unit:YR ;
+    qudt:prefix      prefix:Kilo .
+
+unit:HectoGM
+    qudt:isScalingOf unit:GM ;
+    qudt:prefix      prefix:Hecto .
+
+unit:MilliRAD
+    qudt:convertsTo  unit:RAD ;
+    qudt:isScalingOf unit:RAD ;
+    qudt:prefix      prefix:Milli .
+
+unit:CentiM2-PER-SEC
+    qudt:convertsTo  unit:M2-PER-SEC ;
+    qudt:isScalingOf unit:M2-PER-SEC .
+
+unit:MilliV
+    qudt:convertsTo  unit:V ;
+    qudt:isScalingOf unit:V ;
+    qudt:prefix      prefix:Milli .
+
+unit:NanoW
+    qudt:convertsTo  unit:W ;
+    qudt:isScalingOf unit:W ;
+    qudt:prefix      prefix:Nano .
+
+unit:MilliA-PER-MilliM
+    qudt:convertsTo  unit:A-PER-M ;
+    qudt:isScalingOf unit:A-PER-M .
+
+unit:MicroW
+    qudt:convertsTo  unit:W ;
+    qudt:isScalingOf unit:W ;
+    qudt:prefix      prefix:Micro .
+
+unit:MicroSEC
+    qudt:convertsTo  unit:SEC ;
+    qudt:isScalingOf unit:SEC ;
+    qudt:prefix      prefix:Micro .
+
+unit:MegaHZ-M
+    qudt:convertsTo  unit:HZ-M ;
+    qudt:isScalingOf unit:HZ-M .
+
+unit:DecaM
+    qudt:convertsTo  unit:M ;
+    qudt:isScalingOf unit:M ;
+    qudt:prefix      prefix:Deca .
+
+unit:MilliL-PER-HR
+    qudt:isScalingOf unit:L-PER-SEC .
+
+unit:NanoSEC
+    qudt:convertsTo  unit:SEC ;
+    qudt:isScalingOf unit:SEC ;
+    qudt:prefix      prefix:Nano .
+
+unit:GigaPA
+    qudt:convertsTo  unit:PA ;
+    qudt:isScalingOf unit:PA ;
+    qudt:prefix      prefix:Giga .
+
+unit:MegaPA-L-PER-SEC
+    qudt:isScalingOf unit:PA-L-PER-SEC .
+
+unit:GigaHZ-M
+    qudt:convertsTo  unit:HZ-M ;
+    qudt:isScalingOf unit:HZ-M .
+
+unit:KiloV-A
+    qudt:convertsTo  unit:V-A ;
+    qudt:isScalingOf unit:V-A .
+
+unit:MilliWB
+    qudt:convertsTo  unit:WB ;
+    qudt:isScalingOf unit:WB ;
+    qudt:prefix      prefix:Milli .
+
+unit:MilliSV
+    qudt:convertsTo  unit:SV ;
+    qudt:isScalingOf unit:SV ;
+    qudt:prefix      prefix:Milli .
+
+unit:CentiM-PER-KiloYR
+    qudt:isScalingOf unit:M-PER-YR .
+
+unit:MicroN-M
+    qudt:convertsTo  unit:N-M ;
+    qudt:isScalingOf unit:N-M .
+
+unit:MilliSEC
+    qudt:convertsTo  unit:SEC ;
+    qudt:isScalingOf unit:SEC ;
+    qudt:prefix      prefix:Milli .
+
+unit:KiloC-PER-M2
+    qudt:convertsTo  unit:C-PER-M2 ;
+    qudt:isScalingOf unit:C-PER-M2 .
+
+unit:MicroM3
+    qudt:convertsTo  unit:M3 ;
+    qudt:isScalingOf unit:M3 ;
+    qudt:prefix      prefix:Micro .
+
+unit:MilliGRAY
+    qudt:convertsTo  unit:GRAY ;
+    qudt:isScalingOf unit:GRAY ;
+    qudt:prefix      prefix:Milli .
+
+unit:KibiBYTE
+    qudt:isScalingOf unit:BYTE ;
+    qudt:prefix      prefix:Kibi .
+
+unit:MegaEV-PER-CentiM
+    qudt:isScalingOf unit:EV-PER-M .
+
+unit:KiloA
+    qudt:convertsTo  unit:A ;
+    qudt:isScalingOf unit:A ;
+    qudt:prefix      prefix:Kilo .
+
+unit:MegaYR
+    qudt:isScalingOf unit:YR ;
+    qudt:prefix      prefix:Mega .
+
+unit:MilliPA-SEC
+    qudt:convertsTo  unit:PA-SEC ;
+    qudt:isScalingOf unit:PA-SEC .
+
+unit:TeraBYTE
+    qudt:isScalingOf unit:BYTE ;
+    qudt:prefix      prefix:Tera .
+
+unit:KiloTONNE
+    qudt:isScalingOf unit:TONNE ;
+    qudt:prefix      prefix:Kilo .
+
+unit:MilliN-M
+    qudt:convertsTo  unit:N-M ;
+    qudt:isScalingOf unit:N-M .
+
+unit:KiloL
+    qudt:isScalingOf unit:L ;
+    qudt:prefix      prefix:Kilo .
+
+unit:MegaJ-PER-K
+    qudt:convertsTo  unit:J-PER-K ;
+    qudt:isScalingOf unit:J-PER-K .
+
+unit:MicroH-PER-M
+    qudt:convertsTo  unit:H-PER-M ;
+    qudt:isScalingOf unit:H-PER-M .
+
+unit:KiloW
+    qudt:convertsTo  unit:W ;
+    qudt:isScalingOf unit:W ;
+    qudt:prefix      prefix:Kilo .
+
+unit:V-PER-CentiM
+    qudt:convertsTo  unit:V-PER-M ;
+    qudt:isScalingOf unit:V-PER-M .
+
+unit:MicroTORR
+    qudt:isScalingOf unit:TORR ;
+    qudt:prefix      prefix:Micro .
+
+unit:NanoGM-PER-M3
+    qudt:isScalingOf unit:GM-PER-M3 .
+
+unit:KiloCAL_TH
+    qudt:isScalingOf unit:CAL_TH ;
+    qudt:prefix      prefix:Kilo .
+
+unit:MicroG
+    qudt:isScalingOf unit:G ;
+    qudt:prefix      prefix:Micro .
+
+unit:MegaA
+    qudt:convertsTo  unit:A ;
+    qudt:isScalingOf unit:A ;
+    qudt:prefix      prefix:Mega .
+
+unit:KiloMOL-PER-SEC
+    qudt:convertsTo  unit:MOL-PER-SEC ;
+    qudt:isScalingOf unit:MOL-PER-SEC .
+
+unit:CentiM-PER-SEC2
+    qudt:convertsTo  unit:M-PER-SEC2 ;
+    qudt:isScalingOf unit:M-PER-SEC2 .
+
+unit:NanoFARAD
+    qudt:convertsTo  unit:FARAD ;
+    qudt:isScalingOf unit:FARAD ;
+    qudt:prefix      prefix:Nano .
+
+unit:CentiM3-PER-K
+    qudt:convertsTo  unit:M3-PER-K ;
+    qudt:isScalingOf unit:M3-PER-K .
+
+unit:MegaL
+    qudt:isScalingOf unit:L ;
+    qudt:prefix      prefix:Mega .
+
+unit:MegaS-PER-M
+    qudt:convertsTo  unit:S-PER-M ;
+    qudt:isScalingOf unit:S-PER-M .
+
+unit:HectoPA-PER-BAR
+    qudt:isScalingOf unit:PA-PER-BAR .
+
+unit:DecaGM
+    qudt:isScalingOf unit:GM ;
+    qudt:prefix      prefix:Deca .
+
+unit:MegaJ-PER-SEC
+    qudt:convertsTo  unit:J-PER-SEC ;
+    qudt:isScalingOf unit:J-PER-SEC .
+
+unit:KiloGM-PER-M2
+    qudt:isScalingOf unit:GM-PER-M2 .
+
+unit:MegaW
+    qudt:isScalingOf unit:W ;
+    qudt:prefix      prefix:Mega .
+
+unit:MicroGAL
+    qudt:isScalingOf unit:GAL ;
+    qudt:prefix      prefix:Micro .
+
+unit:ExaJ
+    qudt:convertsTo  unit:J ;
+    qudt:isScalingOf unit:J ;
+    qudt:prefix      prefix:Exa .
+
+unit:NanoGM
+    qudt:isScalingOf unit:GM ;
+    qudt:prefix      prefix:Nano .
+
+unit:PicoM
+    qudt:convertsTo  unit:M ;
+    qudt:isScalingOf unit:M ;
+    qudt:prefix      prefix:Pico .
+
+unit:MilliGM-PER-GM
+    qudt:convertsTo  unit:GM-PER-GM ;
+    qudt:isScalingOf unit:GM-PER-GM .
+
+unit:KiloOHM
+    qudt:convertsTo  unit:OHM ;
+    qudt:isScalingOf unit:OHM ;
+    qudt:prefix      prefix:Kilo .
+
+unit:KiloM-PER-SEC
+    qudt:convertsTo  unit:M-PER-SEC ;
+    qudt:isScalingOf unit:M-PER-SEC .
+
+unit:PicoPA-PER-KiloM
+    qudt:convertsTo  unit:PA-PER-M ;
+    qudt:isScalingOf unit:PA-PER-M .
+
+unit:KiloGAUSS
+    qudt:isScalingOf unit:GAUSS ;
+    qudt:prefix      prefix:Kilo .
+
+unit:FemtoMOL-PER-L
+    qudt:isScalingOf unit:MOL-PER-L .
+
+unit:CentiBAR
+    qudt:isScalingOf unit:BAR ;
+    qudt:prefix      prefix:Centi .
+
+unit:KiloW-HR
+    qudt:convertsTo  unit:W-SEC ;
+    qudt:isScalingOf unit:W-SEC .
+
+unit:KiloGM
+    qudt:isScalingOf unit:GM ;
+    qudt:prefix      prefix:Kilo .
+
+unit:MilliGAL
+    qudt:isScalingOf unit:GAL ;
+    qudt:prefix      prefix:Milli .
+
+unit:MilliGM-PER-DeciL
+    qudt:convertsTo  unit:GM-PER-L ;
+    qudt:isScalingOf unit:GM-PER-L .
+
+unit:DeciL
+    qudt:isScalingOf unit:L ;
+    qudt:prefix      prefix:Deci .
+
+unit:HectoL
+    qudt:isScalingOf unit:L ;
+    qudt:prefix      prefix:Hecto .
+
+unit:NUM-PER-MilliGM
+    qudt:isScalingOf unit:NUM-PER-GM .
+
+unit:KiloA-PER-M2
+    qudt:convertsTo  unit:A-PER-M2 ;
+    qudt:isScalingOf unit:A-PER-M2 .
+
+unit:GigaC-PER-M3
+    qudt:convertsTo  unit:C-PER-M3 ;
+    qudt:isScalingOf unit:C-PER-M3 .
+
+unit:MegaBAR
+    qudt:isScalingOf unit:BAR ;
+    qudt:prefix      prefix:Mega .
+
+unit:PicoMOL-PER-L
+    qudt:isScalingOf unit:MOL-PER-L .
+
+unit:NanoM2
+    qudt:convertsTo  unit:M2 ;
+    qudt:isScalingOf unit:M2 ;
+    qudt:prefix      prefix:Nano .
+
+unit:KiloR
+    qudt:isScalingOf unit:R ;
+    qudt:prefix      prefix:Kilo .
+
+unit:NanoMOL-PER-MicroMOL
+    qudt:convertsTo  unit:MOL-PER-MOL ;
+    qudt:isScalingOf unit:MOL-PER-MOL .
+
+unit:KiloBIT-PER-SEC
+    qudt:isScalingOf unit:BIT-PER-SEC .
+
+unit:MicroGRAY
+    qudt:convertsTo  unit:GRAY ;
+    qudt:isScalingOf unit:GRAY ;
+    qudt:prefix      prefix:Micro .
+
+unit:MilliA
+    qudt:convertsTo  unit:A ;
+    qudt:isScalingOf unit:A ;
+    qudt:prefix      prefix:Milli .
+
+unit:MilliGM-PER-M2
+    qudt:isScalingOf unit:GM-PER-M2 .
+
+unit:MilliFARAD
+    qudt:convertsTo  unit:FARAD ;
+    qudt:isScalingOf unit:FARAD ;
+    qudt:prefix      prefix:Milli .
+
+unit:PicoMOL
+    qudt:isScalingOf unit:MOL ;
+    qudt:prefix      prefix:Pico .
+
+unit:MilliL
+    qudt:isScalingOf unit:L ;
+    qudt:prefix      prefix:Milli .
+
+unit:MicroC-PER-M2
+    qudt:convertsTo  unit:C-PER-M2 ;
+    qudt:isScalingOf unit:C-PER-M2 .
+
+unit:KiloHZ
+    qudt:convertsTo  unit:HZ ;
+    qudt:isScalingOf unit:HZ ;
+    qudt:prefix      prefix:Kilo .
+
+unit:MicroM
+    qudt:convertsTo  unit:M ;
+    qudt:isScalingOf unit:M ;
+    qudt:prefix      prefix:Micro .
+
+unit:NanoM
+    qudt:convertsTo  unit:M ;
+    qudt:isScalingOf unit:M ;
+    qudt:prefix      prefix:Nano .
+
+unit:GM-PER-KiloGM
+    qudt:convertsTo  unit:GM-PER-GM ;
+    qudt:isScalingOf unit:GM-PER-GM .
+
+unit:MilliM-PER-SEC
+    qudt:convertsTo  unit:M-PER-SEC ;
+    qudt:isScalingOf unit:M-PER-SEC .
+
+unit:MilliW
+    qudt:isScalingOf unit:W ;
+    qudt:prefix      prefix:Milli .
+
+unit:KiloCAL_TH-PER-MIN
+    qudt:isScalingOf unit:CAL_TH-PER-SEC .
+
+unit:MilliC-PER-M2
+    qudt:convertsTo  unit:C-PER-M2 ;
+    qudt:isScalingOf unit:C-PER-M2 .
+
+unit:DecaC
+    qudt:convertsTo  unit:C ;
+    qudt:isScalingOf unit:C ;
+    qudt:prefix      prefix:Deca .
+
+unit:CentiPOISE-PER-BAR
+    qudt:isScalingOf unit:POISE-PER-BAR .
+
+unit:MicroMOL-PER-M2-HR
+    qudt:convertsTo  unit:MOL-PER-M2-SEC ;
+    qudt:isScalingOf unit:MOL-PER-M2-SEC .
+
+unit:PicoFARAD
+    qudt:convertsTo  unit:FARAD ;
+    qudt:isScalingOf unit:FARAD ;
+    qudt:prefix      prefix:Pico .
+
+unit:PicoH
+    qudt:convertsTo  unit:H ;
+    qudt:isScalingOf unit:H ;
+    qudt:prefix      prefix:Pico .
+
+unit:NanoMOL-PER-M2-DAY
+    qudt:convertsTo  unit:MOL-PER-M2-SEC ;
+    qudt:isScalingOf unit:MOL-PER-M2-SEC .
+
+unit:MegaGM
+    qudt:isScalingOf unit:GM ;
+    qudt:prefix      prefix:Mega .
+
+unit:MilliMOL-PER-M2-DAY
+    qudt:convertsTo  unit:MOL-PER-M2-SEC ;
+    qudt:isScalingOf unit:MOL-PER-M2-SEC .
+
+unit:KiloGM-PER-MIN
+    qudt:isScalingOf unit:GM-PER-SEC .
+
+unit:PicoS
+    qudt:isScalingOf unit:S ;
+    qudt:prefix      prefix:Pico .
+
+unit:MilliPA
+    qudt:convertsTo  unit:PA ;
+    qudt:isScalingOf unit:PA ;
+    qudt:prefix      prefix:Milli .
+
+unit:MicroMOL-PER-M2-SEC
+    qudt:convertsTo  unit:MOL-PER-M2-SEC ;
+    qudt:isScalingOf unit:MOL-PER-M2-SEC .
+
+unit:KiloGM-PER-CentiM2
+    qudt:isScalingOf unit:GM-PER-M2 .
+
+unit:KiloJ-PER-K
+    qudt:convertsTo  unit:J-PER-K ;
+    qudt:isScalingOf unit:J-PER-K .
+
+unit:MilliGM-PER-MIN
+    qudt:isScalingOf unit:GM-PER-SEC .
+
+unit:TeraOHM
+    qudt:convertsTo  unit:OHM ;
+    qudt:isScalingOf unit:OHM ;
+    qudt:prefix      prefix:Tera .
+
+unit:MilliTORR
+    qudt:isScalingOf unit:TORR ;
+    qudt:prefix      prefix:Milli .
+
+unit:MicroS-PER-M
+    qudt:convertsTo  unit:S-PER-M ;
+    qudt:isScalingOf unit:S-PER-M .
+
+unit:PicoGM-PER-L
+    qudt:convertsTo  unit:GM-PER-L ;
+    qudt:isScalingOf unit:GM-PER-L .
+
+unit:GM-PER-MilliL
+    qudt:convertsTo  unit:GM-PER-L ;
+    qudt:isScalingOf unit:GM-PER-L .
+
+unit:MicroGM-PER-GM
+    qudt:convertsTo  unit:GM-PER-GM ;
+    qudt:isScalingOf unit:GM-PER-GM .
+
+unit:W-PER-CentiM2
+    qudt:convertsTo  unit:W-PER-M2 ;
+    qudt:isScalingOf unit:W-PER-M2 .
+
+unit:NUM-PER-KiloM2
+    qudt:convertsTo  unit:NUM-PER-M2 ;
+    qudt:isScalingOf unit:NUM-PER-M2 .
+
+unit:N-PER-CentiM
+    qudt:convertsTo  unit:N-PER-M ;
+    qudt:isScalingOf unit:N-PER-M .
+
+unit:MOL-PER-DeciM3
+    qudt:convertsTo  unit:MOL-PER-M3 ;
+    qudt:isScalingOf unit:MOL-PER-M3 .
+
+unit:MicroBQ
+    qudt:convertsTo  unit:BQ ;
+    qudt:isScalingOf unit:BQ ;
+    qudt:prefix      prefix:Micro .
+
+unit:KiloC-PER-M3
+    qudt:convertsTo  unit:C-PER-M3 ;
+    qudt:isScalingOf unit:C-PER-M3 .
+
+unit:AttoFARAD
+    qudt:convertsTo  unit:FARAD ;
+    qudt:isScalingOf unit:FARAD ;
+    qudt:prefix      prefix:Atto .
+
+unit:MilliL-PER-SEC
+    qudt:isScalingOf unit:L-PER-SEC .
+
+unit:KiloS-PER-M
+    qudt:convertsTo  unit:S-PER-M ;
+    qudt:isScalingOf unit:S-PER-M .
+
+unit:MegaHZ
+    qudt:convertsTo  unit:HZ ;
+    qudt:isScalingOf unit:HZ ;
+    qudt:prefix      prefix:Mega .
+
+unit:MilliA-HR
+    qudt:convertsTo  unit:A-SEC ;
+    qudt:isScalingOf unit:A-SEC .
+
+unit:CentiM3-PER-M3
+    qudt:convertsTo  unit:M3-PER-M3 ;
+    qudt:isScalingOf unit:M3-PER-M3 .
+
+unit:KiloM
+    qudt:convertsTo  unit:M ;
+    qudt:isScalingOf unit:M ;
+    qudt:prefix      prefix:Kilo .
+
+unit:GibiBYTE
+    qudt:isScalingOf unit:BYTE ;
+    qudt:prefix      prefix:Gibi .
+
+unit:MegaW-HR
+    qudt:convertsTo  unit:W-SEC ;
+    qudt:isScalingOf unit:W-SEC .
+
+unit:DeciS-PER-M
+    qudt:convertsTo  unit:S-PER-M ;
+    qudt:isScalingOf unit:S-PER-M .
+
+unit:MilliG
+    qudt:isScalingOf unit:G ;
+    qudt:prefix      prefix:Milli .
+
+unit:MicroH
+    qudt:convertsTo  unit:H ;
+    qudt:isScalingOf unit:H ;
+    qudt:prefix      prefix:Micro .
+
+unit:NanoH
+    qudt:convertsTo  unit:H ;
+    qudt:isScalingOf unit:H ;
+    qudt:prefix      prefix:Nano .
+
+unit:MegaV-A
+    qudt:convertsTo  unit:V-A ;
+    qudt:isScalingOf unit:V-A .
+
+unit:MilliR
+    qudt:isScalingOf unit:R ;
+    qudt:prefix      prefix:Milli .
+
+unit:MegaC-PER-M2
+    qudt:convertsTo  unit:C-PER-M2 ;
+    qudt:isScalingOf unit:C-PER-M2 .
+
+unit:NanoS
+    qudt:isScalingOf unit:S ;
+    qudt:prefix      prefix:Nano .
+
+unit:TeraC
+    qudt:convertsTo  unit:C ;
+    qudt:isScalingOf unit:C ;
+    qudt:prefix      prefix:Tera .
+
+unit:MegaPA-M3-PER-SEC
+    qudt:convertsTo  unit:PA-M3-PER-SEC ;
+    qudt:isScalingOf unit:PA-M3-PER-SEC .
+
+unit:MicroS
+    qudt:convertsTo  unit:S ;
+    qudt:isScalingOf unit:S ;
+    qudt:prefix      prefix:Micro .
+
+unit:CentiGM
+    qudt:isScalingOf unit:GM ;
+    qudt:prefix      prefix:Centi .
+
+unit:YottaC
+    qudt:convertsTo  unit:C ;
+    qudt:isScalingOf unit:C ;
+    qudt:prefix      prefix:Yotta .
+
+unit:MilliM2-PER-SEC
+    qudt:convertsTo  unit:M2-PER-SEC ;
+    qudt:isScalingOf unit:M2-PER-SEC .
+
+unit:KiloLB_F
+    qudt:isScalingOf unit:LB_F ;
+    qudt:prefix      prefix:Kilo .
+
+unit:MilliGM-PER-KiloGM
+    qudt:convertsTo  unit:GM-PER-GM ;
+    qudt:isScalingOf unit:GM-PER-GM .
+
+unit:MicroCi
+    qudt:isScalingOf unit:Ci ;
+    qudt:prefix      prefix:Micro .
+
+unit:GigaHZ
+    qudt:convertsTo  unit:HZ ;
+    qudt:isScalingOf unit:HZ ;
+    qudt:prefix      prefix:Giga .
+
+unit:KiloGM-PER-M3
+    qudt:isScalingOf unit:GM-PER-M3 .
+
+unit:PicoC
+    qudt:convertsTo  unit:C ;
+    qudt:isScalingOf unit:C ;
+    qudt:prefix      prefix:Pico .
+
+unit:CentiM-PER-HR
+    qudt:convertsTo  unit:M-PER-SEC ;
+    qudt:isScalingOf unit:M-PER-SEC .
+
+unit:NUM-PER-MicroL
+    qudt:isScalingOf unit:NUM-PER-L .
+
+unit:MilliMOL-PER-L
+    qudt:isScalingOf unit:MOL-PER-L .
+
+unit:MicroS-PER-CentiM
+    qudt:convertsTo  unit:S-PER-M ;
+    qudt:isScalingOf unit:S-PER-M .
+
+unit:H-PER-KiloOHM
+    qudt:convertsTo  unit:H-PER-OHM ;
+    qudt:isScalingOf unit:H-PER-OHM .
+
+unit:HectoPA-L-PER-SEC
+    qudt:isScalingOf unit:PA-L-PER-SEC .
+
+unit:MilliBAR-PER-K
+    qudt:isScalingOf unit:BAR-PER-K .
+
+unit:KiloMOL-PER-MIN
+    qudt:convertsTo  unit:MOL-PER-SEC ;
+    qudt:isScalingOf unit:MOL-PER-SEC .
+
+unit:M2-PER-KiloGM
+    qudt:isScalingOf unit:M2-PER-GM .
+
+unit:DeciB
+    qudt:isScalingOf unit:B ;
+    qudt:prefix      prefix:Deci .
+
+unit:KiloGM-PER-KiloMOL
+    qudt:isScalingOf unit:GM-PER-MOL .
+
+unit:CentiM2
+    qudt:convertsTo  unit:M2 ;
+    qudt:isScalingOf unit:M2 ;
+    qudt:prefix      prefix:Centi .
+
+unit:KiloMOL-PER-HR
+    qudt:convertsTo  unit:MOL-PER-SEC ;
+    qudt:isScalingOf unit:MOL-PER-SEC .
+
+unit:DeciM
+    qudt:convertsTo  unit:M ;
+    qudt:isScalingOf unit:M ;
+    qudt:prefix      prefix:Deci .
+
+unit:HectoM
+    qudt:convertsTo  unit:M ;
+    qudt:isScalingOf unit:M ;
+    qudt:prefix      prefix:Hecto .
+
+unit:KiloM-PER-HR
+    qudt:convertsTo  unit:M-PER-SEC ;
+    qudt:isScalingOf unit:M-PER-SEC .
+
+unit:GigaC
+    qudt:convertsTo  unit:C ;
+    qudt:isScalingOf unit:C ;
+    qudt:prefix      prefix:Giga .
+
+unit:MicroIN
+    qudt:isScalingOf unit:IN ;
+    qudt:prefix      prefix:Micro .
+
+unit:MicroBAR
+    qudt:isScalingOf unit:BAR ;
+    qudt:prefix      prefix:Micro .
+
+unit:DecaM3
+    qudt:convertsTo  unit:M3 ;
+    qudt:isScalingOf unit:M3 ;
+    qudt:prefix      prefix:Deca .
+
+unit:FemtoGM
+    qudt:isScalingOf unit:GM ;
+    qudt:prefix      prefix:Femto .
+
+unit:HectoBAR
+    qudt:isScalingOf unit:BAR ;
+    qudt:prefix      prefix:Hecto .
+
+unit:MilliS-PER-M
+    qudt:convertsTo  unit:S-PER-M ;
+    qudt:isScalingOf unit:S-PER-M .
+
+unit:PicoSEC
+    qudt:convertsTo  unit:SEC ;
+    qudt:isScalingOf unit:SEC ;
+    qudt:prefix      prefix:Pico .
+
+unit:CentiL
+    qudt:isScalingOf unit:L ;
+    qudt:prefix      prefix:Centi .
+
+unit:KiloS
+    qudt:convertsTo  unit:S ;
+    qudt:isScalingOf unit:S ;
+    qudt:prefix      prefix:Kilo .
+
+unit:KiloPA-PER-K
+    qudt:isScalingOf unit:PA-PER-K .
+
+unit:A-PER-MilliM
+    qudt:convertsTo  unit:A-PER-M ;
+    qudt:isScalingOf unit:A-PER-M .
+
+unit:MilliGM-PER-M3
+    qudt:isScalingOf unit:GM-PER-M3 .
+
+unit:NanoC
+    qudt:convertsTo  unit:C ;
+    qudt:isScalingOf unit:C ;
+    qudt:prefix      prefix:Nano .
+
+unit:MicroC
+    qudt:convertsTo  unit:C ;
+    qudt:isScalingOf unit:C ;
+    qudt:prefix      prefix:Micro .
+
+unit:DeciTON_Metric
+    qudt:isScalingOf unit:TON_Metric ;
+    qudt:prefix      prefix:Deci .
+
+unit:MegaOHM
+    qudt:convertsTo  unit:OHM ;
+    qudt:isScalingOf unit:OHM ;
+    qudt:prefix      prefix:Mega .
+
+unit:MilliM
+    qudt:convertsTo  unit:M ;
+    qudt:isScalingOf unit:M ;
+    qudt:prefix      prefix:Milli .
+
+unit:MicroN
+    qudt:convertsTo  unit:N ;
+    qudt:isScalingOf unit:N ;
+    qudt:prefix      prefix:Micro .
+
+unit:MicroC-PER-M3
+    qudt:convertsTo  unit:C-PER-M3 ;
+    qudt:isScalingOf unit:C-PER-M3 .
+
+unit:MilliBAR
+    qudt:isScalingOf unit:BAR ;
+    qudt:prefix      prefix:Milli .
+
+unit:NanoS-PER-M
+    qudt:convertsTo  unit:S-PER-M ;
+    qudt:isScalingOf unit:S-PER-M .
+
+unit:KiloGM-PER-L
+    qudt:convertsTo  unit:GM-PER-L ;
+    qudt:isScalingOf unit:GM-PER-L .
+
+unit:NanoMOL-PER-CentiM3-HR
+    qudt:convertsTo  unit:MOL-PER-M3-SEC ;
+    qudt:isScalingOf unit:MOL-PER-M3-SEC .
+
+unit:MegaHZ-PER-T
+    qudt:convertsTo  unit:HZ-PER-T ;
+    qudt:isScalingOf unit:HZ-PER-T .
+
+unit:MegaA-PER-M2
+    qudt:convertsTo  unit:A-PER-M2 ;
+    qudt:isScalingOf unit:A-PER-M2 .
+
+unit:MilliC-PER-M3
+    qudt:convertsTo  unit:C-PER-M3 ;
+    qudt:isScalingOf unit:C-PER-M3 .
+
+unit:MegaS
+    qudt:isScalingOf unit:S ;
+    qudt:prefix      prefix:Mega .
+
+unit:PicoPA
+    qudt:isScalingOf unit:PA ;
+    qudt:prefix      prefix:Pico .
+
+unit:FemtoM
+    qudt:convertsTo  unit:M ;
+    qudt:isScalingOf unit:M ;
+    qudt:prefix      prefix:Femto .
+
+unit:J-PER-CentiM2
+    qudt:convertsTo  unit:J-PER-M2 ;
+    qudt:isScalingOf unit:J-PER-M2 .
+
+unit:MilliDEG_C
+    qudt:isScalingOf unit:DEG_C ;
+    qudt:prefix      prefix:Milli .
+
+unit:PER-MilliSEC
+    qudt:convertsTo  unit:PER-SEC ;
+    qudt:isScalingOf unit:PER-SEC .
+
+unit:W-PER-M2-NanoM
+    qudt:convertsTo  unit:W-PER-M2-M ;
+    qudt:isScalingOf unit:W-PER-M2-M .
+
+unit:KiloGM-PER-CentiM3
+    qudt:isScalingOf unit:GM-PER-M3 .
+
+unit:TebiBYTE
+    qudt:isScalingOf unit:BYTE ;
+    qudt:prefix      prefix:Tebi .
+
+unit:MilliH-PER-KiloOHM
+    qudt:convertsTo  unit:H-PER-OHM ;
+    qudt:isScalingOf unit:H-PER-OHM .
+
+unit:MilliM-PER-MIN
+    qudt:convertsTo  unit:M-PER-SEC ;
+    qudt:isScalingOf unit:M-PER-SEC .
+
+unit:NanoBQ-PER-L
+    qudt:isScalingOf unit:BQ-PER-L .
+
+unit:MegaLB_F
+    qudt:isScalingOf unit:LB_F ;
+    qudt:prefix      prefix:Mega .
+
+unit:GM-PER-MilliM
+    qudt:isScalingOf unit:GM-PER-M .
+
+unit:MicroM-PER-K
+    qudt:convertsTo  unit:M-PER-K ;
+    qudt:isScalingOf unit:M-PER-K .
+
+unit:MegaBIT-PER-SEC
+    qudt:isScalingOf unit:BIT-PER-SEC .
+
+unit:YoctoC
+    qudt:convertsTo  unit:C ;
+    qudt:isScalingOf unit:C ;
+    qudt:prefix      prefix:Yocto .
+
+unit:MegaTOE
+    qudt:isScalingOf unit:TOE ;
+    qudt:prefix      prefix:Mega .
+
+unit:MilliBAR-M3-PER-SEC
+    qudt:isScalingOf unit:BAR-M3-PER-SEC .
+
+unit:C-PER-CentiM2
+    qudt:convertsTo  unit:C-PER-M2 ;
+    qudt:isScalingOf unit:C-PER-M2 .
+
+unit:DeciS
+    qudt:isScalingOf unit:S ;
+    qudt:prefix      prefix:Deci .
+
+unit:KiloPA-PER-BAR
+    qudt:isScalingOf unit:PA-PER-BAR .
+
+unit:KiloC
+    qudt:convertsTo  unit:C ;
+    qudt:isScalingOf unit:C ;
+    qudt:prefix      prefix:Kilo .
+
+unit:MilliGM
+    qudt:isScalingOf unit:GM ;
+    qudt:prefix      prefix:Milli .
+
+unit:MicroSV
+    qudt:convertsTo  unit:SV ;
+    qudt:isScalingOf unit:SV ;
+    qudt:prefix      prefix:Micro .
+
+unit:KiloMOL
+    qudt:convertsTo  unit:MOL ;
+    qudt:isScalingOf unit:MOL ;
+    qudt:prefix      prefix:Kilo .
+
+unit:KiloN
+    qudt:convertsTo  unit:N ;
+    qudt:isScalingOf unit:N ;
+    qudt:prefix      prefix:Kilo .
+
+unit:CentiM3-PER-DAY
+    qudt:convertsTo  unit:M3-PER-SEC ;
+    qudt:isScalingOf unit:M3-PER-SEC .
+
+unit:MicroGM-PER-KiloGM
+    qudt:convertsTo  unit:GM-PER-GM ;
+    qudt:isScalingOf unit:GM-PER-GM .
+
+unit:MilliH
+    qudt:convertsTo  unit:H ;
+    qudt:isScalingOf unit:H ;
+    qudt:prefix      prefix:Milli .
+
+unit:MicroFARAD
+    qudt:convertsTo  unit:FARAD ;
+    qudt:isScalingOf unit:FARAD ;
+    qudt:prefix      prefix:Micro .
+
+unit:MilliV-PER-MIN
+    qudt:convertsTo  unit:V-PER-SEC ;
+    qudt:isScalingOf unit:V-PER-SEC .
+
+unit:NanoT
+    qudt:convertsTo  unit:T ;
+    qudt:isScalingOf unit:T ;
+    qudt:prefix      prefix:Nano .
+
+unit:MilliS
+    qudt:convertsTo  unit:S ;
+    qudt:isScalingOf unit:S ;
+    qudt:prefix      prefix:Milli .
+
+unit:KiloCAL_TH-PER-HR
+    qudt:isScalingOf unit:CAL_TH-PER-SEC .
+
+unit:MegaC
+    qudt:convertsTo  unit:C ;
+    qudt:isScalingOf unit:C ;
+    qudt:prefix      prefix:Mega .
+
+unit:AttoC
+    qudt:convertsTo  unit:C ;
+    qudt:isScalingOf unit:C ;
+    qudt:prefix      prefix:Atto .
+
+unit:MilliL-PER-MIN
+    qudt:isScalingOf unit:L-PER-SEC .
+
+unit:MicroGM-PER-M3
+    qudt:isScalingOf unit:GM-PER-M3 .
+
+unit:MicroATM
+    qudt:isScalingOf unit:ATM ;
+    qudt:prefix      prefix:Micro .
+
+unit:MegaC-PER-M3
+    qudt:convertsTo  unit:C-PER-M3 ;
+    qudt:isScalingOf unit:C-PER-M3 .
+
+unit:KiloEV
+    qudt:isScalingOf unit:EV ;
+    qudt:prefix      prefix:Kilo .
+
+unit:MegaPA-PER-BAR
+    qudt:isScalingOf unit:PA-PER-BAR .
+
+unit:DeciM3-PER-M3
+    qudt:convertsTo  unit:M3-PER-M3 ;
+    qudt:isScalingOf unit:M3-PER-M3 .
+
+unit:MicroT
+    qudt:convertsTo  unit:T ;
+    qudt:isScalingOf unit:T ;
+    qudt:prefix      prefix:Micro .
+
+unit:MilliMOL-PER-M2-SEC
+    qudt:convertsTo  unit:MOL-PER-M2-SEC ;
+    qudt:isScalingOf unit:MOL-PER-M2-SEC .
+
+unit:MegaN
+    qudt:convertsTo  unit:N ;
+    qudt:isScalingOf unit:N ;
+    qudt:prefix      prefix:Mega .
+
+unit:MilliM-PER-HR
+    qudt:convertsTo  unit:M-PER-SEC ;
+    qudt:isScalingOf unit:M-PER-SEC .
+
+unit:MilliM2
+    qudt:convertsTo  unit:M2 ;
+    qudt:isScalingOf unit:M2 ;
+    qudt:prefix      prefix:Milli .
+
+unit:PicoMOL-PER-M2-DAY
+    qudt:convertsTo  unit:MOL-PER-M2-SEC ;
+    qudt:isScalingOf unit:MOL-PER-M2-SEC .
+
+unit:MicroGM-PER-MilliL
+    qudt:convertsTo  unit:GM-PER-L ;
+    qudt:isScalingOf unit:GM-PER-L .
+
+unit:MegaV-A_Reactive
+    qudt:convertsTo  unit:V-A_Reactive ;
+    qudt:isScalingOf unit:V-A_Reactive .
+
+unit:DeciM3-PER-DAY
+    qudt:convertsTo  unit:M3-PER-SEC ;
+    qudt:isScalingOf unit:M3-PER-SEC .
+
+unit:KiloGM-PER-KiloGM
+    qudt:convertsTo  unit:GM-PER-GM ;
+    qudt:isScalingOf unit:GM-PER-GM .
+
+unit:MicroGM-PER-L
+    qudt:convertsTo  unit:GM-PER-L ;
+    qudt:isScalingOf unit:GM-PER-L .
+
+unit:HectoPA-PER-K
+    qudt:isScalingOf unit:PA-PER-K .
+
+unit:PetaC
+    qudt:convertsTo  unit:C ;
+    qudt:isScalingOf unit:C ;
+    qudt:prefix      prefix:Peta .
+
+unit:HectoPA-PER-HR
+    qudt:convertsTo  unit:PA-PER-SEC ;
+    qudt:isScalingOf unit:PA-PER-SEC .
+
+unit:MilliPA-SEC-PER-BAR
+    qudt:isScalingOf unit:PA-SEC-PER-BAR .
+
+unit:DeciC
+    qudt:convertsTo  unit:C ;
+    qudt:isScalingOf unit:C ;
+    qudt:prefix      prefix:Deci .
+
+unit:KiloLB_F-PER-IN2
+    qudt:isScalingOf unit:LB_F-PER-IN2 .
+
+unit:HectoC
+    qudt:convertsTo  unit:C ;
+    qudt:isScalingOf unit:C ;
+    qudt:prefix      prefix:Hecto .
+
+unit:MilliGM-PER-L
+    qudt:convertsTo  unit:GM-PER-L ;
+    qudt:isScalingOf unit:GM-PER-L .
+
+unit:CentiM3
+    qudt:convertsTo  unit:M3 ;
+    qudt:isScalingOf unit:M3 ;
+    qudt:prefix      prefix:Centi .
+
+unit:MilliBAR-PER-BAR
+    qudt:convertsTo  unit:BAR-PER-BAR ;
+    qudt:isScalingOf unit:BAR-PER-BAR .
+
+unit:NanoGM-PER-MicroL
+    qudt:convertsTo  unit:GM-PER-L ;
+    qudt:isScalingOf unit:GM-PER-L .
+
+unit:MicroMOL-PER-MOL
+    qudt:convertsTo  unit:MOL-PER-MOL ;
+    qudt:isScalingOf unit:MOL-PER-MOL .
+
+unit:KiloGM_F
+    qudt:isScalingOf unit:GM_F ;
+    qudt:prefix      prefix:Kilo .
+
+unit:MicroMOL-PER-M2
+    qudt:convertsTo  unit:MOL-PER-M2 ;
+    qudt:isScalingOf unit:MOL-PER-M2 .
+
+unit:MilliS-PER-CentiM
+    qudt:convertsTo  unit:S-PER-M ;
+    qudt:isScalingOf unit:S-PER-M .
+
+unit:A-PER-CentiM
+    qudt:convertsTo  unit:A-PER-M ;
+    qudt:isScalingOf unit:A-PER-M .
+
+unit:GigaW-HR
+    qudt:convertsTo  unit:W-SEC ;
+    qudt:isScalingOf unit:W-SEC .
+
+unit:CentiST
+    qudt:isScalingOf unit:ST ;
+    qudt:prefix      prefix:Centi .
+
+unit:MegaEV
+    qudt:isScalingOf unit:EV ;
+    qudt:prefix      prefix:Mega .
+
+unit:CentiM
+    qudt:prefix      prefix:Centi .
+
+unit:NanoBQ
+    qudt:isScalingOf unit:BQ ;
+    qudt:prefix      prefix:Nano .
+
+unit:MilliC
+    qudt:convertsTo  unit:C ;
+    qudt:isScalingOf unit:C ;
+    qudt:prefix      prefix:Milli .
+
+unit:MilliM-PER-K
+    qudt:convertsTo  unit:M-PER-K ;
+    qudt:isScalingOf unit:M-PER-K .
+
+unit:KiloGM-PER-DeciM3
+    qudt:isScalingOf unit:GM-PER-M3 .
+
+unit:CentiM3-PER-MOL
+    qudt:convertsTo  unit:M3-PER-MOL ;
+    qudt:isScalingOf unit:M3-PER-MOL .
+
+unit:MilliW-PER-CentiM2-MicroM-SR
+    qudt:convertsTo  unit:W-PER-M2-M-SR ;
+    qudt:isScalingOf unit:W-PER-M2-M-SR .
+
+unit:MicroOHM
+    qudt:convertsTo  unit:OHM ;
+    qudt:isScalingOf unit:OHM ;
+    qudt:prefix      prefix:Micro .
+
+unit:KiloGM-PER-KiloM2
+    qudt:isScalingOf unit:GM-PER-M2 .
+
+unit:MilliN
+    qudt:convertsTo  unit:N ;
+    qudt:isScalingOf unit:N ;
+    qudt:prefix      prefix:Milli .
+
+unit:KiloGM-PER-M
+    qudt:isScalingOf unit:GM-PER-M .
+
+unit:KiloBQ
+    qudt:convertsTo  unit:BQ ;
+    qudt:isScalingOf unit:BQ ;
+    qudt:prefix      prefix:Kilo .
+
+unit:TeraJ
+    qudt:convertsTo  unit:J ;
+    qudt:isScalingOf unit:J ;
+    qudt:prefix      prefix:Tera .
+
+unit:FemtoC
+    qudt:convertsTo  unit:C ;
+    qudt:isScalingOf unit:C ;
+    qudt:prefix      prefix:Femto .
+
+unit:MicroH-PER-KiloOHM
+    qudt:convertsTo  unit:H-PER-OHM ;
+    qudt:isScalingOf unit:H-PER-OHM .
+
+unit:MilliMOL-PER-M2
+    qudt:convertsTo  unit:MOL-PER-M2 ;
+    qudt:isScalingOf unit:MOL-PER-M2 .
+
+unit:MilliV-PER-M
+    qudt:convertsTo  unit:V-PER-M ;
+    qudt:isScalingOf unit:V-PER-M .
+
+unit:GigaEV
+    qudt:isScalingOf unit:EV ;
+    qudt:prefix      prefix:Giga .
+
+unit:MilliOHM
+    qudt:convertsTo  unit:OHM ;
+    qudt:isScalingOf unit:OHM ;
+    qudt:prefix      prefix:Milli .
+
+unit:DeciN-M
+    qudt:convertsTo  unit:N-M ;
+    qudt:isScalingOf unit:N-M .
+
+unit:MegaPA-PER-K
+    qudt:isScalingOf unit:PA-PER-K .
+
+unit:MegaV-PER-M
+    qudt:convertsTo  unit:V-PER-M ;
+    qudt:isScalingOf unit:V-PER-M .
+
+unit:DeciTONNE
+    qudt:isScalingOf unit:TONNE ;
+    qudt:prefix      prefix:Deci .
+
+unit:C-PER-MilliM2
+    qudt:convertsTo  unit:C-PER-M2 ;
+    qudt:isScalingOf unit:C-PER-M2 .
+
+unit:KiloLB_F-PER-FT
+    qudt:isScalingOf unit:LB_F-PER-FT .
+
+unit:DeciM3-PER-MOL
+    qudt:convertsTo  unit:M3-PER-MOL ;
+    qudt:isScalingOf unit:M3-PER-MOL .
+
+unit:MilliW-PER-M2-NanoM-SR
+    qudt:convertsTo  unit:W-PER-M2-M-SR ;
+    qudt:isScalingOf unit:W-PER-M2-M-SR .
+
+unit:CentiM-PER-SEC
+    qudt:convertsTo  unit:M-PER-SEC ;
+    qudt:isScalingOf unit:M-PER-SEC .
+
+unit:KiloBYTE
+    qudt:isScalingOf unit:BYTE ;
+    qudt:prefix      prefix:Kilo .
+
+unit:PicoMOL-PER-M3-SEC
+    qudt:convertsTo  unit:MOL-PER-M3-SEC ;
+    qudt:isScalingOf unit:MOL-PER-M3-SEC .
+
+


### PR DESCRIPTION
(Note: This PR includes the changes of #457 )

The reasoning for the suggested changes is developed in #455.

# Changes
The following changes were made (in this order):
1. Fix the 'OZ_PER' typos. 
2. Add a comment in the schema, clarifying what qudt:isScalingOf means, and delete some triples not compatible with this meaning.
3. 
    * Add the notion of `factor units` to the schema: a small addition by which one connects derived units, such as `unit:PER-M3` to its base unit, e.g. `unit:M` and the exponent that is applied, e.g. `-3`. 
    * Based on the unit names, generate `qudt:isScalingOf`, `qudt:convertsTo`, and `qudt:factorUnit/qudt:unit`, `qudt:factorUnit/qudt:exponent` triples.
    * factor units implied by unit IRIs but not actually present in the units file are generated in the process.

# Queries that generate the added triples

The triples in 3. are generated with these queries:

```
PREFIX qudt: <http://qudt.org/schema/qudt/>
PREFIX unit: <http://qudt.org/vocab/unit/>
PREFIX prefix: <http://qudt.org/vocab/prefix/>
PREFIX kind: <http://qudt.org/vocab/quantitykind/>
PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>

CONSTRUCT {
 ?scaledUnit
    qudt:isScalingOf ?baseUnit ;
    qudt:prefix ?prefix ;
    qudt:convertsTo ?convertsTo .
}
#SELECT ?scaledUnit ?baseUnit ?convertsTo ?prefix
where
{
    {
        {

            {
                # select all base units (not using prefixes)
                ?scaledUnit a qudt:Unit ;
                    BIND(REPLACE(STR(?scaledUnit), "^.+/", "") as ?scaledUnitLocalName)
                    FILTER EXISTS {
                        ?prefix
                            a qudt:Prefix ;
                            rdfs:label ?prefixLabel
                        FILTER(CONTAINS(?scaledUnitLocalName, STR(?prefixLabel)))
                    }
            }

            {
                SELECT (CONCAT("\\b(",GROUP_CONCAT(STR(?prefixLabel); separator ="|"), ")") as ?prefixRegex) where
                {
                    ?prefix
                        a qudt:Prefix ;
                        rdfs:label ?prefixLabel .
                 }
            }

        }

        # select all base units (not using prefixes)
        # special handling for prefix + time, e.g.
        # 'unit:MegaYR qudt:isScalingOf unit:YR', not unit:SEC

        ?baseUnit a qudt:Unit ;
        BIND(REPLACE(STR(?baseUnit), "^.+/", "") as ?baseUnitLocalName)
        BIND("(YR|MO|DAY|HR|MIN)\\b" as ?timeRegex)
        FILTER (
                    (
                        REPLACE(?scaledUnitLocalName, CONCAT(?prefixRegex, ?timeRegex), "") = ?scaledUnitLocalName
                        && ?baseUnitLocalName = REPLACE(REPLACE(?scaledUnitLocalName, ?prefixRegex, ""), ?timeRegex, "SEC")
                    ) || (
                        REPLACE(?scaledUnitLocalName, CONCAT(?prefixRegex, ?timeRegex), "") != ?scaledUnitLocalName
                        && ?baseUnitLocalName = REPLACE(?scaledUnitLocalName, ?prefixRegex, "")
                    )
        )
    }
    OPTIONAL {
        ?prefix a qudt:Prefix ;
            rdfs:label ?prefixLabel ;
            FILTER (!CONTAINS(?baseUnitLocalName, "-"))
            FILTER (CONTAINS(?scaledUnitLocalName, STR(?prefixLabel)))
    }
    OPTIONAL {
        ?scaledUnit qudt:conversionMultiplier ?scaledMultiplier . # require any multiplier
        ?baseUnit
            qudt:conversionMultiplier ?cm .
        optional {
            ?baseUnit qudt:conversionOffset ?co
        }
        FILTER( !BOUND(?co) || ?co = 0 )
        FILTER( ?cm = 1 )
        BIND(?baseUnit as ?convertsTo)
    }
}
order by ?baseUnit ?scaledUnit
```
and
```
PREFIX qudt: <http://qudt.org/schema/qudt/>
PREFIX unit: <http://qudt.org/vocab/unit/>
PREFIX prefix: <http://qudt.org/vocab/prefix/>
PREFIX kind: <http://qudt.org/vocab/quantitykind/>
PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>

CONSTRUCT {
    ?derivedUnit qudt:factorUnit [
        qudt:unit ?baseUnit ;
        qudt:exponent ?exponent
    ] .
    ?baseUnit a ?missingUnitType ;
        rdfs:comment ?comment .
}
#SELECT * WHERE
#select count(*) where
{
    {
        SELECT distinct ?derivedUnit ?exponent ?baseUnitLocalNameExtracted ?baseUnit
        WHERE
        {
            ?derivedUnit a qudt:Unit ;
                BIND(REPLACE(STR(?derivedUnit), "^.+/", "") as ?derivedUnitLocalName)
            FILTER(REPLACE(?derivedUnitLocalName, "(PER|2|3|4|5|6|-)\\b", "") != ?derivedUnitLocalName)
            FILTER(?derivedUnitLocalName NOT IN (
                "Gold-OunceTroy",
                "Palladium-OunceTroy",
                "Silver-OunceTroy",
                "Platinum-OunceTroy",
                "failures-in-time",
                "USDollar-NextDay"
            ))

            VALUES ?skipUnits { 0 1 2 3 4 5 6 }
            BIND("(\\w+(_\\w+)?\\d?)" as ?baseUnitRegex)
            BIND("(\\w+(_\\w+)?\\d?|PER)" as ?skipUnitRegex)
            BIND(CONCAT("^(",?skipUnitRegex,"-){", STR(?skipUnits), "}", ?baseUnitRegex, "(-" ,?skipUnitRegex, ")*$") as ?selectUnitRegex )
            BIND(REPLACE(?derivedUnitLocalName, ?selectUnitRegex, "$4") as ?baseUnitLocalNameExtractedTmp)
            BIND(REPLACE(?baseUnitLocalNameExtractedTmp, "^(\\w*[^\\d])(\\d?)$", "$1") as ?baseUnitLocalNameExtracted)
            BIND(REPLACE(?baseUnitLocalNameExtractedTmp, "^(\\w*[^\\d])(\\d?)$", "$2") as ?exponentTmpStr)
            BIND(IF(?exponentTmpStr = "", STRDT("1",xsd:integer), STRDT(?exponentTmpStr,xsd:integer)) as ?exponentTmp)
            VALUES ( ?matchString ?dontMatchString ?expFactor) {
                ( "^.*PER-.*\\b@@UNIT@@\\b.*$" "dontfindthis" -1 )
                ( "^.*\\b@@UNIT@@\\b.*PER.*$" "dontfindthis"  1 )
                ( ".+" "\\bPER\\b" 1 )
            }
            FILTER(REPLACE(?derivedUnitLocalName, REPLACE(?matchString, "@@UNIT@@", ?baseUnitLocalNameExtractedTmp), "") != ?derivedUnitLocalName)
            FILTER(REPLACE(?derivedUnitLocalName, ?dontMatchString, "") = ?derivedUnitLocalName)
            BIND(?exponentTmp * ?expFactor as ?exponent)
            FILTER( ?baseUnitLocalNameExtractedTmp != "PER" )
            FILTER( ! CONTAINS(?baseUnitLocalNameExtractedTmp, "-") )
            BIND(IRI(CONCAT("http://qudt.org/vocab/unit/", ?baseUnitLocalNameExtracted)) as ?baseUnit)
        }
    }

    OPTIONAL {
        ?baseUnit a qudt:Unit .
        BIND(true as ?baseUnitExists)
    }
    OPTIONAL {
        BIND ("This unit was added while generating qudt:factorUnit information as a missing factor unit"@en as ?comment)
        BIND (qudt:Unit as ?missingUnitType)
        FILTER(!BOUND(?baseUnitExists))
    }
}
order by ?derivedUnit ?baseUnit
```

# Use cases

With this PR, one can find units based on prefix and unit name using the follwing query:
```
PREFIX qudt: <http://qudt.org/schema/qudt/>
PREFIX unit: <http://qudt.org/vocab/unit/>
PREFIX kind: <http://qudt.org/vocab/quantitykind/>
PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>

# bind ?baseUnitLabel and ?prefixLabel, get the scaled unit
SELECT * where
{
    #VALUES (?prefixLabel ?baseUnitLabel ) { ("Pico" "Meter") }

    ?unit a qudt:Unit;
       rdfs:label ?label ;
       qudt:isScalingOf ?baseUnit ;
       qudt:prefix ?prefix ;
       qudt:isScalingOf ?baseUnit .

    ?baseUnit a qudt:Unit ;
        rdfs:label ?actualBaseUnitLabel .

    ?prefix a qudt:Prefix ;
        rdfs:label ?actualPrefixLabel .

    FILTER(UCASE(STR(?actualBaseUnitLabel)) = UCASE(?baseUnitLabel))
    FILTER(UCASE(STR(?actualPrefixLabel)) = UCASE(?prefixLabel))
    optional {
       ?unit qudt:conversionMultiplier ?conversionMultiplier
    }
    optional {
        ?unit qudt:hasQuantityKind ?quantityKind
    }
    optional {
           ?unit qudt:conversionOffset ?conversionOffset
        }
    optional {
       ?unit qudt:symbol ?symbol
    }
}
```

To get the unit if you know the factor units and exponents (in this case, 3 factor units):
```
PREFIX qudt: <http://qudt.org/schema/qudt/>
PREFIX unit: <http://qudt.org/vocab/unit/>
PREFIX kind: <http://qudt.org/vocab/quantitykind/>
PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>

# Bind
# ?baseUnit1 ?exponent1 ?baseUnit2 ?exponent2 ?baseUnit3 ?exponent3
# to get the derived unit as ?unit
SELECT * WHERE
{
    {
        #VALUES (?baseUnit1 ?exponent1 ?baseUnit2 ?exponent2 ?baseUnit3 ?exponent3) { (unit:MOL 1 unit:M -2 unit:SEC -1 ) }
        ?unit a qudt:Unit ;
           rdfs:label ?label ;
           qudt:factorUnit ?factorUnit1 ;
           qudt:factorUnit ?factorUnit2 ;
           qudt:factorUnit ?factorUnit3 .
        ?factorUnit1
            qudt:unit ?baseUnit1 ;
            qudt:exponent ?exponent1 .
        ?factorUnit2
            qudt:unit ?baseUnit2 ;
            qudt:exponent ?exponent2 .
        ?factorUnit3
            qudt:unit ?baseUnit3 ;
            qudt:exponent ?exponent3 .
        ?baseUnit1 a qudt:Unit .
        ?baseUnit2 a qudt:Unit .
        ?baseUnit3 a qudt:Unit .

        # force binding different factors
        FILTER(?factorUnit1 NOT IN (?factorUnit2, ?factorUnit3))
        FILTER(?factorUnit2 NOT IN (?factorUnit1, ?factorUnit3))

        #make sure we have no other factor units
        OPTIONAL {
            ?unit qudt:factorUnit ?factorUnitX .
            FILTER(?factorUnitX NOT IN(?factorUnit1, ?factorUnit2, ?factorUnit3))
        }
        FILTER( !BOUND(?factorUnitX) )
    }

    OPTIONAL {
        ?unit qudt:prefix ?prefix
    }
    OPTIONAL {
       ?unit qudt:conversionMultiplier ?conversionMultiplier
    }
    OPTIONAL {
        ?unit qudt:hasQuantityKind ?quantityKind
    }
    OPTIONAL {
        ?unit qudt:conversionOffset ?conversionOffset
    }
    OPTIONAL {
        ?unit qudt:symbol ?symbol
    }
}
```

# Future work

One open issue will be to find all scaled units that don't have `qudt:convertsTo` triples because their base unit itself converts to another unit. In these cases, the base unit has to be annotated manually and the triples then generated for all of its scaled units.

Another issue could be to look for missing based units for scaled units. I did not check, but it's quite possbile that for some units with scaling prefix there is no base unit.

EDIT: fixed the factorUnit query (see also commit 799e47f)