### PR TITLE
Create unit:FT-PER-DAY

### DIFF
--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -5814,6 +5814,21 @@ unit:FT-PDL
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Foot Poundal"@en ;
 .
+unit:FT-PER-DAY
+  a qudt:Unit ;
+  dcterms:description "\"Foot per Day\" is an Imperial unit for  'Linear Velocity' expressed as \\(ft/d\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 0.00000352777777777778 ;
+  qudt:definedUnitOfSystem sou:IMPERIAL ;
+  qudt:definedUnitOfSystem sou:USCS ;
+  qudt:expression "\\(ft/d\\)"^^qudt:LatexString ;
+  qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T-1D0 ;
+  qudt:hasQuantityKind quantitykind:Velocity ;
+  qudt:ucumCode "[ft_i].d-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[ft_i]/d"^^qudt:UCUMcs ;
+  qudt:unitOfSystem sou:IMPERIAL ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Foot per Day"@en ;
+.
 unit:FT-PER-DEG_F
   a qudt:Unit ;
   qudt:conversionMultiplier 0.54864 ;


### PR DESCRIPTION
I'm working with drilling data where the velocity is described in foot per day (feet per day).

Foot per day doesn't appear to be in IEC 61360 or UNECE that I could find. I created this by copying and modifying `unit:FT-PER-HR`.

```turtle
unit:FT-PER-DAY
  a qudt:Unit ;
  dcterms:description "\"Foot per Day\" is an Imperial unit for  'Linear Velocity' expressed as \\(ft/d\\)."^^qudt:LatexString ;
  qudt:conversionMultiplier 0.00000352777777777778 ;
  qudt:definedUnitOfSystem sou:IMPERIAL ;
  qudt:definedUnitOfSystem sou:USCS ;
  qudt:expression "\\(ft/d\\)"^^qudt:LatexString ;
  qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T-1D0 ;
  qudt:hasQuantityKind quantitykind:Velocity ;
  qudt:ucumCode "[ft_i].d-1"^^qudt:UCUMcs ;
  qudt:ucumCode "[ft_i]/d"^^qudt:UCUMcs ;
  qudt:unitOfSystem sou:IMPERIAL ;
  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
  rdfs:label "Foot per Day"@en ;
.
```