### PR TITLE
Minor dimensionality and quantity kind fixes

### DIFF
--- a/vocab/dimensionvectors/VOCAB_QUDT-DIMENSION-VECTORS-v2.1.ttl
+++ b/vocab/dimensionvectors/VOCAB_QUDT-DIMENSION-VECTORS-v2.1.ttl
@@ -410,6 +410,22 @@ qkdv:A0E-1L3I0M0H0T-1D0
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/dimensionvector> ;
   rdfs:label "A0E-1L3I0M0H0T-1D0" ;
 .
+qkdv:A0E-1L3I0M1H0T-2D0
+  a qudt:QuantityKindDimensionVector_ISO ;
+  a qudt:QuantityKindDimensionVector_Imperial ;
+  a qudt:QuantityKindDimensionVector_SI ;
+  qudt:dimensionExponentForAmountOfSubstance 0 ;
+  qudt:dimensionExponentForElectricCurrent -1 ;
+  qudt:dimensionExponentForLength 3 ;
+  qudt:dimensionExponentForLuminousIntensity 0 ;
+  qudt:dimensionExponentForMass 1 ;
+  qudt:dimensionExponentForThermodynamicTemperature 0 ;
+  qudt:dimensionExponentForTime -2 ;
+  qudt:dimensionlessExponent 0 ;
+  qudt:hasReferenceQuantityKind quantitykind:MagneticDipoleMoment ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/dimensionvector> ;
+  rdfs:label "A0E-1L3I0M1H0T-2D0" ;
+.
 qkdv:A0E-1L3I0M1H0T-3D0
   a qudt:QuantityKindDimensionVector_ISO ;
   a qudt:QuantityKindDimensionVector_Imperial ;

--- a/vocab/dimensionvectors/VOCAB_QUDT-DIMENSION-VECTORS-v2.1.ttl
+++ b/vocab/dimensionvectors/VOCAB_QUDT-DIMENSION-VECTORS-v2.1.ttl
@@ -3568,6 +3568,22 @@ qkdv:A1E0L0I0M0H1T0D0
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/dimensionvector> ;
   rdfs:label "A1E0L0I0M0H1T0D0" ;
 .
+qkdv:A1E0L0I0M1H0T0D0
+  a qudt:QuantityKindDimensionVector_ISO ;
+  a qudt:QuantityKindDimensionVector_Imperial ;
+  a qudt:QuantityKindDimensionVector_SI ;
+  qudt:dimensionExponentForAmountOfSubstance 1 ;
+  qudt:dimensionExponentForElectricCurrent 0 ;
+  qudt:dimensionExponentForLength 0 ;
+  qudt:dimensionExponentForLuminousIntensity 0 ;
+  qudt:dimensionExponentForMass 1 ;
+  qudt:dimensionExponentForThermodynamicTemperature 0 ;
+  qudt:dimensionExponentForTime 0 ;
+  qudt:dimensionlessExponent 0 ;
+  qudt:hasReferenceQuantityKind quantitykind:MassAmountOfSubstance ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/dimensionvector> ;
+  rdfs:label "A1E0L0I0M1H0T0D0" ;
+.
 qkdv:A1E0L1I0M-2H0T2D0
   a qudt:QuantityKindDimensionVector_ISO ;
   a qudt:QuantityKindDimensionVector_Imperial ;

--- a/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
+++ b/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
@@ -9269,7 +9269,7 @@ quantitykind:LuminousFlux
   qudt:baseUnitDimensions "\\(J \\cdot U\\)"^^qudt:LatexString ;
   qudt:baseUnitDimensions "\\(cd\\)"^^qudt:LatexString ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Luminous_flux"^^xsd:anyURI ;
-  qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
+  qudt:hasDimensionVector qkdv:A0E0L0I1M0H0T0D0 ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Luminous_flux"^^xsd:anyURI ;
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=43012"^^xsd:anyURI ;
   qudt:latexDefinition "\\(\\Phi_v = K_m \\int_{0}^{\\infty}{\\Phi_\\lambda(\\lambda)}{V(\\lambda)d\\lambda}\\), where \\(K_m\\) is the maximum spectral luminous efficacy, \\(\\Phi_\\lambda(\\lambda)\\) is the spectral radiant flux, \\(V(\\lambda)\\) is the spectral luminous efficiency, and \\(\\lambda\\) is the wavelength."^^qudt:LatexString ;

--- a/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
+++ b/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
@@ -9932,7 +9932,7 @@ quantitykind:MassAbsorptionCoefficient
 quantitykind:MassAmountOfSubstance
   a qudt:QuantityKind ;
   qudt:applicableUnit unit:LB-MOL ;
-  qudt:hasDimensionVector qkdv:A1E0L0I0M0H0T0D0 ;
+  qudt:hasDimensionVector qkdv:A1E0L0I0M1H0T0D0 ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
   rdfs:label "Mass Amount of Substance"@en ;
 .

--- a/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
+++ b/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
@@ -11109,6 +11109,7 @@ quantitykind:MolalityOfSolute
 quantitykind:MolarAbsorptionCoefficient
   a qudt:QuantityKind ;
   qudt:applicableUnit unit:M2-PER-KiloGM ;
+  qudt:exactMatch quantitykind:MolarAttenuationCoefficient ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M-1H0T0D0 ;
   qudt:latexDefinition "\\(x = aV_m\\), where \\(a\\) is the linear absorption coefficient and \\(V_m\\) is the molar volume."^^qudt:LatexString ;
   qudt:plainTextDescription "\"Molar Absorption Coefficient\" is a spectrophotometric unit indicating the light a substance absorbs with respect to length, usually centimeters, and concentration, usually moles per liter." ;
