### PR TITLE
Fix some units that are not of quantity kind Currency

### DIFF
--- a/vocab/dimensionvectors/VOCAB_QUDT-DIMENSION-VECTORS-v2.1.ttl
+++ b/vocab/dimensionvectors/VOCAB_QUDT-DIMENSION-VECTORS-v2.1.ttl
@@ -1809,6 +1809,23 @@ qkdv:A0E0L0I0M1H0T0D0
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/dimensionvector> ;
   rdfs:label "A0E0L0I0M1H0T0D0" ;
 .
+qkdv:A0E0L0I0M1H0T2D0
+  a qudt:QuantityKindDimensionVector_CGS ;
+  a qudt:QuantityKindDimensionVector_ISO ;
+  a qudt:QuantityKindDimensionVector_Imperial ;
+  a qudt:QuantityKindDimensionVector_SI ;
+  qudt:dimensionExponentForAmountOfSubstance 0 ;
+  qudt:dimensionExponentForElectricCurrent 0 ;
+  qudt:dimensionExponentForLength 0 ;
+  qudt:dimensionExponentForLuminousIntensity 0 ;
+  qudt:dimensionExponentForMass 1 ;
+  qudt:dimensionExponentForThermodynamicTemperature 0 ;
+  qudt:dimensionExponentForTime 2 ;
+  qudt:dimensionlessExponent 0 ;
+  qudt:latexDefinition "\\(M T^2\\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/dimensionvector> ;
+  rdfs:label "A0E0L0I0M1H0T2D0" ;
+.
 qkdv:A0E0L0I0M1H1T0D0
   a qudt:QuantityKindDimensionVector_ISO ;
   a qudt:QuantityKindDimensionVector_Imperial ;

--- a/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
+++ b/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
@@ -3233,6 +3233,15 @@ quantitykind:Currency
   rdfs:label "Currency"@en ;
   skos:broader quantitykind:Asset ;
 .
+quantitykind:CurrencyPerFlight
+  a qudt:QuantityKind ;
+  qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
+  qudt:qkdvDenominator qkdv:A0E0L0I0M0H0T0D1 ;
+  qudt:qkdvNumerator qkdv:A0E0L0I0M0H0T0D1 ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Currency Per Flight"@en ;
+  skos:broader quantitykind:DimensionlessRatio ;
+.
 quantitykind:CurrentLinkage
   a qudt:QuantityKind ;
   qudt:applicableUnit unit:A ;

--- a/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
+++ b/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
@@ -3094,7 +3094,6 @@ quantitykind:Currency
   qudt:applicableUnit unit:EuropeanUnitOfAccount9 ;
   qudt:applicableUnit unit:FalklandIslandsPound ;
   qudt:applicableUnit unit:FijiDollar ;
-  qudt:applicableUnit unit:Flight ;
   qudt:applicableUnit unit:Forint ;
   qudt:applicableUnit unit:FrancCongolais ;
   qudt:applicableUnit unit:GibraltarPound ;
@@ -3115,7 +3114,6 @@ quantitykind:Currency
   qudt:applicableUnit unit:JapaneseYen ;
   qudt:applicableUnit unit:JordanianDinar ;
   qudt:applicableUnit unit:KenyanShilling ;
-  qudt:applicableUnit unit:KiloGM-SEC2 ;
   qudt:applicableUnit unit:Kina ;
   qudt:applicableUnit unit:Kroon ;
   qudt:applicableUnit unit:KuwaitiDinar ;
@@ -3133,7 +3131,6 @@ quantitykind:Currency
   qudt:applicableUnit unit:Lilangeni ;
   qudt:applicableUnit unit:LithuanianLitas ;
   qudt:applicableUnit unit:Loti ;
-  qudt:applicableUnit unit:MDOLLAR-PER-FLIGHT ;
   qudt:applicableUnit unit:MalagasyAriary ;
   qudt:applicableUnit unit:MalawiKwacha ;
   qudt:applicableUnit unit:MalaysianRinggit ;
@@ -3144,7 +3141,6 @@ quantitykind:Currency
   qudt:applicableUnit unit:MexicanPeso ;
   qudt:applicableUnit unit:MexicanUnidadDeInversion ;
   qudt:applicableUnit unit:MillionUSD ;
-  qudt:applicableUnit unit:MillionUSD-PER-YR ;
   qudt:applicableUnit unit:MoldovanLeu ;
   qudt:applicableUnit unit:MoroccanDirham ;
   qudt:applicableUnit unit:Naira ;
@@ -3163,7 +3159,6 @@ quantitykind:Currency
   qudt:applicableUnit unit:OmaniRial ;
   qudt:applicableUnit unit:Ouguiya ;
   qudt:applicableUnit unit:PAB ;
-  qudt:applicableUnit unit:PER-H ;
   qudt:applicableUnit unit:Paanga ;
   qudt:applicableUnit unit:PakistanRupee ;
   qudt:applicableUnit unit:Palladium-OunceTroy ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -6418,7 +6418,6 @@ unit:FijiDollar
 unit:Flight
   a qudt:Unit ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
-  qudt:hasQuantityKind quantitykind:Currency ;
   qudt:symbol "flight" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Flight"@en ;
@@ -10154,8 +10153,7 @@ unit:KiloGM-SEC2
   qudt:conversionMultiplier 1.0 ;
   qudt:definedUnitOfSystem sou:SI ;
   qudt:expression "\\(kilog-sec2\\)"^^qudt:LatexString ;
-  qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
-  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T2D0 ;
   qudt:ucumCode "kg.s2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kilogram Square Second"@en ;
@@ -12749,7 +12747,6 @@ unit:MDOLLAR-PER-FLIGHT
   a qudt:Unit ;
   qudt:expression "\\(\\(M\\$/Flight\\)\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
-  qudt:hasQuantityKind quantitykind:Currency ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Million US Dollars per Flight"@en ;
 .
@@ -16544,8 +16541,6 @@ unit:MillionUSD-PER-YR
   a qudt:DerivedUnit ;
   a qudt:Unit ;
   qudt:expression "\\(\\(M\\$/yr\\)\\)"^^qudt:LatexString ;
-  qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
-  qudt:hasQuantityKind quantitykind:Currency ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Million US Dollars per Year"@en ;
 .
@@ -18677,8 +18672,7 @@ unit:PER-GigaEV2
 .
 unit:PER-H
   a qudt:Unit ;
-  qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
-  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:hasDimensionVector qkdv:A0E2L-2I0M-1H0T2D0 ;
   qudt:ucumCode "H-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C89" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -12748,6 +12748,7 @@ unit:MDOLLAR-PER-FLIGHT
   a qudt:Unit ;
   qudt:expression "\\(\\(M\\$/Flight\\)\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
+  qudt:hasQuantityKind quantitykind:CurrencyPerFlight ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Million US Dollars per Flight"@en ;
 .

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -6418,6 +6418,7 @@ unit:FijiDollar
 unit:Flight
   a qudt:Unit ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
+  qudt:hasQuantityKind quantitykind:Dimensionless ;
   qudt:symbol "flight" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Flight"@en ;


### PR DESCRIPTION
There are a few units that were defined as Currency units which (probably aren't):

- Some are currency per time, but that didn't exist yet and am not sure what the appropriate way is to represent the dimensionality of that (is the "dimensionless" exponent 1 or 0?)
- The appropriate dimension vector for PER-H already existed, so that was connected
- The appropriate dimension vector for KiloGM-SEC2 did not exist, so that was added and connected