### PR TITLE
Fixed a couple of ill-formed UCUM codes

### DIFF
--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -6388,7 +6388,7 @@ unit:GAL_UK-PER-MIN
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA503" ;
   qudt:plainTextDescription "unit gallon (UK dry or liq.) according to the Imperial system of units divided by the SI unit minute" ;
-  qudt:ucumCode "[gal_br].m-1in"^^qudt:UCUMcs ;
+  qudt:ucumCode "[gal_br].m-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G3" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Gallon (UK) Per Minute"@en ;
@@ -9223,7 +9223,7 @@ unit:KiloCAL-PER-CentiM-SEC-DEG_C
   qudt:expression "\\(kilocal-per-cm-sec-degc\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H-1T-3D0 ;
   qudt:hasQuantityKind quantitykind:ThermalConductivity ;
-  qudt:ucumCode "kcol.cm-1.s-1.Cel-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "kcal.cm-1.s-1.Cel-1"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:CGS ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kilocalorie per Centimeter Second Degree Celsius"@en-us ;
@@ -13703,7 +13703,7 @@ unit:MegaV-A_Reactive
   qudt:hasQuantityKind quantitykind:ReactivePower ;
   qudt:iec61360Code "0112/2///62720#UAB199" ;
   qudt:plainTextDescription "1 000 000-fold of the unit volt ampere reactive" ;
-  qudt:ucumCode "MV.A{reactive)"^^qudt:UCUMcs ;
+  qudt:ucumCode "MV.A{reactive}"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "MAR" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Megavolt Ampere Reactive"@en ;
@@ -13715,7 +13715,7 @@ unit:MegaV-A_Reactive-HR
   qudt:hasQuantityKind quantitykind:Energy ;
   qudt:iec61360Code "0112/2///62720#UAB198" ;
   qudt:plainTextDescription "product of the 1,000,000-fold of the unit volt ampere reactive and the unit hour" ;
-  qudt:ucumCode "MV.A{reactive).h"^^qudt:UCUMcs ;
+  qudt:ucumCode "MV.A{reactive}.h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "MAH" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Megavolt Ampere Reactive Hour"@en ;
@@ -14704,7 +14704,6 @@ unit:MicroTORR
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerArea ;
   qudt:symbol "μTorr" ;
-  qudt:ucumCode "uTorr"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "MicroTorr"@en ;
 .
@@ -14835,7 +14834,7 @@ unit:MilliARCSEC
   qudt:hasQuantityKind quantitykind:Angle ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Minute_of_arc"^^xsd:anyURI ;
   qudt:symbol "mas" ;
-  qudt:ucumCode "m\""^^qudt:UCUMcs ;
+  qudt:ucumCode "m''"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Milli ArcSecond"@en ;
   owl:sameAs unit:RAD ;
@@ -16122,8 +16121,7 @@ unit:MilliTORR
   qudt:conversionMultiplier 0.133322 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerArea ;
-  qudt:symbol "utorr" ;
-  qudt:ucumCode "mTorr"^^qudt:UCUMcs ;
+  qudt:symbol "mTorr" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "MilliTorr"@en ;
 .
@@ -16445,8 +16443,8 @@ unit:N-M2-PER-A
   qudt:conversionMultiplier 1.0 ;
   qudt:hasDimensionVector qkdv:A0E1L2I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:MagneticDipoleMoment ;
-  qudt:ucumCode "N.m^2.A-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "N.m^2/A"^^qudt:UCUMcs ;
+  qudt:ucumCode "N.m2.A-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "N.m2/A"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P49" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Newton Meter Squared per Ampere"@en-us ;
@@ -20963,7 +20961,7 @@ unit:SEC-PER-RAD-M3
   qudt:hasQuantityKind quantitykind:DensityOfStates ;
   qudt:iec61360Code "0112/2///62720#UAB352" ;
   qudt:informativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
-  qudt:ucumCode "s."^^qudt:UCUMcs ;
+  qudt:ucumCode "s.rad-1.m-3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "Q22" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Second per Radian Cubic Meter"@en-us ;
@@ -21365,7 +21363,7 @@ unit:Silver-OunceTroy
   qudt:expression "\\(XAG\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
-  qudt:ucumCode "[oz_tr](Ag}"^^qudt:UCUMcs ;
+  qudt:ucumCode "[oz_tr]{Ag}"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Silver (one Troy ounce)"@en ;
 .
@@ -21769,7 +21767,7 @@ unit:TONNE-PER-HR
   qudt:hasQuantityKind quantitykind:MassFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAB994" ;
   qudt:plainTextDescription "unit tonne divided by the unit for time hour" ;
-  qudt:ucumCode "t.hr-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "t.h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E18" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Tonne Per Hour"@en ;
@@ -21939,7 +21937,7 @@ unit:TON_Metric-PER-HR
   qudt:hasQuantityKind quantitykind:MassFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAB994" ;
   qudt:plainTextDescription "unit tonne divided by the unit for time hour" ;
-  qudt:ucumCode "t.hr-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "t.h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E18" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Tonne Per Hour"@en ;
@@ -22146,7 +22144,6 @@ unit:TORR
   qudt:informativeReference "http://en.wikipedia.org/wiki/Torr?oldid=495199381"^^xsd:anyURI ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/torr> ;
   qudt:symbol "Torr" ;
-  qudt:ucumCode "Torr"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "UA" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Torr"@en ;


### PR DESCRIPTION
I've been working on a UCUM parser with the intent to generate printable html for any kind of UCUM expression and while at it I discovered a couple of ill formed UCUM codes which I fixed. In case of _torrs_ there is no is actually no UCUM code for it so I went ahead and removed those entries.