### PR TITLE
fix UCUM code of unit:REV derived units (revealed with ABECTO)

### DIFF
--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -21010,7 +21010,7 @@ unit:REV
   qudt:informativeReference "http://en.wikipedia.org/wiki/Revolution?oldid=494110330"^^xsd:anyURI ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/revolution> ;
   qudt:symbol "rev" ;
-  qudt:ucumCode "{#}"^^qudt:UCUMcs ;
+  qudt:ucumCode "circ"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M44" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Revolution"@en ;
@@ -21022,7 +21022,7 @@ unit:REV-PER-HR
   qudt:expression "\\(rev/h\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:AngularVelocity ;
-  qudt:ucumCode "{#}.h-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "circ.h-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Revolution per Hour"@en ;
 .
@@ -21035,7 +21035,7 @@ unit:REV-PER-MIN
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:AngularVelocity ;
   qudt:iec61360Code "0112/2///62720#UAB231" ;
-  qudt:ucumCode "{#}.min-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "circ.min-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M46" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Revolution per Minute"@en ;
@@ -21048,7 +21048,7 @@ unit:REV-PER-SEC
   qudt:expression "\\(rev/s\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:AngularVelocity ;
-  qudt:ucumCode "{#}.s-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "circ.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "RPS" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Revolution per Second"@en ;
@@ -21060,7 +21060,7 @@ unit:REV-PER-SEC2
   qudt:expression "\\(rev/s2\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:AngularAcceleration ;
-  qudt:ucumCode "{#}.s-2"^^qudt:UCUMcs ;
+  qudt:ucumCode "circ.s-2"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:CGS ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Revolution per Square Second"@en ;


### PR DESCRIPTION
This fixes the UCUM codes of unit:REV derived units replacing `{#}` by `circ`. I am not completely certain, if `circ` is the proper code to use, but it is the only code representing a plane angle equal to 360°. The alternative would be, to remove these `qudt:ucumCode` statements.