### PR TITLE
Remove incorrect HP-based units

### DIFF
--- a/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
+++ b/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
@@ -4991,8 +4991,6 @@ quantitykind:ElectricPower
   qudt:applicableUnit unit:FT-LB_F-PER-SEC ;
   qudt:applicableUnit unit:GigaW ;
   qudt:applicableUnit unit:HP ;
-  qudt:applicableUnit unit:HP-PER-M ;
-  qudt:applicableUnit unit:HP-PER-V ;
   qudt:applicableUnit unit:HP_Boiler ;
   qudt:applicableUnit unit:HP_Brake ;
   qudt:applicableUnit unit:HP_Electric ;
@@ -12774,8 +12772,6 @@ quantitykind:Power
   qudt:applicableUnit unit:FT-LB_F-PER-SEC ;
   qudt:applicableUnit unit:GigaW ;
   qudt:applicableUnit unit:HP ;
-  qudt:applicableUnit unit:HP-PER-M ;
-  qudt:applicableUnit unit:HP-PER-V ;
   qudt:applicableUnit unit:HP_Boiler ;
   qudt:applicableUnit unit:HP_Brake ;
   qudt:applicableUnit unit:HP_Electric ;
@@ -13488,8 +13484,6 @@ quantitykind:RadiantFlux
   qudt:applicableUnit unit:FT-LB_F-PER-SEC ;
   qudt:applicableUnit unit:GigaW ;
   qudt:applicableUnit unit:HP ;
-  qudt:applicableUnit unit:HP-PER-M ;
-  qudt:applicableUnit unit:HP-PER-V ;
   qudt:applicableUnit unit:HP_Boiler ;
   qudt:applicableUnit unit:HP_Brake ;
   qudt:applicableUnit unit:HP_Electric ;
@@ -14948,8 +14942,6 @@ quantitykind:SoundPower
   qudt:applicableUnit unit:FT-LB_F-PER-SEC ;
   qudt:applicableUnit unit:GigaW ;
   qudt:applicableUnit unit:HP ;
-  qudt:applicableUnit unit:HP-PER-M ;
-  qudt:applicableUnit unit:HP-PER-V ;
   qudt:applicableUnit unit:HP_Boiler ;
   qudt:applicableUnit unit:HP_Brake ;
   qudt:applicableUnit unit:HP_Electric ;
@@ -17932,8 +17924,6 @@ quantitykind:WaterHorsepower
   qudt:applicableUnit unit:FT-LB_F-PER-SEC ;
   qudt:applicableUnit unit:GigaW ;
   qudt:applicableUnit unit:HP ;
-  qudt:applicableUnit unit:HP-PER-M ;
-  qudt:applicableUnit unit:HP-PER-V ;
   qudt:applicableUnit unit:HP_Boiler ;
   qudt:applicableUnit unit:HP_Brake ;
   qudt:applicableUnit unit:HP_Electric ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -7724,26 +7724,6 @@ unit:HP
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Horsepower"@en ;
 .
-unit:HP-PER-M
-  a qudt:Unit ;
-  dcterms:description "\"Horsepower Metric\" is a unit for  'Power' expressed as \\(hp/m\\)."^^qudt:LatexString ;
-  qudt:expression "\\(hp/m\\)"^^qudt:LatexString ;
-  qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:Power ;
-  qudt:ucumCode "[HP].m-1"^^qudt:UCUMcs ;
-  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
-  rdfs:label "Horsepower Metric"@en ;
-.
-unit:HP-PER-V
-  a qudt:Unit ;
-  dcterms:description "\"Horsepower Electric\" is a unit for  'Power' expressed as \\(hp/V\\)."^^qudt:LatexString ;
-  qudt:expression "\\(hp/V\\)"^^qudt:LatexString ;
-  qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:Power ;
-  qudt:ucumCode "[HP].V-1"^^qudt:UCUMcs ;
-  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
-  rdfs:label "Horsepower Electric"@en ;
-.
 unit:HP_Boiler
   a qudt:Unit ;
   dcterms:description "\"Boiler Horsepower\" is a unit for  'Power' expressed as \\(hp_boiler\\)."^^qudt:LatexString ;


### PR DESCRIPTION
It appears that the units `unit:HP-PER-M` and `unit:HP-PER-V` are incorrectly defined, or more specifically the URI doesn't follow the naming convention. From the labels/descriptions it seems like they were intended to be `unit:HP_Metric` and `unit:HP_Electric` respectively. Since these already exist, I propose these are deleted.

This PR removes those two units and references to those units.