### PR TITLE
add a label for TONNE-PER-HA-YR

### DIFF
--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -22138,6 +22138,7 @@ unit:TONNE-PER-HA-YR
   qudt:plainTextDescription "A measure of density equivalent to 1000kg per hectare per year or one Megagram per hectare per year, typically used to express a volume of biomass or crop yield." ;
   qudt:symbol "t/ha/year" ;
   qudt:ucumCode "t.har-1.year-1"^^qudt:UCUMcs ;
+  rdfs:label "tonne per hectare year"@en ;
 .
 unit:TONNE-PER-HR
   a qudt:Unit ;


### PR DESCRIPTION
`unit:TONNE-PER-HA-YR` is missing its `rdf:label`. Adding "tonne per hectare year" referring to other examples