### PR TITLE
Create unit:GigaBIT-PER-SEC

### DIFF
--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -7312,6 +7312,21 @@ unit:GigaBQ
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Gigabecquerel"@en ;
 .
+unit:GigaBIT-PER-SEC
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "A gigabit per second (Gbit/s or Gb/s) is a unit of data transfer rate equal to 1,000,000,000 bits per second."^^rdf:HTML ;
+  qudt:conversionMultiplier 0.000000001 ;
+  qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
+  qudt:hasQuantityKind quantitykind:DataRate ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Data-rate_units#Gigabit_per_second"^^xsd:anyURI ;
+  qudt:isScalingOf unit:MegaBIT-PER-SEC ;
+  qudt:symbol "Gbps" ;
+  qudt:uneceCommonCode "B80" ;
+  qudt:ucumCode "Gbit.s-2"^^qudt:UCUMcs ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Gigabit per Second"@en ;
+.
 unit:GigaBYTE
   a qudt:CountingUnit ;
   a qudt:Unit ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -7323,7 +7323,7 @@ unit:GigaBIT-PER-SEC
   qudt:isScalingOf unit:MegaBIT-PER-SEC ;
   qudt:symbol "Gbps" ;
   qudt:uneceCommonCode "B80" ;
-  qudt:ucumCode "Gbit.s-2"^^qudt:UCUMcs ;
+  qudt:ucumCode "Gbit.s-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Gigabit per Second"@en ;
 .


### PR DESCRIPTION
Create `unit:GigaBIT-PER-SEC` as a further scaling of `unit:MegaBIT-PER-SEC`. I'm trying to describe the characteristics of some network equipment with interface speeds in gigabits per second.

I've stated `qudt:ucumCode "Gbit.s-1"` for this unit, but I'm a bit unsure about this. The related units already in QUDT don't seem to declare a uniform set of UCUM codes. The code for `unit:KiloBIT-PER-SEC` in particular is probably incorrect.

| unit | qudt:ucumCode |
| -- | -- |
| unit:BIT-PER-SEC | `Bd`, `bit.s-1`, `bit/s` |
| unit:KiloBIT-PER-SEC | `kbit.s-2` |
| unit:MegaBIT-PER-SEC | `MBd`, `Mbit/s` |