### PR TITLE
Fix units related to Elementary Charge

### DIFF
--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -5062,8 +5062,8 @@ unit:DominicanPeso
 .
 unit:E
   a qudt:Unit ;
-  dcterms:description "\"Elementary Charge\", usually denoted as \\(e\\), is the electric charge carried by a single proton, or equivalently, the negation (opposite) of the electric charge carried by a single electron. This elementary charge is a fundamental physical constant. To avoid confusion over its sign, e is sometimes called the elementary positive charge. This charge has a measured value of approximately \\(1.602176565(35) \\times 10 coulombs\\). In the cgs system, \\(e\\) is \\(4.80320425(10) \\times 10 statcoulombs\\)."^^qudt:LatexString ;
-  qudt:conversionMultiplier 16.02176565 ;
+  dcterms:description "\"Elementary Charge\", usually denoted as \\(e\\), is the electric charge carried by a single proton, or equivalently, the negation (opposite) of the electric charge carried by a single electron. This elementary charge is a fundamental physical constant. To avoid confusion over its sign, e is sometimes called the elementary positive charge. This charge has a measured value of approximately \\(1.602176634 \\times 10^{-19} coulombs\\). In the cgs system, \\(e\\) is \\(4.80320471257026372 \\times 10^{-10} statcoulombs\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 0.0000000000000000001602176634 ;
   qudt:hasDimensionVector qkdv:A0E1L0I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:ElectricCharge ;
   qudt:symbol "e" ;
@@ -5233,9 +5233,9 @@ unit:ERLANG
 .
 unit:EV
   a qudt:Unit ;
-  dcterms:description "An electron volt (eV) is the energy that an electron gains when it travels through a potential of one volt. You can imagine that the electron starts at the negative plate of a parallel plate capacitor and accelerates to the positive plate, which is at one volt higher potential. Numerically \\(1 eV\\) equals \\(1.6x10^{-19} joules\\), where \\(1 joule\\) is \\(6.2x10^{18} eV\\). For example, it would take \\(6.2x10^{20} eV/sec\\) to light a 100 watt light bulb."^^qudt:LatexString ;
+  dcterms:description "An electron volt (eV) is the energy that an electron gains when it travels through a potential of one volt. You can imagine that the electron starts at the negative plate of a parallel plate capacitor and accelerates to the positive plate, which is at one volt higher potential. Numerically \\(1 eV\\) approximates \\(1.6x10^{-19} joules\\), where \\(1 joule\\) is \\(6.2x10^{18} eV\\). For example, it would take \\(6.2x10^{20} eV/sec\\) to light a 100 watt light bulb."^^qudt:LatexString ;
   qudt:allowedUnitOfSystem sou:SI ;
-  qudt:conversionMultiplier 0.00000000000000000016021765314 ;
+  qudt:conversionMultiplier 0.0000000000000000001602176634 ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Electron_volt"^^xsd:anyURI ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Energy ;
@@ -5251,7 +5251,7 @@ unit:EV
 .
 unit:EV-PER-ANGSTROM
   a qudt:Unit ;
-  qudt:conversionMultiplier 0.000000001602176 ;
+  qudt:conversionMultiplier 0.000000001602176634 ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:TotalLinearStoppingPower ;
   qudt:latexSymbol "\\(ev/\\AA\\)"^^qudt:LatexString ;
@@ -5264,7 +5264,7 @@ unit:EV-PER-ANGSTROM
 unit:EV-PER-K
   a qudt:Unit ;
   dcterms:description "\\(\\textbf{Electron Volt per Kelvin} is a unit for 'Heat Capacity' expressed as \\(ev/K\\)."^^qudt:LatexString ;
-  qudt:conversionMultiplier 0.00000000000000000016021765314 ;
+  qudt:conversionMultiplier 0.0000000000000000001602176634 ;
   qudt:expression "\\(ev/K\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H-1T-2D0 ;
   qudt:hasQuantityKind quantitykind:HeatCapacity ;
@@ -5275,7 +5275,7 @@ unit:EV-PER-K
 .
 unit:EV-PER-M
   a qudt:Unit ;
-  qudt:conversionMultiplier 0.0000000000000000001602176 ;
+  qudt:conversionMultiplier 0.0000000000000000001602176634 ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:TotalLinearStoppingPower ;
   qudt:iec61360Code "0112/2///62720#UAA426" ;
@@ -5290,7 +5290,7 @@ unit:EV-PER-M
 unit:EV-PER-T
   a qudt:Unit ;
   dcterms:description "\"Electron Volt per Tesla\" is a unit for  'Magnetic Dipole Moment' expressed as \\(eV T^{-1}\\)."^^qudt:LatexString ;
-  qudt:conversionMultiplier 0.00000000000000000016021765314 ;
+  qudt:conversionMultiplier 0.0000000000000000001602176634 ;
   qudt:expression "\\(eV T^{-1}\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E1L2I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:MagneticDipoleMoment ;
@@ -5302,7 +5302,7 @@ unit:EV-PER-T
 unit:EV-SEC
   a qudt:Unit ;
   dcterms:description "\"Electron Volt Second\" is a unit for  'Angular Momentum' expressed as \\(eV s\\)."^^qudt:LatexString ;
