### PR TITLE
Add missing dimension vectors

### DIFF
--- a/schema/shacl/SCHEMA_QUDT_NoOWL-v2.1.18.ttl
+++ b/schema/shacl/SCHEMA_QUDT_NoOWL-v2.1.18.ttl
@@ -2098,6 +2098,7 @@ qudt:Unit-hasDimensionVector
   sh:path qudt:hasDimensionVector ;
   sh:class qudt:QuantityKindDimensionVector ;
   sh:maxCount 1 ;
+  sh:minCount 1 ;
 .
 qudt:Unit-hasQuantityKind
   a sh:PropertyShape ;

--- a/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
+++ b/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
@@ -6036,7 +6036,7 @@ quantitykind:EvaporativeHeatTransfer
 quantitykind:EvaporativeHeatTransferCoefficient
   a qudt:QuantityKind ;
   qudt:applicableUnit unit:W-PER-M2-PA ;
-  qudt:hasDimensionVector qkdv:A0E0L0I0M1H-1T-3D0 ;
+  qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T-1D0 ;
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=43012"^^xsd:anyURI ;
   qudt:plainTextDescription "\"Evaporative Heat Transfer Coefficient\" is the areic heat transfer coefficient multiplied by the water vapor pressure difference between skind and the environment, and by the exchange area." ;
   qudt:symbol "h_e" ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -2831,6 +2831,7 @@ unit:CFU
   a qudt:Unit ;
   dcterms:description "\"Colony Forming Unit\" is a unit for  'Microbial Formation' expressed as \\(CFU\\)."^^qudt:LatexString ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Colony-forming_unit"^^xsd:anyURI ;
+  qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:MicrobialFormation ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Colony-forming_unit?oldid=473146689"^^xsd:anyURI ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/colonyFormingUnit> ;
@@ -4739,6 +4740,7 @@ unit:DeciBAR-PER-YR
 unit:DeciB_C
   a qudt:Unit ;
   dcterms:description "\"Decibel Carrier Unit\" is a unit for  'Signal Detection Threshold' expressed as \\(dBc\\)."^^qudt:LatexString ;
+  qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:SignalDetectionThreshold ;
   qudt:symbol "dBc" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -11748,6 +11750,7 @@ unit:LM
   qudt:dbpediaMatch "http://dbpedia.org/resource/Lumen"^^xsd:anyURI ;
   qudt:definedUnitOfSystem sou:SI ;
   qudt:derivedCoherentUnitOfSystem sou:SI ;
+  qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:LuminousFlux ;
   qudt:iec61360Code "0112/2///62720#UAA718" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Lumen?oldid=492885414"^^xsd:anyURI ;
@@ -11766,6 +11769,7 @@ unit:LM-PER-W
   qudt:conversionMultiplier 1.0 ;
   qudt:derivedCoherentUnitOfSystem sou:SI ;
   qudt:expression "\\(lm-per-w\\)"^^qudt:LatexString ;
+  qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:LuminousEfficacy ;
   qudt:hasQuantityKind quantitykind:SpectralLuminousEfficiency ;
   qudt:iec61360Code "0112/2///62720#UAA719" ;
@@ -11779,6 +11783,7 @@ unit:LM-SEC
   dcterms:description "In photometry, the lumen second is the SI derived unit of luminous energy. It is based on the lumen, the SI unit of luminous flux, and the second, the SI base unit of time.  The lumen second is sometimes called the talbot (symbol T).  An older name for the lumen second was the lumberg."^^rdf:HTML ;
   qudt:derivedCoherentUnitOfSystem sou:SI ;
   qudt:expression "\\(lm s\\)"^^qudt:LatexString ;
+  qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:LuminousEnergy ;
   qudt:iec61360Code "0112/2///62720#UAA722" ;
   qudt:ucumCode "lm.s-1"^^qudt:UCUMcs ;
@@ -13046,6 +13051,7 @@ unit:MOHM
   dcterms:description "A unit of mechanical mobility for sound waves, being the reciprocal of the mechanical ohm unit of impedance, i.e., for an acoustic medium, the ratio of the flux or volumic speed (area times particle speed) of the resulting waves through it to the effective sound pressure (i.e. force) causing them, the unit being qualified, according to the units used, as m.k.s. or c.g.s. The mechanical ohm is equivalent to \\(1\\,dyn\\cdot\\,s\\cdot cm^{-1}\\) or \\(10^{-3} N\\cdot s\\cdot m^{-1}\\)."^^qudt:LatexString ;
   qudt:conversionMultiplier 1000.0 ;
   qudt:expression "\\(mohm\\)"^^qudt:LatexString ;