@@ -11116,6 +11117,7 @@ quantitykind:MolarAbsorptionCoefficient
   qudt:systemDerivedQuantityKind qudt:SOQ_SI ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
   rdfs:label "Molar Absorption Coefficient"@en ;
+  owl:sameAs quantitykind:MolarAttenuationCoefficient ;
   skos:exactMatch <http://medical-dictionary.thefreedictionary.com/molar+absorption+coefficient> ;
 .
 quantitykind:MolarAngularMomentum
@@ -11131,6 +11133,7 @@ quantitykind:MolarAngularMomentum
 quantitykind:MolarAttenuationCoefficient
   a qudt:QuantityKind ;
   qudt:applicableUnit unit:M2-PER-MOL ;
+  qudt:exactMatch quantitykind:MolarAbsorptionCoefficient ;
   qudt:hasDimensionVector qkdv:A-1E0L2I0M0H0T0D0 ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Mass_attenuation_coefficient"^^xsd:anyURI ;
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
@@ -11139,6 +11142,7 @@ quantitykind:MolarAttenuationCoefficient
   qudt:plainTextDescription "\"Molar Attenuation Coefficient\" is a measurement of how strongly a chemical species or substance absorbs or scatters light at a given wavelength, per amount of substance." ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
   rdfs:label "Molar Attenuation Coefficient"@en ;
+  owl:sameAs quantitykind:MolarAbsorptionCoefficient ;
   skos:closeMatch quantitykind:MassAttenuationCoefficient ;
 .
 quantitykind:MolarConductivity

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -11738,7 +11738,7 @@ unit:LM
   qudt:dbpediaMatch "http://dbpedia.org/resource/Lumen"^^xsd:anyURI ;
   qudt:definedUnitOfSystem sou:SI ;
   qudt:derivedCoherentUnitOfSystem sou:SI ;
-  qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
+  qudt:hasDimensionVector qkdv:A0E0L0I1M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:LuminousFlux ;
   qudt:iec61360Code "0112/2///62720#UAA718" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Lumen?oldid=492885414"^^xsd:anyURI ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -16746,7 +16746,7 @@ unit:N-M2-PER-A
   a qudt:Unit ;
   qudt:conversionMultiplier 1.0 ;
   qudt:exactMatch unit:WB-M ;
-  qudt:hasDimensionVector qkdv:A0E1L2I0M0H0T0D0 ;
+  qudt:hasDimensionVector qkdv:A0E-1L3I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:MagneticDipoleMoment ;
   qudt:ucumCode "N.m2.A-1"^^qudt:UCUMcs ;
   qudt:ucumCode "N.m2/A"^^qudt:UCUMcs ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -12369,7 +12369,6 @@ unit:M2-PER-KiloGM
   qudt:hasQuantityKind quantitykind:MassAbsorptionCoefficient ;
   qudt:hasQuantityKind quantitykind:MassAttenuationCoefficient ;
   qudt:hasQuantityKind quantitykind:MassEnergyTransferCoefficient ;
-  qudt:hasQuantityKind quantitykind:MolarAbsorptionCoefficient ;
   qudt:iec61360Code "0112/2///62720#UAA750" ;
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
   qudt:ucumCode "m2.kg-1"^^qudt:UCUMcs ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -11741,7 +11741,7 @@ unit:LM
   qudt:hasDimensionVector qkdv:A0E0L0I1M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:LuminousFlux ;
   qudt:iec61360Code "0112/2///62720#UAA718" ;
-  qudt:informativeReference "http://en.wikipedia.org/wiki/Lumen?oldid=492885414"^^xsd:anyURI ;
+  qudt:informativeReference "https://en.wikipedia.org/wiki/Lumen_(unit)"^^xsd:anyURI ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/lumen> ;
   qudt:siUnitsExpression "cd.sr" ;
   qudt:symbol "lm" ;
@@ -12399,6 +12399,7 @@ unit:M2-PER-MOL
   qudt:expression "\\(m^2/mol\\)"^^qudt:LatexString ;
   qudt:expression "\\(m^{2}/mol\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A-1E0L2I0M0H0T0D0 ;
+  qudt:hasQuantityKind quantitykind:MolarAbsorptionCoefficient ;
   qudt:hasQuantityKind quantitykind:MolarAttenuationCoefficient ;
   qudt:iec61360Code "0112/2///62720#UAA751" ;
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;


### PR DESCRIPTION
A few fixes I can confidently make:
- `unit:M2-PER-KiloGM` can't be of `quantitykind:MolarAbsorptionCoefficient` - removed it
- `unit:LB-MOL` is not of dimensionality `qkdv:A1E0L0I0M0H0T0D0` - added and set to `qkdv:A1E0L0I0M1H0T0D0`
- `unit:WB-M` has dimension vector `qkdv:A0E-1L3I0M1H0T-2D0` but that dimension vector is not defined - add `qkdv:A0E-1L3I0M1H0T-2D0` and also set it as the dimension vector of `unit:N-M2-PER-A` (which is a `qudt:exactMatch` for `unit:WB-M`)
- `quantitykind:LuminousFlux` is not of dimensionality `qkdv:A0E0L2I0M1H0T-3D0` - set to `qkdv:A0E0L0I1M0H0T0D0`
- `unit:LM` is not of dimensionality `qkdv:A0E0L2I0M1H0T-3D0` - set to `qkdv:A0E0L0I1M0H0T0D0`

Note that the last two are related to #562 .