### PR TITLE
Fix syntax of vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl

### DIFF
--- a/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
+++ b/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
@@ -665,7 +665,7 @@ quantitykind:AmountOfSubstancePerUnitVolume
   qudt:applicableUnit unit:MicroMOL-PER-L ;
   qudt:applicableUnit unit:MilliMOL-PER-L ;
   qudt:applicableUnit unit:MilliMOL-PER-M3 ;
-  qudt:applicableUnit unit:NanoMOL-PER-L
+  qudt:applicableUnit unit:NanoMOL-PER-L ;
   qudt:applicableUnit unit:PicoMOL-PER-L ;
   qudt:applicableUnit unit:PicoMOL-PER-M3 ;
   qudt:baseUnitDimensions "\\(M/L^3\\)"^^qudt:LatexString ;


### PR DESCRIPTION
Hi. This fixes a syntax error in VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl .