### PR TITLE
Fix quantitykind prefix case for agrimetrics units

### DIFF
--- a/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
+++ b/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
@@ -17672,18 +17672,18 @@ vaem:GMD_QUDT-QUANTITY-KINDS-ALL
   rdfs:label "QUDT Quantity Kinds Vocabulary Version 2.1.16" ;
 .
 
-quantityKind:GrowingDegreeDay_Cereal
+quantitykind:GrowingDegreeDay_Cereal
     a qudt:QuantityKind ;
     rdfs:label "Growing Degree Days (Cereals)" ;
     qudt:hasDimensionVector qkdv:A0E0L0I0M0H1T1D0 ;
     qudt:plainTextDescription "The sum of excess temperature over 5.5°C, where the temperature is the mean of the minimum and maximum atmospheric temperature in a day. This measure is appropriate for most cereal crops." ;
     rdfs:isDefinedBy <https://data.agrimetrics.co.uk/ontologies/qudt-extension> ;
-    skos:broader quantityKind:TimeTemperature .
+    skos:broader quantitykind:TimeTemperature .
 
-quantityKind:ShannonDiversityIndex
+quantitykind:ShannonDiversityIndex
     a qudt:QuantityKind ;
     rdfs:label "Shannon Diversity Index";
     qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
     qudt:plainTextDescription "Information entropy applied to a collection of indiviual organisms [of selected species] in a sample area. A measure of biodiversity." ;
     rdfs:isDefinedBy <https://data.agrimetrics.co.uk/ontologies/qudt-extension> ;
-    skos:broader quantityKind:InformationEntropy .
+    skos:broader quantitykind:InformationEntropy .

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -23746,7 +23746,7 @@ unit:DEG_C_GROWING_CEREAL-DAY
     qudt:conversionOffset "0.0"^^xsd:double ;
     qudt:hasDimensionVector qkdv:A0E0L0I0M0H1T1D0 ;
     qudt:plainTextDescription "The sum of excess temperature over 5.5°C, where the temperature is the mean of the minimum and maximum atmospheric temperature in a day. This measure is appropriate for most cereal crops." ;
-    qudt:hasQuantityKind quantityKind:GrowingDegreeDay_Cereal ;
+    qudt:hasQuantityKind quantitykind:GrowingDegreeDay_Cereal ;
     rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> .
 
 unit:M2-PER-M2
@@ -23756,11 +23756,11 @@ unit:M2-PER-M2
     qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
     qudt:qkdvDenominator qkdv:A0E0L2I0M0H0T0D0 ;
     qudt:qkdvNumerator qkdv:A0E0L2I0M0H0T0D0 ;
-    qudt:hasQuantityKind quantityKind:AreaRatio ;
+    qudt:hasQuantityKind quantitykind:AreaRatio ;
     qudt:conversionMultiplier "1"^^xsd:double ;
     qudt:conversionOffset "0.0"^^xsd:double ;
     qudt:plainTextDescription "A square metre unit of area per square metre"^^rdf:HTML ;
-    <http://qudt.org/schema/qudt/symbol> "m^2/m^2" ;
+    qudt:symbol "m^2/m^2" ;
     rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> .
 
 unit:FRACTION
@@ -23770,7 +23770,7 @@ unit:FRACTION
     qudt:conversionOffset "0"^^xsd:double ;
     qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
     qudt:plainTextDescription "Fraction is a unit for 'Dimensionless Ratio' expressed as the value of the ratio itself." ;
-    qudt:hasQuantityKind quantityKind:DimensionlessRatio ;
+    qudt:hasQuantityKind quantitykind:DimensionlessRatio ;
     rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> .
 
 unit:MicroG-PER-CentiM2
@@ -23780,7 +23780,7 @@ unit:MicroG-PER-CentiM2
     qudt:conversionOffset "0"^^xsd:double ;
     qudt:hasDimensionVector qkdv:A0E0L-2I0M1H0T0D0 ;
     qudt:plainTextDescription "A unit of mass per area, equivalent to 0.01 grammes per square metre" ;
-    qudt:hasQuantityKind quantityKind:MassPerArea ;
+    qudt:hasQuantityKind quantitykind:MassPerArea ;
     rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> .
 
 unit:KiloW-HR-PER-M2
@@ -23790,7 +23790,7 @@ unit:KiloW-HR-PER-M2
     qudt:conversionOffset "0"^^xsd:double ;
     qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-2D0 ;
     qudt:plainTextDescription "A unit of energy per unit area, equivalent to 3 600 000 joules per square metre." ;
-    qudt:hasQuantityKind quantityKind:EnergyPerArea ;
+    qudt:hasQuantityKind quantitykind:EnergyPerArea ;
     rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> .
 
 unit:IU-PER-MilliGM
@@ -23800,6 +23800,6 @@ unit:IU-PER-MilliGM
     qudt:conversionOffset "0"^^xsd:double ;
     qudt:hasDimensionVector qkdv:A1E0L0I0M-1H0T0D0 ;
     qudt:plainTextDescription "International Units per milligramme." ;
-    qudt:hasQuantityKind quantityKind:AmountOfSubstancePerUnitMass ;
+    qudt:hasQuantityKind quantitykind:AmountOfSubstancePerUnitMass ;
     rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> .
 


### PR DESCRIPTION
restores parsability to affected ttl's