-  qudt:conversionMultiplier 0.00000000000000000016021765314 ;
+  qudt:conversionMultiplier 0.0000000000000000001602176634 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:AngularMomentum ;
   qudt:symbol "eV s" ;
@@ -5372,9 +5372,9 @@ unit:EgyptianPound
 .
 unit:ElementaryCharge
   a qudt:Unit ;
-  dcterms:description "\\(\\textbf{Elementary Charge}, usually denoted as \\(e\\), is the electric charge carried by a single proton, or equivalently, the negation (opposite) of the electric charge carried by a single electron. This elementary charge is a fundamental physical constant. To avoid confusion over its sign, e is sometimes called the elementary positive charge. This charge has a measured value of approximately \\(1.602176565(35) \\times 10\\,coulombs\\). In the cgs system, \\(e\\) is \\(4.80320425(10) \\times 10\\, statcoulombs\\)."^^qudt:LatexString ;
+  dcterms:description "\\(\\textbf{Elementary Charge}, usually denoted as \\(e\\), is the electric charge carried by a single proton, or equivalently, the negation (opposite) of the electric charge carried by a single electron. This elementary charge is a fundamental physical constant. To avoid confusion over its sign, e is sometimes called the elementary positive charge. This charge has a measured value of approximately \\(1.602176634 \\times 10^{-19} coulombs\\). In the cgs system, \\(e\\) is \\(4.80320471257026372 \\times 10^{-10} statcoulombs\\)."^^qudt:LatexString ;
   qudt:allowedUnitOfSystem sou:SI ;
-  qudt:conversionMultiplier 16.02176565 ;
+  qudt:conversionMultiplier 0.0000000000000000001602176634 ;
   qudt:hasDimensionVector qkdv:A0E1L0I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:ElectricCharge ;
   qudt:symbol "e" ;
@@ -7410,7 +7410,7 @@ unit:GigaEV
   a qudt:DerivedUnit ;
   a qudt:Unit ;
   dcterms:description "\"Giga Electron Volt\" is a unit for  'Energy And Work' expressed as \\(GeV\\)."^^qudt:LatexString ;
-  qudt:conversionMultiplier 0.00000000016021765314 ;
+  qudt:conversionMultiplier 0.0000000001602176634 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Energy ;
   qudt:symbol "GeV" ;
@@ -9669,7 +9669,7 @@ unit:KiloEV
   a qudt:DerivedUnit ;
   a qudt:Unit ;
   dcterms:description "\"Kilo Electron Volt\" is a unit for  'Energy And Work' expressed as \\(keV\\)."^^qudt:LatexString ;
-  qudt:conversionMultiplier 0.00000000000000016021765314 ;
+  qudt:conversionMultiplier 0.0000000000000001602176634 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Energy ;
   qudt:symbol "keV" ;
@@ -9682,7 +9682,7 @@ unit:KiloEV-PER-MicroM
   a qudt:DerivedUnit ;
   a qudt:Unit ;
   dcterms:description "\"Kilo Electron Volt per Micrometer\" is a unit for  'Linear Energy Transfer' expressed as \\(keV/microM\\)."^^qudt:LatexString ;
-  qudt:conversionMultiplier 0.000000000160217653 ;
+  qudt:conversionMultiplier 0.0000000001602176634 ;
   qudt:expression "\\(keV/microM\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:LinearEnergyTransfer ;
@@ -13575,7 +13575,7 @@ unit:MegaEV
   a qudt:DerivedUnit ;
   a qudt:Unit ;
   dcterms:description "\\(\\textbf{Mega Electron Volt} is a unit for  'Energy And Work' expressed as \\(MeV\\)."^^qudt:LatexString ;
-  qudt:conversionMultiplier 0.00000000000016021765314 ;
+  qudt:conversionMultiplier 0.0000000000001602176634 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Energy ;
   qudt:symbol "MeV" ;
@@ -13587,7 +13587,7 @@ unit:MegaEV
 unit:MegaEV-FemtoM
   a qudt:Unit ;
   dcterms:description "\\(\\textbf{Mega Electron Volt Femtometer} is a unit for  'Length Energy' expressed as \\(MeV fm\\)."^^qudt:LatexString ;
-  qudt:conversionMultiplier 0.000000000000000000000000000160217653 ;
+  qudt:conversionMultiplier 0.0000000000000000000000000001602176634 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:LengthEnergy ;
   qudt:prefix prefix:Mega ;
@@ -13601,7 +13601,7 @@ unit:MegaEV-PER-CentiM
   a qudt:DerivedUnit ;
   a qudt:Unit ;
   dcterms:description "\"Mega Electron Volt per Centimeter\" is a unit for  'Linear Energy Transfer' expressed as \\(MeV/cm\\)."^^qudt:LatexString ;
-  qudt:conversionMultiplier 0.000000000016021765314 ;
+  qudt:conversionMultiplier 0.00000000001602176634 ;
   qudt:expression "\\(MeV/cm\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:LinearEnergyTransfer ;


### PR DESCRIPTION
Found due to deviation revealed with ABECTO (see #525).

Please also note the duplicate `unit:E` and ` unit:ElementaryCharge` which I was not sure how to handle.