+  qudt:hasDimensionVector qkdv:A0E0L0I0M-1H0T1D0 ;
   qudt:hasQuantityKind quantitykind:MechanicalMobility ;
   qudt:informativeReference "http://www.oxfordreference.com/view/10.1093/acref/9780198605225.001.0001/acref-9780198605225-e-914"^^xsd:anyURI ;
   qudt:latexDefinition "\\(1\\:{mohm_{cgs}} = 1\\:\\frac {cm} {dyn.s}\\: (=\\:1\\:\\frac s g \\:in\\:base\\:c.g.s.\\:terms)\\)"^^qudt:LatexString ;
@@ -17074,6 +17080,7 @@ unit:NP
 unit:NTU
   a qudt:Unit ;
   dcterms:description "\"Nephelometry Turbidity Unit\" is a C.G.S System unit for  'Turbidity' expressed as \\(NTU\\)."^^qudt:LatexString ;
+  qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Turbidity ;
   qudt:symbol "NTU" ;
   qudt:unitOfSystem sou:CGS ;
@@ -21074,6 +21081,7 @@ unit:RAYL
   dcterms:description "dcterms:description \"\\(\\textbf{Rayl}\\) is one of two units of specific acoustic impedance. When sound waves pass through any physical substance the pressure of the waves causes the particles of the substance to move. The sound specific impedance is the ratio between the sound pressure and the particle velocity it produces. The specific impedance is one rayl if unit pressure produces unit velocity. It is defined as follows: \\(1\\; rayl = 1 dyn\\cdot s\\cdot cm^{-3}\\) Or in SI as: \\(1 \\; rayl = 10^{-1}Pa\\cdot s\\cdot m^{-1}\\), which equals \\(10\\,N \\cdot s\\cdot m^{-3}\\).\"\"\"^^qudt:LatexString ;" ;
   qudt:conversionMultiplier 1.0 ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Rayl"^^xsd:anyURI ;
+  qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:SpecificAcousticImpedance ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Rayl?oldid=433570842"^^xsd:anyURI ;
   qudt:unitOfSystem sou:CGS ;
@@ -23729,6 +23737,7 @@ unit:W-PER-M2-PA
   dcterms:description "Watt Per Square Meter Per Pascal (\\(W/m^2-pa\\)) is a unit of Evaporative Heat Transfer."^^qudt:LatexString ;
   qudt:conversionMultiplier 1.0 ;
   qudt:expression "\\(W/(m^2.pa)\\)"^^qudt:LatexString ;
+  qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:EvaporativeHeatTransferCoefficient ;
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=43012"^^xsd:anyURI ;
   qudt:ucumCode "W.m-2.Pa-1"^^qudt:UCUMcs ;
@@ -23818,7 +23827,7 @@ unit:WB
   qudt:hasDimensionVector qkdv:A0E-1L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:MagneticFlux ;
   qudt:iec61360Code "0112/2///62720#UAA317" ;
-  qudt:informativeReference "http://en.wikipedia.org/wiki/Weber?oldid=491210387"^^xsd:anyURI ;
+  qudt:informativeReference "https://en.wikipedia.org/wiki/Weber_(unit)"^^xsd:anyURI ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/weber> ;
   qudt:siUnitsExpression "V.s" ;
   qudt:symbol "Wb" ;
@@ -23833,6 +23842,7 @@ unit:WB-M
   a qudt:Unit ;
   qudt:conversionMultiplier 1.0 ;
   qudt:exactMatch unit:N-M2-PER-A ;
+  qudt:hasDimensionVector qkdv:A0E-1L3I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:MagneticDipoleMoment ;
   qudt:iec61360Code "0112/2///62720#UAB333" ;
   qudt:informativeReference "http://www.simetric.co.uk/siderived.htm"^^xsd:anyURI ;


### PR DESCRIPTION
Resolves #549 in the way discussed there.

* Adds qudt:hasDimensionVector triples for all units that did not have one prior to this commit:
    - unit:CFU
    - unit:DeciB_C
    - unit:LM
    - unit:LM-SEC
    - unit:LM-PER-W
    - unit:MOHM
    - unit:NTU
    - unit:RAYL
    - unit:W-PER-M2-PA
    - unit:WB-M

* fixes the dimension vector of quantitykind:EvaporativeHeatTransferCoefficient
* updates the informative reference of unit:WB.