### PR TITLE
Add/update/standardize ~1500 values for qudt:symbol

### DIFF
--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -73,7 +73,7 @@ unit:A-HR
   qudt:iec61360Code "0112/2///62720#UAA102" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Ampere-hour"^^xsd:anyURI ;
   qudt:informativeReference "http://www.oxfordreference.com/view/10.1093/acref/9780199233991.001.0001/acref-9780199233991-e-86"^^xsd:anyURI ;
-  qudt:symbol "A h" ;
+  qudt:symbol "A⋅hr" ;
   qudt:ucumCode "A.h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "AMH" ;
   qudt:unitOfSystem sou:CGS ;
@@ -90,6 +90,7 @@ unit:A-M2
   qudt:iec61360Code "0112/2///62720#UAA106" ;
   qudt:informativeReference "http://encyclopedia2.thefreedictionary.com/ampere+meter+squared"^^xsd:anyURI ;
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:symbol "A⋅m²" ;
   qudt:ucumCode "A.m2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A5" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -106,6 +107,7 @@ unit:A-M2-PER-J-SEC
   qudt:hasQuantityKind quantitykind:MagneticDipoleMoment ;
   qudt:informativeReference "http://encyclopedia2.thefreedictionary.com/ampere+square+meter+per+joule+second"^^xsd:anyURI ;
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:symbol "A⋅m²/(J⋅s)" ;
   qudt:ucumCode "A.m2.J-1.s-1"^^qudt:UCUMcs ;
   qudt:ucumCode "A.m2/(J.s)"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -120,6 +122,7 @@ unit:A-PER-CentiM
   qudt:hasQuantityKind quantitykind:MagneticFieldStrength_H ;
   qudt:iec61360Code "0112/2///62720#UAB073" ;
   qudt:plainTextDescription "SI base unit ampere divided by the 0.01-fold of the SI base unit metre" ;
+  qudt:symbol "A/cm" ;
   qudt:ucumCode "A.cm-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A2" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -133,6 +136,7 @@ unit:A-PER-CentiM2
   qudt:hasQuantityKind quantitykind:ElectricCurrentDensity ;
   qudt:iec61360Code "0112/2///62720#UAB052" ;
   qudt:plainTextDescription "SI base unit ampere divided by the 0.0001-fold  of the power of the SI base unit metre by exponent 2" ;
+  qudt:symbol "A/cm²" ;
   qudt:ucumCode "A.cm-2"^^qudt:UCUMcs ;
   qudt:ucumCode "A/cm2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A4" ;
@@ -149,6 +153,7 @@ unit:A-PER-DEG_C
   qudt:hasQuantityKind quantitykind:ElectricCurrentPerUnitTemperature ;
   qudt:informativeReference "http://books.google.com/books?id=zkErAAAAYAAJ&pg=PA60&lpg=PA60&dq=ampere+per+degree"^^xsd:anyURI ;
   qudt:informativeReference "http://web.mit.edu/course/21/21.guide/use-tab.htm"^^xsd:anyURI ;
+  qudt:symbol "A/°C" ;
   qudt:ucumCode "A.Cel-1"^^qudt:UCUMcs ;
   qudt:ucumCode "A/Cel"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:CGS ;
@@ -163,6 +168,7 @@ unit:A-PER-J
   qudt:expression "\\(A/J\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E1L-2I0M-1H0T3D0 ;
   qudt:hasQuantityKind quantitykind:ElectricCurrentPerUnitEnergy ;
+  qudt:symbol "A/J" ;
   qudt:ucumCode "A.J-1"^^qudt:UCUMcs ;
   qudt:ucumCode "A/J"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -181,6 +187,7 @@ unit:A-PER-M
   qudt:hasQuantityKind quantitykind:LinearElectricCurrentDensity ;
   qudt:hasQuantityKind quantitykind:MagneticFieldStrength_H ;
   qudt:iec61360Code "0112/2///62720#UAA104" ;
+  qudt:symbol "A/m" ;
   qudt:ucumCode "A.m-1"^^qudt:UCUMcs ;
   qudt:ucumCode "A/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "AE" ;
@@ -202,6 +209,7 @@ unit:A-PER-M2
   qudt:hasQuantityKind quantitykind:TotalCurrentDensity ;
   qudt:iec61360Code "0112/2///62720#UAA105" ;
   qudt:informativeReference "https://cdd.iec.ch/cdd/iec61360/iec61360.nsf/Units/0112-2---62720%23UAA105"^^xsd:anyURI ;
+  qudt:symbol "A/m²" ;
   qudt:ucumCode "A.m-2"^^qudt:UCUMcs ;
   qudt:ucumCode "A/m2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A41" ;
@@ -216,6 +224,7 @@ unit:A-PER-M2-K2
   qudt:hasQuantityKind quantitykind:RichardsonConstant ;
   qudt:iec61360Code "0112/2///62720#UAB353" ;
   qudt:informativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
+  qudt:symbol "A/m²⋅k²" ;
   qudt:ucumCode "A.m-2.K-1"^^qudt:UCUMcs ;
   qudt:ucumCode "A/(m2.K)"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A6" ;
@@ -231,6 +240,7 @@ unit:A-PER-MilliM
   qudt:hasQuantityKind quantitykind:MagneticFieldStrength_H ;
   qudt:iec61360Code "0112/2///62720#UAB072" ;
   qudt:plainTextDescription "SI base unit ampere divided by the 0.001-fold of the SI base unit metre" ;
+  qudt:symbol "A/mm" ;
   qudt:ucumCode "A.mm-1"^^qudt:UCUMcs ;
   qudt:ucumCode "A/mm"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A3" ;
@@ -245,6 +255,7 @@ unit:A-PER-MilliM2
   qudt:hasQuantityKind quantitykind:ElectricCurrentDensity ;
   qudt:iec61360Code "0112/2///62720#UAB051" ;
   qudt:plainTextDescription "SI base unit ampere divided by the 0.000 001-fold of the power of the SI base unit metre by exponent 2" ;
+  qudt:symbol "A/mm²" ;
   qudt:ucumCode "A.mm-2"^^qudt:UCUMcs ;
   qudt:ucumCode "A/mm2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A7" ;
@@ -262,6 +273,7 @@ unit:A-PER-RAD
   qudt:expression "\\(a-per-rad\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E1L0I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:ElectricCurrentPerAngle ;
+  qudt:symbol "A/rad" ;
   qudt:ucumCode "A.rad-1"^^qudt:UCUMcs ;
   qudt:ucumCode "A/rad"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -274,6 +286,7 @@ unit:A-SEC
   qudt:hasQuantityKind quantitykind:ElectricCharge ;
   qudt:iec61360Code "0112/2///62720#UAA107" ;
   qudt:plainTextDescription "product out of the SI base unit ampere and the SI base unit second" ;
+  qudt:symbol "A⋅s" ;
   qudt:ucumCode "A.s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A8" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -312,7 +325,7 @@ unit:AC-FT
   qudt:informativeReference "http://en.wikipedia.org/wiki/Acre-foot"^^xsd:anyURI ;
   qudt:informativeReference "http://www.oxfordreference.com/view/10.1093/acref/9780198605225.001.0001/acref-9780198605225-e-35"^^xsd:anyURI ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/acreFoot> ;
-  qudt:symbol "ac-ft" ;
+  qudt:symbol "ac⋅ft" ;
   qudt:ucumCode "[acr_br].[ft_i]"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:IMPERIAL ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -351,7 +364,7 @@ unit:AMU
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Mass ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Atomic_mass_unit"^^xsd:anyURI ;
-  qudt:symbol "μ" ;
+  qudt:symbol "amu" ;
   qudt:ucumCode "u"^^qudt:UCUMcs ;
   qudt:udunitsCode "u" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -463,7 +476,7 @@ unit:AT
   qudt:derivedCoherentUnitOfSystem sou:SI ;
   qudt:hasDimensionVector qkdv:A0E1L0I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:MagnetomotiveForce ;
-  qudt:symbol "At" ;
+  qudt:symbol "AT" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Ampere Turn"@en ;
 .
@@ -475,6 +488,7 @@ unit:AT-PER-IN
   qudt:expression "\\(At/in\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E1L-1I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:MagneticFieldStrength_H ;
+  qudt:symbol "At/in" ;
   qudt:unitOfSystem sou:USCS ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Ampere Turn per Inch"@en ;
@@ -489,6 +503,7 @@ unit:AT-PER-M
   qudt:expression "\\(At/m\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E1L-1I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:MagneticFieldStrength_H ;
+  qudt:symbol "At/m" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Ampere Turn per Meter"@en-us ;
   rdfs:label "Ampere Turn per Metre"@en ;
@@ -550,7 +565,7 @@ unit:AU
   qudt:iec61360Code "0112/2///62720#UAB066" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Astronomical_unit"^^xsd:anyURI ;
   qudt:plainTextDescription "An astronomical unit (abbreviated as AU, au, a.u., or ua) is a unit of length equal to 149,597,870,700 metres (92,955,807.273 mi) or approximately the mean Earth Sun distance. The symbol ua is recommended by the International Bureau of Weights and Measures, and the international standard ISO 80000, while au is recommended by the International Astronomical Union, and is more common in Anglosphere countries. In general, the International System of Units only uses capital letters for the symbols of units which are named after individual scientists, while au or a.u. can also mean atomic unit or even arbitrary unit. However, the use of AU to refer to the astronomical unit is widespread. The astronomical constant whose value is one astronomical unit is referred to as unit distance and is given the symbol A. [Wikipedia]" ;
-  qudt:symbol "㍳" ;
+  qudt:symbol "AU" ;
   qudt:ucumCode "AU"^^qudt:UCUMcs ;
   qudt:udunitsCode "au" ;
   qudt:udunitsCode "ua" ;
@@ -626,6 +641,7 @@ unit:A_Ab-CentiM2
   qudt:hasDimensionVector qkdv:A0E2L-3I0M-1H0T3D0 ;
   qudt:hasQuantityKind quantitykind:ElectricConductivity ;
   qudt:informativeReference "http://wordinfo.info/unit/4266"^^xsd:anyURI ;
+  qudt:symbol "abA⋅cm²" ;
   qudt:ucumCode "Bi.cm2"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:CGS ;
   vaem:todo "Determine type for magnetic moment" ;
@@ -643,6 +659,7 @@ unit:A_Ab-PER-CentiM2
   qudt:hasQuantityKind quantitykind:ElectricCurrentDensity ;
   qudt:informativeReference "http://wordinfo.info/results/abampere"^^xsd:anyURI ;
   qudt:informativeReference "http://www.efunda.com/glossary/units/units--electric_current_density--abampere_per_square_centimeter.cfm"^^xsd:anyURI ;
+  qudt:symbol "abA/cm²" ;
   qudt:ucumCode "Bi.cm-2"^^qudt:UCUMcs ;
   qudt:ucumCode "Bi/cm2"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:CGS ;
@@ -672,6 +689,7 @@ unit:A_Stat-PER-CentiM2
   qudt:expression "\\(statA / cm^{2}\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E1L-2I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:ElectricCurrentDensity ;
+  qudt:symbol "statA/cm²" ;
   qudt:unitOfSystem sou:CGS ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Statampere per Square Centimeter"@en-us ;
@@ -702,6 +720,7 @@ unit:AttoFARAD
   qudt:isScalingOf unit:FARAD ;
   qudt:plainTextDescription "0,000 000 000 000 000 001-fold of the SI derived unit farad" ;
   qudt:prefix prefix:Atto ;
+  qudt:symbol "aF" ;
   qudt:ucumCode "aF"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H48" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -716,6 +735,7 @@ unit:AttoJ
   qudt:isScalingOf unit:J ;
   qudt:plainTextDescription "0,000 000 000 000 000 001-fold of the derived SI unit joule" ;
   qudt:prefix prefix:Atto ;
+  qudt:symbol "aJ" ;
   qudt:ucumCode "aJ"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A13" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -728,6 +748,7 @@ unit:AttoJ-SEC
   qudt:hasQuantityKind quantitykind:Action ;
   qudt:iec61360Code "0112/2///62720#UAB151" ;
   qudt:plainTextDescription "unit of the Planck's constant as product of the SI derived unit joule and the SI base unit second" ;
+  qudt:symbol "aJ⋅s" ;
   qudt:ucumCode "aJ.s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B18" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -790,6 +811,7 @@ unit:BAR-L-PER-SEC
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAA326" ;
   qudt:plainTextDescription "product of the unit bar and the unit litre divided by the SI base unit second" ;
+  qudt:symbol "bar⋅L/s" ;
   qudt:ucumCode "bar.L.s-1"^^qudt:UCUMcs ;
   qudt:ucumCode "bar.L/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F91" ;
@@ -804,6 +826,7 @@ unit:BAR-M3-PER-SEC
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAA814" ;
   qudt:plainTextDescription "product out of the 0.001-fold of the unit bar and the power of the SI base unit metre with the exponent 3 divided by the SI base unit second" ;
+  qudt:symbol "bar⋅m³/s" ;
   qudt:ucumCode "bar.m3.s-1"^^qudt:UCUMcs ;
   qudt:ucumCode "bar.m3/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F92" ;
@@ -818,6 +841,7 @@ unit:BAR-PER-BAR
   qudt:hasQuantityKind quantitykind:PressureRatio ;
   qudt:iec61360Code "0112/2///62720#UAA325" ;
   qudt:plainTextDescription "pressure relation consisting of the unit bar divided by the unit bar" ;
+  qudt:symbol "bar/bar" ;
   qudt:ucumCode "bar.bar-1"^^qudt:UCUMcs ;
   qudt:ucumCode "bar/bar"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J56" ;
@@ -831,6 +855,7 @@ unit:BAR-PER-K
   qudt:hasQuantityKind quantitykind:PressureCoefficient ;
   qudt:iec61360Code "0112/2///62720#UAA324" ;
   qudt:plainTextDescription "unit with the name bar divided by the SI base unit kelvin" ;
+  qudt:symbol "bar/K" ;
   qudt:ucumCode "bar.K-1"^^qudt:UCUMcs ;
   qudt:ucumCode "bar/K"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F81" ;
@@ -844,6 +869,7 @@ unit:BARAD
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerArea ;
   qudt:hasQuantityKind quantitykind:VaporPressure ;
+  qudt:symbol "Ba" ;
   qudt:unitOfSystem sou:CGS ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Barad"@en ;
@@ -880,7 +906,7 @@ unit:BARYE
   qudt:informativeReference "http://en.wikipedia.org/wiki/Barye?oldid=478631158"^^xsd:anyURI ;
   qudt:latexDefinition "\\(g/(cm\\cdot s{2}\\)"^^qudt:LatexString ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/barye> ;
-  qudt:symbol "ρ" ;
+  qudt:symbol "Ba" ;
   qudt:unitOfSystem sou:CGS ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Barye"@en ;
@@ -925,6 +951,7 @@ unit:BBL_UK_PET
   qudt:hasQuantityKind quantitykind:Volume ;
   qudt:iec61360Code "0112/2///62720#UAA329" ;
   qudt:plainTextDescription "unit of the volume for crude oil according to the Imperial system of units" ;
+  qudt:symbol "bbl{UK petroleum}" ;
   qudt:uneceCommonCode "J57" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Barrel (UK Petroleum)"@en ;
@@ -936,6 +963,7 @@ unit:BBL_UK_PET-PER-DAY
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA331" ;
   qudt:plainTextDescription "unit of the volume barrel (UK petroleum) for crude oil according to the Imperial system of units divided by the unit day" ;
+  qudt:symbol "bbl{UK petroleum}/day" ;
   qudt:uneceCommonCode "J59" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Barrel (UK Petroleum) Per Day"@en ;
@@ -947,6 +975,7 @@ unit:BBL_UK_PET-PER-HR
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA332" ;
   qudt:plainTextDescription "unit of the volume barrel (UK petroleum) for crude oil according to the Imperial system of units divided by the unit hour" ;
+  qudt:symbol "bbl{UK petroleum}/hr" ;
   qudt:uneceCommonCode "J60" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Barrel (UK Petroleum) Per Hour"@en ;
@@ -958,6 +987,7 @@ unit:BBL_UK_PET-PER-MIN
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA330" ;
   qudt:plainTextDescription "unit of the volume barrel (UK petroleum) for crude oil according to the Imperial system of units divided by the unit minute" ;
+  qudt:symbol "bbl{UK petroleum}/min" ;
   qudt:uneceCommonCode "J58" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Barrel (UK Petroleum) Per Minute"@en ;
@@ -969,6 +999,7 @@ unit:BBL_UK_PET-PER-SEC
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA333" ;
   qudt:plainTextDescription "unit of the volume barrel (UK petroleum) for crude oil according to the Imperial system of units divided by the SI base unit second" ;
+  qudt:symbol "bbl{UK petroleum}" ;
   qudt:uneceCommonCode "J61" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Barrel (UK Petroleum) Per Second"@en ;
@@ -980,6 +1011,7 @@ unit:BBL_US
   qudt:hasQuantityKind quantitykind:Volume ;
   qudt:iec61360Code "0112/2///62720#UAA334" ;
   qudt:plainTextDescription "unit of the volume for crude oil according to the Anglo-American system of units" ;
+  qudt:symbol "bbl{US petroleum}" ;
   qudt:ucumCode "[bbl_us]"^^qudt:UCUMcs ;
   qudt:udunitsCode "bbl" ;
   qudt:uneceCommonCode "BLL" ;
@@ -993,6 +1025,7 @@ unit:BBL_US-PER-DAY
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA335" ;
   qudt:plainTextDescription "unit of the volume barrel (US petroleum) for crude oil according to the Anglo-American system of units divided by the unit day" ;
+  qudt:symbol "bsh{US petroleum}/day" ;
   qudt:ucumCode "[bbl_us].d-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[bbl_us]/d"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B1" ;
@@ -1006,6 +1039,7 @@ unit:BBL_US-PER-MIN
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA337" ;
   qudt:plainTextDescription "unit of the volume barrel (US petroleum) for crude oil according to the Anglo-American system of units divided by the unit minute" ;
+  qudt:symbol "bbl{US petroleum}/min" ;
   qudt:ucumCode "[bbl_us].min-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[bbl_us]/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "5A" ;
@@ -1019,6 +1053,7 @@ unit:BBL_US_DRY
   qudt:hasQuantityKind quantitykind:DryVolume ;
   qudt:iec61360Code "0112/2///62720#UAB117" ;
   qudt:plainTextDescription "non SI-conform unit of the volume in the USA which applies to a resolution from 1912: 1 dry barrel (US) equals approximately to 115,63 litre" ;
+  qudt:symbol "bbl{US dry}" ;
   qudt:uneceCommonCode "BLD" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Dry Barrel (US)"@en ;
@@ -1030,6 +1065,7 @@ unit:BBL_US_PET-PER-HR
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA336" ;
   qudt:plainTextDescription "unit of the volume barrel (US petroleum) for crude oil according to the Anglo-American system of units divided by the unit hour" ;
+  qudt:symbol "bbl{UK petroleum}/hr" ;
   qudt:ucumCode "[bbl_us].h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[bbl_us]/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J62" ;
@@ -1043,6 +1079,7 @@ unit:BBL_US_PET-PER-SEC
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA338" ;
   qudt:plainTextDescription "unit of the volume barrel (US petroleum) for crude oil according to the Anglo-American system of units divided by the SI base unit second" ;
+  qudt:symbol "bbl{UK petroleum}/s" ;
   qudt:ucumCode "[bbl_us].s-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[bbl_us]/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J62" ;
@@ -1067,7 +1104,7 @@ unit:BEAT-PER-MIN
   dcterms:description "\"Heart Beat per Minute\" is a unit for  'Heart Rate' expressed as \\(BPM\\)."^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:HeartRate ;
-  qudt:symbol "beats-per-min" ;
+  qudt:symbol "BPM" ;
   qudt:ucumCode "/min{H.B.}"^^qudt:UCUMcs ;
   qudt:ucumCode "min-1{H.B.}"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -1080,6 +1117,7 @@ unit:BFT
   qudt:hasQuantityKind quantitykind:Speed ;
   qudt:iec61360Code "0112/2///62720#UAA110" ;
   qudt:plainTextDescription "unit for classification of winds according to their speed, developed by Sir Francis Beaufort as measure for the over-all behaviour of a ship's sail at different wind speeds" ;
+  qudt:symbol "Beufort" ;
   qudt:uneceCommonCode "M19" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Beaufort"@en ;
@@ -1127,7 +1165,7 @@ unit:BIT
   qudt:iec61360Code "0112/2///62720#UAA339" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Bit?oldid=495288173"^^xsd:anyURI ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/bit> ;
-  qudt:symbol "bit" ;
+  qudt:symbol "b" ;
   qudt:ucumCode "bit"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J63" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -1141,7 +1179,7 @@ unit:BIT-PER-SEC
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:DataRate ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Data_rate_units#Kilobyte_per_second"^^xsd:anyURI ;
-  qudt:symbol "bit/s" ;
+  qudt:symbol "b/s" ;
   qudt:ucumCode "Bd"^^qudt:UCUMcs ;
   qudt:ucumCode "bit.s-1"^^qudt:UCUMcs ;
   qudt:ucumCode "bit/s"^^qudt:UCUMcs ;
@@ -1184,6 +1222,7 @@ unit:BQ-PER-KiloGM
   qudt:informativeReference "http://www.efunda.com/glossary/units/units--specific_radioactivity--becquerel_per_kilogram.cfm"^^xsd:anyURI ;
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
   qudt:plainTextDescription "\"Becquerel per Kilogram\" is used to describe radioactivity, which is often expressed in becquerels per unit of volume or weight, to express how much radioactive material is contained in a sample." ;
+  qudt:symbol "Bq/kg" ;
   qudt:ucumCode "Bq.kg-1"^^qudt:UCUMcs ;
   qudt:ucumCode "Bq/kg"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A18" ;
@@ -1196,6 +1235,7 @@ unit:BQ-PER-L
   qudt:conversionMultiplier 1000.0 ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:ActivityConcentration ;
+  qudt:symbol "Bq/L" ;
   qudt:ucumCode "Bq.L-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Becquerels per litre"@en ;
@@ -1208,6 +1248,7 @@ unit:BQ-PER-M2
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:SurfaceActivityDensity ;
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:symbol "Bq/m²" ;
   qudt:ucumCode "Bq.m-2"^^qudt:UCUMcs ;
   qudt:ucumCode "Bq/m2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -1226,6 +1267,7 @@ unit:BQ-PER-M3
   qudt:informativeReference "http://www.efunda.com/glossary/units/units--radioactivity_concentration--becquerel_per_cubic_meter.cfm"^^xsd:anyURI ;
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
   qudt:plainTextDescription "The SI derived unit of unit in the category of Radioactivity concentration." ;
+  qudt:symbol "Bq/m³" ;
   qudt:ucumCode "Bq.m-3"^^qudt:UCUMcs ;
   qudt:ucumCode "Bq/m3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A19" ;
@@ -1239,6 +1281,7 @@ unit:BQ-SEC-PER-M3
   qudt:conversionMultiplier 1.0 ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:AbsoluteActivity ;
+  qudt:symbol "Bq⋅s/m³" ;
   qudt:ucumCode "Bq.s.m-3"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Becquerels second per cubic metre"@en ;
@@ -1250,6 +1293,7 @@ unit:BREATH-PER-MIN
   qudt:expression "\\(breaths/min\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:RespiratoryRate ;
+  qudt:symbol "breath/min" ;
   qudt:ucumCode "/min{breath}"^^qudt:UCUMcs ;
   qudt:ucumCode "min-1{breath}"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -1279,7 +1323,7 @@ unit:BTU_IT
   qudt:informativeReference "http://physics.nist.gov/Pubs/SP811/appenB9.html"^^xsd:anyURI ;
   qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_ics/catalogue_detail_ics.htm?csnumber=31890"^^xsd:anyURI ;
   qudt:informativeReference "http://www.knowledgedoor.com/2/units_and_constants_handbook/british-thermal-unit_group.html"^^xsd:anyURI ;
-  qudt:symbol "Btu_{it}" ;
+  qudt:symbol "Btu{IT}" ;
   qudt:ucumCode "[Btu_IT]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "BTU" ;
   qudt:unitOfSystem sou:IMPERIAL ;
@@ -1296,6 +1340,7 @@ unit:BTU_IT-FT
   qudt:expression "\\(Btu-ft\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ThermalEnergyLength ;
+  qudt:symbol "Btu⋅ft" ;
   qudt:ucumCode "[Btu_IT].[ft_i]"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:IMPERIAL ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -1313,6 +1358,7 @@ unit:BTU_IT-FT-PER-FT2-HR-DEG_F
   qudt:informativeReference "http://en.wikipedia.org/wiki/Thermal_conductivity"^^xsd:anyURI ;
   qudt:informativeReference "http://www.translatorscafe.com/cafe/EN/units-converter/thermal-conductivity/c/"^^xsd:anyURI ;
   qudt:plainTextDescription "British thermal unit (international table) foot per hour Square foot degree Fahrenheit is the unit of the thermal conductivity according to the Imperial system of units." ;
+  qudt:symbol "Btu{IT}⋅ft/(ft²⋅hr⋅°F)" ;
   qudt:ucumCode "[Btu_IT].[ft_i].[ft_i]-2.h-1.[degF]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_IT].[ft_i]/([ft_i]2.h.[degF])"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J40" ;
@@ -1331,6 +1377,7 @@ unit:BTU_IT-IN
   qudt:expression "\\(Btu-in\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ThermalEnergyLength ;
+  qudt:symbol "Btu⋅in" ;
   qudt:ucumCode "[Btu_IT].[in_i]"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:IMPERIAL ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -1349,6 +1396,7 @@ unit:BTU_IT-IN-PER-FT2-HR-DEG_F
   qudt:informativeReference "http://www.translatorscafe.com/cafe/EN/units-converter/thermal-conductivity/c/"^^xsd:anyURI ;
   qudt:latexSymbol "\\(Btu_{it} \\cdot in/(hr \\cdot ft^{2}  \\cdot degF)\\)"^^qudt:LatexString ;
   qudt:plainTextDescription "BTU (th) Inch per Square Foot Hour Degree Fahrenheit is an Imperial unit for 'Thermal Conductivity', an International British thermal unit inch per second per square foot per degree Fahrenheit is a unit of thermal conductivity in the US Customary Units and British Imperial Units." ;
+  qudt:symbol "Btu{IT}⋅in/(ft²⋅hr⋅°F)" ;
   qudt:ucumCode "[Btu_IT].[in_i].[ft_i]-2.h-1.[degF]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_IT].[in_i]/([ft_i]2.h.[degF])"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J41" ;
@@ -1370,6 +1418,7 @@ unit:BTU_IT-IN-PER-FT2-SEC-DEG_F
   qudt:iec61360Code "0112/2///62720#UAA118" ;
   qudt:informativeReference "http://www.translatorscafe.com/cafe/EN/units-converter/thermal-conductivity/c/"^^xsd:anyURI ;
   qudt:plainTextDescription "British thermal unit (international table) inch per second Square foot degree Fahrenheit is the unit of the thermal conductivity according to the Imperial system of units." ;
+  qudt:symbol "Btu{IT}⋅in/(ft²⋅s⋅°F)" ;
   qudt:ucumCode "[Btu_IT].[in_i].[ft_i]-2.s-1.[degF]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_IT].[in_i]/([ft_i]2.s.[degF])"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J42" ;
@@ -1386,6 +1435,7 @@ unit:BTU_IT-IN-PER-HR-FT2-DEG_F
   qudt:hasQuantityKind quantitykind:ThermalConductivity ;
   qudt:iec61360Code "0112/2///62720#UAA117" ;
   qudt:plainTextDescription "unit of the thermal conductivity according to the Imperial system of units" ;
+  qudt:symbol "Btu{IT}⋅in/(hr⋅ft²⋅°F)" ;
   qudt:ucumCode "[Btu_IT].[in_i].h-1.[ft_i]-2.[degF]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_IT].[in_i]/(h.[ft_i]2.[degF])"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J41" ;
@@ -1401,6 +1451,7 @@ unit:BTU_IT-IN-PER-SEC-FT2-DEG_F
   qudt:hasQuantityKind quantitykind:ThermalConductivity ;
   qudt:iec61360Code "0112/2///62720#UAA118" ;
   qudt:plainTextDescription "unit of the thermal conductivity according to the Imperial system of units" ;
+  qudt:symbol "Btu{IT}⋅in/(s⋅ft²⋅°F)" ;
   qudt:ucumCode "[Btu_IT].[in_i].s-1.[ft_i]-2.[degF]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_IT].[in_i]/(s.[ft_i]2.[degF])"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J42" ;
@@ -1419,6 +1470,7 @@ unit:BTU_IT-PER-DEG_F
   qudt:expression "\\(btu-per-degF\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H-1T-2D0 ;
   qudt:hasQuantityKind quantitykind:HeatCapacity ;
+  qudt:symbol "Btu{IT}/°F" ;
   qudt:ucumCode "[Btu_IT].[degF]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_IT]/[degF]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "N60" ;
@@ -1434,6 +1486,7 @@ unit:BTU_IT-PER-DEG_R
   qudt:expression "\\(btu-per-degR\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H-1T-2D0 ;
   qudt:hasQuantityKind quantitykind:HeatCapacity ;
+  qudt:symbol "Btu{IT}/°R" ;
   qudt:ucumCode "[Btu_IT].[degR]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_IT]/[degR]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "N62" ;
@@ -1451,6 +1504,7 @@ unit:BTU_IT-PER-FT2
   qudt:expression "\\(Btu/ft^{2}\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:EnergyPerArea ;
+  qudt:symbol "Btu{IT}/ft²" ;
   qudt:ucumCode "[Btu_IT].[ft_i]-2"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_IT]/[ft_i]2"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:IMPERIAL ;
@@ -1466,6 +1520,7 @@ unit:BTU_IT-PER-FT2-HR-DEG_F
   qudt:expression "\\(Btu/(hr-ft^{2}-degF)\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H-1T-3D0 ;
   qudt:hasQuantityKind quantitykind:CoefficientOfHeatTransfer ;
+  qudt:symbol "Btu{IT}/(hr⋅ft²⋅°F)" ;
   qudt:ucumCode "[Btu_IT].[ft_i]-2.h-1.[degF]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_IT]/([ft_i]2.h.[degF])"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:IMPERIAL ;
@@ -1481,6 +1536,7 @@ unit:BTU_IT-PER-FT2-SEC-DEG_F
   qudt:expression "\\(Btu/(ft^{2}-s-degF)\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H-1T-3D0 ;
   qudt:hasQuantityKind quantitykind:CoefficientOfHeatTransfer ;
+  qudt:symbol "Btu{IT}/(ft²⋅s⋅°F)" ;
   qudt:ucumCode "[Btu_IT].[ft_i]-2.s-1.[degF]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_IT]/([ft_i]2.s.[degF])"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "N76" ;
@@ -1498,6 +1554,7 @@ unit:BTU_IT-PER-FT3
   qudt:informativeReference "http://physics.nist.gov/Pubs/SP811/appenB9.html"^^xsd:anyURI ;
   qudt:informativeReference "http://www.efunda.com/glossary/units/units--energy_density--british_thermal_unit_it_per_cubic_foot.cfm"^^xsd:anyURI ;
   qudt:informativeReference "http://www.translatorscafe.com/cafe/EN/units-converter/fuel-efficiency--volume/c/"^^xsd:anyURI ;
+  qudt:symbol "Btu{IT}/ft³" ;
   qudt:ucumCode "[Btu_IT].[ft_i]-3"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_IT]/[ft_i]3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "N58" ;
@@ -1517,6 +1574,7 @@ unit:BTU_IT-PER-HR
   qudt:hasQuantityKind quantitykind:HeatFlowRate ;
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:informativeReference "http://www.simetric.co.uk/sibtu.htm"^^xsd:anyURI ;
+  qudt:symbol "Btu{IT}/hr" ;
   qudt:ucumCode "[Btu_IT].h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_IT]/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "2I" ;
@@ -1534,6 +1592,7 @@ unit:BTU_IT-PER-HR-FT2
   qudt:expression "\\(Btu/(hr-ft^{2})\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:PowerPerArea ;
+  qudt:symbol "Btu{IT}/(hr⋅ft²)" ;
   qudt:ucumCode "[Btu_IT].h-1.[ft_i]-2"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_IT]/(h.[ft_i]2)"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:IMPERIAL ;
@@ -1547,6 +1606,7 @@ unit:BTU_IT-PER-HR-FT2-DEG_R
   qudt:hasQuantityKind quantitykind:CoefficientOfHeatTransfer ;
   qudt:iec61360Code "0112/2///62720#UAB099" ;
   qudt:plainTextDescription "unit of the heat transfer coefficient according to the Imperial system of units" ;
+  qudt:symbol "Btu{IT}/(hr⋅ft²⋅°R)" ;
   qudt:ucumCode "[Btu_IT].h-1.[ft_i]-2.[degR]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_IT]/(h.[ft_i]2.[degR])"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A23" ;
@@ -1564,6 +1624,7 @@ unit:BTU_IT-PER-LB
   qudt:hasQuantityKind quantitykind:SpecificEnergy ;
   qudt:informativeReference "http://physics.nist.gov/Pubs/SP811/appenB9.html"^^xsd:anyURI ;
   qudt:informativeReference "http://www.efunda.com/glossary/units/units--energy_density--british_thermal_unit_it_per_cubic_foot.cfm"^^xsd:anyURI ;
+  qudt:symbol "Btu{IT}/lb" ;
   qudt:ucumCode "[Btu_IT].[lb_av]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_IT]/[lb_av]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "AZ" ;
@@ -1580,6 +1641,7 @@ unit:BTU_IT-PER-LB-DEG_F
   qudt:expression "\\(Btu/(lb-degF)\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H-1T-2D0 ;
   qudt:hasQuantityKind quantitykind:SpecificHeatCapacity ;
+  qudt:symbol "Btu{IT}/(lb⋅°F)" ;
   qudt:ucumCode "[Btu_IT].[lb_av]-1.[degF]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_IT]/([lb_av].[degF])"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:IMPERIAL ;
@@ -1594,6 +1656,7 @@ unit:BTU_IT-PER-LB-DEG_R
   qudt:expression "\\(Btu/(lb-degR)\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H-1T-2D0 ;
   qudt:hasQuantityKind quantitykind:SpecificHeatCapacity ;
+  qudt:symbol "Btu{IT}/(lb⋅°R)" ;
   qudt:ucumCode "[Btu_IT].[lb_av]-1.[degR]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_IT]/([lb_av].[degR])"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -1606,6 +1669,7 @@ unit:BTU_IT-PER-LB-MOL
   qudt:expression "\\(Btu/(lb-mol)\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:EnergyPerMassAmountOfSubstance ;
+  qudt:symbol "Btu{IT}/(lb⋅mol)" ;
   qudt:ucumCode "[Btu_IT].[lb_av]-1.mol-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_IT]/([lb_av].mol)"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:IMPERIAL ;
@@ -1619,6 +1683,7 @@ unit:BTU_IT-PER-LB_F
   qudt:hasQuantityKind quantitykind:Length ;
   qudt:iec61360Code "0112/2///62720#UAB150" ;
   qudt:plainTextDescription "unit of the heat energy according to the Imperial system of units divided by the unit avoirdupois pound of force according to the avoirdupois system of units" ;
+  qudt:symbol "Btu{IT}/lbf" ;
   qudt:ucumCode "[Btu_IT].[lbf_av]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_IT]/[lbf_av]"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -1631,6 +1696,7 @@ unit:BTU_IT-PER-LB_F-DEG_F
   qudt:hasQuantityKind quantitykind:SpecificHeatCapacity ;
   qudt:iec61360Code "0112/2///62720#UAA119" ;
   qudt:plainTextDescription "unit of the heat energy according to the Imperial system of units divided by the product of the units avoirdupois pound according to the avoirdupois system of units and degree Fahrenheit" ;
+  qudt:symbol "Btu{IT}/(lbf⋅°F)" ;
   qudt:ucumCode "[Btu_IT].[lbf_av]-1.[degF]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_IT]/([lbf_av].[degF])"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J43" ;
@@ -1644,6 +1710,7 @@ unit:BTU_IT-PER-LB_F-DEG_R
   qudt:hasQuantityKind quantitykind:SpecificHeatCapacity ;
   qudt:iec61360Code "0112/2///62720#UAB141" ;
   qudt:plainTextDescription "unit of the heat capacity as British thermal unit according to the international table related to degree Rankine according to the Imperial system of units divided by the unit avoirdupois pound according to the avoirdupois system of units" ;
+  qudt:symbol "Btu{IT}/(lbf⋅°R)" ;
   qudt:ucumCode "[Btu_IT].[lbf_av]-1.[degR]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_IT]/([lbf_av].[degR])"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A21" ;
@@ -1657,6 +1724,7 @@ unit:BTU_IT-PER-MIN
   qudt:hasQuantityKind quantitykind:HeatFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA120" ;
   qudt:plainTextDescription "unit of the heat energy according to the Imperial system of units divided by the unit minute" ;
+  qudt:symbol "Btu{IT}/min" ;
   qudt:ucumCode "[Btu_IT].min-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_IT]/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J44" ;
@@ -1671,6 +1739,7 @@ unit:BTU_IT-PER-MOL-DEG_F
   qudt:expression "\\(Btu/(lb-mol-degF)\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A-1E0L2I0M1H-1T-2D0 ;
   qudt:hasQuantityKind quantitykind:MolarHeatCapacity ;
+  qudt:symbol "Btu{IT}/(lb⋅mol⋅°F)" ;
   qudt:ucumCode "[Btu_IT].mol-1.[degF]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_IT]/(mol.[degF])"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:IMPERIAL ;
@@ -1689,6 +1758,7 @@ unit:BTU_IT-PER-SEC
   qudt:hasQuantityKind quantitykind:HeatFlowRate ;
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:informativeReference "http://www.simetric.co.uk/sibtu.htm"^^xsd:anyURI ;
+  qudt:symbol "Btu{IT}/s" ;
   qudt:ucumCode "[Btu_IT].s-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_IT]/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J45" ;
@@ -1703,6 +1773,7 @@ unit:BTU_IT-PER-SEC-FT-DEG_R
   qudt:hasQuantityKind quantitykind:ThermalConductivity ;
   qudt:iec61360Code "0112/2///62720#UAB107" ;
   qudt:plainTextDescription "unit of the thermal conductivity according to the Imperial system of units" ;
+  qudt:symbol "Btu{IT}/(s⋅ft⋅°R)" ;
   qudt:ucumCode "[Btu_IT].s-1.[ft_i]-1.[degR]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_IT]/(s.[ft_i].[degR])"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A22" ;
@@ -1719,6 +1790,7 @@ unit:BTU_IT-PER-SEC-FT2
   qudt:expression "\\(Btu/(s-ft^{2})\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:PowerPerArea ;
+  qudt:symbol "Btu{IT}/(s⋅ft²)" ;
   qudt:ucumCode "[Btu_IT].s-1.[ft_i]-2"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_IT]/(s.[ft_i]2)"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "N53" ;
@@ -1733,6 +1805,7 @@ unit:BTU_IT-PER-SEC-FT2-DEG_R
   qudt:hasQuantityKind quantitykind:CoefficientOfHeatTransfer ;
   qudt:iec61360Code "0112/2///62720#UAB098" ;
   qudt:plainTextDescription "unit of the heat transfer coefficient according to the Imperial system of units" ;
+  qudt:symbol "Btu{IT}/(s⋅ft²⋅°R)" ;
   qudt:ucumCode "[Btu_IT].s-1.[ft_i]-2.[degR]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_IT]/(s.[ft_i]2.[degR])"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A20" ;
@@ -1746,6 +1819,7 @@ unit:BTU_MEAN
   qudt:hasQuantityKind quantitykind:ThermalEnergy ;
   qudt:iec61360Code "0112/2///62720#UAA113" ;
   qudt:plainTextDescription "unit of the heat energy according to the Imperial system of units" ;
+  qudt:symbol "BTU{mean}" ;
   qudt:ucumCode "[Btu_m]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J39" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -1762,7 +1836,7 @@ unit:BTU_TH
   qudt:informativeReference "http://physics.nist.gov/Pubs/SP811/appenB9.html"^^xsd:anyURI ;
   qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_ics/catalogue_detail_ics.htm?csnumber=31890"^^xsd:anyURI ;
   qudt:informativeReference "http://www.knowledgedoor.com/2/units_and_constants_handbook/british-thermal-unit_group.html"^^xsd:anyURI ;
-  qudt:symbol "Btu_{th}" ;
+  qudt:symbol "Btu{th}" ;
   qudt:ucumCode "[Btu_th]"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:IMPERIAL ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -1780,6 +1854,7 @@ unit:BTU_TH-FT-PER-FT2-HR-DEG_F
   qudt:hasQuantityKind quantitykind:ThermalConductivity ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Thermal_conductivity"^^xsd:anyURI ;
   qudt:informativeReference "http://www.translatorscafe.com/cafe/EN/units-converter/thermal-conductivity/c/"^^xsd:anyURI ;
+  qudt:symbol "Btu{th}⋅ft/(ft²⋅hr⋅°F)" ;
   qudt:ucumCode "[Btu_IT].[ft_i]-2.h-1.[degF]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_IT]/([ft_i]2.h.[degF])"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:IMPERIAL ;
@@ -1793,6 +1868,7 @@ unit:BTU_TH-FT-PER-HR-FT2-DEG_F
   qudt:hasQuantityKind quantitykind:ThermalConductivity ;
   qudt:iec61360Code "0112/2///62720#UAA123" ;
   qudt:plainTextDescription "unit of the thermal conductivity according to the Imperial system of units" ;
+  qudt:symbol "Btu{th}⋅ft/(hr⋅ft²⋅°F)" ;
   qudt:ucumCode "[Btu_th].[ft_i].h-1.[ft_i]-2.[degF]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_th].[ft_i]/(h.[ft_i]2.[degF])"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J46" ;
@@ -1813,6 +1889,7 @@ unit:BTU_TH-IN-PER-FT2-HR-DEG_F
   qudt:informativeReference "http://www.translatorscafe.com/cafe/EN/units-converter/thermal-conductivity/c/"^^xsd:anyURI ;
   qudt:latexSymbol "\\(Btu_{th} \\cdot in/(hr \\cdot ft^{2}  \\cdot degF)\\)"^^qudt:LatexString ;
   qudt:plainTextDescription "Unit of thermal conductivity according to the Imperial system of units" ;
+  qudt:symbol "Btu{th}⋅in/(ft²⋅hr⋅°F)" ;
   qudt:ucumCode "[Btu_th].[in_i].[ft_i]-2.h-1.[degF]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_th].[in_i]/([ft_i]2.h.[degF])"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J48" ;
@@ -1833,6 +1910,7 @@ unit:BTU_TH-IN-PER-FT2-SEC-DEG_F
   qudt:iec61360Code "0112/2///62720#UAA126" ;
   qudt:informativeReference "http://www.translatorscafe.com/cafe/EN/units-converter/thermal-conductivity/c/"^^xsd:anyURI ;
   qudt:plainTextDescription "Unit of thermal conductivity according to the Imperial system of units" ;
+  qudt:symbol "Btu{th}⋅in/(ft²⋅s⋅°F)" ;
   qudt:ucumCode "[Btu_th].[in_i].[ft_i]-2.s-1.[degF]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_th].[in_i]/([ft_i]2.s.[degF])"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:IMPERIAL ;
@@ -1849,6 +1927,7 @@ unit:BTU_TH-PER-FT3
   qudt:informativeReference "http://physics.nist.gov/Pubs/SP811/appenB9.html"^^xsd:anyURI ;
   qudt:informativeReference "http://www.efunda.com/glossary/units/units--energy_density--british_thermal_unit_it_per_cubic_foot.cfm"^^xsd:anyURI ;
   qudt:informativeReference "http://www.translatorscafe.com/cafe/EN/units-converter/fuel-efficiency--volume/c/"^^xsd:anyURI ;
+  qudt:symbol "Btu{th}/ft³" ;
   qudt:ucumCode "[Btu_th].[ft_i]-3"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_th]/[ft_i]3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "N59" ;
@@ -1863,6 +1942,7 @@ unit:BTU_TH-PER-HR
   qudt:hasQuantityKind quantitykind:HeatFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA124" ;
   qudt:plainTextDescription "unit of the heat energy according to the Imperial system of units divided by the unit hour" ;
+  qudt:symbol "Btu{th}/hr" ;
   qudt:ucumCode "[Btu_th].h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_th]/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J47" ;
@@ -1878,6 +1958,7 @@ unit:BTU_TH-PER-LB
   qudt:hasQuantityKind quantitykind:SpecificEnergy ;
   qudt:informativeReference "http://physics.nist.gov/Pubs/SP811/appenB9.html"^^xsd:anyURI ;
   qudt:informativeReference "http://www.efunda.com/glossary/units/units--thermal_heat_capacity--british_thermal_unit_therm_per_pound_mass.cfm"^^xsd:anyURI ;
+  qudt:symbol "btu{th}/lb" ;
   qudt:ucumCode "[Btu_th].[lb_av]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_th]/[lb_av]"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:IMPERIAL ;
@@ -1891,6 +1972,7 @@ unit:BTU_TH-PER-LB-DEG_F
   qudt:hasQuantityKind quantitykind:SpecificHeatCapacity ;
   qudt:iec61360Code "0112/2///62720#UAA127" ;
   qudt:plainTextDescription "unit of the thermal conductivity according to the Imperial system of units divided by the units pound and degree Fahrenheit" ;
+  qudt:symbol "Btu{th}/(lb⋅°F)" ;
   qudt:ucumCode "[Btu_th].[lb_av]-1.[degF]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_th]/([lb_av].[degF])"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J50" ;
@@ -1904,6 +1986,7 @@ unit:BTU_TH-PER-MIN
   qudt:hasQuantityKind quantitykind:HeatFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA128" ;
   qudt:plainTextDescription "unit of the heat energy according to the Imperial system of units divided by the unit minute" ;
+  qudt:symbol "Btu{th}/min" ;
   qudt:ucumCode "[Btu_th].min-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_th]/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J51" ;
@@ -1917,6 +2000,7 @@ unit:BTU_TH-PER-SEC
   qudt:hasQuantityKind quantitykind:HeatFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA129" ;
   qudt:plainTextDescription "unit of the heat energy according to the Imperial system of units divided by the SI base unit second" ;
+  qudt:symbol "Btu{th}/s" ;
   qudt:ucumCode "[Btu_th].s-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_th]/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J52" ;
@@ -1932,7 +2016,7 @@ unit:BU_UK
   qudt:hasQuantityKind quantitykind:DryVolume ;
   qudt:iec61360Code "0112/2///62720#UAA344" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Bushel?oldid=476704875"^^xsd:anyURI ;
-  qudt:symbol "bui" ;
+  qudt:symbol "bsh{UK}" ;
   qudt:ucumCode "[bu_br]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "BUI" ;
   qudt:unitOfSystem sou:USCS ;
@@ -1946,6 +2030,7 @@ unit:BU_UK-PER-DAY
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA345" ;
   qudt:plainTextDescription "unit of the volume bushel (UK) (for fluids and for dry measures) according to the Imperial system of units divided by the unit for time day" ;
+  qudt:symbol "bsh{UK}/day" ;
   qudt:ucumCode "[bu_br].d-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[bu_br]/d"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J64" ;
@@ -1959,6 +2044,7 @@ unit:BU_UK-PER-HR
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA346" ;
   qudt:plainTextDescription "unit of the volume bushel (UK) (for fluids and for dry measures) according to the Imperial system of units divided by the unit for time hour" ;
+  qudt:symbol "bsh{UK}/hr" ;
   qudt:uneceCommonCode "J65" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Bushel (UK) Per Hour"@en ;
@@ -1970,6 +2056,7 @@ unit:BU_UK-PER-MIN
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA347" ;
   qudt:plainTextDescription "unit of the volume bushel (UK) (for fluids and for dry measures) according to the Imperial system of units divided by the unit for time minute" ;
+  qudt:symbol "bsh{UK}/min" ;
   qudt:ucumCode "[bu_br].min-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[bu_br]/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J66" ;
@@ -1983,6 +2070,7 @@ unit:BU_UK-PER-SEC
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA348" ;
   qudt:plainTextDescription "unit of the volume bushel (UK) (for fluids and for dry measures) according to the Imperial system of units divided by the SI base unit second" ;
+  qudt:symbol "bsh{UK}/s" ;
   qudt:ucumCode "[bu_br].s-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[bu_br]/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J67" ;
@@ -2000,7 +2088,7 @@ unit:BU_US
   qudt:iec61360Code "0112/2///62720#UAA353" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Bushel?oldid=476704875"^^xsd:anyURI ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/bushel-US> ;
-  qudt:symbol "bua" ;
+  qudt:symbol "bsh{US}" ;
   qudt:ucumCode "[bu_us]"^^qudt:UCUMcs ;
   qudt:udunitsCode "bu" ;
   qudt:uneceCommonCode "BUA" ;
@@ -2015,6 +2103,7 @@ unit:BU_US_DRY-PER-DAY
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA349" ;
   qudt:plainTextDescription "unit of the volume bushel (US dry) for dry measure according to the Anglo-American system of units divided by the unit for time day" ;
+  qudt:symbol "bsh{US}/day" ;
   qudt:ucumCode "[bu_us].d-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[bu_us]/d"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J68" ;
@@ -2028,6 +2117,7 @@ unit:BU_US_DRY-PER-HR
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA350" ;
   qudt:plainTextDescription "unit of the volume bushel (US dry) for dry measure according to the Anglo-American system of units divided by the unit for time hour" ;
+  qudt:symbol "bsh{US}/hr" ;
   qudt:ucumCode "[bu_us].h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[bu_us]/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J69" ;
@@ -2041,6 +2131,7 @@ unit:BU_US_DRY-PER-MIN
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA351" ;
   qudt:plainTextDescription "unit of the volume bushel (US dry) for dry measure according to the Anglo-American system of units divided by the unit for time minute" ;
+  qudt:symbol "bsh{US}/min" ;
   qudt:ucumCode "[bu_us].min-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[bu_us]/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J70" ;
@@ -2054,6 +2145,7 @@ unit:BU_US_DRY-PER-SEC
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA352" ;
   qudt:plainTextDescription "unit of the volume bushel (US dry) for dry measure according to the Anglo-American system of units divided by the SI base unit second" ;
+  qudt:symbol "bsh{US}/s" ;
   qudt:ucumCode "[bu_us].s-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[bu_us]/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J71" ;
@@ -2227,7 +2319,7 @@ unit:C-M
   qudt:hasDimensionVector qkdv:A0E1L1I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:ElectricDipoleMoment ;
   qudt:iec61360Code "0112/2///62720#UAA133" ;
-  qudt:symbol "C m" ;
+  qudt:symbol "C⋅m" ;
   qudt:ucumCode "C.m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A26" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -2242,6 +2334,7 @@ unit:C-M2
   qudt:expression "\\(C m^{2}\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E1L2I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:ElectricQuadrupoleMoment ;
+  qudt:symbol "C⋅m²" ;
   qudt:ucumCode "C.m2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Coulomb Square Meter"@en-us ;
@@ -2255,6 +2348,7 @@ unit:C-M2-PER-V
   qudt:hasDimensionVector qkdv:A0E2L0I0M-1H0T4D0 ;
   qudt:hasQuantityKind quantitykind:Polarizability ;
   qudt:iec61360Code "0112/2///62720#UAB486" ;
+  qudt:symbol "C⋅m²/V" ;
   qudt:ucumCode "C.m2.V-1"^^qudt:UCUMcs ;
   qudt:ucumCode "C.m2/V"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A27" ;
@@ -2269,6 +2363,7 @@ unit:C-PER-CentiM2
   qudt:hasQuantityKind quantitykind:ElectricChargePerArea ;
   qudt:iec61360Code "0112/2///62720#UAB101" ;
   qudt:plainTextDescription "derived SI unit coulomb divided by the 0.0001-fold of the power of the SI base unit metre by exponent 2" ;
+  qudt:symbol "C/cm²" ;
   qudt:ucumCode "C.cm-2"^^qudt:UCUMcs ;
   qudt:ucumCode "C/cm2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A33" ;
@@ -2283,6 +2378,7 @@ unit:C-PER-CentiM3
   qudt:hasQuantityKind quantitykind:ElectricChargeVolumeDensity ;
   qudt:iec61360Code "0112/2///62720#UAB120" ;
   qudt:plainTextDescription "derived SI unit coulomb divided by the 0.000 001-fold of the power of the SI base unit metre by exponent 3" ;
+  qudt:symbol "C/cm³" ;
   qudt:ucumCode "C.cm-3"^^qudt:UCUMcs ;
   qudt:ucumCode "C/cm3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A28" ;
@@ -2301,6 +2397,7 @@ unit:C-PER-KiloGM
   qudt:hasDimensionVector qkdv:A0E1L0I0M-1H0T1D0 ;
   qudt:hasQuantityKind quantitykind:ElectricChargePerMass ;
   qudt:iec61360Code "0112/2///62720#UAA131" ;
+  qudt:symbol "C/kg" ;
   qudt:ucumCode "C.kg-1"^^qudt:UCUMcs ;
   qudt:ucumCode "C/kg"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "CKG" ;
@@ -2317,6 +2414,7 @@ unit:C-PER-KiloGM-SEC
   qudt:iec61360Code "0112/2///62720#UAA132" ;
   qudt:informativeReference "http://en.wikibooks.org/wiki/Basic_Physics_of_Nuclear_Medicine/Units_of_Radiation_Measurement"^^xsd:anyURI ;
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:symbol "C/kg⋅s" ;
   qudt:ucumCode "C.kg-1.s-1"^^qudt:UCUMcs ;
   qudt:ucumCode "C/(kg.s)"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A31" ;
@@ -2335,6 +2433,7 @@ unit:C-PER-M
   qudt:hasQuantityKind quantitykind:ElectricChargeLineDensity ;
   qudt:hasQuantityKind quantitykind:ElectricChargeLinearDensity ;
   qudt:iec61360Code "0112/2///62720#UAB337" ;
+  qudt:symbol "C/m" ;
   qudt:ucumCode "C.m-1"^^qudt:UCUMcs ;
   qudt:ucumCode "C/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P10" ;
@@ -2353,6 +2452,7 @@ unit:C-PER-M2
   qudt:hasQuantityKind quantitykind:ElectricChargeSurfaceDensity ;
   qudt:hasQuantityKind quantitykind:ElectricPolarization ;
   qudt:iec61360Code "0112/2///62720#UAA134" ;
+  qudt:symbol "C/m²" ;
   qudt:ucumCode "C.m-2"^^qudt:UCUMcs ;
   qudt:ucumCode "C/m2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A34" ;
@@ -2373,6 +2473,7 @@ unit:C-PER-M3
   qudt:hasQuantityKind quantitykind:ElectricChargeDensity ;
   qudt:hasQuantityKind quantitykind:ElectricChargeVolumeDensity ;
   qudt:iec61360Code "0112/2///62720#UAA135" ;
+  qudt:symbol "C/m³" ;
   qudt:ucumCode "C.m-3"^^qudt:UCUMcs ;
   qudt:ucumCode "C/m3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A29" ;
@@ -2391,6 +2492,7 @@ unit:C-PER-MOL
   qudt:hasDimensionVector qkdv:A-1E1L0I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:ElectricChargePerAmountOfSubstance ;
   qudt:iec61360Code "0112/2///62720#UAB142" ;
+  qudt:symbol "c/mol" ;
   qudt:ucumCode "C.mol-1"^^qudt:UCUMcs ;
   qudt:ucumCode "C/mol"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A32" ;
@@ -2404,6 +2506,7 @@ unit:C-PER-MilliM2
   qudt:hasQuantityKind quantitykind:ElectricChargePerArea ;
   qudt:iec61360Code "0112/2///62720#UAB100" ;
   qudt:plainTextDescription "derived SI unit coulomb divided by the 0.000 001-fold of the power of the SI base unit metre by exponent 2" ;
+  qudt:symbol "C/mm²" ;
   qudt:ucumCode "C.mm-2"^^qudt:UCUMcs ;
   qudt:ucumCode "C/mm2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A35" ;
@@ -2418,6 +2521,7 @@ unit:C-PER-MilliM3
   qudt:hasQuantityKind quantitykind:ElectricChargeVolumeDensity ;
   qudt:iec61360Code "0112/2///62720#UAB119" ;
   qudt:plainTextDescription "derived SI unit coulomb divided by the 0.000 000 001-fold of the power of the SI base unit metre by exponent 3" ;
+  qudt:symbol "C/mm³" ;
   qudt:ucumCode "C.mm-3"^^qudt:UCUMcs ;
   qudt:ucumCode "C/mm3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A30" ;
@@ -2433,6 +2537,7 @@ unit:C2-M-PER-J
   qudt:expression "\\(C^{2} m^{2} J^{-1}\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E2L0I0M-1H0T4D0 ;
   qudt:hasQuantityKind quantitykind:Polarizability ;
+  qudt:symbol "C²⋅m²/J" ;
   qudt:ucumCode "C2.m.J-1"^^qudt:UCUMcs ;
   qudt:ucumCode "C2.m/J"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -2447,6 +2552,7 @@ unit:C3-M-PER-J2
   qudt:expression "\\(C^{3} m^{3} J^{-2}\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E3L-1I0M-2H0T7D0 ;
   qudt:hasQuantityKind quantitykind:CubicElectricDipoleMomentPerSquareEnergy ;
+  qudt:symbol "C³⋅m³/J²" ;
   qudt:ucumCode "C3.m.J-2"^^qudt:UCUMcs ;
   qudt:ucumCode "C3.m/J2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -2461,6 +2567,7 @@ unit:C4-M4-PER-J3
   qudt:expression "\\(C^4m^4/J^3\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E4L-2I0M-3H0T10D0 ;
   qudt:hasQuantityKind quantitykind:QuarticElectricDipoleMomentPerCubicEnergy ;
+  qudt:symbol "C⁴m⁴/J³" ;
   qudt:ucumCode "C4.m4.J-3"^^qudt:UCUMcs ;
   qudt:ucumCode "C4.m4/J3"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -2487,6 +2594,7 @@ unit:CAL_15_DEG_C
   qudt:hasQuantityKind quantitykind:ThermalEnergy ;
   qudt:iec61360Code "0112/2///62720#UAB139" ;
   qudt:plainTextDescription "unit for the quantity of heat which is required to warm up 1 g  of water, which is free of air, at a constant pressure of 101.325 kPa (the pressure of the standard atmosphere on sea level) from 14.5 degrees Celsius to 15.5 degrees Celsius" ;
+  qudt:symbol "cal{15 °C}" ;
   qudt:ucumCode "cal_[15]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A1" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -2500,6 +2608,7 @@ unit:CAL_IT
   qudt:hasQuantityKind quantitykind:Energy ;
   qudt:hasQuantityKind quantitykind:ThermalEnergy ;
   qudt:informativeReference "http://physics.nist.gov/Pubs/SP811/appenB9.html"^^xsd:anyURI ;
+  qudt:symbol "cal{IT}" ;
   qudt:ucumCode "cal_IT"^^qudt:UCUMcs ;
   qudt:udunitsCode "cal" ;
   qudt:uneceCommonCode "D70" ;
@@ -2518,6 +2627,7 @@ unit:CAL_IT-PER-GM
   qudt:informativeReference "http://physics.nist.gov/Pubs/SP811/appenB9.html"^^xsd:anyURI ;
   qudt:informativeReference "http://www.efunda.com/glossary/units/units--thermal_heat_capacity--british_thermal_unit_therm_per_pound_mass.cfm"^^xsd:anyURI ;
   qudt:plainTextDescription "unit calorie according to the international steam table divided by the 0.001-fold of the SI base unit kilogram" ;
+  qudt:symbol "cal{IT}/g" ;
   qudt:ucumCode "cal_IT.g-1"^^qudt:UCUMcs ;
   qudt:ucumCode "cal_IT/g"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D75" ;
@@ -2532,6 +2642,7 @@ unit:CAL_IT-PER-GM-DEG_C
   qudt:hasQuantityKind quantitykind:SpecificHeatCapacity ;
   qudt:iec61360Code "0112/2///62720#UAA362" ;
   qudt:plainTextDescription "unit calorieIT divided by the products of the units gram and degree Celsius" ;
+  qudt:symbol "cal{IT}/(g⋅°C)" ;
   qudt:ucumCode "cal_IT.g-1.Cel-1"^^qudt:UCUMcs ;
   qudt:ucumCode "cal_IT/(g.Cel)"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J76" ;
@@ -2545,6 +2656,7 @@ unit:CAL_IT-PER-GM-K
   qudt:hasQuantityKind quantitykind:SpecificHeatCapacity ;
   qudt:iec61360Code "0112/2///62720#UAA363" ;
   qudt:plainTextDescription "unit calorieIT divided by the product of the SI base unit gram and Kelvin" ;
+  qudt:symbol "cal{IT}/(g⋅K)" ;
   qudt:ucumCode "cal_IT.g-1.K-1"^^qudt:UCUMcs ;
   qudt:ucumCode "cal_IT/(g.K)"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D76" ;
@@ -2558,6 +2670,7 @@ unit:CAL_IT-PER-SEC-CentiM-K
   qudt:hasQuantityKind quantitykind:ThermalConductivity ;
   qudt:iec61360Code "0112/2///62720#UAB108" ;
   qudt:plainTextDescription "unit of the thermal conductivity according to the Imperial system of units" ;
+  qudt:symbol "cal{IT}/(s⋅cm⋅K)" ;
   qudt:ucumCode "cal_IT.s-1.cm-1.K-1"^^qudt:UCUMcs ;
   qudt:ucumCode "cal_IT/(s.cm.K)"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D71" ;
@@ -2572,6 +2685,7 @@ unit:CAL_IT-PER-SEC-CentiM2-K
   qudt:hasQuantityKind quantitykind:CoefficientOfHeatTransfer ;
   qudt:iec61360Code "0112/2///62720#UAB096" ;
   qudt:plainTextDescription "unit of the heat transfer coefficient according to the Imperial system of units" ;
+  qudt:symbol "cal{IT}/(s⋅cm²⋅K)" ;
   qudt:ucumCode "cal_IT.s-1.cm-2.K-1"^^qudt:UCUMcs ;
   qudt:ucumCode "cal_IT/(s.cm2.K)"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D72" ;
@@ -2586,6 +2700,7 @@ unit:CAL_MEAN
   qudt:hasQuantityKind quantitykind:ThermalEnergy ;
   qudt:iec61360Code "0112/2///62720#UAA360" ;
   qudt:plainTextDescription "unit used particularly for calorific values of foods" ;
+  qudt:symbol "cal{mean}" ;
   qudt:ucumCode "cal_m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J75" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -2606,7 +2721,7 @@ unit:CAL_TH
 \\(\\approx 1.163 \\times 10^{-6} kWh\\)
 
 \\(\\approx 2.611 \\times 10^{19} eV\\)"""^^qudt:LatexString ;
-  qudt:symbol "cal_{th}" ;
+  qudt:symbol "cal" ;
   qudt:ucumCode "cal_th"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D35" ;
   qudt:unitOfSystem sou:CGS ;
@@ -2620,6 +2735,7 @@ unit:CAL_TH-PER-CentiM-SEC-DEG_C
   qudt:hasQuantityKind quantitykind:ThermalConductivity ;
   qudt:iec61360Code "0112/2///62720#UAA365" ;
   qudt:plainTextDescription "unit of the thermal conductivity according to the Imperial system of units" ;
+  qudt:symbol "cal{th}/(cm⋅s⋅°C)" ;
   qudt:ucumCode "cal_th.cm-1.s-1.Cel-1"^^qudt:UCUMcs ;
   qudt:ucumCode "cal_th/(cm.s.Cel)"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J78" ;
@@ -2638,6 +2754,7 @@ unit:CAL_TH-PER-G
   qudt:hasQuantityKind quantitykind:SpecificEnergy ;
   qudt:informativeReference "http://physics.nist.gov/Pubs/SP811/appenB9.html"^^xsd:anyURI ;
   qudt:informativeReference "http://www.efunda.com/glossary/units/units--thermal_heat_capacity--british_thermal_unit_therm_per_pound_mass.cfm"^^xsd:anyURI ;
+  qudt:symbol "calTH/g" ;
   qudt:ucumCode "cal_th.g-1"^^qudt:UCUMcs ;
   qudt:ucumCode "cal_th/g"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:IMPERIAL ;
@@ -2657,6 +2774,7 @@ unit:CAL_TH-PER-GM
   qudt:informativeReference "http://physics.nist.gov/Pubs/SP811/appenB9.html"^^xsd:anyURI ;
   qudt:informativeReference "http://www.efunda.com/glossary/units/units--thermal_heat_capacity--british_thermal_unit_therm_per_pound_mass.cfm"^^xsd:anyURI ;
   qudt:plainTextDescription "unit thermochemical calorie divided by the 0.001-fold of the SI base unit kilogram" ;
+  qudt:symbol "cal{th}/g" ;
   qudt:ucumCode "cal_th.g-1"^^qudt:UCUMcs ;
   qudt:ucumCode "cal_th/g"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B36" ;
@@ -2671,6 +2789,7 @@ unit:CAL_TH-PER-GM-DEG_C
   qudt:hasQuantityKind quantitykind:SpecificHeatCapacity ;
   qudt:iec61360Code "0112/2///62720#UAA366" ;
   qudt:plainTextDescription "unit calorie (thermochemical) divided by the product of the unit gram and degree Celsius" ;
+  qudt:symbol "cal{th}/(g⋅°C)" ;
   qudt:ucumCode "cal_th.g-1.Cel-1"^^qudt:UCUMcs ;
   qudt:ucumCode "cal_th/(g.Cel)"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J79" ;
@@ -2684,6 +2803,7 @@ unit:CAL_TH-PER-GM-K
   qudt:hasQuantityKind quantitykind:SpecificHeatCapacity ;
   qudt:iec61360Code "0112/2///62720#UAA367" ;
   qudt:plainTextDescription "unit calorie (thermochemical) divided by the product of the SI derived unit gram and the SI base unit Kelvin" ;
+  qudt:symbol "cal{th}/(g⋅K)" ;
   qudt:ucumCode "cal_th.g-1.K-1"^^qudt:UCUMcs ;
   qudt:ucumCode "cal_th/(g.K)"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D37" ;
@@ -2697,6 +2817,7 @@ unit:CAL_TH-PER-MIN
   qudt:hasQuantityKind quantitykind:HeatFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA368" ;
   qudt:plainTextDescription "unit calorie divided by the unit minute" ;
+  qudt:symbol "cal{th}/min" ;
   qudt:ucumCode "cal_th.min-1"^^qudt:UCUMcs ;
   qudt:ucumCode "cal_th/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J81" ;
@@ -2710,6 +2831,7 @@ unit:CAL_TH-PER-SEC
   qudt:hasQuantityKind quantitykind:HeatFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA369" ;
   qudt:plainTextDescription "unit calorie divided by the SI base unit second" ;
+  qudt:symbol "cal{th}/s" ;
   qudt:ucumCode "cal_th.s-1"^^qudt:UCUMcs ;
   qudt:ucumCode "cal_th/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J82" ;
@@ -2723,6 +2845,7 @@ unit:CAL_TH-PER-SEC-CentiM-K
   qudt:hasQuantityKind quantitykind:ThermalConductivity ;
   qudt:iec61360Code "0112/2///62720#UAB109" ;
   qudt:plainTextDescription "unit of the thermal conductivity according to the Imperial system of units" ;
+  qudt:symbol "cal{th}/(s⋅cm⋅K)" ;
   qudt:ucumCode "cal_th.s-1.cm-1.K-1"^^qudt:UCUMcs ;
   qudt:ucumCode "cal_th/(s.cm.K)"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D38" ;
@@ -2737,6 +2860,7 @@ unit:CAL_TH-PER-SEC-CentiM2-K
   qudt:hasQuantityKind quantitykind:CoefficientOfHeatTransfer ;
   qudt:iec61360Code "0112/2///62720#UAB097" ;
   qudt:plainTextDescription "unit of the heat transfer coefficient according to the Imperial system of units" ;
+  qudt:symbol "cal{th}/(s⋅cm²⋅K)" ;
   qudt:ucumCode "cal_th.s-1.cm-2.K-1"^^qudt:UCUMcs ;
   qudt:ucumCode "cal_th/(s.cm2.K)"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D39" ;
@@ -2754,6 +2878,7 @@ unit:CARAT
   qudt:hasQuantityKind quantitykind:Mass ;
   qudt:iec61360Code "0112/2///62720#UAB166" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Carat?oldid=477129057"^^xsd:anyURI ;
+  qudt:symbol "ct" ;
   qudt:ucumCode "[car_m]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "CTM" ;
   qudt:unitOfSystem sou:CGS ;
@@ -2769,6 +2894,7 @@ unit:CASES-PER-1000I-YR
   qudt:hasQuantityKind quantitykind:Incidence ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Incidence_(epidemiology)"^^xsd:anyURI ;
   qudt:plainTextDescription "The typical expression of morbidity rate, expressed as cases per 1000 individuals, per year." ;
+  qudt:symbol "Cases/1000 individuals/year" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Cases per 1000 individuals per year"@en ;
 .
@@ -2801,6 +2927,7 @@ unit:CD-PER-IN2
   qudt:hasDimensionVector qkdv:A0E0L-2I1M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Luminance ;
   qudt:iec61360Code "0112/2///62720#UAB257" ;
+  qudt:symbol "cd/in²" ;
   qudt:ucumCode "cd.[in_i]-2"^^qudt:UCUMcs ;
   qudt:ucumCode "cd/[in_i]2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P28" ;
@@ -2818,6 +2945,7 @@ unit:CD-PER-M2
   qudt:hasDimensionVector qkdv:A0E0L-2I1M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Luminance ;
   qudt:iec61360Code "0112/2///62720#UAA371" ;
+  qudt:symbol "cd/m²" ;
   qudt:ucumCode "cd.m-2"^^qudt:UCUMcs ;
   qudt:ucumCode "cd/m2"^^qudt:UCUMcs ;
   qudt:udunitsCode "nt" ;
@@ -2879,7 +3007,7 @@ unit:CM_H2O
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerArea ;
   qudt:hasQuantityKind quantitykind:VaporPressure ;
-  qudt:symbol "cmH2O" ;
+  qudt:symbol "cmH₂0" ;
   qudt:unitOfSystem sou:CGS ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Centimeter of Water"@en-us ;
@@ -2896,7 +3024,7 @@ unit:CORD
   qudt:hasQuantityKind quantitykind:DryVolume ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Cord?oldid=490232340"^^xsd:anyURI ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/cord> ;
-  qudt:symbol "C" ;
+  qudt:symbol "cord" ;
   qudt:ucumCode "[crd_us]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "WCD" ;
   qudt:unitOfSystem sou:USCS ;
@@ -2911,7 +3039,7 @@ unit:CP
   qudt:hasDimensionVector qkdv:A0E0L0I1M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:LuminousIntensity ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Candlepower?oldid=491140098"^^xsd:anyURI ;
-  qudt:symbol "cd" ;
+  qudt:symbol "cp" ;
   qudt:unitOfSystem sou:CGS ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Candlepower"@en ;
@@ -2936,6 +3064,7 @@ unit:CUP_US
   qudt:hasQuantityKind quantitykind:LiquidVolume ;
   qudt:iec61360Code "0112/2///62720#UAA404" ;
   qudt:plainTextDescription "unit of the volume according to the Anglo-American system of units" ;
+  qudt:symbol "cup{US}" ;
   qudt:ucumCode "[cup_us]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G21" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -2949,6 +3078,7 @@ unit:CWT_LONG
   qudt:expression "\\(cwt long\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Mass ;
+  qudt:symbol "cwt{long}" ;
   qudt:ucumCode "[lcwt_av]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "CWI" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -2965,6 +3095,7 @@ unit:CWT_SHORT
   qudt:expression "\\(cwt\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Mass ;
+  qudt:symbol "cwt{short}" ;
   qudt:ucumCode "[scwt_av]"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Hundred Weight - Short"@en ;
@@ -2999,6 +3130,7 @@ Abcoulomb Per Square Centimeter (abcoulomb/cm2) has a dimension of \\(L_2TI\\). 
   qudt:hasQuantityKind quantitykind:ElectricChargePerArea ;
   qudt:informativeReference "http://www.efunda.com/glossary/units/units--electric_charge_surface_density--abcoulomb_per_square_centimeter.cfm"^^xsd:anyURI ;
   qudt:latexDefinition "\\(abcoulomb/cm^2\\)"^^qudt:LatexString ;
+  qudt:symbol "abC/cm²" ;
   qudt:ucumCode "10.C.cm-2"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:CGS ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -3033,6 +3165,7 @@ unit:C_Stat-PER-CentiM2
   qudt:expression "\\(statc-per-cm2\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E1L-2I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:ElectricChargePerArea ;
+  qudt:symbol "statC/cm²" ;
   qudt:unitOfSystem sou:CGS ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Statcoulomb per Square Centimeter"@en-us ;
@@ -3045,6 +3178,7 @@ unit:C_Stat-PER-MOL
   qudt:expression "\\(statC/mol\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A-1E1L0I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:ElectricChargePerAmountOfSubstance ;
+  qudt:symbol "statC/mol" ;
   qudt:unitOfSystem sou:CGS ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Statcoulomb per Mole"@en ;
@@ -3128,6 +3262,7 @@ unit:CentiGM
   qudt:isScalingOf unit:KiloGM ;
   qudt:plainTextDescription "0,000 01-fold of the SI base unit kilogram" ;
   qudt:prefix prefix:Centi ;
+  qudt:symbol "cg" ;
   qudt:ucumCode "cg"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "CGM" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -3140,6 +3275,7 @@ unit:CentiL
   qudt:hasQuantityKind quantitykind:LiquidVolume ;
   qudt:iec61360Code "0112/2///62720#UAA373" ;
   qudt:plainTextDescription "0,01-fold of the unit litre" ;
+  qudt:symbol "cL" ;
   qudt:ucumCode "cL"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "CLT" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -3158,7 +3294,7 @@ unit:CentiM
   qudt:informativeReference "http://en.wikipedia.org/wiki/Centimetre?oldid=494931891"^^xsd:anyURI ;
   qudt:isScalingOf unit:M ;
   qudt:prefix prefix:Centi ;
-  qudt:symbol "㎝" ;
+  qudt:symbol "cm" ;
   qudt:ucumCode "cm"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "CMT" ;
   qudt:unitOfSystem sou:CGS ;
@@ -3174,6 +3310,7 @@ unit:CentiM-PER-HR
   qudt:hasQuantityKind quantitykind:Velocity ;
   qudt:iec61360Code "0112/2///62720#UAA378" ;
   qudt:plainTextDescription "0,01-fold of the SI base unit metre divided by the unit hour" ;
+  qudt:symbol "cm/hr" ;
   qudt:ucumCode "cm.h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "cm/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H49" ;
@@ -3188,6 +3325,7 @@ unit:CentiM-PER-K
   qudt:hasQuantityKind quantitykind:LinearThermalExpansion ;
   qudt:iec61360Code "0112/2///62720#UAA376" ;
   qudt:plainTextDescription "0,01-fold of the SI base unit metre divided by the SI base unit kelvin" ;
+  qudt:symbol "cm/K" ;
   qudt:ucumCode "cm.K-1"^^qudt:UCUMcs ;
   qudt:ucumCode "cm/K"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F51" ;
@@ -3200,6 +3338,7 @@ unit:CentiM-PER-KiloYR
   qudt:conversionMultiplier 0.000000000000316880878140289 ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Velocity ;
+  qudt:symbol "cm/(1000 yr)" ;
   qudt:ucumCode "cm.ka-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Centimetres per thousand years"@en ;
@@ -3216,6 +3355,7 @@ unit:CentiM-PER-SEC
   qudt:hasQuantityKind quantitykind:Velocity ;
   qudt:iec61360Code "0112/2///62720#UAA379" ;
   qudt:latexDefinition "\\(cm/s\\)"^^qudt:LatexString ;
+  qudt:symbol "cm/s" ;
   qudt:ucumCode "cm.s-1"^^qudt:UCUMcs ;
   qudt:ucumCode "cm/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "2M" ;
@@ -3235,6 +3375,7 @@ unit:CentiM-PER-SEC2
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Acceleration ;
   qudt:iec61360Code "0112/2///62720#UAB398" ;
+  qudt:symbol "cm/s²" ;
   qudt:ucumCode "cm.s-2"^^qudt:UCUMcs ;
   qudt:ucumCode "cm/s2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M39" ;
@@ -3250,6 +3391,7 @@ unit:CentiM-SEC-DEG_C
   qudt:expression "\\(cm-s-degC\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H1T1D0 ;
   qudt:hasQuantityKind quantitykind:LengthTemperatureTime ;
+  qudt:symbol "cm⋅s⋅°C" ;
   qudt:ucumCode "cm.s.Cel-1"^^qudt:UCUMcs ;
   qudt:ucumCode "cm.s/Cel"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:CGS ;
@@ -3271,7 +3413,7 @@ unit:CentiM2
   qudt:iec61360Code "0112/2///62720#UAA384" ;
   qudt:isScalingOf unit:M2 ;
   qudt:prefix prefix:Centi ;
-  qudt:symbol "㎠" ;
+  qudt:symbol "cm²" ;
   qudt:ucumCode "cm2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "CMK" ;
   qudt:unitOfSystem sou:CGS ;
@@ -3288,6 +3430,7 @@ unit:CentiM2-MIN
   qudt:expression "\\(cm^{2}m\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:AreaTime ;
+  qudt:symbol "cm²m" ;
   qudt:ucumCode "cm2.min"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Square Centimeter Minute"@en-us ;
@@ -3297,6 +3440,7 @@ unit:CentiM2-PER-CentiM3
   a qudt:Unit ;
   qudt:conversionMultiplier 100.0 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T0D0 ;
+  qudt:symbol "cm²/cm³" ;
   qudt:ucumCode "cm2.cm-3"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Square centimetres per cubic centimetre"@en ;
@@ -3306,6 +3450,7 @@ unit:CentiM2-PER-SEC
   qudt:conversionMultiplier 0.0001 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:AreaPerTime ;
+  qudt:symbol "cm²/s" ;
   qudt:ucumCode "cm2.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M81" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -3321,6 +3466,7 @@ unit:CentiM2-SEC
   qudt:expression "\\(cm^2 . s\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:AreaTime ;
+  qudt:symbol "cm²⋅s" ;
   qudt:ucumCode "cm2.s"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:CGS ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -3339,6 +3485,7 @@ unit:CentiM3
   qudt:iec61360Code "0112/2///62720#UAA385" ;
   qudt:isScalingOf unit:M3 ;
   qudt:prefix prefix:Centi ;
+  qudt:symbol "cm³" ;
   qudt:ucumCode "cm3"^^qudt:UCUMcs ;
   qudt:udunitsCode "cc" ;
   qudt:uneceCommonCode "CMQ" ;
@@ -3353,6 +3500,7 @@ unit:CentiM3-PER-CentiM3
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:VolumeFraction ;
   qudt:plainTextDescription "volume ratio consisting of the 0.000 001-fold of the power of the SI base unit metre with the exponent 3 divided by the power of the SI base unit metre with the exponent 3" ;
+  qudt:symbol "cm³/cm³" ;
   qudt:ucumCode "cm3.cm-3"^^qudt:UCUMcs ;
   qudt:ucumCode "cm3/cm3"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -3366,6 +3514,7 @@ unit:CentiM3-PER-DAY
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA388" ;
   qudt:plainTextDescription "0,000 001-fold of the power of the SI base unit metre with the exponent 3 divided by the unit day" ;
+  qudt:symbol "cm³/day" ;
   qudt:ucumCode "cm3.d-1"^^qudt:UCUMcs ;
   qudt:ucumCode "cm3/d"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G47" ;
@@ -3380,6 +3529,7 @@ unit:CentiM3-PER-HR
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA391" ;
   qudt:plainTextDescription "0,000 001-fold of the power of the SI base unit metre with the exponent 3 divided by the unit hour" ;
+  qudt:symbol "cm³/hr" ;
   qudt:ucumCode "cm3.h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "cm3/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G48" ;
@@ -3394,6 +3544,7 @@ unit:CentiM3-PER-K
   qudt:hasQuantityKind quantitykind:VolumeThermalExpansion ;
   qudt:iec61360Code "0112/2///62720#UAA386" ;
   qudt:plainTextDescription "0,000 001-fold of the power of the SI base unit metre with the exponent 3 divided by the SI base unit kelvin" ;
+  qudt:symbol "cm³/K" ;
   qudt:ucumCode "cm3.K-1"^^qudt:UCUMcs ;
   qudt:ucumCode "cm3/K"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G27" ;
@@ -3408,6 +3559,7 @@ unit:CentiM3-PER-M3
   qudt:hasQuantityKind quantitykind:VolumeFraction ;
   qudt:iec61360Code "0112/2///62720#UAA394" ;
   qudt:plainTextDescription "volume ratio consisting of the 0.000 001-fold of the power of the SI base unit metre with the exponent 3 divided by the power of the SI base unit metre with the exponent 3" ;
+  qudt:symbol "cm³/m³" ;
   qudt:ucumCode "cm3.m-3"^^qudt:UCUMcs ;
   qudt:ucumCode "cm3/m3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J87" ;
@@ -3422,6 +3574,7 @@ unit:CentiM3-PER-MIN
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA395" ;
   qudt:plainTextDescription "0,000 001-fold of the power of the SI base unit metre with the exponent 3 divided by the unit minute" ;
+  qudt:symbol "cm³/min" ;
   qudt:ucumCode "cm3.min-1"^^qudt:UCUMcs ;
   qudt:ucumCode "cm3/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G49" ;
@@ -3437,6 +3590,7 @@ unit:CentiM3-PER-MOL
   qudt:hasQuantityKind quantitykind:MolarVolume ;
   qudt:iec61360Code "0112/2///62720#UAA398" ;
   qudt:plainTextDescription "0.000 001-fold of the power of the SI base unit metre with the exponent 3 divided by the SI base unit mol" ;
+  qudt:symbol "cm³/mol" ;
   qudt:ucumCode "cm3.mol-1"^^qudt:UCUMcs ;
   qudt:ucumCode "cm3/mol"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A36" ;
@@ -3463,6 +3617,7 @@ unit:CentiM3-PER-SEC
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA399" ;
   qudt:plainTextDescription "0,000 001-fold of the power of the SI base unit metre with the exponent 3 divided by the SI base unit second" ;
+  qudt:symbol "cm³/s" ;
   qudt:ucumCode "cm3.s-1"^^qudt:UCUMcs ;
   qudt:ucumCode "cm3/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "2J" ;
@@ -3478,6 +3633,7 @@ unit:CentiMOL-PER-KiloGM
   qudt:hasQuantityKind quantitykind:IonicStrength ;
   qudt:hasQuantityKind quantitykind:MolalityOfSolute ;
   qudt:plainTextDescription "1/100 of SI unit of amount of substance per kilogram" ;
+  qudt:symbol "cmol/kg" ;
   qudt:ucumCode "cmol.kg-1"^^qudt:UCUMcs ;
   qudt:ucumCode "cmol/kg"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -3494,7 +3650,7 @@ unit:CentiM_H2O
   qudt:iec61360Code "0112/2///62720#UAA402" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Centimetre_of_water?oldid=487656894"^^xsd:anyURI ;
   qudt:plainTextDescription "non SI conforming unit of pressure that corresponds to the static pressure generated by a water column with a height of 1 centimetre" ;
-  qudt:symbol "cmH2O" ;
+  qudt:symbol "cmH₂0" ;
   qudt:ucumCode "cm[H2O]"^^qudt:UCUMcs ;
   qudt:udunitsCode "cmH2O" ;
   qudt:udunitsCode "cm_H2O" ;
@@ -3514,6 +3670,7 @@ unit:CentiM_HG
   qudt:hasQuantityKind quantitykind:VaporPressure ;
   qudt:iec61360Code "0112/2///62720#UAA403" ;
   qudt:plainTextDescription "not SI conform unit of the pressure, that corresponds with the static pressure generated by a mercury column with the height of 1 centimetre" ;
+  qudt:symbol "cmHg" ;
   qudt:ucumCode "cm[Hg]"^^qudt:UCUMcs ;
   qudt:udunitsCode "cmHg" ;
   qudt:udunitsCode "cm_Hg" ;
@@ -3529,6 +3686,7 @@ unit:CentiN-M
   qudt:hasQuantityKind quantitykind:Torque ;
   qudt:iec61360Code "0112/2///62720#UAA355" ;
   qudt:plainTextDescription "0,01-fold of the product of the SI derived unit newton and SI base unit metre" ;
+  qudt:symbol "cN⋅m" ;
   qudt:ucumCode "cN.m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J72" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -3556,6 +3714,7 @@ unit:CentiPOISE-PER-BAR
   qudt:hasQuantityKind quantitykind:Time ;
   qudt:iec61360Code "0112/2///62720#UAA358" ;
   qudt:plainTextDescription "0.01-fold of the CGS unit of the dynamic viscosity poise divided by the unit of the pressure bar" ;
+  qudt:symbol "cP/bar" ;
   qudt:ucumCode "cP.bar-1"^^qudt:UCUMcs ;
   qudt:ucumCode "cP/bar"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J74" ;
@@ -3736,7 +3895,7 @@ unit:DAY
   qudt:iec61360Code "0112/2///62720#UAA407" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Day?oldid=494970012"^^xsd:anyURI ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/day> ;
-  qudt:symbol "d" ;
+  qudt:symbol "day" ;
   qudt:ucumCode "d"^^qudt:UCUMcs ;
   qudt:udunitsCode "d" ;
   qudt:uneceCommonCode "DAY" ;
@@ -3751,7 +3910,7 @@ unit:DAY_Sidereal
   qudt:iec61360Code "0112/2///62720#UAA412" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Sidereal_time"^^xsd:anyURI ;
   qudt:informativeReference "http://scienceworld.wolfram.com/astronomy/SiderealDay.html"^^xsd:anyURI ;
-  qudt:symbol "d" ;
+  qudt:symbol "day{sidereal}" ;
   qudt:ucumCode "d"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Sidereal Day"@en ;
@@ -3764,6 +3923,7 @@ unit:DEATHS-PER-1000000I-YR
   qudt:hasQuantityKind quantitykind:MortalityRate ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Mortality_rate"^^xsd:anyURI ;
   qudt:plainTextDescription "The expression of mortality rate, expressed as deaths per Million individuals, per year." ;
+  qudt:symbol "deaths/million individuals/yr" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Deaths per Million individuals per year"@en ;
 .
@@ -3775,6 +3935,7 @@ unit:DEATHS-PER-1000I-YR
   qudt:hasQuantityKind quantitykind:MortalityRate ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Mortality_rate"^^xsd:anyURI ;
   qudt:plainTextDescription "The typical expression of mortality rate, expressed as deaths per 1000 individuals, per year." ;
+  qudt:symbol "deaths/1000 individuals/yr" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Deaths per 1000 individuals per year"@en ;
 .
@@ -3786,7 +3947,7 @@ unit:DECADE
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Dimensionless ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Decade_(log_scale)"^^xsd:anyURI ;
-  qudt:symbol "oct" ;
+  qudt:symbol "dec" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Dec"@en ;
 .
@@ -3814,6 +3975,7 @@ unit:DEG-PER-HR
   qudt:expression "\\(deg/h\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:AngularVelocity ;
+  qudt:symbol "°/h" ;
   qudt:ucumCode "deg.h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "deg/h"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:IMPERIAL ;
@@ -3825,6 +3987,7 @@ unit:DEG-PER-M
   dcterms:description "A change of angle in one SI unit of length."@en ;
   qudt:conversionMultiplier 0.0174532925199433 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T0D0 ;
+  qudt:symbol "°/m" ;
   qudt:ucumCode "deg.m-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H27" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -3837,6 +4000,7 @@ unit:DEG-PER-MIN
   qudt:expression "\\(deg-per-min\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:AngularVelocity ;
+  qudt:symbol "°/min" ;
   qudt:ucumCode "deg.min-1"^^qudt:UCUMcs ;
   qudt:ucumCode "deg/min"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -3851,6 +4015,7 @@ unit:DEG-PER-SEC
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:AngularVelocity ;
   qudt:iec61360Code "0112/2///62720#UAA026" ;
+  qudt:symbol "°/s" ;
   qudt:ucumCode "deg.s-1"^^qudt:UCUMcs ;
   qudt:ucumCode "deg/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E96" ;
@@ -3867,6 +4032,7 @@ unit:DEG-PER-SEC2
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:AngularAcceleration ;
   qudt:iec61360Code "0112/2///62720#UAB407" ;
+  qudt:symbol "°/s²" ;
   qudt:ucumCode "deg.s-2"^^qudt:UCUMcs ;
   qudt:ucumCode "deg/s2"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:IMPERIAL ;
@@ -3880,6 +4046,7 @@ unit:DEG2
   qudt:expression "\\(deg^2\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:SolidAngle ;
+  qudt:symbol "°²" ;
   qudt:ucumCode "deg2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Square degree"@en ;
@@ -3891,6 +4058,7 @@ unit:DEGREE_API
   qudt:hasQuantityKind quantitykind:Gravity_API ;
   qudt:iec61360Code "0112/2///62720#UAA027" ;
   qudt:plainTextDescription "unit for the determination of the density of petroleum at 60 degrees F (15.56 degrees C)" ;
+  qudt:symbol "°API" ;
   qudt:uneceCommonCode "J13" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Degree API"@en ;
@@ -3902,6 +4070,7 @@ unit:DEGREE_BALLING
   qudt:hasQuantityKind quantitykind:MassDensity ;
   qudt:iec61360Code "0112/2///62720#UAA031" ;
   qudt:plainTextDescription "unit for the mixing ratio of a soluble dry substance in water at 17.5 degrees C similar to the percent designation for solutions, in which a solution of 1 g saccharose in 100 g saccharose/ water solution corresponds to 1 degree Balling and respectively a one percent solution" ;
+  qudt:symbol "°Balling" ;
   qudt:uneceCommonCode "J17" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Degree Balling"@en ;
@@ -3915,6 +4084,7 @@ unit:DEGREE_BAUME
   qudt:plainTextDescription """graduation of the areometer scale for determination of densitiy of fluids.
 
 The Baumé scale is a pair of hydrometer scales developed by French pharmacist Antoine Baumé in 1768 to measure density of various liquids. The unit of the Baumé scale has been notated variously as degrees Baumé, B°, Bé° and simply Baumé (the accent is not always present). One scale measures the density of liquids heavier than water and the other, liquids lighter than water. The Baumé of distilled water is 0. The API gravity scale is based on errors in early implementations of the Baumé scale.""" ;
+  qudt:symbol "°Bé{origin}" ;
   qudt:uneceCommonCode "J14" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Degree Baume (origin Scale)"@en ;
@@ -3926,6 +4096,7 @@ unit:DEGREE_BAUME_US_HEAVY
   qudt:hasQuantityKind quantitykind:MassDensity ;
   qudt:iec61360Code "0112/2///62720#UAA029" ;
   qudt:plainTextDescription "graduation of the areometer scale for determination of density of fluids according to the Anglo-American system of units, which are heavier than water" ;
+  qudt:symbol "°Bé{US Heavy}" ;
   qudt:uneceCommonCode "J15" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Degree Baume (US Heavy)"@en ;
@@ -3937,6 +4108,7 @@ unit:DEGREE_BAUME_US_LIGHT
   qudt:hasQuantityKind quantitykind:MassDensity ;
   qudt:iec61360Code "0112/2///62720#UAA030" ;
   qudt:plainTextDescription "graduation of the areometer scale for determination of density of fluids according to the Anglo-American system of units, which are lighter than water" ;
+  qudt:symbol "°Bé{US Light}" ;
   qudt:uneceCommonCode "J16" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Degree Baume (US Light)"@en ;
@@ -3948,6 +4120,7 @@ unit:DEGREE_BRIX
   qudt:hasQuantityKind quantitykind:MassDensity ;
   qudt:iec61360Code "0112/2///62720#UAA032" ;
   qudt:plainTextDescription "unit named according to Adolf Brix for the mixing ratio of a soluble dry substance in water with 15.5 °C similar to the percent designation for solutions, in which a solution of 1 g saccharose in 100 g saccharose/water solution corresponds to 1 °Brix and respectively an one percent solution" ;
+  qudt:symbol "°Bx" ;
   qudt:uneceCommonCode "J18" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Degree Brix"@en ;
@@ -3959,6 +4132,7 @@ unit:DEGREE_OECHSLE
   qudt:hasQuantityKind quantitykind:MassDensity ;
   qudt:iec61360Code "0112/2///62720#UAA048" ;
   qudt:plainTextDescription "unit of the density of the must, as measure for the proportion of the soluble material in the grape must" ;
+  qudt:symbol "°Oe" ;
   qudt:uneceCommonCode "J27" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Degree Oechsle"@en ;
@@ -3970,6 +4144,7 @@ unit:DEGREE_PLATO
   qudt:hasQuantityKind quantitykind:MassDensity ;
   qudt:iec61360Code "0112/2///62720#UAA049" ;
   qudt:plainTextDescription "unit for the mixing ratio of the original gravity in the beer brew at 17,5 °C before the fermentation" ;
+  qudt:symbol "°P" ;
   qudt:uneceCommonCode "PLA" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Degree Plato"@en ;
@@ -3981,6 +4156,7 @@ unit:DEGREE_TWADDELL
   qudt:hasQuantityKind quantitykind:MassDensity ;
   qudt:iec61360Code "0112/2///62720#UAA054" ;
   qudt:plainTextDescription "unit of the density of fluids, which are heavier than water" ;
+  qudt:symbol "°Tw" ;
   qudt:uneceCommonCode "J31" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Degree Twaddell"@en ;
@@ -4005,6 +4181,7 @@ unit:DEG_C
   qudt:informativeReference "http://en.wikipedia.org/wiki/Celsius?oldid=494152178"^^xsd:anyURI ;
   qudt:latexDefinition "\\(\\,^{\\circ}{\\rm C}\\)"^^qudt:LatexString ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/degreeCelsius> ;
+  qudt:symbol "°C" ;
   qudt:ucumCode "Cel"^^qudt:UCUMcs ;
   qudt:udunitsCode "°C" ;
   qudt:udunitsCode "℃" ;
@@ -4020,6 +4197,7 @@ unit:DEG_C-CentiM
   qudt:expression "\\(cm-degC\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H1T0D0 ;
   qudt:hasQuantityKind quantitykind:LengthTemperature ;
+  qudt:symbol "°C⋅cm" ;
   qudt:ucumCode "Cel.cm"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:CGS ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -4031,6 +4209,7 @@ unit:DEG_C-KiloGM-PER-M2
   dcterms:description "Derived unit for the product of the temperature in degrees Celsius and the mass density of a medium, integrated over vertical depth or height in metres."@en ;
   qudt:conversionMultiplier 1.0 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M1H1T0D0 ;
+  qudt:symbol "°C⋅kg/m²" ;
   qudt:ucumCode "Cel.kg.m-2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Degrees Celsius kilogram per square metre"@en ;
@@ -4042,6 +4221,7 @@ unit:DEG_C-PER-HR
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H1T-1D0 ;
   qudt:hasQuantityKind quantitykind:TemperaturePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA036" ;
+  qudt:symbol "°C/hr" ;
   qudt:ucumCode "Cel.h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "Cel/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H12" ;
@@ -4055,6 +4235,7 @@ unit:DEG_C-PER-K
   qudt:hasQuantityKind quantitykind:TemperatureRatio ;
   qudt:iec61360Code "0112/2///62720#UAA034" ;
   qudt:plainTextDescription "unit with the name Degree Celsius divided by the SI base unit kelvin" ;
+  qudt:symbol "°C/K" ;
   qudt:ucumCode "Cel.K-1"^^qudt:UCUMcs ;
   qudt:ucumCode "Cel/K"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E98" ;
@@ -4065,6 +4246,7 @@ unit:DEG_C-PER-M
   a qudt:Unit ;
   qudt:conversionMultiplier 1.0 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H1T0D0 ;
+  qudt:symbol "°C/m" ;
   qudt:ucumCode "Cel.m-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Degrees Celsius per metre"@en ;
@@ -4076,6 +4258,7 @@ unit:DEG_C-PER-MIN
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H1T-1D0 ;
   qudt:hasQuantityKind quantitykind:TemperaturePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA037" ;
+  qudt:symbol "°C/m" ;
   qudt:ucumCode "Cel.min-1"^^qudt:UCUMcs ;
   qudt:ucumCode "Cel/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H13" ;
@@ -4089,6 +4272,7 @@ unit:DEG_C-PER-SEC
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H1T-1D0 ;
   qudt:hasQuantityKind quantitykind:TemperaturePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA038" ;
+  qudt:symbol "°C/s" ;
   qudt:ucumCode "Cel.s-1"^^qudt:UCUMcs ;
   qudt:ucumCode "Cel/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H14" ;
@@ -4101,6 +4285,7 @@ unit:DEG_C-PER-YR
   qudt:conversionMultiplier 0.0000000316880878140289 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H1T-1D0 ;
   qudt:hasQuantityKind quantitykind:TemperaturePerTime ;
+  qudt:symbol "°C/yr" ;
   qudt:ucumCode "Cel.a-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Degrees Celsius per year"@en ;
@@ -4111,6 +4296,7 @@ unit:DEG_C-WK
   qudt:conversionMultiplier 604800.0 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H1T1D0 ;
   qudt:hasQuantityKind quantitykind:TimeTemperature ;
+  qudt:symbol "°C/wk" ;
   qudt:ucumCode "Cel.wk"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Degree Celsius week"@en ;
@@ -4119,6 +4305,7 @@ unit:DEG_C2-PER-SEC
   a qudt:Unit ;
   qudt:conversionMultiplier 1.0 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H2T-1D0 ;
+  qudt:symbol "°C²⋅s" ;
   qudt:ucumCode "K2.s-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Square Degrees Celsius per second"@en ;
@@ -4130,6 +4317,7 @@ unit:DEG_C_GROWING_CEREAL-DAY
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H1T1D0 ;
   qudt:hasQuantityKind quantitykind:GrowingDegreeDay_Cereal ;
   qudt:plainTextDescription "The sum of excess temperature over 5.5°C, where the temperature is the mean of the minimum and maximum atmospheric temperature in a day. This measure is appropriate for most cereal crops." ;
+  qudt:symbol "GDD" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Growing Degree Days (Cereals)"@en ;
 .
@@ -4148,6 +4336,7 @@ unit:DEG_F
   qudt:hasQuantityKind quantitykind:Temperature ;
   qudt:iec61360Code "0112/2///62720#UAA039" ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/degreeFahrenheit> ;
+  qudt:symbol "°F" ;
   qudt:ucumCode "[degF]"^^qudt:UCUMcs ;
   qudt:udunitsCode "°F" ;
   qudt:udunitsCode "℉" ;
@@ -4165,6 +4354,7 @@ unit:DEG_F-HR
   qudt:expression "\\(degF-hr\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M-1H1T3D0 ;
   qudt:hasQuantityKind quantitykind:ThermalResistivity ;
+  qudt:symbol "°F⋅hr" ;
   qudt:unitOfSystem sou:IMPERIAL ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Degree Fahrenheit Hour"@en ;
@@ -4176,6 +4366,7 @@ unit:DEG_F-HR-FT2-PER-BTU_IT
   qudt:hasQuantityKind quantitykind:ThermalInsulance ;
   qudt:iec61360Code "0112/2///62720#UAA043" ;
   qudt:plainTextDescription "unit of the thermal resistor according to the Imperial system of units" ;
+  qudt:symbol "°F⋅hr⋅ft²/Btu{IT}" ;
   qudt:ucumCode "[degF].h-1.[ft_i]-2.[Btu_IT]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[degF]/(h.[ft_i]2.[Btu_IT])"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J22" ;
@@ -4189,6 +4380,7 @@ unit:DEG_F-HR-FT2-PER-BTU_TH
   qudt:hasQuantityKind quantitykind:ThermalInsulance ;
   qudt:iec61360Code "0112/2///62720#UAA040" ;
   qudt:plainTextDescription "unit of the thermal resistor according to the according to the Imperial system of units" ;
+  qudt:symbol "°F⋅hr⋅ft²/Btu{th}" ;
   qudt:ucumCode "[degF].h-1.[ft_i]-2.[Btu_th]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[degF]/(h.[ft_i]2.[Btu_th])"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J19" ;
@@ -4204,6 +4396,7 @@ unit:DEG_F-HR-PER-BTU_IT
   qudt:expression "\\(degF-hr/Btu\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M-1H1T3D0 ;
   qudt:hasQuantityKind quantitykind:ThermalResistance ;
+  qudt:symbol "°F⋅hr/Btu" ;
   qudt:ucumCode "[degF].h.[Btu_IT]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[degF].h/[Btu_IT]"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:IMPERIAL ;
@@ -4219,6 +4412,7 @@ unit:DEG_F-PER-HR
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H1T-1D0 ;
   qudt:hasQuantityKind quantitykind:TemperaturePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA044" ;
+  qudt:symbol "°F/h" ;
   qudt:ucumCode "[degF].h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[degF]/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J23" ;
@@ -4232,6 +4426,7 @@ unit:DEG_F-PER-K
   qudt:hasQuantityKind quantitykind:TemperatureRatio ;
   qudt:iec61360Code "0112/2///62720#UAA041" ;
   qudt:plainTextDescription "traditional unit degree Fahrenheit for temperature according to the Anglo-American system of units divided by the SI base unit Kelvin" ;
+  qudt:symbol "°F/K" ;
   qudt:ucumCode "[degF].K-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[degF]/K"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J20" ;
@@ -4247,6 +4442,7 @@ unit:DEG_F-PER-MIN
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H1T-1D0 ;
   qudt:hasQuantityKind quantitykind:TemperaturePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA045" ;
+  qudt:symbol "°F/m" ;
   qudt:ucumCode "[degF].min-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[degF]/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J24" ;
@@ -4262,6 +4458,7 @@ unit:DEG_F-PER-SEC
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H1T-1D0 ;
   qudt:hasQuantityKind quantitykind:TemperaturePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA046" ;
+  qudt:symbol "°F/s" ;
   qudt:ucumCode "[degF].s-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[degF]/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J25" ;
@@ -4277,6 +4474,7 @@ unit:DEG_F-PER-SEC2
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H1T-1D0 ;
   qudt:hasQuantityKind quantitykind:TemperaturePerTime ;
   qudt:plainTextDescription "'Degree Fahrenheit per Square Second' is a unit for expressing the acceleration of a temperature expressed as 'degF /s2'." ;
+  qudt:symbol "°F/s²" ;
   qudt:ucumCode "[degF].s-2"^^qudt:UCUMcs ;
   qudt:ucumCode "[degF]/s2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -4296,7 +4494,6 @@ unit:DEG_R
   qudt:informativeReference "http://en.wikipedia.org/wiki/Rankine_scale"^^xsd:anyURI ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/degreeRankine> ;
   qudt:symbol "°R" ;
-  qudt:symbol "°Ra" ;
   qudt:ucumCode "[degR]"^^qudt:UCUMcs ;
   qudt:udunitsCode "°R" ;
   qudt:uneceCommonCode "A48" ;
@@ -4312,6 +4509,7 @@ unit:DEG_R-PER-HR
   qudt:hasQuantityKind quantitykind:TemperaturePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA051" ;
   qudt:isScalingOf unit:DEG_R-PER-MIN ;
+  qudt:symbol "°R/h" ;
   qudt:ucumCode "[degR].h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[degR]/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J28" ;
@@ -4327,6 +4525,7 @@ unit:DEG_R-PER-MIN
   qudt:hasQuantityKind quantitykind:TemperaturePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA052" ;
   qudt:isScalingOf unit:DEG_R-PER-SEC ;
+  qudt:symbol "°R/m" ;
   qudt:ucumCode "[degR].min-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[degR]/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J29" ;
@@ -4341,6 +4540,7 @@ unit:DEG_R-PER-SEC
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H1T-1D0 ;
   qudt:hasQuantityKind quantitykind:TemperaturePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA053" ;
+  qudt:symbol "°R/s" ;
   qudt:ucumCode "[degR].s-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[degR]/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J30" ;
@@ -4370,6 +4570,7 @@ unit:DPI
   qudt:hasQuantityKind quantitykind:InverseLength ;
   qudt:iec61360Code "0112/2///62720#UAA421" ;
   qudt:plainTextDescription "point density as amount of the picture base element divided by the unit inch according to the Anglo-American and the Imperial system of units" ;
+  qudt:symbol "DPI" ;
   qudt:ucumCode "{dot}/[in_i]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E39" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -4382,6 +4583,7 @@ unit:DRAM_UK
   qudt:hasQuantityKind quantitykind:Mass ;
   qudt:iec61360Code "0112/2///62720#UAB181" ;
   qudt:plainTextDescription "non SI-conforming unit of mass comes from the Anglo-American Troy or Apothecaries' Weight System of units which is  mainly used in England, in the Netherlands and in the USA as a commercial weight" ;
+  qudt:symbol "dr{UK}" ;
   qudt:ucumCode "[dr_ap]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "DRI" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -4394,6 +4596,7 @@ unit:DRAM_US
   qudt:hasQuantityKind quantitykind:Mass ;
   qudt:iec61360Code "0112/2///62720#UAB180" ;
   qudt:plainTextDescription "non SI-conform unit of the mass according to the avoirdupois system of units: 1 dram (av. ) = 1/16 ounce (av. ) = 1/256 pound (av.)" ;
+  qudt:symbol "dr{US}" ;
   qudt:ucumCode "[dr_av]"^^qudt:UCUMcs ;
   qudt:udunitsCode "dr" ;
   qudt:udunitsCode "fldr" ;
@@ -4448,6 +4651,7 @@ unit:DYN-CentiM
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Torque ;
   qudt:iec61360Code "0112/2///62720#UAA423" ;
+  qudt:symbol "dyn⋅cm" ;
   qudt:ucumCode "dyn.cm"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J94" ;
   qudt:unitOfSystem sou:CGS ;
@@ -4462,6 +4666,7 @@ unit:DYN-PER-CentiM
   qudt:hasQuantityKind quantitykind:ForcePerLength ;
   qudt:iec61360Code "0112/2///62720#UAB106" ;
   qudt:plainTextDescription "CGS unit of the surface tension" ;
+  qudt:symbol "dyn/cm" ;
   qudt:ucumCode "dyn.cm-1"^^qudt:UCUMcs ;
   qudt:ucumCode "dyn/cm"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "DX" ;
@@ -4480,6 +4685,7 @@ unit:DYN-PER-CentiM2
   qudt:hasQuantityKind quantitykind:ForcePerArea ;
   qudt:hasQuantityKind quantitykind:VaporPressure ;
   qudt:iec61360Code "0112/2///62720#UAA424" ;
+  qudt:symbol "dyn/cm²" ;
   qudt:ucumCode "dyn.cm-2"^^qudt:UCUMcs ;
   qudt:ucumCode "dyn/cm2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D9" ;
@@ -4495,6 +4701,7 @@ unit:DYN-SEC-PER-CentiM
   qudt:hasQuantityKind quantitykind:MassFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAB144" ;
   qudt:plainTextDescription "CGS unit of the mechanical impedance" ;
+  qudt:symbol "dyn⋅s/cm" ;
   qudt:ucumCode "dyn.s.cm-1"^^qudt:UCUMcs ;
   qudt:ucumCode "dyn.s/cm"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A51" ;
@@ -4509,6 +4716,7 @@ unit:DYN-SEC-PER-CentiM3
   qudt:hasQuantityKind quantitykind:MassPerAreaTime ;
   qudt:iec61360Code "0112/2///62720#UAB102" ;
   qudt:plainTextDescription "CGS unit of the acoustic image impedance of the medium" ;
+  qudt:symbol "dyn⋅s/cm³" ;
   qudt:ucumCode "dyn.s.cm-3"^^qudt:UCUMcs ;
   qudt:ucumCode "dyn.s/cm3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A50" ;
@@ -4595,6 +4803,7 @@ unit:DecaARE
   qudt:hasQuantityKind quantitykind:Area ;
   qudt:iec61360Code "0112/2///62720#UAB049" ;
   qudt:plainTextDescription "unit of the area which is mainly common in the agriculture and forestry: 1 da = 10 a" ;
+  qudt:symbol "daa" ;
   qudt:ucumCode "daar"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "DAA" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -4625,6 +4834,7 @@ unit:DecaGM
   qudt:isScalingOf unit:KiloGM ;
   qudt:plainTextDescription "0,01-fold of the SI base unit kilogram" ;
   qudt:prefix prefix:Deca ;
+  qudt:symbol "dag" ;
   qudt:ucumCode "dag"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "DJ" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -4637,6 +4847,7 @@ unit:DecaL
   qudt:hasQuantityKind quantitykind:Volume ;
   qudt:iec61360Code "0112/2///62720#UAB115" ;
   qudt:plainTextDescription "10-fold of the unit litre" ;
+  qudt:symbol "daL" ;
   qudt:ucumCode "daL"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A44" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -4652,6 +4863,7 @@ unit:DecaM
   qudt:isScalingOf unit:M ;
   qudt:plainTextDescription "10-fold of the SI base unit metre" ;
   qudt:prefix prefix:Deca ;
+  qudt:symbol "dam" ;
   qudt:ucumCode "dam"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A45" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -4667,6 +4879,7 @@ unit:DecaM3
   qudt:isScalingOf unit:M3 ;
   qudt:plainTextDescription "1 000-fold of the power of the SI base unit metre by exponent 3" ;
   qudt:prefix prefix:Deca ;
+  qudt:symbol "dam³" ;
   qudt:ucumCode "dam3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "DMA" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -4683,6 +4896,7 @@ unit:DecaPA
   qudt:isScalingOf unit:PA ;
   qudt:plainTextDescription "10-fold of the derived SI unit pascal" ;
   qudt:prefix prefix:Deca ;
+  qudt:symbol "daPa" ;
   qudt:ucumCode "daPa"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H75" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -4728,6 +4942,7 @@ unit:DeciBAR-PER-YR
   qudt:conversionMultiplier 0.00031688 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerAreaTime ;
+  qudt:symbol "dbar/yr" ;
   qudt:ucumCode "dbar.a-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Decibars per year"@en ;
@@ -4747,7 +4962,7 @@ unit:DeciB_M
   dcterms:description "\"Decibel Referred to 1mw\" is a 'Dimensionless Ratio' expressed as \\(dBm\\)."^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:DimensionlessRatio ;
-  qudt:symbol "dBm" ;
+  qudt:symbol "dBmW" ;
   qudt:udunitsCode "Bm" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Decibel Referred to 1mw"@en ;
@@ -4777,6 +4992,7 @@ unit:DeciGM
   qudt:isScalingOf unit:KiloGM ;
   qudt:plainTextDescription "0.0001-fold of the SI base unit kilogram" ;
   qudt:prefix prefix:Deci ;
+  qudt:symbol "dg" ;
   qudt:ucumCode "dg"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "DG" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -4789,6 +5005,7 @@ unit:DeciL
   qudt:hasQuantityKind quantitykind:Volume ;
   qudt:iec61360Code "0112/2///62720#UAB113" ;
   qudt:plainTextDescription "0.1-fold of the unit litre" ;
+  qudt:symbol "dL" ;
   qudt:ucumCode "dL"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "DLT" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -4802,6 +5019,7 @@ unit:DeciL-PER-GM
   qudt:hasQuantityKind quantitykind:SpecificVolume ;
   qudt:iec61360Code "0112/2///62720#UAB094" ;
   qudt:plainTextDescription "0.1-fold of the unit of the volume litre divided by the 0.001-fold of the SI base unit kilogram" ;
+  qudt:symbol "dL/g" ;
   qudt:ucumCode "dL.g-1"^^qudt:UCUMcs ;
   qudt:ucumCode "dL/g"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "22" ;
@@ -4818,7 +5036,7 @@ unit:DeciM
   qudt:iec61360Code "0112/2///62720#UAA412" ;
   qudt:isScalingOf unit:M ;
   qudt:prefix prefix:Deci ;
-  qudt:symbol "㍷" ;
+  qudt:symbol "dm" ;
   qudt:ucumCode "dm"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "DMT" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -4834,7 +5052,7 @@ unit:DeciM2
   qudt:isScalingOf unit:M2 ;
   qudt:plainTextDescription "0.1-fold of the power of the SI base unit metre with the exponent 2" ;
   qudt:prefix prefix:Deci ;
-  qudt:symbol "㍸" ;
+  qudt:symbol "dm²" ;
   qudt:ucumCode "dm2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "DMK" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -4850,6 +5068,7 @@ unit:DeciM3
   qudt:isScalingOf unit:M3 ;
   qudt:plainTextDescription "0.1-fold of the power of the SI base unit metre with the exponent 3" ;
   qudt:prefix prefix:Deci ;
+  qudt:symbol "dm³" ;
   qudt:ucumCode "dm3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "DMQ" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -4863,6 +5082,7 @@ unit:DeciM3-PER-DAY
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA415" ;
   qudt:plainTextDescription "0,001-fold of the power of the SI base unit metre with the exponent 3 divided by the unit for time day" ;
+  qudt:symbol "dm³/day" ;
   qudt:ucumCode "dm3.d-1"^^qudt:UCUMcs ;
   qudt:ucumCode "dm3/d"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J90" ;
@@ -4877,6 +5097,7 @@ unit:DeciM3-PER-HR
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA416" ;
   qudt:plainTextDescription "0,001-fold of the power of the SI base unit metre with the exponent 3 divided by the unit hour" ;
+  qudt:symbol "dm³/hr" ;
   qudt:ucumCode "dm3.h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "dm3/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E92" ;
@@ -4891,6 +5112,7 @@ unit:DeciM3-PER-M3
   qudt:hasQuantityKind quantitykind:VolumeFraction ;
   qudt:iec61360Code "0112/2///62720#UAA417" ;
   qudt:plainTextDescription "volume ratio consisting of the 0.001-fold of the power of the SI base unit metre with the exponent 3 divided by the power of the SI base unit metre with the exponent 3" ;
+  qudt:symbol "dm³/m³" ;
   qudt:ucumCode "dm3.m-3"^^qudt:UCUMcs ;
   qudt:ucumCode "dm3/m3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J91" ;
@@ -4905,6 +5127,7 @@ unit:DeciM3-PER-MIN
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA418" ;
   qudt:plainTextDescription "0,001-fold of the power of the SI base unit metre with the exponent 3 divided by the unit for time minute" ;
+  qudt:symbol "dm³/min" ;
   qudt:ucumCode "dm3.min-3"^^qudt:UCUMcs ;
   qudt:ucumCode "dm3/min3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J92" ;
@@ -4920,6 +5143,7 @@ unit:DeciM3-PER-MOL
   qudt:hasQuantityKind quantitykind:MolarVolume ;
   qudt:iec61360Code "0112/2///62720#UAA419" ;
   qudt:plainTextDescription "0,001-fold of the power of the SI base unit metre with the exponent 3 divided by the SI base unit mol" ;
+  qudt:symbol "dm³/mol" ;
   qudt:ucumCode "dm3.mol-1"^^qudt:UCUMcs ;
   qudt:ucumCode "dm3/mol"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A37" ;
@@ -4934,6 +5158,7 @@ unit:DeciM3-PER-SEC
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA420" ;
   qudt:plainTextDescription "0,001-fold of the power of the SI base unit metre with the exponent 3 divided by the unit for time second" ;
+  qudt:symbol "dm³/s" ;
   qudt:ucumCode "dm3.s-1"^^qudt:UCUMcs ;
   qudt:ucumCode "dm3/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J93" ;
@@ -4948,6 +5173,7 @@ unit:DeciN-M
   qudt:hasQuantityKind quantitykind:Torque ;
   qudt:iec61360Code "0112/2///62720#UAB084" ;
   qudt:plainTextDescription "0.1-fold of the product of the derived SI unit joule and the SI base unit metre" ;
+  qudt:symbol "dN⋅m" ;
   qudt:ucumCode "dN.m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "DN" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -4961,7 +5187,7 @@ unit:DeciS-PER-M
   qudt:hasDimensionVector qkdv:A0E2L-3I0M-1H0T3D0 ;
   qudt:hasQuantityKind quantitykind:Conductivity ;
   qudt:plainTextDescription "Decisiemens per metre." ;
-  qudt:symbol "ds/m" ;
+  qudt:symbol "dS/m" ;
   qudt:ucumCode "dS.m-1"^^qudt:UCUMcs ;
   qudt:ucumCode "dS/m"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -4973,6 +5199,7 @@ unit:DeciTONNE
   qudt:exactMatch unit:DeciTON_Metric ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Mass ;
+  qudt:symbol "dt" ;
   qudt:uneceCommonCode "DTN" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "DeciTonne"@en ;
@@ -4986,6 +5213,7 @@ unit:DeciTON_Metric
   qudt:hasQuantityKind quantitykind:Mass ;
   qudt:iec61360Code "0112/2///62720#UAB078" ;
   qudt:plainTextDescription "100-fold of the SI base unit kilogram" ;
+  qudt:symbol "dt" ;
   qudt:ucumCode "dt"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "DTN" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -5015,6 +5243,7 @@ unit:Denier
   qudt:iec61360Code "0112/2///62720#UAB244" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Denier?oldid=463382291"^^xsd:anyURI ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Units_of_textile_measurement#Denier"^^xsd:anyURI ;
+  qudt:symbol "D" ;
   qudt:ucumCode "[den]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A49" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -5100,6 +5329,7 @@ unit:ERG-PER-CentiM
   qudt:hasQuantityKind quantitykind:TotalLinearStoppingPower ;
   qudt:iec61360Code "0112/2///62720#UAB145" ;
   qudt:plainTextDescription "CGS unit of the length-related energy" ;
+  qudt:symbol "erg/cm" ;
   qudt:ucumCode "erg.cm-1"^^qudt:UCUMcs ;
   qudt:ucumCode "erg/cm"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A58" ;
@@ -5117,6 +5347,7 @@ unit:ERG-PER-CentiM2-SEC
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:PowerPerArea ;
   qudt:iec61360Code "0112/2///62720#UAB055" ;
+  qudt:symbol "erg/(cm²⋅s)" ;
   qudt:ucumCode "erg.cm-2.s-1"^^qudt:UCUMcs ;
   qudt:ucumCode "erg/(cm2.s)"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A65" ;
@@ -5134,6 +5365,7 @@ unit:ERG-PER-CentiM3
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:EnergyDensity ;
   qudt:iec61360Code "0112/2///62720#UAB146" ;
+  qudt:symbol "erg/cm³" ;
   qudt:ucumCode "erg.cm-3"^^qudt:UCUMcs ;
   qudt:ucumCode "erg/cm3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A60" ;
@@ -5151,6 +5383,7 @@ unit:ERG-PER-G
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:SpecificEnergy ;
   qudt:iec61360Code "0112/2///62720#UAB061" ;
+  qudt:symbol "erg/g" ;
   qudt:ucumCode "erg.g-1"^^qudt:UCUMcs ;
   qudt:ucumCode "erg/g"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A61" ;
@@ -5165,6 +5398,7 @@ unit:ERG-PER-GM
   qudt:hasQuantityKind quantitykind:SpecificEnergy ;
   qudt:iec61360Code "0112/2///62720#UAB061" ;
   qudt:plainTextDescription "CGS unit of the mass-related energy" ;
+  qudt:symbol "erg/g" ;
   qudt:ucumCode "erg.g-1"^^qudt:UCUMcs ;
   qudt:ucumCode "erg/g"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A61" ;
@@ -5178,6 +5412,7 @@ unit:ERG-PER-GM-SEC
   qudt:hasQuantityKind quantitykind:AbsorbedDoseRate ;
   qudt:iec61360Code "0112/2///62720#UAB147" ;
   qudt:plainTextDescription "CGS unit of the mass-related power" ;
+  qudt:symbol "erg/(g⋅s)" ;
   qudt:ucumCode "erg.g-1.s-1"^^qudt:UCUMcs ;
   qudt:ucumCode "erg/(g.s)"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A62" ;
@@ -5195,6 +5430,7 @@ unit:ERG-PER-SEC
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAA430" ;
   qudt:latexDefinition "\\(g\\cdot cm^{2}/s^{3}\\)"^^qudt:LatexString ;
+  qudt:symbol "erg/s" ;
   qudt:ucumCode "erg.s-1"^^qudt:UCUMcs ;
   qudt:ucumCode "erg/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A63" ;
@@ -5210,7 +5446,7 @@ unit:ERG-SEC
   qudt:derivedUnitOfSystem sou:CGS-GAUSS ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:AngularMomentum ;
-  qudt:symbol "erg s" ;
+  qudt:symbol "erg⋅s" ;
   qudt:ucumCode "erg.s"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:CGS ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -5255,6 +5491,7 @@ unit:EV-PER-ANGSTROM
   qudt:hasQuantityKind quantitykind:TotalLinearStoppingPower ;
   qudt:latexSymbol "\\(ev/\\AA\\)"^^qudt:LatexString ;
   qudt:plainTextDescription "unit electronvolt divided by the unit angstrom" ;
+  qudt:symbol "eV/Å" ;
   qudt:ucumCode "eV.Ao-1"^^qudt:UCUMcs ;
   qudt:ucumCode "eV/Ao"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -5267,6 +5504,7 @@ unit:EV-PER-K
   qudt:expression "\\(ev/K\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H-1T-2D0 ;
   qudt:hasQuantityKind quantitykind:HeatCapacity ;
+  qudt:symbol "ev/K" ;
   qudt:ucumCode "eV.K-1"^^qudt:UCUMcs ;
   qudt:ucumCode "eV/K"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -5279,6 +5517,7 @@ unit:EV-PER-M
   qudt:hasQuantityKind quantitykind:TotalLinearStoppingPower ;
   qudt:iec61360Code "0112/2///62720#UAA426" ;
   qudt:plainTextDescription "unit electronvolt divided by the SI base unit metre" ;
+  qudt:symbol "eV/m" ;
   qudt:ucumCode "eV.m-1"^^qudt:UCUMcs ;
   qudt:ucumCode "eV/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A54" ;
@@ -5293,6 +5532,7 @@ unit:EV-PER-T
   qudt:expression "\\(eV T^{-1}\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E1L2I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:MagneticDipoleMoment ;
+  qudt:symbol "eV/T" ;
   qudt:ucumCode "eV.T-1"^^qudt:UCUMcs ;
   qudt:ucumCode "eV/T"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -5304,7 +5544,7 @@ unit:EV-SEC
   qudt:conversionMultiplier 0.0000000000000000001602176634 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:AngularMomentum ;
-  qudt:symbol "eV s" ;
+  qudt:symbol "eV⋅s" ;
   qudt:ucumCode "eV.s-1"^^qudt:UCUMcs ;
   qudt:ucumCode "eV/s"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -5322,7 +5562,7 @@ where, \\(e\\) is the elementary charge, \\(\\epsilon_0\\) is the electric const
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Energy ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Hartree?oldid=489318053"^^xsd:anyURI ;
-  qudt:symbol "E_h" ;
+  qudt:symbol "Ha" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Hartree"@en ;
 .
@@ -5340,6 +5580,7 @@ unit:EarthMass
 0.0105 Saturn mass (Saturn has 95.16 Earth masses)[3]
 0.0583 Neptune mass (Neptune has 17.147 Earth masses)[4]
 0.000 003 003 Solar mass (\\(M_{\\odot}\\)) (The Sun has 332946 Earth masses)"""^^qudt:LatexString ;
+  qudt:symbol "M⊕" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Earth mass"@en ;
 .
@@ -5489,6 +5730,7 @@ unit:ExaJ
   qudt:isScalingOf unit:J ;
   qudt:plainTextDescription "1 000 000 000 000 000 000-fold of the derived SI unit joule" ;
   qudt:prefix prefix:Exa ;
+  qudt:symbol "EJ" ;
   qudt:ucumCode "EJ"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A68" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -5559,6 +5801,7 @@ unit:FARAD-PER-KiloM
   qudt:hasQuantityKind quantitykind:Permittivity ;
   qudt:iec61360Code "0112/2///62720#UAA145" ;
   qudt:plainTextDescription "SI derived unit farad divided by the 1 000-fold of the SI base unit metre" ;
+  qudt:symbol "F/km" ;
   qudt:ucumCode "F.km-1"^^qudt:UCUMcs ;
   qudt:ucumCode "F/km"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H33" ;
@@ -5577,6 +5820,7 @@ unit:FARAD-PER-M
   qudt:hasDimensionVector qkdv:A0E2L-3I0M-1H0T4D0 ;
   qudt:hasQuantityKind quantitykind:Permittivity ;
   qudt:iec61360Code "0112/2///62720#UAA146" ;
+  qudt:symbol "F/m" ;
   qudt:ucumCode "F.m-1"^^qudt:UCUMcs ;
   qudt:ucumCode "F/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A69" ;
@@ -5609,6 +5853,7 @@ unit:FARAD_Ab-PER-CentiM
   qudt:expression "\\(abf-per-cm\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E2L-3I0M-1H0T4D0 ;
   qudt:hasQuantityKind quantitykind:Permittivity ;
+  qudt:symbol "abf/cm" ;
   qudt:ucumCode "GF.cm-1"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:CGS ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -5638,7 +5883,7 @@ unit:FATH
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Length ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Fathom?oldid=493265429"^^xsd:anyURI ;
-  qudt:symbol "fath" ;
+  qudt:symbol "fathom" ;
   qudt:ucumCode "[fth_i]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "AK" ;
   qudt:unitOfSystem sou:IMPERIAL ;
@@ -5654,7 +5899,7 @@ unit:FBM
   qudt:definedUnitOfSystem sou:USCS ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Volume ;
-  qudt:symbol "Bf" ;
+  qudt:symbol "BDFT" ;
   qudt:ucumCode "[bf_i]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "BFT" ;
   qudt:unitOfSystem sou:IMPERIAL ;
@@ -5682,7 +5927,7 @@ unit:FM
   qudt:hasQuantityKind quantitykind:Length ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Fermi_(unit)"^^xsd:anyURI ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/fermi> ;
-  qudt:symbol "㎙" ;
+  qudt:symbol "fm" ;
   qudt:uneceCommonCode "A71" ;
   qudt:unitOfSystem sou:SI ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -5713,6 +5958,7 @@ unit:FRACTION
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:DimensionlessRatio ;
   qudt:plainTextDescription "Fraction is a unit for 'Dimensionless Ratio' expressed as the value of the ratio itself." ;
+  qudt:symbol "÷" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Fraction"@en ;
 .
@@ -5755,6 +6001,7 @@ unit:FT-LA
   qudt:expression "\\(ft-L\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L-2I1M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Luminance ;
+  qudt:symbol "ft⋅L" ;
   qudt:ucumCode "[ft_i].Lmb"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Foot Lambert"@en ;
@@ -5770,6 +6017,7 @@ unit:FT-LB_F
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Energy ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Foot-pound_force?oldid=453269257"^^xsd:anyURI ;
+  qudt:symbol "ft⋅lbf" ;
   qudt:ucumCode "[ft_i].[lbf_av]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "85" ;
   qudt:unitOfSystem sou:IMPERIAL ;
@@ -5786,6 +6034,7 @@ unit:FT-LB_F-PER-FT2
   qudt:expression "\\(ft-lbf/ft^{2}\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:EnergyPerArea ;
+  qudt:symbol "ft⋅lbf/ft²" ;
   qudt:ucumCode "[ft_i].[lbf_av].[sft_i]-1"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:IMPERIAL ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -5801,6 +6050,7 @@ unit:FT-LB_F-PER-FT2-SEC
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:PowerPerArea ;
   qudt:latexSymbol "\\(ft \\cdot lbf/(ft^2 \\cdot s)\\)"^^qudt:LatexString ;
+  qudt:symbol "ft⋅lbf/ft²s" ;
   qudt:ucumCode "[ft_i].[lbf_av].[sft_i]-1.s-1"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:IMPERIAL ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -5815,6 +6065,7 @@ unit:FT-LB_F-PER-HR
   qudt:expression "\\(ft-lbf/hr\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:Power ;
+  qudt:symbol "ft⋅lbf/hr" ;
   qudt:ucumCode "[ft_i].[lbf_av].h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K15" ;
   qudt:unitOfSystem sou:IMPERIAL ;
@@ -5828,6 +6079,7 @@ unit:FT-LB_F-PER-M2
   qudt:expression "\\(ft-lbf/m^{2}\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:EnergyPerArea ;
+  qudt:symbol "ft⋅lbf/m²" ;
   qudt:ucumCode "[ft_i].[lbf_av].m-2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Foot Pound Force per Square Meter"@en-us ;
@@ -5842,6 +6094,7 @@ unit:FT-LB_F-PER-MIN
   qudt:expression "\\(ft-lbf/min\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:Power ;
+  qudt:symbol "ft⋅lbf/min" ;
   qudt:ucumCode "[ft_i].[lbf_av].min-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K16" ;
   qudt:unitOfSystem sou:IMPERIAL ;
@@ -5857,6 +6110,7 @@ unit:FT-LB_F-PER-SEC
   qudt:expression "\\(ft-lbf/s\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:Power ;
+  qudt:symbol "ft⋅lbf/s" ;
   qudt:ucumCode "[ft_i].[lbf_av].s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A74" ;
   qudt:unitOfSystem sou:IMPERIAL ;
@@ -5869,6 +6123,7 @@ unit:FT-LB_F-SEC
   qudt:expression "\\(lbf / s\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:AngularMomentum ;
+  qudt:symbol "lbf/s" ;
   qudt:ucumCode "[ft_i].[lbf_av].s"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Foot Pound Force Second"@en ;
@@ -5883,7 +6138,7 @@ unit:FT-PDL
   qudt:hasQuantityKind quantitykind:Energy ;
   qudt:iec61360Code "0112/2///62720#UAB220" ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/footPoundal> ;
-  qudt:symbol "ft-pdl" ;
+  qudt:symbol "ft⋅pdl" ;
   qudt:uneceCommonCode "N46" ;
   qudt:unitOfSystem sou:IMPERIAL ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -5898,6 +6153,7 @@ unit:FT-PER-DAY
   qudt:expression "\\(ft/d\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Velocity ;
+  qudt:symbol "ft/day" ;
   qudt:ucumCode "[ft_i].d-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[ft_i]/d"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:IMPERIAL ;
@@ -5911,6 +6167,7 @@ unit:FT-PER-DEG_F
   qudt:hasQuantityKind quantitykind:LinearThermalExpansion ;
   qudt:iec61360Code "0112/2///62720#UAA441" ;
   qudt:plainTextDescription "unit foot as a linear measure according to the Anglo-American and the Imperial system of units divided by the unit for temperature degree Fahrenheit" ;
+  qudt:symbol "ft/°F" ;
   qudt:ucumCode "[ft_i].[lbf_av].[degF]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K13" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -5926,6 +6183,7 @@ unit:FT-PER-HR
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Velocity ;
   qudt:iec61360Code "0112/2///62720#UAA442" ;
+  qudt:symbol "ft/hr" ;
   qudt:ucumCode "[ft_i].h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[ft_i]/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K14" ;
@@ -5943,6 +6201,7 @@ unit:FT-PER-MIN
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Velocity ;
   qudt:iec61360Code "0112/2///62720#UAA448" ;
+  qudt:symbol "ft/min" ;
   qudt:ucumCode "[ft_i].min-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[ft_i]/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "FR" ;
@@ -5962,6 +6221,7 @@ unit:FT-PER-SEC
   qudt:hasQuantityKind quantitykind:Velocity ;
   qudt:iec61360Code "0112/2///62720#UAA449" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Foot_per_second?oldid=491316573"^^xsd:anyURI ;
+  qudt:symbol "ft/s" ;
   qudt:ucumCode "[ft_i].s-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[ft_i]/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "FS" ;
@@ -5980,6 +6240,7 @@ unit:FT-PER-SEC2
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Acceleration ;
   qudt:iec61360Code "0112/2///62720#UAA452" ;
+  qudt:symbol "ft/s²" ;
   qudt:ucumCode "[ft_i].s-2"^^qudt:UCUMcs ;
   qudt:ucumCode "[ft_i]/s2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A73" ;
@@ -5998,6 +6259,7 @@ unit:FT2
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Area ;
   qudt:iec61360Code "0112/2///62720#UAA454" ;
+  qudt:symbol "ft²" ;
   qudt:ucumCode "[ft_i]2"^^qudt:UCUMcs ;
   qudt:ucumCode "[sft_i]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "FTK" ;
@@ -6014,6 +6276,7 @@ unit:FT2-DEG_F
   qudt:expression "\\(ft^{2}-degF\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H1T0D0 ;
   qudt:hasQuantityKind quantitykind:AreaTemperature ;
+  qudt:symbol "ft²⋅°F" ;
   qudt:ucumCode "[sft_i].[degF]"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:IMPERIAL ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -6028,6 +6291,7 @@ unit:FT2-HR-DEG_F
   qudt:expression "\\(ft^{2}-hr-degF\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H1T1D0 ;
   qudt:hasQuantityKind quantitykind:AreaTimeTemperature ;
+  qudt:symbol "ft²⋅hr⋅°F" ;
   qudt:ucumCode "[sft_i].h.[degF]"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:IMPERIAL ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -6042,6 +6306,7 @@ unit:FT2-HR-DEG_F-PER-BTU_IT
   qudt:expression "\\(sqft-hr-degF/btu\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M-1H1T3D0 ;
   qudt:hasQuantityKind quantitykind:ThermalInsulance ;
+  qudt:symbol "sqft⋅hr⋅°F/btu" ;
   qudt:ucumCode "[sft_i].h.[degF].[Btu_IT]-1"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:IMPERIAL ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -6056,6 +6321,7 @@ unit:FT2-PER-BTU_IT-IN
   qudt:expression "\\(ft2-per-btu-in\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M-1H1T3D0 ;
   qudt:hasQuantityKind quantitykind:ThermalResistivity ;
+  qudt:symbol "ft²/btu⋅in" ;
   qudt:ucumCode "[sft_i].[Btu_IT]-1.[in_i]-1"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:IMPERIAL ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -6072,6 +6338,7 @@ unit:FT2-PER-HR
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:AreaPerTime ;
   qudt:iec61360Code "0112/2///62720#UAB247" ;
+  qudt:symbol "ft²/hr" ;
   qudt:ucumCode "[sft_i].h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M79" ;
   qudt:unitOfSystem sou:IMPERIAL ;
@@ -6088,6 +6355,7 @@ unit:FT2-PER-SEC
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:AreaPerTime ;
   qudt:iec61360Code "0112/2///62720#UAA455" ;
+  qudt:symbol "ft²/s" ;
   qudt:ucumCode "[sft_i].s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "S3" ;
   qudt:unitOfSystem sou:IMPERIAL ;
@@ -6103,6 +6371,7 @@ unit:FT2-SEC-DEG_F
   qudt:expression "\\(ft^{2}-s-degF\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H1T1D0 ;
   qudt:hasQuantityKind quantitykind:AreaTimeTemperature ;
+  qudt:symbol "ft²⋅s⋅°F" ;
   qudt:ucumCode "[sft_i].s.[degF]"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:IMPERIAL ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -6119,6 +6388,7 @@ unit:FT3
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Volume ;
   qudt:iec61360Code "0112/2///62720#UAA456" ;
+  qudt:symbol "ft³" ;
   qudt:ucumCode "[cft_i]"^^qudt:UCUMcs ;
   qudt:ucumCode "[ft_i]3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "FTQ" ;
@@ -6133,6 +6403,7 @@ unit:FT3-PER-DAY
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA458" ;
   qudt:plainTextDescription "power of the unit foot according to the Anglo-American and the Imperial system of units with the exponent 3 divided by the unit for time day" ;
+  qudt:symbol "ft³/day" ;
   qudt:ucumCode "[cft_i].d-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K22" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -6145,6 +6416,7 @@ unit:FT3-PER-DEG_F
   qudt:hasQuantityKind quantitykind:VolumeThermalExpansion ;
   qudt:iec61360Code "0112/2///62720#UAA457" ;
   qudt:plainTextDescription "power of the unit foot as a linear measure according to the Anglo-American and the Imperial system of units with the exponent 3 divided by the unit for temperature degree Fahrenheit" ;
+  qudt:symbol "ft³/°F" ;
   qudt:ucumCode "[cft_i].[degF]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K21" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -6157,6 +6429,7 @@ unit:FT3-PER-HR
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA459" ;
   qudt:plainTextDescription "power of the unit foot according to the Anglo-American and the Imperial system of units with the exponent 3 divided by the unit hour" ;
+  qudt:symbol "ft³/hr" ;
   qudt:ucumCode "[cft_i].h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "2K" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -6174,6 +6447,7 @@ unit:FT3-PER-MIN
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
   qudt:iec61360Code "0112/2///62720#UAA461" ;
+  qudt:symbol "ft³/min" ;
   qudt:ucumCode "[cft_i].min-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[cft_i]/min"^^qudt:UCUMcs ;
   qudt:ucumCode "[ft_i]3.min-1"^^qudt:UCUMcs ;
@@ -6190,6 +6464,7 @@ unit:FT3-PER-MIN-FT2
   qudt:hasQuantityKind quantitykind:Speed ;
   qudt:iec61360Code "0112/2///62720#UAB086" ;
   qudt:plainTextDescription "unit of the volume flow rate according to the Anglio-American and imperial system of units cubic foot per minute related to the transfer area according to the Anglian American and Imperial system of units square foot" ;
+  qudt:symbol "ft³/(min⋅ft²)" ;
   qudt:ucumCode "[cft_i].min-1.[sft_i]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "36" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -6207,6 +6482,7 @@ unit:FT3-PER-SEC
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
   qudt:iec61360Code "0112/2///62720#UAA462" ;
+  qudt:symbol "ft³/s" ;
   qudt:ucumCode "[cft_i].s-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[cft_i]/s"^^qudt:UCUMcs ;
   qudt:ucumCode "[ft_i]3.s-1"^^qudt:UCUMcs ;
@@ -6223,7 +6499,7 @@ unit:FT_H2O
   qudt:hasQuantityKind quantitykind:ForcePerArea ;
   qudt:hasQuantityKind quantitykind:VaporPressure ;
   qudt:iec61360Code "0112/2///62720#UAA463" ;
-  qudt:symbol "ftH2O" ;
+  qudt:symbol "ftH₂0" ;
   qudt:ucumCode "[ft_i'H2O]"^^qudt:UCUMcs ;
   qudt:udunitsCode "ftH2O" ;
   qudt:udunitsCode "fth2o" ;
@@ -6239,6 +6515,7 @@ unit:FT_HG
   qudt:hasQuantityKind quantitykind:VaporPressure ;
   qudt:iec61360Code "0112/2///62720#UAA464" ;
   qudt:plainTextDescription "not SI conform unit of the pressure, at which 1 ftHg corresponds to the static pressure, which is excited by a mercury column with a height of 1 foot" ;
+  qudt:symbol "ftHg" ;
   qudt:ucumCode "[ft_i'Hg]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K25" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -6251,7 +6528,7 @@ unit:FT_US
   qudt:definedUnitOfSystem sou:USCS ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Length ;
-  qudt:symbol "ft_us" ;
+  qudt:symbol "ft{US Survey}" ;
   qudt:ucumCode "[ft_us]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M51" ;
   qudt:unitOfSystem sou:USCS ;
@@ -6270,7 +6547,7 @@ unit:FUR
   qudt:hasQuantityKind quantitykind:Length ;
   qudt:iec61360Code "0112/2///62720#UAB204" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Furlong?oldid=492237369"^^xsd:anyURI ;
-  qudt:symbol "fur" ;
+  qudt:symbol "furlong" ;
   qudt:ucumCode "[fur_us]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M50" ;
   qudt:unitOfSystem sou:IMPERIAL ;
@@ -6284,6 +6561,7 @@ unit:FUR_Long
   qudt:expression "\\(longfur\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Length ;
+  qudt:symbol "furlong{long}" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Long Furlong"@en ;
 .
@@ -6324,6 +6602,7 @@ unit:FemtoGM-PER-KiloGM
   qudt:hasQuantityKind quantitykind:MassRatio ;
   qudt:qkdvDenominator qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:qkdvNumerator qkdv:A0E0L0I0M1H0T0D0 ;
+  qudt:symbol "fg/kg" ;
   qudt:ucumCode "fg.kg-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Femtograms per kilogram"@en ;
@@ -6334,6 +6613,7 @@ unit:FemtoGM-PER-L
   qudt:conversionMultiplier 0.000000000000001 ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:MassDensity ;
+  qudt:symbol "fg/L" ;
   qudt:ucumCode "fg.L-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Femtograms per litre"@en ;
@@ -6347,6 +6627,7 @@ unit:FemtoJ
   qudt:isScalingOf unit:J ;
   qudt:plainTextDescription "0,000 000 000 000 001-fold of the derived SI unit joule" ;
   qudt:prefix prefix:Femto ;
+  qudt:symbol "fJ" ;
   qudt:ucumCode "fJ"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A70" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -6358,6 +6639,7 @@ unit:FemtoL
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Volume ;
   qudt:plainTextDescription "0.000000000000001-fold of the unit litre" ;
+  qudt:symbol "fL" ;
   qudt:ucumCode "fL"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "Q32" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -6389,6 +6671,7 @@ unit:FemtoMOL-PER-KiloGM
   qudt:conversionMultiplier 0.000000000000001 ;
   qudt:hasDimensionVector qkdv:A1E0L0I0M-1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:AmountOfSubstancePerUnitMass ;
+  qudt:symbol "fmol/kg" ;
   qudt:ucumCode "fmol.kg-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Femtomoles per kilogram"@en ;
@@ -6400,6 +6683,7 @@ unit:FemtoMOL-PER-L
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:AmountOfSubstancePerUnitVolume ;
   qudt:hasQuantityKind quantitykind:Solubility_Water ;
+  qudt:symbol "fmol/L" ;
   qudt:ucumCode "fmol.L-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Femtomoles per litre"@en ;
@@ -6486,7 +6770,7 @@ unit:GAL_IMP
   qudt:definedUnitOfSystem sou:IMPERIAL ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:LiquidVolume ;
-  qudt:symbol "gal" ;
+  qudt:symbol "gal{Imp}" ;
   qudt:ucumCode "[gal_br]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "GLI" ;
   qudt:unitOfSystem sou:IMPERIAL ;
@@ -6500,6 +6784,7 @@ unit:GAL_UK
   qudt:hasQuantityKind quantitykind:LiquidVolume ;
   qudt:iec61360Code "0112/2///62720#UAA500" ;
   qudt:plainTextDescription "unit of the volume for fluids according to the Imperial system of units" ;
+  qudt:symbol "gal{UK}" ;
   qudt:ucumCode "[gal_br]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "GLI" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -6512,6 +6797,7 @@ unit:GAL_UK-PER-DAY
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA501" ;
   qudt:plainTextDescription "unit gallon (UK dry or liq.) according to the Imperial system of units divided by the SI unit day" ;
+  qudt:symbol "gal{UK}/day" ;
   qudt:ucumCode "[gal_br].d-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K26" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -6524,6 +6810,7 @@ unit:GAL_UK-PER-HR
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA502" ;
   qudt:plainTextDescription "unit gallon (UK dry or Liq.) according to the Imperial system of units divided by the SI unit hour" ;
+  qudt:symbol "gal{UK}/hr" ;
   qudt:ucumCode "[gal_br].h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K27" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -6536,6 +6823,7 @@ unit:GAL_UK-PER-MIN
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA503" ;
   qudt:plainTextDescription "unit gallon (UK dry or liq.) according to the Imperial system of units divided by the SI unit minute" ;
+  qudt:symbol "gal{UK}/min" ;
   qudt:ucumCode "[gal_br].m-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G3" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -6548,6 +6836,7 @@ unit:GAL_UK-PER-SEC
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA504" ;
   qudt:plainTextDescription "unit gallon (UK dry or liq.) according to the Imperial system of units divided by the SI base unit second" ;
+  qudt:symbol "gal{UK}/s" ;
   qudt:ucumCode "[gal_br].s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K28" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -6560,7 +6849,7 @@ unit:GAL_US
   qudt:definedUnitOfSystem sou:USCS ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:LiquidVolume ;
-  qudt:symbol "gal" ;
+  qudt:symbol "gal{US}" ;
   qudt:ucumCode "[gal_us]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "GLL" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -6576,6 +6865,7 @@ unit:GAL_US-PER-DAY
   qudt:expression "\\(gal/d\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:symbol "gal/day" ;
   qudt:ucumCode "[gal_us].d-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[gal_us]/d"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "GB" ;
@@ -6589,6 +6879,7 @@ unit:GAL_US-PER-HR
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA507" ;
   qudt:plainTextDescription "unit gallon (US, liq.) according to the Anglo-American system of units divided by the SI unit hour" ;
+  qudt:symbol "gal{US}/hr" ;
   qudt:ucumCode "[gal_us].h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G50" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -6603,6 +6894,7 @@ unit:GAL_US-PER-MIN
   qudt:expression "\\(gal/min\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:symbol "gal/min" ;
   qudt:ucumCode "[gal_us].min-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[gal_us]/min"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -6615,6 +6907,7 @@ unit:GAL_US-PER-SEC
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA509" ;
   qudt:plainTextDescription "unit gallon (US, liq.) according to the Anglo-American system of units divided by the SI base unit second" ;
+  qudt:symbol "gal{US}/s" ;
   qudt:ucumCode "[gal_us].s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K30" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -6627,7 +6920,7 @@ unit:GAL_US_DRY
   qudt:definedUnitOfSystem sou:USCS ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:DryVolume ;
-  qudt:symbol "dry_gal" ;
+  qudt:symbol "gal{US Dry}" ;
   qudt:ucumCode "[gal_wi]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "GLD" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -6642,6 +6935,7 @@ unit:GAUGE_FR
   qudt:hasQuantityKind quantitykind:Length ;
   qudt:iec61360Code "0112/2///62720#UAB377" ;
   qudt:plainTextDescription "unit for the diameter of thin tubes in the medical technology (e.g. catheter) and telecommunications engineering (e.g. fiberglasses)." ;
+  qudt:symbol "French gauge" ;
   qudt:ucumCode "[Ch]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H79" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -6656,6 +6950,7 @@ unit:GAUSS
   qudt:hasQuantityKind quantitykind:MagneticFluxDensity ;
   qudt:iec61360Code "0112/2///62720#UAB135" ;
   qudt:plainTextDescription "CGS unit of the magnetic flux density B" ;
+  qudt:symbol "Gs" ;
   qudt:ucumCode "G"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "76" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -6688,6 +6983,7 @@ unit:GI_UK
   qudt:hasQuantityKind quantitykind:Volume ;
   qudt:iec61360Code "0112/2///62720#UAA511" ;
   qudt:plainTextDescription "unit of the volume for fluids according to the Imperial system of units (1/32 Imperial Gallon)" ;
+  qudt:symbol "gill{UK}" ;
   qudt:ucumCode "[gil_br]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "GII" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -6700,6 +6996,7 @@ unit:GI_UK-PER-DAY
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA512" ;
   qudt:plainTextDescription "unit of the volume gill (UK) for fluids according to the Imperial system of units divided by the unit for time day" ;
+  qudt:symbol "gill{UK}/day" ;
   qudt:ucumCode "[gil_br].d-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K32" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -6712,6 +7009,7 @@ unit:GI_UK-PER-HR
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA513" ;
   qudt:plainTextDescription "unit of the volume gill (UK) for fluids according to the Imperial system of units divided by the unit for time hour" ;
+  qudt:symbol "gill{UK}/hr" ;
   qudt:ucumCode "[gil_br].h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K33" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -6724,6 +7022,7 @@ unit:GI_UK-PER-MIN
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA514" ;
   qudt:plainTextDescription "unit of the volume gill (UK) for fluids according to the Imperial system of units divided by the unit for time minute" ;
+  qudt:symbol "gill{UK}/min" ;
   qudt:ucumCode "[gil_br].min-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K34" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -6736,6 +7035,7 @@ unit:GI_UK-PER-SEC
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA515" ;
   qudt:plainTextDescription "unit of the volume gill (UK) for fluids according to the Imperial system of units divided by the SI base unit second" ;
+  qudt:symbol "gill{UK}/s" ;
   qudt:ucumCode "[gil_br].s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K35" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -6748,6 +7048,7 @@ unit:GI_US
   qudt:hasQuantityKind quantitykind:Volume ;
   qudt:iec61360Code "0112/2///62720#UAA516" ;
   qudt:plainTextDescription "unit of the volume according the Anglo-American system of units (1/32 US Gallon)" ;
+  qudt:symbol "gill{US}" ;
   qudt:ucumCode "[gil_us]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "GIA" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -6760,6 +7061,7 @@ unit:GI_US-PER-DAY
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA517" ;
   qudt:plainTextDescription "unit of the volume gill (US) for fluids according to the Anglo-American system of units divided by the unit for time day" ;
+  qudt:symbol "gill{US}/day" ;
   qudt:ucumCode "[gil_us].d-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K36" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -6772,6 +7074,7 @@ unit:GI_US-PER-HR
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA518" ;
   qudt:plainTextDescription "unit of the volume gill (US) for fluids according to the Anglo-American system of units divided by the unit for time hour" ;
+  qudt:symbol "gill{US}/hr" ;
   qudt:ucumCode "[gil_us].h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K37" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -6784,6 +7087,7 @@ unit:GI_US-PER-MIN
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA519" ;
   qudt:plainTextDescription "unit of the volume gill (US) for fluids according to the Anglo-American system of units divided by the unit for time minute" ;
+  qudt:symbol "gill{US}/min" ;
   qudt:ucumCode "[gil_us].min-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K38" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -6796,6 +7100,7 @@ unit:GI_US-PER-SEC
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA520" ;
   qudt:plainTextDescription "unit of the volume gill (US) for fluids according to the Anglo-American system of units divided by the SI base unit second" ;
+  qudt:symbol "gill{US}/s" ;
   qudt:ucumCode "[gil_us].s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K39" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -6829,6 +7134,7 @@ unit:GM-MilliM
   qudt:hasQuantityKind quantitykind:LengthMass ;
   qudt:iec61360Code "0112/2///62720#UAB381" ;
   qudt:plainTextDescription "unit of the imbalance as product of the 0.001-fold of the SI base unit kilogram and the 0.001-fold of the SI base unit metre" ;
+  qudt:symbol "g/mm" ;
   qudt:ucumCode "g.mm"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H84" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -6842,6 +7148,7 @@ unit:GM-PER-CentiM2
   qudt:hasQuantityKind quantitykind:MassPerArea ;
   qudt:iec61360Code "0112/2///62720#UAB103" ;
   qudt:plainTextDescription "0,001-fold of the SI base unit kilogram divided by the 0.0001-fold of the power of the SI base unit metre and exponent 2" ;
+  qudt:symbol "g/cm²" ;
   qudt:ucumCode "g.cm-2"^^qudt:UCUMcs ;
   qudt:ucumCode "g/cm2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "25" ;
@@ -6854,6 +7161,7 @@ unit:GM-PER-CentiM2-YR
   dcterms:description "A rate of change of 0.001 of the SI unit of mass over 0.00001 of the SI unit of area in a period of an average calendar year (365.25 days)"@en ;
   qudt:conversionMultiplier 0.000000316880878140289 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M1H0T-1D0 ;
+  qudt:symbol "g/(cm²⋅yr)" ;
   qudt:ucumCode "g.cm-2.a-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Grams per square centimetre per year"@en ;
@@ -6865,6 +7173,7 @@ unit:GM-PER-CentiM3
   qudt:hasQuantityKind quantitykind:MassDensity ;
   qudt:iec61360Code "0112/2///62720#UAA469" ;
   qudt:plainTextDescription "0,001-fold of the SI base unit kilogram divided by the 0.000 001-fold of the power of the SI base unit metre with the exponent 3" ;
+  qudt:symbol "g/cm³" ;
   qudt:ucumCode "g.cm-3"^^qudt:UCUMcs ;
   qudt:ucumCode "g/cm3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "23" ;
@@ -6879,6 +7188,7 @@ unit:GM-PER-DAY
   qudt:hasQuantityKind quantitykind:MassFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA472" ;
   qudt:plainTextDescription "0,001-fold of the SI base unit kilogram divided by the unit day" ;
+  qudt:symbol "g/day" ;
   qudt:ucumCode "g.d-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F26" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -6890,6 +7200,7 @@ unit:GM-PER-DEG_C
   qudt:expression "\\(g-degC\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H1T0D0 ;
   qudt:hasQuantityKind quantitykind:MassTemperature ;
+  qudt:symbol "g/°C" ;
   qudt:ucumCode "d.Cel-1"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:CGS ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -6902,6 +7213,7 @@ unit:GM-PER-DeciM3
   qudt:hasQuantityKind quantitykind:MassDensity ;
   qudt:iec61360Code "0112/2///62720#UAA475" ;
   qudt:plainTextDescription "0,001-fold of the SI base unit kilogram divided by the 0.001-fold of the power of the SI base unit metre with the exponent 3" ;
+  qudt:symbol "g/dm³" ;
   qudt:ucumCode "g.dm-3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F23" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -6916,6 +7228,7 @@ unit:GM-PER-GM
   qudt:hasQuantityKind quantitykind:MassRatio ;
   qudt:qkdvDenominator qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:qkdvNumerator qkdv:A0E0L0I0M1H0T0D0 ;
+  qudt:symbol "g/g" ;
   qudt:ucumCode "g.g-1"^^qudt:UCUMcs ;
   qudt:ucumCode "g/g"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -6928,6 +7241,7 @@ unit:GM-PER-HR
   qudt:hasQuantityKind quantitykind:MassFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA478" ;
   qudt:plainTextDescription "0,001-fold of the SI base unit kilogram divided by the unit hour" ;
+  qudt:symbol "g/hr" ;
   qudt:ucumCode "g.h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F27" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -6942,6 +7256,7 @@ unit:GM-PER-KiloGM
   qudt:plainTextDescription "0,001 fold of the SI base unit kilogram divided by the SI base unit kilogram" ;
   qudt:qkdvDenominator qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:qkdvNumerator qkdv:A0E0L0I0M1H0T0D0 ;
+  qudt:symbol "g/kg" ;
   qudt:ucumCode "g.kg-1"^^qudt:UCUMcs ;
   qudt:ucumCode "g/kg"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "GK" ;
@@ -6954,6 +7269,7 @@ unit:GM-PER-KiloM
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:MassPerLength ;
   qudt:plainTextDescription "0,001-fold of the SI base unit kilogram divided by the 1000-fold of the SI base unit metre" ;
+  qudt:symbol "g/km" ;
   qudt:ucumCode "g.km-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Gram Per Kilometer"@en-us ;
@@ -6966,6 +7282,7 @@ unit:GM-PER-L
   qudt:hasQuantityKind quantitykind:MassDensity ;
   qudt:iec61360Code "0112/2///62720#UAA482" ;
   qudt:plainTextDescription "0,001-fold of the SI base unit kilogram divided by the unit litre" ;
+  qudt:symbol "g/L" ;
   qudt:ucumCode "g.L-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "GL" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -6979,6 +7296,7 @@ unit:GM-PER-M
   qudt:hasQuantityKind quantitykind:MassPerLength ;
   qudt:iec61360Code "0112/2///62720#UAA485" ;
   qudt:plainTextDescription "0,001-fold of the SI base unit kilogram divided by the SI base unit metre" ;
+  qudt:symbol "g/m" ;
   qudt:ucumCode "g.m-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "GF" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -6992,6 +7310,7 @@ unit:GM-PER-M2
   qudt:hasQuantityKind quantitykind:MassPerArea ;
   qudt:iec61360Code "0112/2///62720#UAA486" ;
   qudt:plainTextDescription "0,001-fold of the SI base unit kilogram divided by the power of the SI base unit metre with the exponent 2" ;
+  qudt:symbol "g/m²" ;
   qudt:ucumCode "g.m-2"^^qudt:UCUMcs ;
   qudt:ucumCode "g/m2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "GM" ;
@@ -7006,6 +7325,7 @@ unit:GM-PER-M2-DAY
   qudt:hasDimensionVector qkdv:A0E0L-2I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:MassPerAreaTime ;
   qudt:plainTextDescription "A metric unit of volume over time indicating the amount generated across one square meter over a day." ;
+  qudt:symbol "g/(m²⋅day)" ;
   qudt:ucumCode "g.m-2.d-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "grams per square meter per day"@en-us ;
@@ -7018,6 +7338,7 @@ unit:GM-PER-M3
   qudt:hasQuantityKind quantitykind:MassDensity ;
   qudt:iec61360Code "0112/2///62720#UAA487" ;
   qudt:plainTextDescription "0,001-fold of the SI base unit kilogram divided by the power of the SI base unit metre with the exponent 3" ;
+  qudt:symbol "g/m³" ;
   qudt:ucumCode "g.m-3"^^qudt:UCUMcs ;
   qudt:ucumCode "g/m3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A93" ;
@@ -7032,6 +7353,7 @@ unit:GM-PER-MIN
   qudt:hasQuantityKind quantitykind:MassFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA490" ;
   qudt:plainTextDescription "0,001-fold of the SI base unit kilogram divided by the unit minute" ;
+  qudt:symbol "g/min" ;
   qudt:ucumCode "g.min-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F28" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -7044,6 +7366,7 @@ unit:GM-PER-MOL
   qudt:hasQuantityKind quantitykind:MolarMass ;
   qudt:iec61360Code "0112/2///62720#UAA496" ;
   qudt:plainTextDescription "0,01-fold of the SI base unit kilogram divided by the SI base unit mol" ;
+  qudt:symbol "g/mol" ;
   qudt:ucumCode "g.mol-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A94" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -7056,6 +7379,7 @@ unit:GM-PER-MilliL
   qudt:hasQuantityKind quantitykind:MassDensity ;
   qudt:iec61360Code "0112/2///62720#UAA493" ;
   qudt:plainTextDescription "0,001-fold of the SI base unit kilogram divided by the 0.001-fold of the unit litre" ;
+  qudt:symbol "g/mL" ;
   qudt:ucumCode "g.mL-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "GJ" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -7069,6 +7393,7 @@ unit:GM-PER-MilliM
   qudt:hasQuantityKind quantitykind:MassPerLength ;
   qudt:iec61360Code "0112/2///62720#UAB376" ;
   qudt:plainTextDescription "0,001-fold of the SI base unit kilogram divided by the 0.001-fold the SI base unit meter" ;
+  qudt:symbol "g/mm" ;
   qudt:ucumCode "g.mm-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H76" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -7082,6 +7407,7 @@ unit:GM-PER-SEC
   qudt:hasQuantityKind quantitykind:MassFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA497" ;
   qudt:plainTextDescription "0,001fold of the SI base unit kilogram divided by the SI base unit second" ;
+  qudt:symbol "g/s" ;
   qudt:ucumCode "g.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F29" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -7094,6 +7420,7 @@ unit:GM_Carbon-PER-M2-DAY
   qudt:hasDimensionVector qkdv:A0E0L-2I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:MassPerAreaTime ;
   qudt:plainTextDescription "A metric unit of volume over time indicating the amount generated across one square meter over a day. Used to express productivity of an ecosystem." ;
+  qudt:symbol "g{carbon}/(m²⋅day)" ;
   qudt:ucumCode "g.m-2.d-1{C}"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "grams Carbon per square meter per day"@en-us ;
@@ -7107,6 +7434,7 @@ unit:GM_F-PER-CentiM2
   qudt:hasQuantityKind quantitykind:VaporPressure ;
   qudt:iec61360Code "0112/2///62720#UAA510" ;
   qudt:plainTextDescription "not SI conform unit of the pressure" ;
+  qudt:symbol "gf/cm²" ;
   qudt:ucumCode "gf.cm-2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K31" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -7120,6 +7448,7 @@ unit:GM_Nitrogen-PER-M2-DAY
   qudt:hasDimensionVector qkdv:A0E0L-2I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:MassPerAreaTime ;
   qudt:plainTextDescription "A metric unit of volume over time indicating the amount of Nitrogen generated across one square meter over a day. Used to express productivity of an ecosystem." ;
+  qudt:symbol "g{nitrogen}/(m²⋅day)" ;
   qudt:ucumCode "g.m-2.d-1{N}"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "grams Nitrogen per square meter per day"@en-us ;
@@ -7183,7 +7512,7 @@ unit:GRAIN
   qudt:iec61360Code "0112/2///62720#UAA523" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Cereal?oldid=495222949"^^xsd:anyURI ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/grain> ;
-  qudt:symbol "gr" ;
+  qudt:symbol "gr{UK}" ;
   qudt:ucumCode "[gr]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "GRN" ;
   qudt:unitOfSystem sou:IMPERIAL ;
@@ -7199,6 +7528,7 @@ unit:GRAIN-PER-GAL
   qudt:expression "\\(gr/gal\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Density ;
+  qudt:symbol "grain{UK}/gal" ;
   qudt:ucumCode "[gr].[gal_br]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K41" ;
   qudt:unitOfSystem sou:IMPERIAL ;
@@ -7212,6 +7542,7 @@ unit:GRAIN-PER-GAL_US
   qudt:hasQuantityKind quantitykind:MassDensity ;
   qudt:iec61360Code "0112/2///62720#UAA524" ;
   qudt:plainTextDescription "unit of the density according to the Anglo-American system of units" ;
+  qudt:symbol "grain{US}/gal" ;
   qudt:ucumCode "[gr].[gal_us]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K41" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -7251,6 +7582,7 @@ unit:GRAY-PER-SEC
   qudt:hasQuantityKind quantitykind:AbsorbedDoseRate ;
   qudt:hasQuantityKind quantitykind:KermaRate ;
   qudt:iec61360Code "0112/2///62720#UAA164" ;
+  qudt:symbol "Gy/s" ;
   qudt:ucumCode "Gy.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A96" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -7266,6 +7598,7 @@ unit:GT
   qudt:informativeReference "https://en.wikipedia.org/wiki/Gross_tonnage"^^xsd:anyURI ;
   qudt:latexDefinition "\\({ GT=V\\times (0.2+0.02\\times \\log _{10}(V))}\\) where V is measured in cubic meters."^^qudt:LatexString ;
   qudt:plainTextDescription "Gross tonnage (GT, G.T. or gt) is a nonlinear measure of a ship's overall internal volume. Gross tonnage is different from gross register tonnage. Gross tonnage is used to determine things such as a ship's manning regulations, safety rules, registration fees, and port dues, whereas the older gross register tonnage is a measure of the volume of only certain enclosed spaces." ;
+  qudt:symbol "G.T." ;
   qudt:ucumCode "t{gross}"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "GT" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -7341,6 +7674,7 @@ unit:GigaBQ
   qudt:isScalingOf unit:BQ ;
   qudt:plainTextDescription "1 000 000 000-fold of the derived SI unit becquerel" ;
   qudt:prefix prefix:Giga ;
+  qudt:symbol "GBq" ;
   qudt:ucumCode "GBq"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "GBQ" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -7399,6 +7733,7 @@ unit:GigaC-PER-M3
   qudt:hasQuantityKind quantitykind:Speed ;
   qudt:iec61360Code "0112/2///62720#UAA149" ;
   qudt:plainTextDescription "1 000 000 000-fold of the SI derived unit coulomb divided by the power of the SI base unit metre with the exponent 3" ;
+  qudt:symbol "GC/m³" ;
   qudt:ucumCode "GC.m-3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A84" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -7447,6 +7782,7 @@ unit:GigaHZ-M
   qudt:hasQuantityKind quantitykind:Velocity ;
   qudt:iec61360Code "0112/2///62720#UAA151" ;
   qudt:plainTextDescription "product of the 1 000 000 000-fold of the SI derived unit hertz and the SI base unit metre" ;
+  qudt:symbol "GHz⋅M" ;
   qudt:ucumCode "GHz.m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M18" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -7463,6 +7799,7 @@ unit:GigaJ
   qudt:isScalingOf unit:J ;
   qudt:plainTextDescription "1 000 000 000-fold of the SI derived unit joule" ;
   qudt:prefix prefix:Giga ;
+  qudt:symbol "GJ" ;
   qudt:ucumCode "GJ"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "GV" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -7477,6 +7814,7 @@ unit:GigaOHM
   qudt:isScalingOf unit:OHM ;
   qudt:plainTextDescription "1 000 000 000-fold of the SI derived unit ohm" ;
   qudt:prefix prefix:Giga ;
+  qudt:symbol "GΩ" ;
   qudt:ucumCode "GOhm"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A87" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -7492,6 +7830,7 @@ unit:GigaPA
   qudt:isScalingOf unit:PA ;
   qudt:plainTextDescription "1 000 000 000-fold of the SI derived unit pascal" ;
   qudt:prefix prefix:Giga ;
+  qudt:symbol "GPa" ;
   qudt:ucumCode "GP"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A89" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -7507,6 +7846,7 @@ unit:GigaW
   qudt:isScalingOf unit:W ;
   qudt:plainTextDescription "1 000 000 000-fold of the SI derived unit watt" ;
   qudt:prefix prefix:Giga ;
+  qudt:symbol "GW" ;
   qudt:ucumCode "GW"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A90" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -7519,6 +7859,7 @@ unit:GigaW-HR
   qudt:hasQuantityKind quantitykind:Energy ;
   qudt:iec61360Code "0112/2///62720#UAA155" ;
   qudt:plainTextDescription "1 000 000 000-fold of the product of the SI derived unit watt and the unit hour" ;
+  qudt:symbol "GW⋅hr" ;
   qudt:ucumCode "GW.h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "GWH" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -7557,7 +7898,7 @@ unit:Gs
   qudt:informativeReference "http://en.wikipedia.org/wiki/Gauss_(unit)"^^xsd:anyURI ;
   qudt:informativeReference "http://www.diracdelta.co.uk/science/source/g/a/gauss/source.html"^^xsd:anyURI ;
   qudt:informativeReference "http://www.oxfordreference.com/view/10.1093/acref/9780198605225.001.0001/acref-9780198605225-e-526?rskey=HAbfz2"^^xsd:anyURI ;
-  qudt:symbol "Gs" ;
+  qudt:symbol "G" ;
   qudt:ucumCode "G"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:CGS ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -7631,6 +7972,7 @@ unit:H-PER-KiloOHM
   qudt:hasQuantityKind quantitykind:Time ;
   qudt:iec61360Code "0112/2///62720#UAA167" ;
   qudt:plainTextDescription "SI derived unit henry divided by the 1 000-fold of the SI derived unit ohm" ;
+  qudt:symbol "H/kΩ" ;
   qudt:ucumCode "H.kOhm-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H03" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -7647,6 +7989,7 @@ unit:H-PER-M
   qudt:hasQuantityKind quantitykind:Permeability ;
   qudt:iec61360Code "0112/2///62720#UAA168" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Henry?oldid=491435978"^^xsd:anyURI ;
+  qudt:symbol "H/m" ;
   qudt:ucumCode "H.m-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A98" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -7660,6 +8003,7 @@ unit:H-PER-OHM
   qudt:hasQuantityKind quantitykind:Time ;
   qudt:iec61360Code "0112/2///62720#UAA166" ;
   qudt:plainTextDescription "SI derived unit henry divided by the SI derived unit ohm" ;
+  qudt:symbol "H/Ω" ;
   qudt:ucumCode "H.Ohm-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H04" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -7691,6 +8035,7 @@ unit:HART
   qudt:informativeReference "http://en.wikipedia.org/wiki/Ban_(information)"^^xsd:anyURI ;
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31898"^^xsd:anyURI ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/hartley> ;
+  qudt:symbol "Hart" ;
   qudt:uneceCommonCode "Q15" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Hartley"@en ;
@@ -7705,6 +8050,7 @@ unit:HART-PER-SEC
   qudt:iec61360Code "0112/2///62720#UAB347" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Ban_(information)"^^xsd:anyURI ;
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31898"^^xsd:anyURI ;
+  qudt:symbol "Hart/s" ;
   qudt:uneceCommonCode "Q18" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Hartley per Second"@en ;
@@ -7727,6 +8073,12 @@ unit:HP
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Horsepower"@en ;
 .
+unit:HP-PER-M
+  qudt:symbol "HP{metric}" ;
+.
+unit:HP-PER-V
+  qudt:symbol "HP{electric}" ;
+.
 unit:HP_Boiler
   a qudt:Unit ;
   dcterms:description "\"Boiler Horsepower\" is a unit for  'Power' expressed as \\(hp_boiler\\)."^^qudt:LatexString ;
@@ -7734,6 +8086,7 @@ unit:HP_Boiler
   qudt:expression "\\(boiler_hp\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:Power ;
+  qudt:symbol "HP{boiler}" ;
   qudt:uneceCommonCode "K42" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Boiler Horsepower"@en ;
@@ -7745,6 +8098,7 @@ unit:HP_Brake
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAA536" ;
   qudt:plainTextDescription "unit of the power according to the Imperial system of units" ;
+  qudt:symbol "HP{brake}" ;
   qudt:uneceCommonCode "K42" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Horsepower (brake)"@en ;
@@ -7756,6 +8110,7 @@ unit:HP_Electric
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAA537" ;
   qudt:plainTextDescription "unit of the power according to the Anglo-American system of units" ;
+  qudt:symbol "HP{electric}" ;
   qudt:uneceCommonCode "K43" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Horsepower (electric)"@en ;
@@ -7767,6 +8122,7 @@ unit:HP_Metric
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAA534" ;
   qudt:plainTextDescription "unit of the mechanical power according to the Anglo-American system of units" ;
+  qudt:symbol "HP{metric}" ;
   qudt:uneceCommonCode "HJ" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Horsepower (metric)"@en ;
@@ -7783,7 +8139,7 @@ unit:HR
   qudt:iec61360Code "0112/2///62720#UAA525" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Hour?oldid=495040268"^^xsd:anyURI ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/hour> ;
-  qudt:symbol "h" ;
+  qudt:symbol "hr" ;
   qudt:ucumCode "h"^^qudt:UCUMcs ;
   qudt:udunitsCode "h" ;
   qudt:uneceCommonCode "HUR" ;
@@ -7801,6 +8157,7 @@ unit:HR-FT2
   qudt:expression "\\(hr-ft^{2}\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:AreaTime ;
+  qudt:symbol "hr⋅ft²" ;
   qudt:ucumCode "h.[ft_i]2"^^qudt:UCUMcs ;
   qudt:ucumCode "h.[sft_i]"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:IMPERIAL ;
@@ -7814,7 +8171,7 @@ unit:HR_Sidereal
   qudt:hasQuantityKind quantitykind:Time ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Sidereal_time"^^xsd:anyURI ;
   qudt:isScalingOf unit:DAY_Sidereal ;
-  qudt:symbol "hr" ;
+  qudt:symbol "hr{sidereal}" ;
   qudt:ucumCode "h"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Sidereal Hour"@en ;
@@ -7847,6 +8204,7 @@ unit:HZ-M
   qudt:hasQuantityKind quantitykind:Speed ;
   qudt:iec61360Code "0112/2///62720#UAA171" ;
   qudt:plainTextDescription "product of the SI derived unit hertz and the SI base unit metre" ;
+  qudt:symbol "Hz⋅M" ;
   qudt:ucumCode "Hz.m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H34" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -7861,6 +8219,7 @@ unit:HZ-PER-K
   qudt:expression "\\(Hz K^{-1}\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:InverseTimeTemperature ;
+  qudt:symbol "Hz/K" ;
   qudt:ucumCode "Hz.K-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Hertz per Kelvin"@en ;
@@ -7873,6 +8232,7 @@ unit:HZ-PER-T
   qudt:expression "\\(Hz T^{-1}\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E1L0I0M-1H0T1D0 ;
   qudt:hasQuantityKind quantitykind:ElectricChargePerMass ;
+  qudt:symbol "Hz/T" ;
   qudt:ucumCode "Hz.T-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Hertz per Tesla"@en ;
@@ -7885,6 +8245,7 @@ unit:HZ-PER-V
   qudt:expression "\\(Hz V^{-1}\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E1L-2I0M-1H0T2D0 ;
   qudt:hasQuantityKind quantitykind:InverseMagneticFlux ;
+  qudt:symbol "Hz/V" ;
   qudt:ucumCode "Hz.V-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Hertz per Volt"@en ;
@@ -7928,6 +8289,7 @@ unit:H_Stat-PER-CentiM
   qudt:hasDimensionVector qkdv:A0E-2L1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ElectromagneticPermeability ;
   qudt:hasQuantityKind quantitykind:Permeability ;
+  qudt:symbol "statH/cm" ;
   qudt:unitOfSystem sou:CGS ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Stathenry per Centimeter"@en-us ;
@@ -7961,6 +8323,7 @@ unit:HectoBAR
   qudt:hasQuantityKind quantitykind:VaporPressure ;
   qudt:iec61360Code "0112/2///62720#UAB087" ;
   qudt:plainTextDescription "100-fold of the unit bar" ;
+  qudt:symbol "hbar" ;
   qudt:ucumCode "hbar"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "HBA" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -7991,6 +8354,7 @@ unit:HectoGM
   qudt:isScalingOf unit:KiloGM ;
   qudt:plainTextDescription "0.1-fold of the SI base unit kilogram" ;
   qudt:prefix prefix:Hecto ;
+  qudt:symbol "hg" ;
   qudt:ucumCode "hg"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "HGM" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -8003,6 +8367,7 @@ unit:HectoL
   qudt:hasQuantityKind quantitykind:Volume ;
   qudt:iec61360Code "0112/2///62720#UAA533" ;
   qudt:plainTextDescription "100-fold of the unit litre" ;
+  qudt:symbol "hL" ;
   qudt:ucumCode "hL"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "HLT" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -8018,6 +8383,7 @@ unit:HectoM
   qudt:isScalingOf unit:M ;
   qudt:plainTextDescription "100-fold of the SI base unit metre" ;
   qudt:prefix prefix:Hecto ;
+  qudt:symbol "hm" ;
   qudt:ucumCode "hm"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "HMT" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -8051,6 +8417,7 @@ unit:HectoPA-L-PER-SEC
   qudt:hasQuantityKind quantitykind:PowerArea ;
   qudt:iec61360Code "0112/2///62720#UAA530" ;
   qudt:plainTextDescription "product out of the 100-fold of the SI derived unit pascal and the unit litre divided by the SI base unit second" ;
+  qudt:symbol "hPa⋅L/s" ;
   qudt:ucumCode "hPa.L.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F93" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -8064,6 +8431,7 @@ unit:HectoPA-M3-PER-SEC
   qudt:hasQuantityKind quantitykind:PowerArea ;
   qudt:iec61360Code "0112/2///62720#UAA531" ;
   qudt:plainTextDescription "product out of the 100-fold of the SI unit pascal and the power of the SI base unit metre with the exponent 3 divided by the SI base unit second" ;
+  qudt:symbol "hPa⋅m³/s" ;
   qudt:ucumCode "hPa.m3.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F94" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -8077,6 +8445,7 @@ unit:HectoPA-PER-BAR
   qudt:hasQuantityKind quantitykind:PressureRatio ;
   qudt:iec61360Code "0112/2///62720#UAA529" ;
   qudt:plainTextDescription "100-fold of the SI derived unit pascal divided by the unit bar" ;
+  qudt:symbol "hPa/bar" ;
   qudt:ucumCode "hPa.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E99" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -8088,6 +8457,7 @@ unit:HectoPA-PER-HR
   qudt:conversionMultiplier 0.0277777777777778 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerAreaTime ;
+  qudt:symbol "hPa/hr" ;
   qudt:ucumCode "hPa.h-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Hectopascals per hour"@en ;
@@ -8099,6 +8469,7 @@ unit:HectoPA-PER-K
   qudt:hasQuantityKind quantitykind:PressureCoefficient ;
   qudt:iec61360Code "0112/2///62720#UAA528" ;
   qudt:plainTextDescription "100-fold of the SI derived unit pascal divided by the SI base unit kelvin" ;
+  qudt:symbol "hPa/K" ;
   qudt:ucumCode "hPa.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F82" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -8139,6 +8510,7 @@ unit:Hundredweight_UK
   qudt:hasQuantityKind quantitykind:Mass ;
   qudt:iec61360Code "0112/2///62720#UAA405" ;
   qudt:plainTextDescription "out of use unit of the mass according to the Imperial system of units" ;
+  qudt:symbol "cwt{long}" ;
   qudt:ucumCode "[lcwt_av]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "CWI" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -8153,6 +8525,7 @@ unit:Hundredweight_US
   qudt:hasQuantityKind quantitykind:Mass ;
   qudt:iec61360Code "0112/2///62720#UAA406" ;
   qudt:plainTextDescription "out of use unit of the mass according to the Imperial system of units" ;
+  qudt:symbol "cwt{short}" ;
   qudt:ucumCode "[scwt_av]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "CWA" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -8170,7 +8543,7 @@ unit:IN
   qudt:hasQuantityKind quantitykind:Length ;
   qudt:iec61360Code "0112/2///62720#UAA539" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Inch?oldid=492522790"^^xsd:anyURI ;
-  qudt:symbol "㏌" ;
+  qudt:symbol "in" ;
   qudt:ucumCode "[in_i]"^^qudt:UCUMcs ;
   qudt:udunitsCode "in" ;
   qudt:uneceCommonCode "INH" ;
@@ -8186,6 +8559,7 @@ unit:IN-PER-DEG_F
   qudt:hasQuantityKind quantitykind:LinearThermalExpansion ;
   qudt:iec61360Code "0112/2///62720#UAA540" ;
   qudt:plainTextDescription "unit inch according to the Anglo-American and the Imperial system of units divided by the unit for temperature degree Fahrenheit" ;
+  qudt:symbol "in/°F" ;
   qudt:ucumCode "[in_i].[degF]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K45" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -8202,6 +8576,7 @@ unit:IN-PER-SEC
   qudt:hasQuantityKind quantitykind:PropellantBurnRate ;
   qudt:hasQuantityKind quantitykind:Velocity ;
   qudt:iec61360Code "0112/2///62720#UAA542" ;
+  qudt:symbol "in/s" ;
   qudt:ucumCode "[in_i].s-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[in_i]/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "IU" ;
@@ -8220,6 +8595,7 @@ unit:IN-PER-SEC2
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Acceleration ;
   qudt:iec61360Code "0112/2///62720#UAB044" ;
+  qudt:symbol "in/s²" ;
   qudt:ucumCode "[in_i].s-2"^^qudt:UCUMcs ;
   qudt:ucumCode "[in_i]/s2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "IV" ;
@@ -8238,6 +8614,7 @@ unit:IN2
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Area ;
   qudt:iec61360Code "0112/2///62720#UAA547" ;
+  qudt:symbol "in²" ;
   qudt:ucumCode "[in_i]2"^^qudt:UCUMcs ;
   qudt:ucumCode "[sin_i]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "INK" ;
@@ -8252,6 +8629,7 @@ unit:IN2-PER-SEC
   qudt:hasQuantityKind quantitykind:AreaPerTime ;
   qudt:iec61360Code "0112/2///62720#UAA548" ;
   qudt:plainTextDescription "power of the unit inch according to the Anglo-American and the Imperial system of units with the exponent 2 divided by the SI base unit second" ;
+  qudt:symbol "in²/s" ;
   qudt:ucumCode "[sin_i].s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G08" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -8268,6 +8646,7 @@ unit:IN3
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Volume ;
   qudt:iec61360Code "0112/2///62720#UAA549" ;
+  qudt:symbol "in³" ;
   qudt:ucumCode "[cin_i]"^^qudt:UCUMcs ;
   qudt:ucumCode "[in_i]3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "INQ" ;
@@ -8282,6 +8661,7 @@ unit:IN3-PER-HR
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA550" ;
   qudt:plainTextDescription "power of the unit inch according to the Anglo-American and the Imperial system of units with the exponent 3 divided by the unit hour" ;
+  qudt:symbol "in³/hr" ;
   qudt:ucumCode "[cin_i].h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G56" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -8299,6 +8679,7 @@ unit:IN3-PER-MIN
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
   qudt:iec61360Code "0112/2///62720#UAA551" ;
+  qudt:symbol "in³/min" ;
   qudt:ucumCode "[cin_i].min-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[cin_i]/min"^^qudt:UCUMcs ;
   qudt:ucumCode "[in_i]3.min-1"^^qudt:UCUMcs ;
@@ -8315,6 +8696,7 @@ unit:IN3-PER-SEC
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA552" ;
   qudt:plainTextDescription "power of the unit inch according to the Anglo-American and the Imperial system of units with the exponent 3 divided by the SI base unit second" ;
+  qudt:symbol "in³/s" ;
   qudt:ucumCode "[cin_i].s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G58" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -8327,6 +8709,7 @@ unit:IN4
   qudt:hasQuantityKind quantitykind:SecondAxialMomentOfArea ;
   qudt:iec61360Code "0112/2///62720#UAA545" ;
   qudt:plainTextDescription "power of the unit inch according to the Anglo-American and the Imperial system of units with the exponent 4" ;
+  qudt:symbol "in⁴" ;
   qudt:ucumCode "[in_i]4"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D69" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -8342,7 +8725,7 @@ unit:IN_H2O
   qudt:hasQuantityKind quantitykind:VaporPressure ;
   qudt:iec61360Code "0112/2///62720#UAA553" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Inch_of_water?oldid=466175519"^^xsd:anyURI ;
-  qudt:symbol "inAq" ;
+  qudt:symbol "inH₂0" ;
   qudt:ucumCode "[in_i'H2O]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F78" ;
   qudt:unitOfSystem sou:USCS ;
@@ -8390,6 +8773,7 @@ unit:IU-PER-L
   qudt:expression "\\(IU/L\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:SerumOrPlasmaLevel ;
+  qudt:symbol "IU/L" ;
   qudt:ucumCode "[IU].L-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[IU]/L"^^qudt:UCUMcs ;
   qudt:ucumCode "[iU].L-1"^^qudt:UCUMcs ;
@@ -8405,6 +8789,7 @@ unit:IU-PER-MilliGM
   qudt:hasDimensionVector qkdv:A1E0L0I0M-1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:AmountOfSubstancePerUnitMass ;
   qudt:plainTextDescription "International Units per milligramme." ;
+  qudt:symbol "IU/mg" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "International Unit per milligram"@en ;
 .
@@ -8497,6 +8882,7 @@ unit:J-M-PER-MOL
   qudt:expression "\\(J m mol^{-1}\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A-1E0L3I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:LengthMolarEnergy ;
+  qudt:symbol "J⋅m/mol" ;
   qudt:ucumCode "J.m.mol-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Joule Meter per Mole"@en-us ;
@@ -8510,7 +8896,7 @@ unit:J-M2
   qudt:hasQuantityKind quantitykind:TotalAtomicStoppingPower ;
   qudt:iec61360Code "0112/2///62720#UAA181" ;
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
-  qudt:symbol "J㎡" ;
+  qudt:symbol "J⋅m²" ;
   qudt:ucumCode "J.m2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D73" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -8526,6 +8912,7 @@ unit:J-M2-PER-KiloGM
   qudt:hasQuantityKind quantitykind:TotalMassStoppingPower ;
   qudt:iec61360Code "0112/2///62720#UAB487" ;
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:symbol "j⋅m²/kg" ;
   qudt:ucumCode "J.m2.kg-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B20" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -8539,6 +8926,7 @@ unit:J-PER-CentiM2
   qudt:hasQuantityKind quantitykind:EnergyPerArea ;
   qudt:iec61360Code "0112/2///62720#UAB188" ;
   qudt:plainTextDescription "derived SI unit joule divided by the 0.0001-fold of the power of the SI base unit metre by exponent 2" ;
+  qudt:symbol "J/cm²" ;
   qudt:ucumCode "J.cm-2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E43" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -8552,6 +8940,7 @@ unit:J-PER-CentiM2-DAY
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:PowerPerArea ;
   qudt:hasQuantityKind quantitykind:Radiosity ;
+  qudt:symbol "J/(cm²⋅day)" ;
   qudt:ucumCode "J.cm-2.d-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Joules per square centimetre per day"@en ;
@@ -8563,6 +8952,7 @@ unit:J-PER-GM
   qudt:hasQuantityKind quantitykind:SpecificEnergy ;
   qudt:iec61360Code "0112/2///62720#UAA174" ;
   qudt:plainTextDescription "SI derived unit joule divided by the 0.001-fold of the SI base unit kilogram" ;
+  qudt:symbol "J/g" ;
   qudt:ucumCode "J.g-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D95" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -8574,6 +8964,7 @@ unit:J-PER-HR
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:plainTextDescription "SI derived unit joule divided by the 3600 times the SI base unit second" ;
+  qudt:symbol "J/hr" ;
   qudt:ucumCode "J.h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P16" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -8591,6 +8982,7 @@ unit:J-PER-K
   qudt:hasQuantityKind quantitykind:Entropy ;
   qudt:hasQuantityKind quantitykind:HeatCapacity ;
   qudt:iec61360Code "0112/2///62720#UAA173" ;
+  qudt:symbol "J/K" ;
   qudt:ucumCode "J.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "JE" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -8611,6 +9003,7 @@ unit:J-PER-KiloGM
   qudt:hasQuantityKind quantitykind:SpecificHelmholtzEnergy ;
   qudt:hasQuantityKind quantitykind:SpecificInternalEnergy ;
   qudt:iec61360Code "0112/2///62720#UAA175" ;
+  qudt:symbol "J/kg" ;
   qudt:ucumCode "J.kg-1"^^qudt:UCUMcs ;
   qudt:ucumCode "J/kg"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J2" ;
@@ -8633,6 +9026,7 @@ unit:J-PER-KiloGM-K
   qudt:hasQuantityKind quantitykind:SpecificHeatCapacityAtSaturation ;
   qudt:iec61360Code "0112/2///62720#UAA176" ;
   qudt:latexSymbol "\\(J/(kg \\cdot K)\\)"^^qudt:LatexString ;
+  qudt:symbol "J/(kg⋅K)" ;
   qudt:ucumCode "J.kg-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B11" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -8649,6 +9043,7 @@ unit:J-PER-KiloGM-K-M3
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H-1T-2D0 ;
   qudt:hasQuantityKind quantitykind:SpecificHeatCapacityAtConstantVolume ;
   qudt:hasQuantityKind quantitykind:SpecificHeatVolume ;
+  qudt:symbol "J/(kg⋅K⋅m³)" ;
   qudt:ucumCode "J.kg-1.K.m-3"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Joule per Kilogram Kelvin Cubic Meter"@en-us ;
@@ -8664,6 +9059,7 @@ unit:J-PER-KiloGM-K-PA
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H-1T-2D0 ;
   qudt:hasQuantityKind quantitykind:SpecificHeatCapacityAtConstantPressure ;
   qudt:hasQuantityKind quantitykind:SpecificHeatPressure ;
+  qudt:symbol "J/(kg⋅K⋅Pa)" ;
   qudt:ucumCode "J.kg-1.K-1.Pa-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Joule per Kilogram Kelvin per Pascal"@en ;
@@ -8679,6 +9075,7 @@ unit:J-PER-M
   qudt:hasQuantityKind quantitykind:TotalLinearStoppingPower ;
   qudt:iec61360Code "0112/2///62720#UAA178" ;
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:symbol "J/m" ;
   qudt:ucumCode "J.m-1"^^qudt:UCUMcs ;
   qudt:ucumCode "J/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B12" ;
@@ -8699,6 +9096,7 @@ unit:J-PER-M2
   qudt:hasQuantityKind quantitykind:EnergyPerArea ;
   qudt:hasQuantityKind quantitykind:RadiantFluence ;
   qudt:iec61360Code "0112/2///62720#UAA179" ;
+  qudt:symbol "J/m²" ;
   qudt:ucumCode "J.m-2"^^qudt:UCUMcs ;
   qudt:ucumCode "J/m2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B13" ;
@@ -8720,6 +9118,7 @@ unit:J-PER-M3
   qudt:hasQuantityKind quantitykind:RadiantEnergyDensity ;
   qudt:hasQuantityKind quantitykind:VolumicElectromagneticEnergy ;
   qudt:iec61360Code "0112/2///62720#UAA180" ;
+  qudt:symbol "J/m³" ;
   qudt:ucumCode "J.m-3"^^qudt:UCUMcs ;
   qudt:ucumCode "J/m3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B8" ;
@@ -8737,6 +9136,7 @@ unit:J-PER-M3-K
   qudt:expression "\\(J/(m^{3} K)\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H-1T-2D0 ;
   qudt:hasQuantityKind quantitykind:VolumetricHeatCapacity ;
+  qudt:symbol "J/(m³⋅K)" ;
   qudt:ucumCode "J.m-3.K-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Joule per Cubic Meter Kelvin"@en-us ;
@@ -8751,6 +9151,7 @@ unit:J-PER-M4
   qudt:hasDimensionVector qkdv:A0E0L-2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:SpectralRadiantEnergyDensity ;
   qudt:iec61360Code "0112/2///62720#UAA177" ;
+  qudt:symbol "J/m⁴" ;
   qudt:ucumCode "J.m-4"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B14" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -8770,6 +9171,7 @@ unit:J-PER-MOL
   qudt:hasQuantityKind quantitykind:ElectricPolarizability ;
   qudt:hasQuantityKind quantitykind:MolarEnergy ;
   qudt:iec61360Code "0112/2///62720#UAA183" ;
+  qudt:symbol "J/mol" ;
   qudt:ucumCode "J.mol-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B15" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -8787,6 +9189,7 @@ unit:J-PER-MOL-K
   qudt:hasQuantityKind quantitykind:MolarEntropy ;
   qudt:hasQuantityKind quantitykind:MolarHeatCapacity ;
   qudt:iec61360Code "0112/2///62720#UAA184" ;
+  qudt:symbol "J/(mol⋅K)" ;
   qudt:ucumCode "J.mol-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B16" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -8798,6 +9201,7 @@ unit:J-PER-SEC
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:plainTextDescription "SI derived unit joule divided by the SI base unit second" ;
+  qudt:symbol "J/s" ;
   qudt:ucumCode "J.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P14" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -8814,6 +9218,7 @@ unit:J-PER-T
   qudt:hasDimensionVector qkdv:A0E1L2I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:MagneticDipoleMoment ;
   qudt:iec61360Code "0112/2///62720#UAB336" ;
+  qudt:symbol "J/T" ;
   qudt:ucumCode "J.T-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "Q10" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -8828,6 +9233,7 @@ unit:J-PER-T2
   qudt:hasDimensionVector qkdv:A0E2L2I0M-1H0T2D0 ;
   qudt:hasQuantityKind quantitykind:EnergyPerSquareMagneticFluxDensity ;
   qudt:informativeReference "http://www.eng.fsu.edu/~dommelen/quantum/style_a/elecmagfld.html"^^xsd:anyURI ;
+  qudt:symbol "J/T²" ;
   qudt:ucumCode "J.T-2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Joule per Square Tesla"@en ;
@@ -8843,7 +9249,7 @@ unit:J-SEC
   qudt:hasQuantityKind quantitykind:Action ;
   qudt:hasQuantityKind quantitykind:AngularMomentum ;
   qudt:iec61360Code "0112/2///62720#UAB151" ;
-  qudt:symbol "J s" ;
+  qudt:symbol "J⋅s" ;
   qudt:ucumCode "J.s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B18" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -8857,6 +9263,7 @@ unit:J-SEC-PER-MOL
   qudt:expression "\\(J s mol^{-1}\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A-1E0L2I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:MolarAngularMomentum ;
+  qudt:symbol "J⋅s/mol" ;
   qudt:ucumCode "J.s.mol-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Joule Second per Mole"@en ;
@@ -8930,7 +9337,7 @@ unit:K-DAY
   qudt:conversionMultiplier 86400.0 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H1T1D0 ;
   qudt:hasQuantityKind quantitykind:TimeTemperature ;
-  qudt:symbol "K d" ;
+  qudt:symbol "K⋅day" ;
   qudt:ucumCode "K.d"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kelvin day"@en ;
@@ -8940,6 +9347,7 @@ unit:K-M
   qudt:conversionMultiplier 1.0 ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H1T0D0 ;
   qudt:hasQuantityKind quantitykind:LengthTemperature ;
+  qudt:symbol "K⋅m" ;
   qudt:ucumCode "K.m"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kelvin metres"@en ;
@@ -8948,6 +9356,7 @@ unit:K-M-PER-SEC
   a qudt:Unit ;
   qudt:conversionMultiplier 1.0 ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H1T-1D0 ;
+  qudt:symbol "K⋅m/s" ;
   qudt:ucumCode "K.m.s-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kelvin metres per second"@en ;
@@ -8959,6 +9368,7 @@ unit:K-M-PER-W
   qudt:hasQuantityKind quantitykind:ThermalResistivity ;
   qudt:iec61360Code "0112/2///62720#UAB488" ;
   qudt:plainTextDescription "product of the SI base unit kelvin and the SI base unit metre divided by the derived SI unit watt" ;
+  qudt:symbol "K⋅m/W" ;
   qudt:ucumCode "K.m.W-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H35" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -8969,6 +9379,7 @@ unit:K-M2-PER-KiloGM-SEC
   a qudt:Unit ;
   qudt:conversionMultiplier 1.0 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M-1H1T-1D0 ;
+  qudt:symbol "K⋅m²/(kg⋅s)" ;
   qudt:ucumCode "K.m2.kg-1.s-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kelvin square metres per kilogram per second"@en ;
@@ -8977,6 +9388,7 @@ unit:K-PA-PER-SEC
   a qudt:Unit ;
   qudt:conversionMultiplier 1.0 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H1T-3D0 ;
+  qudt:symbol "K⋅Pa/s" ;
   qudt:ucumCode "K.Pa.s-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kelvin Pascals per second"@en ;
@@ -8989,6 +9401,7 @@ unit:K-PER-HR
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H1T-1D0 ;
   qudt:hasQuantityKind quantitykind:TemperaturePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA189" ;
+  qudt:symbol "K/h" ;
   qudt:ucumCode "K.h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F10" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -9001,6 +9414,7 @@ unit:K-PER-K
   qudt:hasQuantityKind quantitykind:TemperatureRatio ;
   qudt:iec61360Code "0112/2///62720#UAA186" ;
   qudt:plainTextDescription "SI base unit kelvin divided by the SI base unit kelvin" ;
+  qudt:symbol "K/K" ;
   qudt:ucumCode "K.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F02" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -9011,6 +9425,7 @@ unit:K-PER-M
   dcterms:description "A change of temperature on the Kelvin temperature scale in one SI unit of length."@en ;
   qudt:conversionMultiplier 1.0 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H1T0D0 ;
+  qudt:symbol "Pa/m" ;
   qudt:ucumCode "K.m-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Degrees Kelvin per metre"@en ;
@@ -9024,6 +9439,7 @@ unit:K-PER-MIN
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H1T-1D0 ;
   qudt:hasQuantityKind quantitykind:TemperaturePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA191" ;
+  qudt:symbol "K/m" ;
   qudt:ucumCode "K.min-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F11" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -9038,6 +9454,7 @@ unit:K-PER-SEC
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H1T-1D0 ;
   qudt:hasQuantityKind quantitykind:TemperaturePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA192" ;
+  qudt:symbol "K/s" ;
   qudt:ucumCode "K.s-1"^^qudt:UCUMcs ;
   qudt:ucumCode "K/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F12" ;
@@ -9052,6 +9469,7 @@ unit:K-PER-T
   qudt:expression "\\(K T^{-1}\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E1L0I0M-1H1T2D0 ;
   qudt:hasQuantityKind quantitykind:TemperaturePerMagneticFluxDensity ;
+  qudt:symbol "K/T" ;
   qudt:ucumCode "K.T-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kelvin per Tesla"@en ;
@@ -9067,6 +9485,7 @@ unit:K-PER-W
   qudt:hasDimensionVector qkdv:A0E0L-2I0M-1H1T3D0 ;
   qudt:hasQuantityKind quantitykind:ThermalResistance ;
   qudt:iec61360Code "0112/2///62720#UAA187" ;
+  qudt:symbol "K/W" ;
   qudt:ucumCode "K.W-1"^^qudt:UCUMcs ;
   qudt:ucumCode "K/W"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B21" ;
@@ -9078,6 +9497,7 @@ unit:K-SEC
   qudt:conversionMultiplier 1.0 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H1T1D0 ;
   qudt:hasQuantityKind quantitykind:TimeTemperature ;
+  qudt:symbol "K⋅s" ;
   qudt:ucumCode "K.s"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kelvin second"@en ;
@@ -9086,6 +9506,7 @@ unit:K2
   a qudt:Unit ;
   qudt:conversionMultiplier 1.0 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H2T0D0 ;
+  qudt:symbol "K²" ;
   qudt:ucumCode "K2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Square Kelvin"@en ;
@@ -9134,6 +9555,7 @@ unit:KIP_F-PER-IN2
   qudt:hasQuantityKind quantitykind:ForcePerArea ;
   qudt:hasQuantityKind quantitykind:VaporPressure ;
   qudt:iec61360Code "0112/2///62720#UAB242" ;
+  qudt:symbol "kip/in²" ;
   qudt:ucumCode "k[lbf_av].[in_i]-2"^^qudt:UCUMcs ;
   qudt:udunitsCode "ksi" ;
   qudt:uneceCommonCode "N20" ;
@@ -9170,6 +9592,7 @@ unit:KN-PER-SEC
   qudt:expression "\\(kt/s\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Acceleration ;
+  qudt:symbol "kn/s" ;
   qudt:ucumCode "[kn_i].s-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[kn_i]/s"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -9187,6 +9610,7 @@ unit:KY
   qudt:hasQuantityKind quantitykind:InverseLength ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Kayser?oldid=458489166"^^xsd:anyURI ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/kayser> ;
+  qudt:symbol "K" ;
   qudt:ucumCode "Ky"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:CGS ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -9241,6 +9665,7 @@ unit:KiloA-HR
   qudt:hasQuantityKind quantitykind:ElectricCharge ;
   qudt:iec61360Code "0112/2///62720#UAB053" ;
   qudt:plainTextDescription "product of the 1 000-fold of the SI base unit ampere and the unit hour" ;
+  qudt:symbol "kA⋅hr" ;
   qudt:ucumCode "kA.h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "TAH" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -9254,6 +9679,7 @@ unit:KiloA-PER-M
   qudt:hasQuantityKind quantitykind:MagneticFieldStrength_H ;
   qudt:iec61360Code "0112/2///62720#UAA558" ;
   qudt:plainTextDescription "1 000-fold of the SI base unit ampere divided by the SI base unit metre" ;
+  qudt:symbol "kA/m" ;
   qudt:ucumCode "kA.m-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B24" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -9267,6 +9693,7 @@ unit:KiloA-PER-M2
   qudt:hasQuantityKind quantitykind:ElectricCurrentDensity ;
   qudt:iec61360Code "0112/2///62720#UAA559" ;
   qudt:plainTextDescription "1 000-fold of the SI base unit ampere divided by the power of the SI base unit metre with the exponent 2" ;
+  qudt:symbol "kA/m²" ;
   qudt:ucumCode "kA.m-2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B23" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -9315,6 +9742,7 @@ unit:KiloBQ
   qudt:isScalingOf unit:BQ ;
   qudt:plainTextDescription "1 000-fold of the SI derived unit becquerel" ;
   qudt:prefix prefix:Kilo ;
+  qudt:symbol "kBq" ;
   qudt:ucumCode "kBq"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "2Q" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -9347,7 +9775,7 @@ unit:KiloBYTE-PER-SEC
   qudt:iec61360Code "0112/2///62720#UAB306" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Data_rate_units#Kilobyte_per_second"^^xsd:anyURI ;
   qudt:isScalingOf unit:BIT-PER-SEC ;
-  qudt:symbol "kbps" ;
+  qudt:symbol "kBps" ;
   qudt:ucumCode "kBy.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P94" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -9378,6 +9806,7 @@ unit:KiloC-PER-M2
   qudt:hasQuantityKind quantitykind:ElectricPolarization ;
   qudt:iec61360Code "0112/2///62720#UAA564" ;
   qudt:plainTextDescription "1 000-fold of the SI derived unit coulomb divided by the power of the SI base unit metre with the exponent 2" ;
+  qudt:symbol "kC/m²" ;
   qudt:ucumCode "kC.m-2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B28" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -9391,6 +9820,7 @@ unit:KiloC-PER-M3
   qudt:hasQuantityKind quantitykind:ElectricChargeVolumeDensity ;
   qudt:iec61360Code "0112/2///62720#UAA565" ;
   qudt:plainTextDescription "1 000-fold of the SI derived unit coulomb divided by the power of the SI base unit metre with the exponent 3" ;
+  qudt:symbol "kC/m³" ;
   qudt:ucumCode "kC.m-3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B27" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -9418,6 +9848,7 @@ unit:KiloCAL-PER-CentiM-SEC-DEG_C
   qudt:expression "\\(kilocal-per-cm-sec-degc\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H-1T-3D0 ;
   qudt:hasQuantityKind quantitykind:ThermalConductivity ;
+  qudt:symbol "kcal/(cm⋅s⋅°C)" ;
   qudt:ucumCode "kcal.cm-1.s-1.Cel-1"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:CGS ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -9432,6 +9863,7 @@ unit:KiloCAL-PER-CentiM2
   qudt:expression "\\(kcal/cm^{2}\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:EnergyPerArea ;
+  qudt:symbol "kcal/cm²" ;
   qudt:ucumCode "kcal.cm-2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kilocalorie per Square Centimeter"@en-us ;
@@ -9445,6 +9877,7 @@ unit:KiloCAL-PER-CentiM2-MIN
   qudt:expression "\\(kcal/(cm^{2}-min)\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:PowerPerArea ;
+  qudt:symbol "kcal/(cm²⋅min)" ;
   qudt:ucumCode "kcal.cm-2.min-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kilocalorie per Square Centimeter Minute"@en-us ;
@@ -9458,6 +9891,7 @@ unit:KiloCAL-PER-CentiM2-SEC
   qudt:expression "\\(kcal/(cm^{2}-s)\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:PowerPerArea ;
+  qudt:symbol "kcal/(cm²⋅s)" ;
   qudt:ucumCode "kcal.cm-2.s-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kilocalorie per Square Centimeter Second"@en-us ;
@@ -9471,6 +9905,7 @@ unit:KiloCAL-PER-GM
   qudt:expression "\\(kcal/gm\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:SpecificEnergy ;
+  qudt:symbol "kcal/g" ;
   qudt:ucumCode "kcal.g-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kilocalorie per Gram"@en ;
@@ -9482,6 +9917,7 @@ unit:KiloCAL-PER-GM-DEG_C
   qudt:expression "\\(kcal/(gm-degC)\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H-1T-2D0 ;
   qudt:hasQuantityKind quantitykind:SpecificHeatCapacity ;
+  qudt:symbol "kcal/(g⋅°C)" ;
   qudt:ucumCode "cal.g-1.Cel-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Calorie per Gram Degree Celsius"@en ;
@@ -9496,6 +9932,7 @@ unit:KiloCAL-PER-MIN
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:HeatFlowRate ;
   qudt:hasQuantityKind quantitykind:Power ;
+  qudt:symbol "kcal/min" ;
   qudt:ucumCode "kcal.min-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K54" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -9508,6 +9945,7 @@ unit:KiloCAL-PER-MOL
   qudt:expression "\\(kcal/mol\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A-1E0L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:MolarEnergy ;
+  qudt:symbol "kcal/mol" ;
   qudt:ucumCode "kcal.mol-1"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:CGS ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -9520,6 +9958,7 @@ unit:KiloCAL-PER-MOL-DEG_C
   qudt:expression "\\(kcal/(mol-degC)\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A-1E0L2I0M1H-1T-2D0 ;
   qudt:hasQuantityKind quantitykind:MolarHeatCapacity ;
+  qudt:symbol "kcal/(mol⋅°C)" ;
   qudt:ucumCode "kcal.mol-1.Cel-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kilocalorie per Mole Degree Celsius"@en ;
@@ -9534,6 +9973,7 @@ unit:KiloCAL-PER-SEC
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:HeatFlowRate ;
   qudt:hasQuantityKind quantitykind:Power ;
+  qudt:symbol "kcal/s" ;
   qudt:ucumCode "kcal.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K55" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -9546,6 +9986,7 @@ unit:KiloCAL_IT
   qudt:hasQuantityKind quantitykind:ThermalEnergy ;
   qudt:iec61360Code "0112/2///62720#UAA589" ;
   qudt:plainTextDescription "1000-fold of the unit calorie, which is used particularly for calorific values of food" ;
+  qudt:symbol "kcal{IT}" ;
   qudt:ucumCode "kcal_IT"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E14" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -9558,6 +9999,7 @@ unit:KiloCAL_IT-PER-HR-M-DEG_C
   qudt:hasQuantityKind quantitykind:ThermalConductivity ;
   qudt:iec61360Code "0112/2///62720#UAA588" ;
   qudt:plainTextDescription "1 000-fold of the no longer approved unit international calorie for energy divided by the product of the SI base unit metre, the unit hour for time and the unit degree Celsius for temperature" ;
+  qudt:symbol "kcal{IT}/(hr⋅m⋅°C)" ;
   qudt:ucumCode "kcal_IT.h-1.m-1.Cel-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K52" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -9571,6 +10013,7 @@ unit:KiloCAL_Mean
   qudt:hasQuantityKind quantitykind:ThermalEnergy ;
   qudt:iec61360Code "0112/2///62720#UAA587" ;
   qudt:plainTextDescription "1000-fold of the unit calorie, which is used particularly for calorific values of food" ;
+  qudt:symbol "kcal{mean}" ;
   qudt:ucumCode "kcal_m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K51" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -9583,6 +10026,7 @@ unit:KiloCAL_TH
   qudt:hasQuantityKind quantitykind:ThermalEnergy ;
   qudt:iec61360Code "0112/2///62720#UAA590" ;
   qudt:plainTextDescription "1000-fold of the unit calorie, which is used particularly for calorific values of food" ;
+  qudt:symbol "kcal{th}" ;
   qudt:ucumCode "[Cal]"^^qudt:UCUMcs ;
   qudt:ucumCode "kcal_th"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K53" ;
@@ -9596,6 +10040,7 @@ unit:KiloCAL_TH-PER-HR
   qudt:hasQuantityKind quantitykind:HeatFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAB184" ;
   qudt:plainTextDescription "1 000-fold of the non-legal unit thermochemical calorie divided by the unit hour" ;
+  qudt:symbol "kcal{th}/hr" ;
   qudt:ucumCode "kcal_th.h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E15" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -9608,6 +10053,7 @@ unit:KiloCAL_TH-PER-MIN
   qudt:hasQuantityKind quantitykind:HeatFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA591" ;
   qudt:plainTextDescription "1000-fold of the unit calorie divided by the unit minute" ;
+  qudt:symbol "kcal{th}/min" ;
   qudt:ucumCode "kcal_th.min-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K54" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -9620,6 +10066,7 @@ unit:KiloCAL_TH-PER-SEC
   qudt:hasQuantityKind quantitykind:HeatFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA592" ;
   qudt:plainTextDescription "1000-fold of the unit calorie divided by the SI base unit second" ;
+  qudt:symbol "kcal{th}/s" ;
   qudt:ucumCode "kcal_th.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K55" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -9633,6 +10080,7 @@ unit:KiloCi
   qudt:hasQuantityKind quantitykind:DecayConstant ;
   qudt:iec61360Code "0112/2///62720#UAB046" ;
   qudt:plainTextDescription "1 000-fold of the unit curie" ;
+  qudt:symbol "kCi" ;
   qudt:ucumCode "kCi"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "2R" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -9659,6 +10107,7 @@ unit:KiloEV-PER-MicroM
   qudt:expression "\\(keV/microM\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:LinearEnergyTransfer ;
+  qudt:symbol "keV/µM" ;
   qudt:ucumCode "keV.um-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kilo Electron Volt per Micrometer"@en-us ;
@@ -9671,6 +10120,7 @@ unit:KiloGAUSS
   qudt:hasQuantityKind quantitykind:MagneticFluxDensity ;
   qudt:iec61360Code "0112/2///62720#UAB136" ;
   qudt:plainTextDescription "1 000-fold of the CGS unit of the magnetic flux density B" ;
+  qudt:symbol "kGs" ;
   qudt:ucumCode "kG"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "78" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -9705,6 +10155,7 @@ unit:KiloGM-CentiM2
   qudt:hasQuantityKind quantitykind:MomentOfInertia ;
   qudt:iec61360Code "0112/2///62720#UAA600" ;
   qudt:plainTextDescription "product of the SI base unit kilogram and the 0 0001fold of the power of the SI base unit metre with the exponent 2" ;
+  qudt:symbol "kg⋅cm²" ;
   qudt:ucumCode "kg.cm2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F18" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -9720,6 +10171,7 @@ unit:KiloGM-K
   qudt:expression "\\(kg-K\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H1T0D0 ;
   qudt:hasQuantityKind quantitykind:MassTemperature ;
+  qudt:symbol "kg⋅K" ;
   qudt:ucumCode "kg.K"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kilogram Kelvin"@en ;
@@ -9733,6 +10185,7 @@ unit:KiloGM-M-PER-SEC
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:LinearMomentum ;
   qudt:iec61360Code "0112/2///62720#UAA615" ;
+  qudt:symbol "kg⋅m/s" ;
   qudt:ucumCode "kg.m.s-1"^^qudt:UCUMcs ;
   qudt:ucumCode "kg.m/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B31" ;
@@ -9751,6 +10204,7 @@ unit:KiloGM-M2
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:MomentOfInertia ;
   qudt:iec61360Code "0112/2///62720#UAA622" ;
+  qudt:symbol "kg⋅m²" ;
   qudt:ucumCode "kg.m2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B32" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -9767,6 +10221,7 @@ unit:KiloGM-M2-PER-SEC
   qudt:hasQuantityKind quantitykind:AngularImpulse ;
   qudt:hasQuantityKind quantitykind:AngularMomentum ;
   qudt:iec61360Code "0112/2///62720#UAA623" ;
+  qudt:symbol "kg⋅m²/s" ;
   qudt:ucumCode "kg.m2.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B33" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -9780,6 +10235,7 @@ unit:KiloGM-MilliM2
   qudt:hasQuantityKind quantitykind:MomentOfInertia ;
   qudt:iec61360Code "0112/2///62720#UAA627" ;
   qudt:plainTextDescription "product of the SI base kilogram and the  0.001-fold of the power of the SI base metre with the exponent 2" ;
+  qudt:symbol "kg⋅mm²" ;
   qudt:ucumCode "kg.mm2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F19" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -9793,6 +10249,7 @@ unit:KiloGM-PER-CentiM2
   qudt:hasQuantityKind quantitykind:MassPerArea ;
   qudt:iec61360Code "0112/2///62720#UAB174" ;
   qudt:plainTextDescription "SI base unit kilogram divided by the 0.0001-fold of the power of the SI base unit metre by exponent 2" ;
+  qudt:symbol "kg/cm²" ;
   qudt:ucumCode "kg.cm-2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D5" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -9806,6 +10263,7 @@ unit:KiloGM-PER-CentiM3
   qudt:hasQuantityKind quantitykind:MassDensity ;
   qudt:iec61360Code "0112/2///62720#UAA597" ;
   qudt:plainTextDescription "SI base unit kilogram divided by the 0.000 001-fold of the power of the SI base unit metre with the exponent 3" ;
+  qudt:symbol "kg⋅cm³" ;
   qudt:ucumCode "kg.cm-3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G31" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -9819,6 +10277,7 @@ unit:KiloGM-PER-DAY
   qudt:hasQuantityKind quantitykind:MassFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA601" ;
   qudt:plainTextDescription "SI base unit kilogram divided by the unit day" ;
+  qudt:symbol "kg/day" ;
   qudt:ucumCode "kg.d-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F30" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -9831,6 +10290,7 @@ unit:KiloGM-PER-DeciM3
   qudt:hasQuantityKind quantitykind:MassDensity ;
   qudt:iec61360Code "0112/2///62720#UAA604" ;
   qudt:plainTextDescription "SI base unit kilogram divided by the 0.001-fold of the power of the SI base unit metre with the exponent 3" ;
+  qudt:symbol "kg⋅dm³" ;
   qudt:ucumCode "kg.dm-3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B34" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -9846,6 +10306,7 @@ unit:KiloGM-PER-HA
   qudt:expression "\\(kg/hare\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:MassPerArea ;
+  qudt:symbol "kg/ha" ;
   qudt:ucumCode "kg.har-1"^^qudt:UCUMcs ;
   qudt:ucumCode "kg/har"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -9862,6 +10323,7 @@ unit:KiloGM-PER-HR
   qudt:hasQuantityKind quantitykind:MassFlowRate ;
   qudt:hasQuantityKind quantitykind:MassPerTime ;
   qudt:iec61360Code "0112/2///62720#UAA607" ;
+  qudt:symbol "kg/h" ;
   qudt:ucumCode "kg.h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "kg/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E93" ;
@@ -9877,6 +10339,7 @@ unit:KiloGM-PER-KiloGM
   qudt:plainTextDescription "SI base unit kilogram divided by the SI base unit kilogram" ;
   qudt:qkdvDenominator qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:qkdvNumerator qkdv:A0E0L0I0M1H0T0D0 ;
+  qudt:symbol "kg/kg" ;
   qudt:ucumCode "kg.kg-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "3H" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -9889,6 +10352,7 @@ unit:KiloGM-PER-KiloM2
   qudt:hasDimensionVector qkdv:A0E0L-2I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:MassPerArea ;
   qudt:hasQuantityKind quantitykind:SurfaceDensity ;
+  qudt:symbol "kg/km²" ;
   qudt:ucumCode "kg.km-2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kilograms per square kilometre"@en ;
@@ -9900,6 +10364,7 @@ unit:KiloGM-PER-KiloMOL
   qudt:hasQuantityKind quantitykind:MolarMass ;
   qudt:iec61360Code "0112/2///62720#UAA611" ;
   qudt:plainTextDescription "SI base unit kilogram divided by the 1 000-fold of the SI base unit mol" ;
+  qudt:symbol "kg/kmol" ;
   qudt:ucumCode "kg.kmol-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F24" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -9912,6 +10377,7 @@ unit:KiloGM-PER-L
   qudt:hasQuantityKind quantitykind:MassDensity ;
   qudt:iec61360Code "0112/2///62720#UAA612" ;
   qudt:plainTextDescription "SI base unit kilogram divided by the unit litre" ;
+  qudt:symbol "kg/L" ;
   qudt:ucumCode "kg.L-1"^^qudt:UCUMcs ;
   qudt:ucumCode "kg/L"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B35" ;
@@ -9931,6 +10397,7 @@ unit:KiloGM-PER-M
   qudt:hasQuantityKind quantitykind:LinearDensity ;
   qudt:hasQuantityKind quantitykind:MassPerLength ;
   qudt:iec61360Code "0112/2///62720#UAA616" ;
+  qudt:symbol "kg/m" ;
   qudt:ucumCode "kg.m-1"^^qudt:UCUMcs ;
   qudt:ucumCode "kg/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "KL" ;
@@ -9944,6 +10411,7 @@ unit:KiloGM-PER-M-HR
   qudt:conversionMultiplier 0.000277777777777778 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:DynamicViscosity ;
+  qudt:symbol "kg/(m⋅hr)" ;
   qudt:ucumCode "kg.m-1.h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "N40" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -9954,6 +10422,7 @@ unit:KiloGM-PER-M-SEC
   qudt:conversionMultiplier 1.0 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:DynamicViscosity ;
+  qudt:symbol "kg/(m⋅s)" ;
   qudt:ucumCode "kg.m-1.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "N37" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -9971,6 +10440,7 @@ unit:KiloGM-PER-M-SEC2
   qudt:hasQuantityKind quantitykind:ForcePerArea ;
   qudt:hasQuantityKind quantitykind:VaporPressure ;
   qudt:siUnitsExpression "kg/m/s^2" ;
+  qudt:symbol "kg/(m⋅s²)" ;
   qudt:ucumCode "kg.m-1.s-2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kilograms per metre per square second"@en ;
@@ -9990,6 +10460,7 @@ unit:KiloGM-PER-M2
   qudt:hasQuantityKind quantitykind:MeanMassRange ;
   qudt:hasQuantityKind quantitykind:SurfaceDensity ;
   qudt:iec61360Code "0112/2///62720#UAA617" ;
+  qudt:symbol "kg/m²" ;
   qudt:ucumCode "kg.m-2"^^qudt:UCUMcs ;
   qudt:ucumCode "kg/m2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "28" ;
@@ -10003,6 +10474,7 @@ unit:KiloGM-PER-M2-SEC
   qudt:exactMatch unit:KiloGM-PER-SEC-M2 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:MassPerAreaTime ;
+  qudt:symbol "kg/(m²⋅s)" ;
   qudt:ucumCode "kg.m-2.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H56" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -10023,6 +10495,7 @@ unit:KiloGM-PER-M3
   qudt:hasQuantityKind quantitykind:MassDensity ;
   qudt:iec61360Code "0112/2///62720#UAA619" ;
   qudt:plainTextDescription "Kilogram per cubic metre is an SI derived unit of density, defined by mass in kilograms divided by volume in cubic metres. The official SI symbolic abbreviation is kg . m^-3, or equivalently either kg/m^3." ;
+  qudt:symbol "kg/m³" ;
   qudt:ucumCode "kg.m-3"^^qudt:UCUMcs ;
   qudt:ucumCode "kg/m3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "KMQ" ;
@@ -10036,6 +10509,7 @@ unit:KiloGM-PER-M3-SEC
   a qudt:Unit ;
   qudt:conversionMultiplier 1.0 ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H0T-1D0 ;
+  qudt:symbol "kg/(m³⋅s)" ;
   qudt:ucumCode "kg.m-3.s-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kilograms per cubic metre per second"@en ;
@@ -10047,6 +10521,7 @@ unit:KiloGM-PER-MIN
   qudt:hasQuantityKind quantitykind:MassFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA624" ;
   qudt:plainTextDescription "SI base unit kilogram divided by the unit minute" ;
+  qudt:symbol "kg/min" ;
   qudt:ucumCode "kg.min-1"^^qudt:UCUMcs ;
   qudt:ucumCode "kg/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F31" ;
@@ -10061,6 +10536,7 @@ unit:KiloGM-PER-MOL
   qudt:expression "\\(kg mol^{-1}\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A-1E0L0I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:MolarMass ;
+  qudt:symbol "kg/mol" ;
   qudt:ucumCode "kg.mol-1"^^qudt:UCUMcs ;
   qudt:ucumCode "kg/mol"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D74" ;
@@ -10075,6 +10551,7 @@ unit:KiloGM-PER-MilliM
   qudt:hasQuantityKind quantitykind:MassPerLength ;
   qudt:iec61360Code "0112/2///62720#UAB070" ;
   qudt:plainTextDescription "SI base unit kilogram divided by the 0.001-fold of the SI base unit metre" ;
+  qudt:symbol "kg/mm" ;
   qudt:ucumCode "kg.mm-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "KW" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -10093,6 +10570,7 @@ unit:KiloGM-PER-SEC
   qudt:hasQuantityKind quantitykind:MassFlowRate ;
   qudt:hasQuantityKind quantitykind:MassPerTime ;
   qudt:iec61360Code "0112/2///62720#UAA629" ;
+  qudt:symbol "kg/s" ;
   qudt:ucumCode "kg.s-1"^^qudt:UCUMcs ;
   qudt:ucumCode "kg/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "KGS" ;
@@ -10107,6 +10585,7 @@ unit:KiloGM-PER-SEC-M2
   qudt:hasQuantityKind quantitykind:MassPerAreaTime ;
   qudt:iec61360Code "0112/2///62720#UAA618" ;
   qudt:plainTextDescription "SI base unit kilogram divided by the product of the power of the SI base unit metre with the exponent 2 and the SI base unit second" ;
+  qudt:symbol "kg/(s⋅m²)" ;
   qudt:ucumCode "kg.(s.m2)-1"^^qudt:UCUMcs ;
   qudt:ucumCode "kg.s-1.m-2"^^qudt:UCUMcs ;
   qudt:ucumCode "kg/(s.m2)"^^qudt:UCUMcs ;
@@ -10126,6 +10605,7 @@ unit:KiloGM-PER-SEC2
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:EnergyPerArea ;
   qudt:latexSymbol "\\(kg \\cdot s^2\\)"^^qudt:LatexString ;
+  qudt:symbol "kg/s²" ;
   qudt:ucumCode "kg.s-2"^^qudt:UCUMcs ;
   qudt:ucumCode "kg/s2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -10138,6 +10618,7 @@ unit:KiloGM-SEC2
   qudt:definedUnitOfSystem sou:SI ;
   qudt:expression "\\(kilog-sec2\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T2D0 ;
+  qudt:symbol "kg⋅s²" ;
   qudt:ucumCode "kg.s2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kilogram Square Second"@en ;
@@ -10146,6 +10627,7 @@ unit:KiloGM2-PER-SEC2
   a qudt:Unit ;
   qudt:conversionMultiplier 1.0 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M2H0T-2D0 ;
+  qudt:symbol "kg/s²" ;
   qudt:ucumCode "kg2.s-2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Square Kilograms per square second"@en ;
@@ -10172,6 +10654,7 @@ unit:KiloGM_F-M
   qudt:hasQuantityKind quantitykind:Torque ;
   qudt:iec61360Code "0112/2///62720#UAA634" ;
   qudt:plainTextDescription "product of the unit kilogram-force and the SI base unit metre" ;
+  qudt:symbol "kgf⋅m" ;
   qudt:ucumCode "kgf.m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B38" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -10185,6 +10668,7 @@ unit:KiloGM_F-M-PER-CentiM2
   qudt:hasQuantityKind quantitykind:ForcePerLength ;
   qudt:iec61360Code "0112/2///62720#UAB189" ;
   qudt:plainTextDescription "product of the unit kilogram-force and the SI base unit metre divided by the 0.0001-fold of the power of the SI base unit metre by exponent 2" ;
+  qudt:symbol "kgf⋅m/cm²" ;
   qudt:ucumCode "kgf.m.cm-2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E44" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -10197,6 +10681,7 @@ unit:KiloGM_F-M-PER-SEC
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:iec61360Code "0112/2///62720#UAB154" ;
   qudt:plainTextDescription "product of the SI base unit metre and the unit kilogram-force according to the Anglo-American and Imperial system of units divided by the SI base unit second" ;
+  qudt:symbol "kgf⋅m/s" ;
   qudt:ucumCode "kgf.m.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B39" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -10211,6 +10696,7 @@ unit:KiloGM_F-PER-CentiM2
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerArea ;
   qudt:hasQuantityKind quantitykind:VaporPressure ;
+  qudt:symbol "kgf/cm²" ;
   qudt:ucumCode "kgf.cm-2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E42" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -10225,6 +10711,7 @@ unit:KiloGM_F-PER-M2
   qudt:hasQuantityKind quantitykind:VaporPressure ;
   qudt:iec61360Code "0112/2///62720#UAA635" ;
   qudt:plainTextDescription "not SI conform unit of the pressure" ;
+  qudt:symbol "kgf/m²" ;
   qudt:ucumCode "kgf.m-2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B40" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -10239,6 +10726,7 @@ unit:KiloGM_F-PER-MilliM2
   qudt:hasQuantityKind quantitykind:VaporPressure ;
   qudt:iec61360Code "0112/2///62720#UAA636" ;
   qudt:plainTextDescription "not SI conform unit of the pressure" ;
+  qudt:symbol "kgf/mm²" ;
   qudt:ucumCode "kgf.mm-2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E41" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -10271,6 +10759,7 @@ unit:KiloHZ-M
   qudt:hasQuantityKind quantitykind:SoundParticleVelocity ;
   qudt:iec61360Code "0112/2///62720#UAA567" ;
   qudt:plainTextDescription "product of the 1 000-fold of the SI derived unit hertz and the SI base unit metre" ;
+  qudt:symbol "kHz⋅m" ;
   qudt:ucumCode "kHz.m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M17" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -10287,6 +10776,7 @@ unit:KiloJ
   qudt:isScalingOf unit:J ;
   qudt:plainTextDescription "1 000-fold of the SI derived unit joule" ;
   qudt:prefix prefix:Kilo ;
+  qudt:symbol "kJ" ;
   qudt:ucumCode "kJ"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "KJO" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -10299,6 +10789,7 @@ unit:KiloJ-PER-K
   qudt:hasQuantityKind quantitykind:EnergyPerTemperature ;
   qudt:iec61360Code "0112/2///62720#UAA569" ;
   qudt:plainTextDescription "1 000-fold of the SI derived unit joule divided by the SI base unit kelvin" ;
+  qudt:symbol "kJ/K" ;
   qudt:ucumCode "kJ.K-1"^^qudt:UCUMcs ;
   qudt:ucumCode "kJ/K"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B41" ;
@@ -10312,6 +10803,7 @@ unit:KiloJ-PER-KiloGM
   qudt:hasQuantityKind quantitykind:SpecificEnergy ;
   qudt:iec61360Code "0112/2///62720#UAA570" ;
   qudt:plainTextDescription "1 000-fold of the SI derived unit joule divided by the SI base unit kilogram" ;
+  qudt:symbol "kJ/kg" ;
   qudt:ucumCode "kJ.kg-1"^^qudt:UCUMcs ;
   qudt:ucumCode "kJ/kg"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B42" ;
@@ -10325,6 +10817,7 @@ unit:KiloJ-PER-KiloGM-K
   qudt:hasQuantityKind quantitykind:SpecificEntropy ;
   qudt:iec61360Code "0112/2///62720#UAA571" ;
   qudt:plainTextDescription "1 000-fold of the SI derived unit joule divided by the product of the SI base unit kilogram and the SI base unit kelvin" ;
+  qudt:symbol "kJ/(kg⋅K)" ;
   qudt:ucumCode "kJ.(kg.K)-1"^^qudt:UCUMcs ;
   qudt:ucumCode "kJ.kg-1.K-1"^^qudt:UCUMcs ;
   qudt:ucumCode "kJ/(kg.K)"^^qudt:UCUMcs ;
@@ -10339,6 +10832,7 @@ unit:KiloJ-PER-MOL
   qudt:hasQuantityKind quantitykind:MolarEnergy ;
   qudt:iec61360Code "0112/2///62720#UAA572" ;
   qudt:plainTextDescription "1 000-fold of the SI derived unit joule divided by the SI base unit mol" ;
+  qudt:symbol "kJ/mol" ;
   qudt:ucumCode "kJ.mol-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B44" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -10351,6 +10845,7 @@ unit:KiloL
   qudt:hasQuantityKind quantitykind:Volume ;
   qudt:iec61360Code "0112/2///62720#UAB114" ;
   qudt:plainTextDescription "1 000-fold of the unit litre" ;
+  qudt:symbol "kL" ;
   qudt:ucumCode "kL"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K6" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -10364,6 +10859,7 @@ unit:KiloL-PER-HR
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAB121" ;
   qudt:plainTextDescription "unit of the volume kilolitres divided by the unit hour" ;
+  qudt:symbol "kL/hr" ;
   qudt:ucumCode "kL.h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "4X" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -10377,6 +10873,7 @@ unit:KiloLB_F-FT-PER-A
   qudt:hasQuantityKind quantitykind:MagneticFlux ;
   qudt:iec61360Code "0112/2///62720#UAB483" ;
   qudt:plainTextDescription "product of the Anglo-American unit pound-force and foot divided by the SI base unit ampere" ;
+  qudt:symbol "klbf⋅ft/A" ;
   qudt:ucumCode "[lbf_av].[ft_i].A-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F22" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -10389,6 +10886,7 @@ unit:KiloLB_F-FT-PER-LB
   qudt:hasQuantityKind quantitykind:SpecificEnergy ;
   qudt:iec61360Code "0112/2///62720#UAB484" ;
   qudt:plainTextDescription "product of the Anglo-American unit pound-force and the Anglo-American unit foot divided by the Anglo-American unit pound (US) of mass" ;
+  qudt:symbol "klbf⋅ft/lb" ;
   qudt:ucumCode "[lbf_av].[ft_i].[lb_av]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G20" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -10401,6 +10899,7 @@ unit:KiloLB_F-PER-FT
   qudt:hasQuantityKind quantitykind:ForcePerLength ;
   qudt:iec61360Code "0112/2///62720#UAB192" ;
   qudt:plainTextDescription "unit of the length-related force" ;
+  qudt:symbol "klbf/ft" ;
   qudt:ucumCode "[lbf_av].[ft_i]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F17" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -10414,6 +10913,7 @@ unit:KiloLB_F-PER-IN2
   qudt:hasQuantityKind quantitykind:VaporPressure ;
   qudt:iec61360Code "0112/2///62720#UAB138" ;
   qudt:plainTextDescription "1 000-fold of the unit for pressure psi as a compounded unit pound-force according to the Anglo-American system of units divided by the power of the unit Inch according to the Anglo-American and Imperial system of units by exponent 2" ;
+  qudt:symbol "kpsi" ;
   qudt:ucumCode "k[lbf_av].[sin_i]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "84" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -10433,7 +10933,7 @@ unit:KiloM
   qudt:informativeReference "http://en.wikipedia.org/wiki/Kilometre?oldid=494821851"^^xsd:anyURI ;
   qudt:isScalingOf unit:M ;
   qudt:prefix prefix:Kilo ;
-  qudt:symbol "㎞" ;
+  qudt:symbol "km" ;
   qudt:ucumCode "km"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "KMT" ;
   qudt:unitOfSystem sou:SI ;
@@ -10447,6 +10947,7 @@ unit:KiloM-PER-DAY
   qudt:conversionMultiplier 0.0115740740740741 ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Velocity ;
+  qudt:symbol "kg/day" ;
   qudt:ucumCode "km.d-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kilometres per day"@en ;
@@ -10461,6 +10962,7 @@ unit:KiloM-PER-HR
   qudt:hasQuantityKind quantitykind:Velocity ;
   qudt:iec61360Code "0112/2///62720#UAA638" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Kilometres_per_hour?oldid=487674812"^^xsd:anyURI ;
+  qudt:symbol "km/hr" ;
   qudt:ucumCode "km.h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "km/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "KMH" ;
@@ -10476,6 +10978,7 @@ unit:KiloM-PER-SEC
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Velocity ;
   qudt:iec61360Code "0112/2///62720#UAB392" ;
+  qudt:symbol "km/s" ;
   qudt:ucumCode "km.s-1"^^qudt:UCUMcs ;
   qudt:ucumCode "km/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M62" ;
@@ -10490,6 +10993,7 @@ unit:KiloM3-PER-SEC2
   qudt:expression "\\(km^3/s^2\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:StandardGravitationalParameter ;
+  qudt:symbol "km³/s²" ;
   qudt:ucumCode "km3.s-2"^^qudt:UCUMcs ;
   qudt:ucumCode "km3/s2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -10505,6 +11009,7 @@ unit:KiloMOL
   qudt:isScalingOf unit:MOL ;
   qudt:plainTextDescription "1 000-fold of the SI base unit mol" ;
   qudt:prefix prefix:Kilo ;
+  qudt:symbol "kmol" ;
   qudt:ucumCode "kmol"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B45" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -10517,6 +11022,7 @@ unit:KiloMOL-PER-HR
   qudt:hasQuantityKind quantitykind:CatalyticActivity ;
   qudt:iec61360Code "0112/2///62720#UAA641" ;
   qudt:plainTextDescription "1 000-fold of the SI base unit mole divided by the unit for time hour" ;
+  qudt:symbol "kmol/hr" ;
   qudt:ucumCode "kmol.h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K58" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -10534,6 +11040,7 @@ unit:KiloMOL-PER-KiloGM
   qudt:hasQuantityKind quantitykind:AmountOfSubstancePerUnitMass ;
   qudt:hasQuantityKind quantitykind:IonicStrength ;
   qudt:hasQuantityKind quantitykind:MolalityOfSolute ;
+  qudt:symbol "kmol/kg" ;
   qudt:ucumCode "kmol.kg-1"^^qudt:UCUMcs ;
   qudt:ucumCode "kmol/kg"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P47" ;
@@ -10548,6 +11055,7 @@ unit:KiloMOL-PER-M3
   qudt:hasQuantityKind quantitykind:Solubility_Water ;
   qudt:iec61360Code "0112/2///62720#UAA642" ;
   qudt:plainTextDescription "1 000-fold of the SI base unit mol divided by the power of the SI base unit metre with the exponent 3" ;
+  qudt:symbol "kmol/m³" ;
   qudt:ucumCode "kmol.m-3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B46" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -10561,6 +11069,7 @@ unit:KiloMOL-PER-MIN
   qudt:hasQuantityKind quantitykind:MolarFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA645" ;
   qudt:plainTextDescription "1 000-fold of the SI base unit mole divided by the unit for time minute" ;
+  qudt:symbol "kmol/min" ;
   qudt:ucumCode "kmol.min-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K61" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -10573,6 +11082,7 @@ unit:KiloMOL-PER-SEC
   qudt:hasQuantityKind quantitykind:MolarFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA646" ;
   qudt:plainTextDescription "1 000-fold of the SI base unit mol divided by the SI base unit second" ;
+  qudt:symbol "kmol/s" ;
   qudt:ucumCode "kmol.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E94" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -10587,6 +11097,7 @@ unit:KiloN
   qudt:isScalingOf unit:N ;
   qudt:plainTextDescription "1 000-fold of the SI derived unit newton" ;
   qudt:prefix prefix:Kilo ;
+  qudt:symbol "kN" ;
   qudt:ucumCode "kN"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B47" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -10599,6 +11110,7 @@ unit:KiloN-M
   qudt:hasQuantityKind quantitykind:Torque ;
   qudt:iec61360Code "0112/2///62720#UAA574" ;
   qudt:plainTextDescription "1 000-fold of the product of the SI derived unit newton and the SI base unit metre" ;
+  qudt:symbol "kN⋅m" ;
   qudt:ucumCode "kN.m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B48" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -10614,6 +11126,7 @@ unit:KiloOHM
   qudt:isScalingOf unit:OHM ;
   qudt:plainTextDescription "1 000-fold of the SI derived unit ohm" ;
   qudt:prefix prefix:Kilo ;
+  qudt:symbol "kΩ" ;
   qudt:ucumCode "kOhm"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B49" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -10626,7 +11139,7 @@ unit:KiloP
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Force ;
   qudt:iec61360Code "0112/2///62720#UAB059" ;
-  qudt:symbol "kp" ;
+  qudt:symbol "kP" ;
   qudt:ucumCode "kgf"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B51" ;
   qudt:unitOfSystem sou:CGS ;
@@ -10659,6 +11172,7 @@ unit:KiloPA-M2-PER-GM
   qudt:hasQuantityKind quantitykind:Acceleration ;
   qudt:iec61360Code "0112/2///62720#UAB130" ;
   qudt:plainTextDescription "sector-specific unit of the burst index as 1 000-fold of the derived unit for pressure pascal related to the substance, represented as a quotient from the 0.001-fold of the SI base unit kilogram divided by the power of the SI base unit metre by exponent 2" ;
+  qudt:symbol "kPa⋅m²/g" ;
   qudt:ucumCode "kPa.m2.g-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "33" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -10672,6 +11186,7 @@ unit:KiloPA-PER-BAR
   qudt:hasQuantityKind quantitykind:PressureRatio ;
   qudt:iec61360Code "0112/2///62720#UAA577" ;
   qudt:plainTextDescription "1 000-fold of the SI derived unit pascal divided by the unit bar" ;
+  qudt:symbol "kPa/bar" ;
   qudt:ucumCode "kPa.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F03" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -10684,6 +11199,7 @@ unit:KiloPA-PER-K
   qudt:hasQuantityKind quantitykind:PressureCoefficient ;
   qudt:iec61360Code "0112/2///62720#UAA576" ;
   qudt:plainTextDescription "1 000-fold of the SI derived unit pascal divided by the SI base unit kelvin" ;
+  qudt:symbol "kPa/K" ;
   qudt:ucumCode "kPa.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F83" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -10696,6 +11212,7 @@ unit:KiloPA-PER-MilliM
   qudt:hasQuantityKind quantitykind:SpectralRadiantEnergyDensity ;
   qudt:iec61360Code "0112/2///62720#UAB060" ;
   qudt:plainTextDescription "1 000-fold of the derived SI unit pascal divided by the 0.001-fold of the SI base unit metre" ;
+  qudt:symbol "kPa/mm" ;
   qudt:ucumCode "kPa.mm-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "34" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -10723,6 +11240,7 @@ unit:KiloPOND
   qudt:hasQuantityKind quantitykind:Force ;
   qudt:iec61360Code "0112/2///62720#UAB059" ;
   qudt:plainTextDescription "illegal unit of the weight, defined as mass of 1 kg which receives a weight of 1 kp through gravitation at sea level, which equates to a force of 9,806 65 newton" ;
+  qudt:symbol "kp" ;
   qudt:uneceCommonCode "B51" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kilopond"@en ;
@@ -10734,6 +11252,7 @@ unit:KiloR
   qudt:hasQuantityKind quantitykind:ElectricChargePerMass ;
   qudt:iec61360Code "0112/2///62720#UAB057" ;
   qudt:plainTextDescription "1 000-fold of the unit roentgen" ;
+  qudt:symbol "kR" ;
   qudt:ucumCode "kR"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "KR" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -10748,6 +11267,7 @@ unit:KiloS
   qudt:isScalingOf unit:S ;
   qudt:plainTextDescription "1 000-fold of the SI derived unit siemens" ;
   qudt:prefix prefix:Kilo ;
+  qudt:symbol "kS" ;
   qudt:ucumCode "kS"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B53" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -10760,6 +11280,7 @@ unit:KiloS-PER-M
   qudt:hasQuantityKind quantitykind:Conductivity ;
   qudt:iec61360Code "0112/2///62720#UAA579" ;
   qudt:plainTextDescription "1 000-fold of the SI derived unit siemens divided by the SI base unit metre" ;
+  qudt:symbol "kS/m" ;
   qudt:ucumCode "kS.m-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B54" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -10789,6 +11310,7 @@ unit:KiloTONNE
   a qudt:Unit ;
   qudt:exactMatch unit:KiloTON_Metric ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T0D0 ;
+  qudt:symbol "kt" ;
   qudt:uneceCommonCode "KTN" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "KiloTonne"@en ;
@@ -10802,6 +11324,7 @@ unit:KiloTON_Metric
   qudt:hasQuantityKind quantitykind:Mass ;
   qudt:iec61360Code "0112/2///62720#UAB080" ;
   qudt:plainTextDescription "1 000 000-fold of the SI base unit kilogram" ;
+  qudt:symbol "kton{short}" ;
   qudt:ucumCode "kt"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "KTN" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -10817,6 +11340,7 @@ unit:KiloV
   qudt:isScalingOf unit:V ;
   qudt:plainTextDescription "1 000-fold of the SI derived unit volt" ;
   qudt:prefix prefix:Kilo ;
+  qudt:symbol "kV" ;
   qudt:ucumCode "kV"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "KVT" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -10829,6 +11353,7 @@ unit:KiloV-A
   qudt:hasQuantityKind quantitykind:ComplexPower ;
   qudt:iec61360Code "0112/2///62720#UAA581" ;
   qudt:plainTextDescription "1 000-fold of the product of the SI derived unit volt and the SI base unit ampere" ;
+  qudt:symbol "kV⋅A" ;
   qudt:ucumCode "kV.A"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "KVA" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -10841,6 +11366,7 @@ unit:KiloV-A-HR
   qudt:hasQuantityKind quantitykind:Energy ;
   qudt:iec61360Code "0112/2///62720#UAB160" ;
   qudt:plainTextDescription "product of the 1 000-fold of the unit for apparent by ampere and the unit hour" ;
+  qudt:symbol "kV⋅A/hr" ;
   qudt:ucumCode "kV.A.h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C79" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -10853,6 +11379,7 @@ unit:KiloV-A_Reactive
   qudt:hasQuantityKind quantitykind:ReactivePower ;
   qudt:iec61360Code "0112/2///62720#UAA648" ;
   qudt:plainTextDescription "1 000-fold of the unit var" ;
+  qudt:symbol "kV⋅A{Reactive}" ;
   qudt:ucumCode "kV.A{reactive}"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "KVR" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -10865,6 +11392,7 @@ unit:KiloV-A_Reactive-HR
   qudt:hasQuantityKind quantitykind:Energy ;
   qudt:iec61360Code "0112/2///62720#UAB195" ;
   qudt:plainTextDescription "product of the 1 000-fold of the unit volt ampere reactive and the unit hour" ;
+  qudt:symbol "kV⋅A{Reactive}⋅hr" ;
   qudt:ucumCode "kV.A.h{reactive}"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K3" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -10877,6 +11405,7 @@ unit:KiloV-PER-M
   qudt:hasQuantityKind quantitykind:ElectricFieldStrength ;
   qudt:iec61360Code "0112/2///62720#UAA582" ;
   qudt:plainTextDescription "1 000-fold of the SI derived unit volt divided by the SI base unit metre" ;
+  qudt:symbol "kV/m" ;
   qudt:ucumCode "kV.m-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B55" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -10911,6 +11440,7 @@ unit:KiloW-HR
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Energy ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Kilowatt_hour?oldid=494927235"^^xsd:anyURI ;
+  qudt:symbol "kW⋅h" ;
   qudt:ucumCode "kW.h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "KWH" ;
   qudt:unitOfSystem sou:CGS ;
@@ -10924,6 +11454,7 @@ unit:KiloW-HR-PER-M2
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:EnergyPerArea ;
   qudt:plainTextDescription "A unit of energy per unit area, equivalent to 3 600 000 joules per square metre." ;
+  qudt:symbol "kW⋅h/m²" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kilowatt hour per square metre"@en ;
 .
@@ -10934,6 +11465,7 @@ unit:KiloWB-PER-M
   qudt:hasQuantityKind quantitykind:MagneticVectorPotential ;
   qudt:iec61360Code "0112/2///62720#UAA585" ;
   qudt:plainTextDescription "1 000-fold of the SI derived unit weber divided by the SI base unit metre" ;
+  qudt:symbol "kWb/m" ;
   qudt:ucumCode "kWb.m-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B56" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -11017,7 +11549,6 @@ unit:L
   qudt:informativeReference "http://en.wikipedia.org/wiki/Litre?oldid=494846400"^^xsd:anyURI ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/litre> ;
   qudt:symbol "L" ;
-  qudt:symbol "l" ;
   qudt:ucumCode "L"^^qudt:UCUMcs ;
   qudt:ucumCode "l"^^qudt:UCUMcs ;
   qudt:udunitsCode "L" ;
@@ -11034,6 +11565,7 @@ unit:L-PER-DAY
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA652" ;
   qudt:plainTextDescription "unit litre divided by the unit day" ;
+  qudt:symbol "L/day" ;
   qudt:ucumCode "L.d-1"^^qudt:UCUMcs ;
   qudt:ucumCode "L/d"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "LD" ;
@@ -11048,6 +11580,7 @@ unit:L-PER-HR
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA655" ;
   qudt:plainTextDescription "Unit litre divided by the unit hour" ;
+  qudt:symbol "L/hr" ;
   qudt:ucumCode "L.h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "L/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E32" ;
@@ -11062,6 +11595,7 @@ unit:L-PER-K
   qudt:hasQuantityKind quantitykind:VolumeThermalExpansion ;
   qudt:iec61360Code "0112/2///62720#UAA650" ;
   qudt:plainTextDescription "unit litre divided by the SI base unit kelvin" ;
+  qudt:symbol "L/K" ;
   qudt:ucumCode "L.K-1"^^qudt:UCUMcs ;
   qudt:ucumCode "L/K"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G28" ;
@@ -11077,6 +11611,7 @@ unit:L-PER-KiloGM
   qudt:hasQuantityKind quantitykind:SpecificVolume ;
   qudt:iec61360Code "0112/2///62720#UAB380" ;
   qudt:plainTextDescription "unit of the volume litre divided by the SI base unit kilogram" ;
+  qudt:symbol "L/kg" ;
   qudt:ucumCode "L.kg-1"^^qudt:UCUMcs ;
   qudt:ucumCode "L/kg"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H83" ;
@@ -11091,6 +11626,7 @@ unit:L-PER-L
   qudt:hasQuantityKind quantitykind:VolumeFraction ;
   qudt:iec61360Code "0112/2///62720#UAA658" ;
   qudt:plainTextDescription "volume ratio consisting of the unit litre divided by the unit litre" ;
+  qudt:symbol "L/L" ;
   qudt:ucumCode "L.L-1"^^qudt:UCUMcs ;
   qudt:ucumCode "L/L"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K62" ;
@@ -11105,6 +11641,7 @@ unit:L-PER-MIN
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA659" ;
   qudt:plainTextDescription "unit litre divided by the unit minute" ;
+  qudt:symbol "L/min" ;
   qudt:ucumCode "L.min-1"^^qudt:UCUMcs ;
   qudt:ucumCode "L/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L2" ;
@@ -11120,6 +11657,7 @@ unit:L-PER-MOL
   qudt:hasQuantityKind quantitykind:MolarVolume ;
   qudt:iec61360Code "0112/2///62720#UAA662" ;
   qudt:plainTextDescription "unit litre divided by the SI base unit mol" ;
+  qudt:symbol "L/mol" ;
   qudt:ucumCode "L.mol-1"^^qudt:UCUMcs ;
   qudt:ucumCode "L/mol"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B58" ;
@@ -11134,6 +11672,7 @@ unit:L-PER-MicroMOL
   qudt:hasDimensionVector qkdv:A-1E0L3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:MolarRefractivity ;
   qudt:hasQuantityKind quantitykind:MolarVolume ;
+  qudt:symbol "L/µmol" ;
   qudt:ucumCode "L.umol-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Litres per micromole"@en ;
@@ -11145,6 +11684,7 @@ unit:L-PER-SEC
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA664" ;
   qudt:plainTextDescription "unit litre divided by the SI base unit second" ;
+  qudt:symbol "L/s" ;
   qudt:ucumCode "L.s-1"^^qudt:UCUMcs ;
   qudt:ucumCode "L/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G51" ;
@@ -11158,6 +11698,7 @@ unit:L-PER-SEC-M2
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VentilationRatePerFloorArea ;
   qudt:plainTextDescription "Ventilation rate in Litres per second divided by the floor area" ;
+  qudt:symbol "L/(m²⋅s)" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Liter Per Second Per Square Meter"@en-us ;
   rdfs:label "Litre Per Second Per Square Metre"@en ;
@@ -11206,6 +11747,7 @@ unit:LB-DEG_F
   qudt:expression "\\(lb-degF\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H1T0D0 ;
   qudt:hasQuantityKind quantitykind:MassTemperature ;
+  qudt:symbol "lb⋅°F" ;
   qudt:ucumCode "[lb_av].[degF]"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:IMPERIAL ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -11219,6 +11761,7 @@ unit:LB-DEG_R
   qudt:expression "\\(lb-degR\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H1T0D0 ;
   qudt:hasQuantityKind quantitykind:MassTemperature ;
+  qudt:symbol "lb⋅°R" ;
   qudt:ucumCode "[lb_av].[degR]"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:IMPERIAL ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -11231,6 +11774,7 @@ unit:LB-FT2
   qudt:hasQuantityKind quantitykind:MomentOfInertia ;
   qudt:iec61360Code "0112/2///62720#UAA671" ;
   qudt:plainTextDescription "product of the unit pound according to the avoirdupois system of units and the power of the unit foot according to the Anglo-American and the Imperial system of units with the exponent 2" ;
+  qudt:symbol "lb⋅ft²" ;
   qudt:ucumCode "[lb_av].[sft_i]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K65" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -11243,6 +11787,7 @@ unit:LB-IN
   qudt:hasQuantityKind quantitykind:LengthMass ;
   qudt:iec61360Code "0112/2///62720#UAB194" ;
   qudt:plainTextDescription "unit of the unbalance (product of avoirdupois pound according to the avoirdupois system of units and inch according to the Anglo-American and Imperial system of units)" ;
+  qudt:symbol "lb⋅in" ;
   qudt:ucumCode "[lb_av].[in_i]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "IA" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -11255,6 +11800,7 @@ unit:LB-IN2
   qudt:hasQuantityKind quantitykind:MomentOfInertia ;
   qudt:iec61360Code "0112/2///62720#UAA672" ;
   qudt:plainTextDescription "product of the unit pound according to the avoirdupois system of units and the power of the unit inch according to the Anglo-American and the Imperial system of units with the exponent 2" ;
+  qudt:symbol "lb⋅in²" ;
   qudt:ucumCode "[lb_av].[sin_i]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F20" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -11269,6 +11815,7 @@ unit:LB-MOL
   qudt:hasDimensionVector qkdv:A1E0L0I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:MassAmountOfSubstance ;
   qudt:iec61360Code "0112/2///62720#UAB402" ;
+  qudt:symbol "lb⋅mol" ;
   qudt:ucumCode "[lb_av].mol"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P44" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -11281,6 +11828,7 @@ unit:LB-MOL-DEG_F
   qudt:expression "\\(lb-mol-degF\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A1E0L0I0M0H1T0D0 ;
   qudt:hasQuantityKind quantitykind:MassAmountOfSubstanceTemperature ;
+  qudt:symbol "lb⋅mol⋅°F" ;
   qudt:ucumCode "[lb_av].mol.[degF]"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Pound Mole Degree Fahrenheit"@en ;
@@ -11292,6 +11840,7 @@ unit:LB-PER-DAY
   qudt:hasQuantityKind quantitykind:MassFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA673" ;
   qudt:plainTextDescription "unit of the mass avoirdupois pound according to the avoirdupois system of units divided by the unit for time day" ;
+  qudt:symbol "lb/day" ;
   qudt:ucumCode "[lb_av].d-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K66" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -11306,6 +11855,7 @@ unit:LB-PER-FT
   qudt:expression "\\(lb/ft\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:MassPerLength ;
+  qudt:symbol "lb/ft" ;
   qudt:ucumCode "[lb_av].[ft_i]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P2" ;
   qudt:unitOfSystem sou:IMPERIAL ;
@@ -11321,6 +11871,7 @@ unit:LB-PER-FT-HR
   qudt:expression "\\(lb/(ft-hr)\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:DynamicViscosity ;
+  qudt:symbol "lb/(ft⋅hr)" ;
   qudt:ucumCode "[lb_av].[ft_i]-1.h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K67" ;
   qudt:unitOfSystem sou:IMPERIAL ;
@@ -11336,6 +11887,7 @@ unit:LB-PER-FT-SEC
   qudt:expression "\\(lb/(ft-s)\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:DynamicViscosity ;
+  qudt:symbol "lb/(ft⋅s)" ;
   qudt:ucumCode "[lb_av].[ft_i]-1.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K68" ;
   qudt:unitOfSystem sou:IMPERIAL ;
@@ -11349,6 +11901,7 @@ unit:LB-PER-FT2
   qudt:hasQuantityKind quantitykind:MassPerArea ;
   qudt:iec61360Code "0112/2///62720#UAB262" ;
   qudt:plainTextDescription "unit for areal-related mass as a unit pound according to the avoirdupois system of units divided by the power of the unit foot according to the Anglo-American and Imperial system of units by exponent 2" ;
+  qudt:symbol "lb/ft²" ;
   qudt:ucumCode "[lb_av].[ft_i]-2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "FP" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -11363,6 +11916,7 @@ unit:LB-PER-FT3
   qudt:expression "\\(lb/ft^{3}\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Density ;
+  qudt:symbol "lb/ft³" ;
   qudt:ucumCode "[lb_av].[cft_i]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "87" ;
   qudt:unitOfSystem sou:IMPERIAL ;
@@ -11378,6 +11932,7 @@ unit:LB-PER-GAL
   qudt:expression "\\(lb/gal\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Density ;
+  qudt:symbol "lb/gal" ;
   qudt:ucumCode "[lb_av].[gal_br]-1"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:IMPERIAL ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -11390,6 +11945,7 @@ unit:LB-PER-GAL_UK
   qudt:hasQuantityKind quantitykind:Density ;
   qudt:iec61360Code "0112/2///62720#UAA679" ;
   qudt:plainTextDescription "unit of the mass avoirdupois pound according to the avoirdupois system of units divided by the unit gallon (UK) according to the Imperial system of units" ;
+  qudt:symbol "lb/gal{UK}" ;
   qudt:ucumCode "[lb_av].[gal_br]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K71" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -11402,6 +11958,7 @@ unit:LB-PER-GAL_US
   qudt:hasQuantityKind quantitykind:Density ;
   qudt:iec61360Code "0112/2///62720#UAA680" ;
   qudt:plainTextDescription "unit of the mass avoirdupois pound according to the avoirdupois system divided by the unit gallon (US, liq.) according to the Anglo-American system of units" ;
+  qudt:symbol "lb/gal{US}" ;
   qudt:ucumCode "[lb_av].[gal_us]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "GE" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -11419,6 +11976,7 @@ unit:LB-PER-HR
   qudt:hasQuantityKind quantitykind:MassFlowRate ;
   qudt:hasQuantityKind quantitykind:MassPerTime ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Pound_per_hour?oldid=328571072"^^xsd:anyURI ;
+  qudt:symbol "PPH" ;
   qudt:ucumCode "[lb_av].h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "4U" ;
   qudt:unitOfSystem sou:IMPERIAL ;
@@ -11434,6 +11992,7 @@ unit:LB-PER-IN
   qudt:expression "\\(lb/in\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:MassPerLength ;
+  qudt:symbol "lb/in" ;
   qudt:ucumCode "[lb_av].[in_i]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "PO" ;
   qudt:unitOfSystem sou:IMPERIAL ;
@@ -11449,6 +12008,7 @@ unit:LB-PER-IN2
   qudt:hasQuantityKind quantitykind:SurfaceDensity ;
   qudt:iec61360Code "0112/2///62720#UAB137" ;
   qudt:plainTextDescription "unit of the areal-related mass as avoirdupois pound according to the avoirdupois system of units related to the area square inch according to the Anglo-American and Imperial system of units" ;
+  qudt:symbol "lb/in²" ;
   qudt:ucumCode "[lb_av].[sin_i]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "80" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -11463,6 +12023,7 @@ unit:LB-PER-IN3
   qudt:expression "\\(lb/in^{3}\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Density ;
+  qudt:symbol "lb/in³" ;
   qudt:ucumCode "[lb_av].[cin_i]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "LA" ;
   qudt:unitOfSystem sou:IMPERIAL ;
@@ -11476,6 +12037,7 @@ unit:LB-PER-M3
   qudt:expression "\\(lb/m^{3}\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Density ;
+  qudt:symbol "lb/m³" ;
   qudt:ucumCode "[lb_av].m-3"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Pound per Cubic Meter"@en-us ;
@@ -11491,6 +12053,7 @@ unit:LB-PER-MIN
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:MassFlowRate ;
   qudt:hasQuantityKind quantitykind:MassPerTime ;
+  qudt:symbol "lb/min" ;
   qudt:ucumCode "[lb_av].min-1"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:IMPERIAL ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -11503,6 +12066,7 @@ unit:LB-PER-SEC
   qudt:hasQuantityKind quantitykind:MassFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA692" ;
   qudt:plainTextDescription "unit of the mass avoirdupois pound according to the avoirdupois system of units divided by the SI base unit for time second" ;
+  qudt:symbol "lb/s" ;
   qudt:ucumCode "[lb_av].s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K81" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -11517,6 +12081,7 @@ unit:LB-PER-YD3
   qudt:expression "\\(lb/yd^{3}\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Density ;
+  qudt:symbol "lb/yd³" ;
   qudt:ucumCode "[lb_av].[cyd_i]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K84" ;
   qudt:unitOfSystem sou:IMPERIAL ;
@@ -11550,6 +12115,7 @@ unit:LB_F-FT
   qudt:expression "\\(lbf-ft\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Torque ;
+  qudt:symbol "lbf⋅ft" ;
   qudt:ucumCode "[lbf_av].[ft_i]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M92" ;
   qudt:unitOfSystem sou:IMPERIAL ;
@@ -11565,6 +12131,7 @@ unit:LB_F-IN
   qudt:expression "\\(lbf-in\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Torque ;
+  qudt:symbol "lbf⋅in" ;
   qudt:ucumCode "[lbf_av].[in_i]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F21" ;
   qudt:unitOfSystem sou:IMPERIAL ;
@@ -11580,6 +12147,7 @@ unit:LB_F-PER-FT
   qudt:expression "\\(lbf/ft\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerLength ;
+  qudt:symbol "lbf/ft" ;
   qudt:ucumCode "[lbf_av].[ft_i]-1"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:IMPERIAL ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -11595,6 +12163,7 @@ unit:LB_F-PER-FT2
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerArea ;
   qudt:hasQuantityKind quantitykind:VaporPressure ;
+  qudt:symbol "lbf/ft²" ;
   qudt:ucumCode "[lbf_av].[sft_i]-1"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:IMPERIAL ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -11609,6 +12178,7 @@ unit:LB_F-PER-IN
   qudt:expression "\\(lbf/in\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerLength ;
+  qudt:symbol "lbf/in" ;
   qudt:ucumCode "[lbf_av].[in_i]-1"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:IMPERIAL ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -11640,6 +12210,7 @@ unit:LB_F-PER-IN2-DEG_F
   qudt:hasQuantityKind quantitykind:VolumetricHeatCapacity ;
   qudt:iec61360Code "0112/2///62720#UAA702" ;
   qudt:plainTextDescription "composed unit for pressure (pound-force per square inch) divided by the unit degree Fahrenheit for temperature" ;
+  qudt:symbol "lbf/(in²⋅°F)" ;
   qudt:ucumCode "[lbf_av].[sin_i]-1.[degF]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K86" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -11652,6 +12223,7 @@ unit:LB_F-PER-IN2-SEC
   qudt:expression "\\(lbf / in^{2}-s\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerAreaTime ;
+  qudt:symbol "lbf/in²⋅s" ;
   qudt:ucumCode "[lbf_av].[sin_i]-1.s-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Pound Force per Square Inch Second"@en ;
@@ -11665,6 +12237,7 @@ unit:LB_F-PER-LB
   qudt:expression "\\(lbf/lb\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ThrustToMassRatio ;
+  qudt:symbol "lbf/lb" ;
   qudt:ucumCode "[lbf_av].[lb_av]-1"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:IMPERIAL ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -11679,6 +12252,7 @@ unit:LB_F-SEC-PER-FT2
   qudt:expression "\\(lbf-s/ft^2\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:DynamicViscosity ;
+  qudt:symbol "lbf⋅s/ft²" ;
   qudt:ucumCode "[lbf_av].s.[sft_i]-1"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:IMPERIAL ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -11693,6 +12267,7 @@ unit:LB_F-SEC-PER-IN2
   qudt:expression "\\(lbf-s/in^{2}\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:DynamicViscosity ;
+  qudt:symbol "lbf⋅s/in²" ;
   qudt:ucumCode "[lbf_av].s.[sin_i]-1"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:IMPERIAL ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -11744,6 +12319,7 @@ unit:LM-PER-W
   qudt:hasQuantityKind quantitykind:LuminousEfficacy ;
   qudt:hasQuantityKind quantitykind:SpectralLuminousEfficiency ;
   qudt:iec61360Code "0112/2///62720#UAA719" ;
+  qudt:symbol "lm/W" ;
   qudt:ucumCode "lm.W-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B61" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -11757,6 +12333,7 @@ unit:LM-SEC
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:LuminousEnergy ;
   qudt:iec61360Code "0112/2///62720#UAA722" ;
+  qudt:symbol "lm⋅s" ;
   qudt:ucumCode "lm.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B62" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -11797,6 +12374,7 @@ unit:LUX-HR
   qudt:iec61360Code "0112/2///62720#UAA724" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Lux?oldid=494700274"^^xsd:anyURI ;
   qudt:siUnitsExpression "lm-hr/m^2" ;
+  qudt:symbol "lx⋅hr" ;
   qudt:ucumCode "lx.h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B63" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -11978,6 +12556,7 @@ unit:LunarMass
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Mass ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Moon?oldid=494566371"^^xsd:anyURI ;
+  qudt:symbol "M☾" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Lunar mass"@en ;
 .
@@ -12014,7 +12593,7 @@ unit:M-K
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H1T0D0 ;
   qudt:hasQuantityKind quantitykind:LengthTemperature ;
   qudt:iec61360Code "0112/2///62720#UAB170" ;
-  qudt:symbol "m K" ;
+  qudt:symbol "m⋅K" ;
   qudt:ucumCode "m.K"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D18" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -12031,6 +12610,7 @@ unit:M-K-PER-W
   qudt:expression "\\(K-m/W\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M-1H1T3D0 ;
   qudt:hasQuantityKind quantitykind:ThermalResistivity ;
+  qudt:symbol "K⋅m/W" ;
   qudt:ucumCode "m.K.W-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Meter Kelvin per Watt"@en-us ;
@@ -12043,6 +12623,7 @@ unit:M-KiloGM
   qudt:expression "\\(m-kg\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:LengthMass ;
+  qudt:symbol "m⋅kg" ;
   qudt:ucumCode "m.kg"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Meter Kilogram"@en-us ;
@@ -12057,6 +12638,7 @@ unit:M-PER-FARAD
   qudt:expression "\\(m-per-f\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E-2L3I0M1H0T-4D0 ;
   qudt:hasQuantityKind quantitykind:InversePermittivity ;
+  qudt:symbol "m/f" ;
   qudt:ucumCode "m.F-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Meter per Farad"@en-us ;
@@ -12072,6 +12654,7 @@ unit:M-PER-HR
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Velocity ;
   qudt:iec61360Code "0112/2///62720#UAB328" ;
+  qudt:symbol "m/h" ;
   qudt:ucumCode "m.h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "m/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M60" ;
@@ -12089,6 +12672,7 @@ unit:M-PER-K
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H-1T0D0 ;
   qudt:hasQuantityKind quantitykind:LinearThermalExpansion ;
   qudt:iec61360Code "0112/2///62720#UAA728" ;
+  qudt:symbol "m/k" ;
   qudt:ucumCode "m/K"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F52" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -12105,6 +12689,7 @@ unit:M-PER-MIN
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Velocity ;
   qudt:iec61360Code "0112/2///62720#UAA732" ;
+  qudt:symbol "m/min" ;
   qudt:ucumCode "m.min-1"^^qudt:UCUMcs ;
   qudt:ucumCode "m/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "2X" ;
@@ -12126,6 +12711,7 @@ The official SI symbolic abbreviation is mu00b7s-1, or equivalently either m/s."
   qudt:hasQuantityKind quantitykind:Speed ;
   qudt:hasQuantityKind quantitykind:Velocity ;
   qudt:iec61360Code "0112/2///62720#UAA733" ;
+  qudt:symbol "m/s" ;
   qudt:ucumCode "m.s-1"^^qudt:UCUMcs ;
   qudt:ucumCode "m/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "MTS" ;
@@ -12144,6 +12730,7 @@ unit:M-PER-SEC2
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Acceleration ;
   qudt:iec61360Code "0112/2///62720#UAA736" ;
+  qudt:symbol "m/s²" ;
   qudt:ucumCode "m.s-2"^^qudt:UCUMcs ;
   qudt:ucumCode "m/s2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "MSK" ;
@@ -12157,6 +12744,7 @@ unit:M-PER-YR
   qudt:conversionMultiplier 0.0000000316880878140289 ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Velocity ;
+  qudt:symbol "m/yr" ;
   qudt:ucumCode "m.a-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Metres per year"@en ;
@@ -12173,7 +12761,7 @@ unit:M2
   qudt:hasQuantityKind quantitykind:NuclearQuadrupoleMoment ;
   qudt:iec61360Code "0112/2///62720#UAA744" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Square_metre?oldid=490945508"^^xsd:anyURI ;
-  qudt:symbol "㎡" ;
+  qudt:symbol "m²" ;
   qudt:ucumCode "m2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "MTK" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -12187,6 +12775,7 @@ unit:M2-HR-DEG_C-PER-KiloCAL_IT
   qudt:hasQuantityKind quantitykind:ThermalInsulance ;
   qudt:iec61360Code "0112/2///62720#UAA749" ;
   qudt:plainTextDescription "product of the power of the SI base unit metre with the exponent 2, of the unit hour for time and the unit degree Celsius for temperature divided by the 1000-fold of the out of use unit for energy international calorie" ;
+  qudt:symbol "m²⋅hr⋅°C/kcal{IT}" ;
   qudt:ucumCode "m2.h.Cel/kcal_IT"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L14" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -12198,6 +12787,7 @@ unit:M2-HZ
   qudt:conversionMultiplier 1.0 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:AreaPerTime ;
+  qudt:symbol "m²⋅Hz" ;
   qudt:ucumCode "m2.Hz"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Square metres Hertz"@en ;
@@ -12206,6 +12796,7 @@ unit:M2-HZ2
   a qudt:Unit ;
   qudt:conversionMultiplier 1.0 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-2D0 ;
+  qudt:symbol "m²⋅Hz²" ;
   qudt:ucumCode "m2.Hz2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Square Metres square Hertz"@en ;
@@ -12214,6 +12805,7 @@ unit:M2-HZ3
   a qudt:Unit ;
   qudt:conversionMultiplier 1.0 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-3D0 ;
+  qudt:symbol "m²⋅Hz³" ;
   qudt:ucumCode "m2.Hz3"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Square metres cubic Hertz"@en ;
@@ -12222,6 +12814,7 @@ unit:M2-HZ4
   a qudt:Unit ;
   qudt:conversionMultiplier 1.0 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-4D0 ;
+  qudt:symbol "m²⋅Hz⁴" ;
   qudt:ucumCode "m2.Hz4"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Square metres Hertz^4"@en ;
@@ -12236,6 +12829,7 @@ unit:M2-K
   qudt:expression "\\(m^{2}-K\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H1T0D0 ;
   qudt:hasQuantityKind quantitykind:AreaTemperature ;
+  qudt:symbol "m²⋅K" ;
   qudt:ucumCode "m2.K"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Square Meter Kelvin"@en-us ;
@@ -12253,6 +12847,7 @@ unit:M2-K-PER-W
   qudt:hasQuantityKind quantitykind:ThermalInsulance ;
   qudt:iec61360Code "0112/2///62720#UAA746" ;
   qudt:informativeReference "http://physics.nist.gov/Pubs/SP811/appenB9.html"^^xsd:anyURI ;
+  qudt:symbol "(K²)m/W" ;
   qudt:ucumCode "m2.K.W-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D19" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -12264,6 +12859,7 @@ unit:M2-PER-GM
   qudt:conversionMultiplier 1000.0 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M-1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:MassAttenuationCoefficient ;
+  qudt:symbol "m²/g" ;
   qudt:ucumCode "m2.g-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Square metres per gram"@en ;
@@ -12273,6 +12869,7 @@ unit:M2-PER-GM_DRY
   qudt:conversionMultiplier 1000.0 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M-1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:MassAttenuationCoefficient ;
+  qudt:symbol "m²/g{dry sediment}" ;
   qudt:ucumCode "m2.g-1{dry}"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Square metres per gram of dry sediment"@en ;
@@ -12283,7 +12880,7 @@ unit:M2-PER-HA
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:AreaRatio ;
   qudt:plainTextDescription "Square metres per hectare." ;
-  qudt:symbol "㎡/ha" ;
+  qudt:symbol "m²/ha" ;
   qudt:ucumCode "m2.har-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "square meters per hectare"@en-us ;
@@ -12293,6 +12890,7 @@ unit:M2-PER-HZ
   a qudt:Unit ;
   qudt:conversionMultiplier 1.0 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T1D0 ;
+  qudt:symbol "m²/Hz" ;
   qudt:ucumCode "m2.Hz-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Square metres per Hertz"@en ;
@@ -12301,6 +12899,7 @@ unit:M2-PER-HZ-DEG
   a qudt:Unit ;
   qudt:conversionMultiplier 57.2957795130823 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T1D0 ;
+  qudt:symbol "m²/(Hz⋅°)" ;
   qudt:ucumCode "m2.Hz-1.deg-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Square metres per Hertz per degree"@en ;
@@ -12309,6 +12908,7 @@ unit:M2-PER-HZ2
   a qudt:Unit ;
   qudt:conversionMultiplier 1.0 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T2D0 ;
+  qudt:symbol "m²/Hz²" ;
   qudt:ucumCode "m2.Hz-2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Square metres per square Hertz"@en ;
@@ -12323,6 +12923,7 @@ unit:M2-PER-J
   qudt:hasQuantityKind quantitykind:SpectralCrossSection ;
   qudt:iec61360Code "0112/2///62720#UAA745" ;
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:symbol "m²/j" ;
   qudt:ucumCode "m2.J-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D20" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -12338,6 +12939,7 @@ unit:M2-PER-K
   qudt:expression "\\(m2-per-k\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H-1T0D0 ;
   qudt:hasQuantityKind quantitykind:AreaThermalExpansion ;
+  qudt:symbol "m²/k" ;
   qudt:ucumCode "m2.K-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Square Meter per Kelvin"@en-us ;
@@ -12355,6 +12957,7 @@ unit:M2-PER-KiloGM
   qudt:hasQuantityKind quantitykind:MassEnergyTransferCoefficient ;
   qudt:iec61360Code "0112/2///62720#UAA750" ;
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:symbol "m²/kg" ;
   qudt:ucumCode "m2.kg-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D21" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -12370,7 +12973,7 @@ unit:M2-PER-M2
   qudt:plainTextDescription "A square metre unit of area per square metre" ;
   qudt:qkdvDenominator qkdv:A0E0L2I0M0H0T0D0 ;
   qudt:qkdvNumerator qkdv:A0E0L2I0M0H0T0D0 ;
-  qudt:symbol "㎡/㎡" ;
+  qudt:symbol "m²/m²" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "square meter per square meter"@en-us ;
   rdfs:label "square metre per square metre"@en ;
@@ -12387,6 +12990,7 @@ unit:M2-PER-MOL
   qudt:hasQuantityKind quantitykind:MolarAttenuationCoefficient ;
   qudt:iec61360Code "0112/2///62720#UAA751" ;
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:symbol "m²/mol" ;
   qudt:ucumCode "m2.mol-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D22" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -12400,6 +13004,7 @@ unit:M2-PER-N
   qudt:hasQuantityKind quantitykind:Compressibility ;
   qudt:iec61360Code "0112/2///62720#UAB492" ;
   qudt:plainTextDescription "power of the SI base unit metre with the exponent 2 divided by the derived SI unit newton" ;
+  qudt:symbol "m²/N" ;
   qudt:ucumCode "m2.N-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H59" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -12420,6 +13025,7 @@ unit:M2-PER-SEC
   qudt:hasQuantityKind quantitykind:NeutronDiffusionCoefficient ;
   qudt:hasQuantityKind quantitykind:ThermalDiffusionRatioCoefficient ;
   qudt:iec61360Code "0112/2///62720#UAA752" ;
+  qudt:symbol "m²/s" ;
   qudt:ucumCode "m2.s-1"^^qudt:UCUMcs ;
   qudt:ucumCode "m2/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "S4" ;
@@ -12431,6 +13037,7 @@ unit:M2-PER-SEC2
   a qudt:Unit ;
   qudt:conversionMultiplier 1.0 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-2D0 ;
+  qudt:symbol "m²/s²" ;
   qudt:ucumCode "m2.s-2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Square metres per square second"@en ;
@@ -12446,6 +13053,7 @@ unit:M2-PER-SR
   qudt:iec61360Code "0112/2///62720#UAA986" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Steradian?oldid=494317847"^^xsd:anyURI ;
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:symbol "m²/sr" ;
   qudt:ucumCode "m2.sr-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D24" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -12462,6 +13070,7 @@ unit:M2-PER-SR-J
   qudt:hasQuantityKind quantitykind:SpectralAngularCrossSection ;
   qudt:iec61360Code "0112/2///62720#UAA756" ;
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:symbol "m²/(sr⋅J)" ;
   qudt:ucumCode "m2.sr-1.J-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D25" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -12477,6 +13086,7 @@ unit:M2-PER-V-SEC
   qudt:hasQuantityKind quantitykind:Mobility ;
   qudt:iec61360Code "0112/2///62720#UAA748" ;
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:symbol "m²/(V⋅s)" ;
   qudt:ucumCode "m2.V-1.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D26" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -12487,6 +13097,7 @@ unit:M2-SEC-PER-RAD
   a qudt:Unit ;
   qudt:conversionMultiplier 1.0 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T1D0 ;
+  qudt:symbol "m²⋅s/rad" ;
   qudt:ucumCode "m2.s.rad-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Square metre seconds per radian"@en ;
@@ -12501,6 +13112,7 @@ unit:M2-SR
   qudt:expression "\\(m^{2}-sr\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:AreaAngle ;
+  qudt:symbol "m²⋅sr" ;
   qudt:ucumCode "m2.sr"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Square Meter Steradian"@en-us ;
@@ -12518,6 +13130,7 @@ unit:M3
   qudt:hasQuantityKind quantitykind:Volume ;
   qudt:iec61360Code "0112/2///62720#UAA757" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Cubic_metre?oldid=490956678"^^xsd:anyURI ;
+  qudt:symbol "m³" ;
   qudt:ucumCode "m3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "MTQ" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -12531,6 +13144,7 @@ unit:M3-PER-C
   qudt:hasQuantityKind quantitykind:HallCoefficient ;
   qudt:iec61360Code "0112/2///62720#UAB143" ;
   qudt:informativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
+  qudt:symbol "m³/C" ;
   qudt:ucumCode "m3.C-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A38" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -12544,6 +13158,7 @@ unit:M3-PER-DAY
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA760" ;
   qudt:plainTextDescription "power of the SI base unit metre with the exponent 3 divided by the unit day" ;
+  qudt:symbol "m³/day" ;
   qudt:ucumCode "m3.d-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G52" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -12574,6 +13189,7 @@ unit:M3-PER-HR
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
   qudt:iec61360Code "0112/2///62720#UAA763" ;
+  qudt:symbol "m³/hr" ;
   qudt:ucumCode "m3.h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "m3/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "MQH" ;
@@ -12592,6 +13208,7 @@ unit:M3-PER-K
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H-1T0D0 ;
   qudt:hasQuantityKind quantitykind:VolumeThermalExpansion ;
   qudt:iec61360Code "0112/2///62720#UAA758" ;
+  qudt:symbol "m³/K" ;
   qudt:ucumCode "m3.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G29" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -12607,6 +13224,7 @@ unit:M3-PER-KiloGM
   qudt:hasDimensionVector qkdv:A0E0L3I0M-1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:SpecificVolume ;
   qudt:iec61360Code "0112/2///62720#UAA766" ;
+  qudt:symbol "m³/kg" ;
   qudt:ucumCode "m3.kg-1"^^qudt:UCUMcs ;
   qudt:ucumCode "m3/kg"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A39" ;
@@ -12622,6 +13240,7 @@ unit:M3-PER-KiloGM-SEC2
   qudt:derivedCoherentUnitOfSystem sou:SI ;
   qudt:expression "\\(m^{3} kg^{-1} s^{-2}\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M-1H0T-2D0 ;
+  qudt:symbol "m³/(kg⋅s²)" ;
   qudt:ucumCode "m3.(kg.s2)-1"^^qudt:UCUMcs ;
   qudt:ucumCode "m3.kg-1.s-2"^^qudt:UCUMcs ;
   qudt:ucumCode "m3/(kg.s2)"^^qudt:UCUMcs ;
@@ -12636,6 +13255,7 @@ unit:M3-PER-M3
   qudt:hasQuantityKind quantitykind:VolumeFraction ;
   qudt:iec61360Code "0112/2///62720#UAA767" ;
   qudt:plainTextDescription "power of the SI base unit metre with the exponent 3 divided by the power of the SI base unit metre with the exponent 3" ;
+  qudt:symbol "m³/m³" ;
   qudt:ucumCode "m3.m-3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H60" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -12649,6 +13269,7 @@ unit:M3-PER-MIN
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA768" ;
   qudt:plainTextDescription "power of the SI base unit metre with the exponent 3 divided by the unit minute" ;
+  qudt:symbol "m³/min" ;
   qudt:ucumCode "m3.min-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G53" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -12665,6 +13286,7 @@ unit:M3-PER-MOL
   qudt:hasQuantityKind quantitykind:MolarRefractivity ;
   qudt:hasQuantityKind quantitykind:MolarVolume ;
   qudt:iec61360Code "0112/2///62720#UAA771" ;
+  qudt:symbol "m³/mol" ;
   qudt:ucumCode "m3.mol-1"^^qudt:UCUMcs ;
   qudt:ucumCode "m3/mol"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A40" ;
@@ -12686,6 +13308,7 @@ unit:M3-PER-SEC
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
   qudt:iec61360Code "0112/2///62720#UAA772" ;
+  qudt:symbol "m³/s" ;
   qudt:ucumCode "m3.s-1"^^qudt:UCUMcs ;
   qudt:ucumCode "m3/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "MQS" ;
@@ -12700,6 +13323,7 @@ unit:M3-PER-SEC2
   qudt:expression "\\(m^3/s^2\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:StandardGravitationalParameter ;
+  qudt:symbol "m³/s²" ;
   qudt:ucumCode "m3.s-2"^^qudt:UCUMcs ;
   qudt:ucumCode "m3/s2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -12716,6 +13340,7 @@ unit:M4
   qudt:hasDimensionVector qkdv:A0E0L4I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:SecondAxialMomentOfArea ;
   qudt:hasQuantityKind quantitykind:SecondPolarMomentOfArea ;
+  qudt:symbol "m⁴" ;
   qudt:ucumCode "m4"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Quartic Meter"@en-us ;
@@ -12725,6 +13350,7 @@ unit:M4-PER-SEC
   a qudt:Unit ;
   qudt:conversionMultiplier 1.0 ;
   qudt:hasDimensionVector qkdv:A0E0L4I0M0H0T-1D0 ;
+  qudt:symbol "m⁴/s" ;
   qudt:ucumCode "m4.s-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Metres to the power four per second"@en ;
@@ -12738,6 +13364,7 @@ unit:MACH
   qudt:hasQuantityKind quantitykind:MachNumber ;
   qudt:iec61360Code "0112/2///62720#UAB595" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Mach?oldid=492058934"^^xsd:anyURI ;
+  qudt:symbol "Mach" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Mach"@en ;
 .
@@ -12747,6 +13374,7 @@ unit:MDOLLAR-PER-FLIGHT
   qudt:expression "\\(\\(M\\$/Flight\\)\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:CurrencyPerFlight ;
+  qudt:symbol "$M/flight" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Million US Dollars per Flight"@en ;
 .
@@ -12826,6 +13454,7 @@ unit:MI-PER-HR
   qudt:hasQuantityKind quantitykind:Velocity ;
   qudt:iec61360Code "0112/2///62720#UAB111" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Miles_per_hour?oldid=482840548"^^xsd:anyURI ;
+  qudt:symbol "mi/hr" ;
   qudt:ucumCode "[mi_i].h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[mi_i]/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "HM" ;
@@ -12843,6 +13472,7 @@ unit:MI-PER-MIN
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Velocity ;
   qudt:iec61360Code "0112/2///62720#UAB229" ;
+  qudt:symbol "mi/min" ;
   qudt:ucumCode "[mi_i].min-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[mi_i]/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M57" ;
@@ -12861,6 +13491,7 @@ unit:MI2
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Area ;
   qudt:iec61360Code "0112/2///62720#UAB050" ;
+  qudt:symbol "mi²" ;
   qudt:ucumCode "[mi_i]2"^^qudt:UCUMcs ;
   qudt:ucumCode "[mi_us]2"^^qudt:UCUMcs ;
   qudt:ucumCode "[smi_us]"^^qudt:UCUMcs ;
@@ -12878,6 +13509,7 @@ unit:MI3
   qudt:expression "\\(mi^{3}\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Volume ;
+  qudt:symbol "mi³" ;
   qudt:ucumCode "[mi_i]3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M69" ;
   qudt:unitOfSystem sou:IMPERIAL ;
@@ -12891,6 +13523,7 @@ unit:MIL
   qudt:conversionMultiplier 0.000490873852 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Angle ;
+  qudt:symbol "mil{NATO}" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Mil Angle (NATO)"@en ;
 .
@@ -12944,7 +13577,7 @@ unit:MIN_Sidereal
   qudt:hasQuantityKind quantitykind:Time ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Sidereal_time"^^xsd:anyURI ;
   qudt:isScalingOf unit:HR_Sidereal ;
-  qudt:symbol "min" ;
+  qudt:symbol "min{sidereal}" ;
   qudt:ucumCode "min"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Sidereal Minute"@en ;
@@ -12957,7 +13590,7 @@ unit:MI_N
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Length ;
   qudt:iec61360Code "0112/2///62720#UAB065" ;
-  qudt:symbol "n mile" ;
+  qudt:symbol "nmi" ;
   qudt:ucumCode "[nmi_i]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "NMI" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -12969,6 +13602,7 @@ unit:MI_N-PER-HR
   qudt:exactMatch unit:KN ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Velocity ;
+  qudt:symbol "nmi/hr" ;
   qudt:ucumCode "[nmi_i].h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[nmi_i]/h"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -12982,6 +13616,7 @@ unit:MI_N-PER-MIN
   qudt:expression "\\(nmi/min\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Velocity ;
+  qudt:symbol "nmi/min" ;
   qudt:ucumCode "[nmi_i].min-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[nmi_i]/min"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -12995,7 +13630,7 @@ unit:MI_US
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Length ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Mile"^^xsd:anyURI ;
-  qudt:symbol "mi" ;
+  qudt:symbol "mi{US}" ;
   qudt:ucumCode "[mi_us]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M52" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -13061,6 +13696,7 @@ unit:MOL-DEG_C
   qudt:expression "\\(mol-degC\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A1E0L0I0M0H1T0D0 ;
   qudt:hasQuantityKind quantitykind:TemperatureAmountOfSubstance ;
+  qudt:symbol "mol⋅°C" ;
   qudt:ucumCode "mol.Cel"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:CGS ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -13075,7 +13711,7 @@ unit:MOL-K
   qudt:derivedCoherentUnitOfSystem sou:SI ;
   qudt:hasDimensionVector qkdv:A1E0L0I0M0H1T0D0 ;
   qudt:hasQuantityKind quantitykind:TemperatureAmountOfSubstance ;
-  qudt:symbol "mol-K" ;
+  qudt:symbol "mol⋅K" ;
   qudt:ucumCode "mol.K"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Mole Kelvin"@en ;
@@ -13088,6 +13724,7 @@ unit:MOL-PER-DeciM3
   qudt:hasQuantityKind quantitykind:Solubility_Water ;
   qudt:iec61360Code "0112/2///62720#UAA883" ;
   qudt:plainTextDescription "SI base unit mol divided by the 0.001-fold of the power of the SI base unit metre with the exponent 3" ;
+  qudt:symbol "mol/dm³" ;
   qudt:ucumCode "mol.dm-3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C35" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -13099,6 +13736,7 @@ unit:MOL-PER-GM-HR
   dcterms:description "SI unit of the quantity of matter per SI unit of mass per unit of time expressed in hour."@en ;
   qudt:conversionMultiplier 0.277777777777778 ;
   qudt:hasDimensionVector qkdv:A1E0L0I0M-1H0T-1D0 ;
+  qudt:symbol "mol/(g⋅hr)" ;
   qudt:ucumCode "mol.g-1.h-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Moles per gram per hour"@en ;
@@ -13110,6 +13748,7 @@ unit:MOL-PER-HR
   qudt:hasQuantityKind quantitykind:MolarFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA884" ;
   qudt:plainTextDescription "SI base unit mole divided by the unit for time hour" ;
+  qudt:symbol "mol/hr" ;
   qudt:ucumCode "mol.h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L23" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -13127,6 +13766,7 @@ unit:MOL-PER-KiloGM
   qudt:hasQuantityKind quantitykind:AmountOfSubstancePerUnitMass ;
   qudt:hasQuantityKind quantitykind:IonicStrength ;
   qudt:hasQuantityKind quantitykind:MolalityOfSolute ;
+  qudt:symbol "mol/kg" ;
   qudt:ucumCode "mol.kg-1"^^qudt:UCUMcs ;
   qudt:ucumCode "mol/kg"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C19" ;
@@ -13142,6 +13782,7 @@ unit:MOL-PER-KiloGM-PA
   qudt:hasDimensionVector qkdv:A1E0L1I0M-2H0T2D0 ;
   qudt:hasQuantityKind quantitykind:AmountOfSubstancePerUnitMassPressure ;
   qudt:iec61360Code "0112/2///62720#UAB317" ;
+  qudt:symbol "mol/(kg⋅Pa)" ;
   qudt:ucumCode "mol.kg-1.Pa-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P51" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -13155,6 +13796,7 @@ unit:MOL-PER-L
   qudt:hasQuantityKind quantitykind:Solubility_Water ;
   qudt:iec61360Code "0112/2///62720#UAA888" ;
   qudt:plainTextDescription "SI base unit mol divided by the unit litre" ;
+  qudt:symbol "mol/L" ;
   qudt:ucumCode "mol.L-1"^^qudt:UCUMcs ;
   qudt:ucumCode "mol/L"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C38" ;
@@ -13167,6 +13809,7 @@ unit:MOL-PER-M2
   dcterms:description "SI unit of quantity of matter per SI unit area."@en ;
   qudt:conversionMultiplier 1.0 ;
   qudt:hasDimensionVector qkdv:A1E0L-2I0M0H0T0D0 ;
+  qudt:symbol "mol/m²" ;
   qudt:ucumCode "mol.m-2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Moles per square metre"@en ;
@@ -13176,6 +13819,7 @@ unit:MOL-PER-M2-DAY
   dcterms:description "quantity of matter per unit area per unit of time."@en ;
   qudt:conversionMultiplier 0.0000115740740740741 ;
   qudt:hasDimensionVector qkdv:A1E0L-2I0M0H0T-1D0 ;
+  qudt:symbol "mol/(m²⋅day)" ;
   qudt:ucumCode "mol.m-2.d-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Moles per square metre per day" ;
@@ -13185,6 +13829,7 @@ unit:MOL-PER-M2-SEC
   dcterms:description "SI unit of quantity of matter per SI unit area per SI unit of time."@en ;
   qudt:conversionMultiplier 1.0 ;
   qudt:hasDimensionVector qkdv:A1E0L-2I0M0H0T-1D0 ;
+  qudt:symbol "mol/(m²⋅s)" ;
   qudt:ucumCode "mol.m-2.s-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Moles per square metre per second"@en ;
@@ -13193,6 +13838,7 @@ unit:MOL-PER-M2-SEC-M
   a qudt:Unit ;
   qudt:conversionMultiplier 1.0 ;
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T-1D0 ;
+  qudt:symbol "mol/(m²⋅s⋅m)" ;
   qudt:ucumCode "mol.m-2.s-1.m-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Moles per square metre per second per metre"@en ;
@@ -13201,6 +13847,7 @@ unit:MOL-PER-M2-SEC-M-SR
   a qudt:Unit ;
   qudt:conversionMultiplier 1.0 ;
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T-1D0 ;
+  qudt:symbol "mol/(m²⋅s⋅m⋅sr)" ;
   qudt:ucumCode "mol.m-2.s-1.m-1.sr-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Moles per square metre per second per metre per steradian"@en ;
@@ -13209,6 +13856,7 @@ unit:MOL-PER-M2-SEC-SR
   a qudt:Unit ;
   qudt:conversionMultiplier 1.0 ;
   qudt:hasDimensionVector qkdv:A1E0L-2I0M0H0T-1D0 ;
+  qudt:symbol "mol/(m²⋅s⋅sr)" ;
   qudt:ucumCode "mol.m-2.s-1.sr-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Moles per square metre per second per steradian"@en ;
@@ -13226,6 +13874,7 @@ unit:MOL-PER-M3
   qudt:hasQuantityKind quantitykind:AmountOfSubstancePerUnitVolume ;
   qudt:hasQuantityKind quantitykind:Solubility_Water ;
   qudt:iec61360Code "0112/2///62720#UAA891" ;
+  qudt:symbol "mol/m³" ;
   qudt:ucumCode "mol.m-3"^^qudt:UCUMcs ;
   qudt:ucumCode "mol/m3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C36" ;
@@ -13238,6 +13887,7 @@ unit:MOL-PER-M3-SEC
   dcterms:description "SI unit of quantity of matter per SI unit volume per SI unit of time."@en ;
   qudt:conversionMultiplier 1.0 ;
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T-1D0 ;
+  qudt:symbol "mol/(m³⋅s)" ;
   qudt:ucumCode "mol.m-3.s-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Moles per cubic metre per second"@en ;
@@ -13249,6 +13899,7 @@ unit:MOL-PER-MIN
   qudt:hasQuantityKind quantitykind:MolarFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA894" ;
   qudt:plainTextDescription "SI base unit mole divided by the unit for time minute" ;
+  qudt:symbol "mol/min" ;
   qudt:ucumCode "mol.min-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L30" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -13261,6 +13912,7 @@ unit:MOL-PER-MOL
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:qkdvDenominator qkdv:A1E0L0I0M0H0T0D0 ;
   qudt:qkdvNumerator qkdv:A1E0L0I0M0H0T0D0 ;
+  qudt:symbol "mol/mol" ;
   qudt:ucumCode "mol.mol-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Moles per mole"@en ;
@@ -13272,6 +13924,7 @@ unit:MOL-PER-SEC
   qudt:hasQuantityKind quantitykind:MolarFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA895" ;
   qudt:plainTextDescription "SI base unit mol divided by the SI base unit second" ;
+  qudt:symbol "mol/s" ;
   qudt:ucumCode "mol.s-1"^^qudt:UCUMcs ;
   qudt:ucumCode "mol/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E95" ;
@@ -13424,6 +14077,7 @@ unit:MegaA
   qudt:isScalingOf unit:A ;
   qudt:plainTextDescription "1 000 000-fold of the SI base unit ampere" ;
   qudt:prefix prefix:Mega ;
+  qudt:symbol "MA" ;
   qudt:ucumCode "MA"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H38" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -13436,6 +14090,7 @@ unit:MegaA-PER-M2
   qudt:hasQuantityKind quantitykind:ElectricCurrentDensity ;
   qudt:iec61360Code "0112/2///62720#UAA203" ;
   qudt:plainTextDescription "1 000 000-fold of the SI base unit ampere divided by the power of the SI base unit metre with the exponent 2" ;
+  qudt:symbol "mol/m²" ;
   qudt:ucumCode "MA.m-2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B66" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -13482,6 +14137,7 @@ unit:MegaBQ
   qudt:isScalingOf unit:BQ ;
   qudt:plainTextDescription "1 000 000-fold of the derived unit becquerel" ;
   qudt:prefix prefix:Mega ;
+  qudt:symbol "MBq" ;
   qudt:ucumCode "MBq"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "4N" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -13528,6 +14184,7 @@ unit:MegaC-PER-M2
   qudt:hasQuantityKind quantitykind:ElectricChargePerArea ;
   qudt:iec61360Code "0112/2///62720#UAA207" ;
   qudt:plainTextDescription "1 000 000-fold of the SI derived unit coulomb divided by the power of the SI base unit metre with the exponent 2" ;
+  qudt:symbol "MC/m²" ;
   qudt:ucumCode "MC.m-2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B70" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -13541,6 +14198,7 @@ unit:MegaC-PER-M3
   qudt:hasQuantityKind quantitykind:ElectricChargeDensity ;
   qudt:iec61360Code "0112/2///62720#UAA208" ;
   qudt:plainTextDescription "1 000 000-fold of the SI derived unit coulomb divided by the power of the SI base unit metre with the exponent 3" ;
+  qudt:symbol "MC/m³" ;
   qudt:ucumCode "MC.m-3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B69" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -13567,7 +14225,7 @@ unit:MegaEV-FemtoM
   qudt:hasDimensionVector qkdv:A0E0L3I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:LengthEnergy ;
   qudt:prefix prefix:Mega ;
-  qudt:symbol "MeV fm" ;
+  qudt:symbol "MeV⋅fm" ;
   qudt:ucumCode "MeV.fm"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Mega Electron Volt Femtometer"@en-us ;
@@ -13581,6 +14239,7 @@ unit:MegaEV-PER-CentiM
   qudt:expression "\\(MeV/cm\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:LinearEnergyTransfer ;
+  qudt:symbol "MeV/cm" ;
   qudt:ucumCode "MeV.cm-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Mega Electron Volt per Centimeter"@en-us ;
@@ -13592,6 +14251,7 @@ unit:MegaEV-PER-SpeedOfLight
   qudt:expression "\\(MeV/c\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:LinearMomentum ;
+  qudt:symbol "MeV/c" ;
   qudt:ucumCode "MeV.[c]-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Mega Electron Volt per Speed of Light"@en ;
@@ -13605,6 +14265,7 @@ unit:MegaGM
   qudt:isScalingOf unit:KiloGM ;
   qudt:plainTextDescription "1 000-fold of the SI base unit kilogram" ;
   qudt:prefix prefix:Mega ;
+  qudt:symbol "Mg" ;
   qudt:ucumCode "Mg"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "2U" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -13617,6 +14278,7 @@ unit:MegaGM-PER-M3
   qudt:hasQuantityKind quantitykind:MassDensity ;
   qudt:iec61360Code "0112/2///62720#UAA229" ;
   qudt:plainTextDescription "1 000-fold of the SI base unit kilogram divided by the power of the SI base unit metre with the exponent 3" ;
+  qudt:symbol "Mg/m³" ;
   qudt:ucumCode "Mg.m-3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B72" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -13646,6 +14308,7 @@ unit:MegaHZ-M
   qudt:hasQuantityKind quantitykind:Speed ;
   qudt:iec61360Code "0112/2///62720#UAA210" ;
   qudt:plainTextDescription "product of the 1 000 000-fold of the SI derived unit hertz and the 1 000-fold of the SI base unit metre" ;
+  qudt:symbol "MHz⋅m" ;
   qudt:ucumCode "MHz.m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H39" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -13659,6 +14322,7 @@ unit:MegaHZ-PER-K
   qudt:expression "\\(MHz K^{-1}\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:InverseTimeTemperature ;
+  qudt:symbol "MHz/K" ;
   qudt:ucumCode "MHz.K-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Mega Hertz per Kelvin"@en ;
@@ -13670,6 +14334,7 @@ unit:MegaHZ-PER-T
   qudt:expression "\\(MHz T^{-1}\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E1L0I0M-1H0T1D0 ;
   qudt:hasQuantityKind quantitykind:ElectricChargePerMass ;
+  qudt:symbol "MHz/T" ;
   qudt:ucumCode "MHz.T-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Mega Hertz per Tesla"@en ;
@@ -13684,6 +14349,7 @@ unit:MegaJ
   qudt:isScalingOf unit:J ;
   qudt:plainTextDescription "1,000,000-fold of the derived unit joule" ;
   qudt:prefix prefix:Mega ;
+  qudt:symbol "MJ" ;
   qudt:ucumCode "MJ"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "3B" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -13697,6 +14363,7 @@ unit:MegaJ-PER-K
   qudt:expression "\\(MegaJ/K\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H-1T-2D0 ;
   qudt:hasQuantityKind quantitykind:HeatCapacity ;
+  qudt:symbol "MJ/K" ;
   qudt:ucumCode "MJ.K-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "MegaJoule per Kelvin"@en ;
@@ -13708,6 +14375,7 @@ unit:MegaJ-PER-KiloGM
   qudt:hasQuantityKind quantitykind:SpecificEnergy ;
   qudt:iec61360Code "0112/2///62720#UAB093" ;
   qudt:plainTextDescription "1,000,000-fold of the derived SI unit joule divided by the SI base unit kilogram" ;
+  qudt:symbol "MJ/kg" ;
   qudt:ucumCode "MJ.kg-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "JK" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -13720,6 +14388,7 @@ unit:MegaJ-PER-M2
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:EnergyPerArea ;
   qudt:plainTextDescription "1,000,000-fold of the SI derived unit joule divided by the power of the SI base unit metre with the exponent 2" ;
+  qudt:symbol "MJ/m²" ;
   qudt:ucumCode "MJ.m-2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Megajoule Per Square Meter"@en-us ;
@@ -13732,6 +14401,7 @@ unit:MegaJ-PER-M3
   qudt:hasQuantityKind quantitykind:EnergyDensity ;
   qudt:iec61360Code "0112/2///62720#UAA212" ;
   qudt:plainTextDescription "1,000,000-fold of the SI derived unit joule divided by the power of the SI base unit metre with the exponent 3" ;
+  qudt:symbol "MJ/m³" ;
   qudt:ucumCode "MJ.m-3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "JM" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -13745,6 +14415,7 @@ unit:MegaJ-PER-SEC
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAB177" ;
   qudt:plainTextDescription "quotient of the 1,000,000-fold of the derived SI unit joule divided by the SI base unit second" ;
+  qudt:symbol "MJ/s" ;
   qudt:ucumCode "MJ.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D78" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -13757,6 +14428,7 @@ unit:MegaL
   qudt:hasQuantityKind quantitykind:Volume ;
   qudt:iec61360Code "0112/2///62720#UAB112" ;
   qudt:plainTextDescription "1 000 000-fold of the unit litre" ;
+  qudt:symbol "ML" ;
   qudt:ucumCode "ML"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "MAL" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -13784,6 +14456,7 @@ unit:MegaN
   qudt:isScalingOf unit:N ;
   qudt:plainTextDescription "1,000,000-fold of the SI derived unit newton" ;
   qudt:prefix prefix:Mega ;
+  qudt:symbol "MN" ;
   qudt:ucumCode "MN"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B73" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -13796,6 +14469,7 @@ unit:MegaN-M
   qudt:hasQuantityKind quantitykind:Torque ;
   qudt:iec61360Code "0112/2///62720#UAA214" ;
   qudt:plainTextDescription "1,000,000-fold of the product of the SI derived unit newton and the SI base unit metre" ;
+  qudt:symbol "MN⋅m" ;
   qudt:ucumCode "MN.m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B74" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -13811,6 +14485,7 @@ unit:MegaOHM
   qudt:isScalingOf unit:OHM ;
   qudt:plainTextDescription "1,000,000-fold of the derived unit ohm" ;
   qudt:prefix prefix:Mega ;
+  qudt:symbol "MΩ" ;
   qudt:ucumCode "MOhm"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B75" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -13826,6 +14501,7 @@ unit:MegaPA
   qudt:isScalingOf unit:PA ;
   qudt:plainTextDescription "1,000,000-fold of the derived unit pascal" ;
   qudt:prefix prefix:Mega ;
+  qudt:symbol "MPa" ;
   qudt:ucumCode "MPa"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "MPA" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -13838,6 +14514,7 @@ unit:MegaPA-L-PER-SEC
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAA218" ;
   qudt:plainTextDescription "product out of the 1,000,000-fold of the SI derived unit pascal and the unit litre divided by the SI base unit second" ;
+  qudt:symbol "MPa⋅L/s" ;
   qudt:ucumCode "MPa.L.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F97" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -13851,6 +14528,7 @@ unit:MegaPA-M3-PER-SEC
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAA219" ;
   qudt:plainTextDescription "product out of the 1,000,000-fold of the SI derived unit pascal and the power of the SI base unit metre with the exponent 3 divided by the SI base unit second" ;
+  qudt:symbol "MPa⋅m³/s" ;
   qudt:ucumCode "MPa.m3.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F98" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -13864,6 +14542,7 @@ unit:MegaPA-PER-BAR
   qudt:hasQuantityKind quantitykind:PressureRatio ;
   qudt:iec61360Code "0112/2///62720#UAA217" ;
   qudt:plainTextDescription "1,000,000-fold of the SI derived unit pascal divided by the unit bar" ;
+  qudt:symbol "MPa/bar" ;
   qudt:ucumCode "MPa.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F05" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -13876,6 +14555,7 @@ unit:MegaPA-PER-K
   qudt:hasQuantityKind quantitykind:PressureCoefficient ;
   qudt:iec61360Code "0112/2///62720#UAA216" ;
   qudt:plainTextDescription "1,000,000-fold of the SI derived unit pascal divided by the SI base unit kelvin" ;
+  qudt:symbol "MPa/K" ;
   qudt:ucumCode "MPa.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F85" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -13888,6 +14568,7 @@ unit:MegaS-PER-M
   qudt:hasQuantityKind quantitykind:Conductivity ;
   qudt:iec61360Code "0112/2///62720#UAA220" ;
   qudt:plainTextDescription "1,000,000-fold of the SI derived unit siemens divided by the SI base unit metre" ;
+  qudt:symbol "MS/m" ;
   qudt:ucumCode "MS.m-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B77" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -13915,6 +14596,7 @@ unit:MegaV
   qudt:isScalingOf unit:V ;
   qudt:plainTextDescription "1,000,000-fold of the derived unit volt" ;
   qudt:prefix prefix:Mega ;
+  qudt:symbol "mV" ;
   qudt:ucumCode "MV"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B78" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -13927,6 +14609,7 @@ unit:MegaV-A
   qudt:hasQuantityKind quantitykind:ComplexPower ;
   qudt:iec61360Code "0112/2///62720#UAA222" ;
   qudt:plainTextDescription "1,000,000-fold of the product of the SI derived unit volt and the SI base unit ampere" ;
+  qudt:symbol "MV⋅A" ;
   qudt:ucumCode "MV.A"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "MVA" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -13938,6 +14621,7 @@ unit:MegaV-A-HR
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Energy ;
   qudt:plainTextDescription "product of the 1,000,000-fold of the unit for apparent by ampere and the unit hour" ;
+  qudt:symbol "MV⋅A⋅hr" ;
   qudt:ucumCode "MV.A.h"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Megavolt Ampere Hour"@en ;
@@ -13949,6 +14633,7 @@ unit:MegaV-A_Reactive
   qudt:hasQuantityKind quantitykind:ReactivePower ;
   qudt:iec61360Code "0112/2///62720#UAB199" ;
   qudt:plainTextDescription "1 000 000-fold of the unit volt ampere reactive" ;
+  qudt:symbol "MV⋅A{Reactive}" ;
   qudt:ucumCode "MV.A{reactive}"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "MAR" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -13961,6 +14646,7 @@ unit:MegaV-A_Reactive-HR
   qudt:hasQuantityKind quantitykind:Energy ;
   qudt:iec61360Code "0112/2///62720#UAB198" ;
   qudt:plainTextDescription "product of the 1,000,000-fold of the unit volt ampere reactive and the unit hour" ;
+  qudt:symbol "MV⋅A{Reactive}⋅hr" ;
   qudt:ucumCode "MV.A{reactive}.h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "MAH" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -13973,6 +14659,7 @@ unit:MegaV-PER-M
   qudt:hasQuantityKind quantitykind:ElectricFieldStrength ;
   qudt:iec61360Code "0112/2///62720#UAA223" ;
   qudt:plainTextDescription "1,000,000-fold of the SI derived unit volt divided by the SI base unit metre" ;
+  qudt:symbol "MV/m" ;
   qudt:ucumCode "MV.m-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B79" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -13986,6 +14673,7 @@ unit:MegaW
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:isScalingOf unit:W ;
   qudt:prefix prefix:Mega ;
+  qudt:symbol "MW" ;
   qudt:ucumCode "MW"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "MegaW"@en ;
@@ -13997,6 +14685,7 @@ unit:MegaW-HR
   qudt:hasQuantityKind quantitykind:Energy ;
   qudt:iec61360Code "0112/2///62720#UAA225" ;
   qudt:plainTextDescription "1 000 000-fold of the product of the SI derived unit watt and the unit hour" ;
+  qudt:symbol "MW⋅hr" ;
   qudt:ucumCode "MW.h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "MWH" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -14079,6 +14768,7 @@ unit:MicroATM
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerArea ;
   qudt:hasQuantityKind quantitykind:VaporPressure ;
+  qudt:symbol "µatm" ;
   qudt:ucumCode "uatm"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Microatmospheres"@en ;
@@ -14091,6 +14781,7 @@ unit:MicroBAR
   qudt:hasQuantityKind quantitykind:VaporPressure ;
   qudt:iec61360Code "0112/2///62720#UAB089" ;
   qudt:plainTextDescription "0.000001-fold of the unit bar" ;
+  qudt:symbol "μbar" ;
   qudt:ucumCode "ubar"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B85" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -14105,6 +14796,7 @@ unit:MicroBQ
   qudt:isScalingOf unit:BQ ;
   qudt:plainTextDescription "0.000001-fold of the SI derived unit becquerel" ;
   qudt:prefix prefix:Micro ;
+  qudt:symbol "μBq" ;
   qudt:ucumCode "uBq"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H08" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -14116,6 +14808,7 @@ unit:MicroBQ-PER-KiloGM
   qudt:conversionMultiplier 0.000001 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M-1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:SpecificActivity ;
+  qudt:symbol "µBq/kg" ;
   qudt:ucumCode "uBq.kg-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Microbecquerels per kilogram"@en ;
@@ -14125,6 +14818,7 @@ unit:MicroBQ-PER-L
   qudt:conversionMultiplier 0.001 ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:ActivityConcentration ;
+  qudt:symbol "µBq/L" ;
   qudt:ucumCode "uBq.L-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Microbecquerels per litre"@en ;
@@ -14140,7 +14834,7 @@ unit:MicroC
   qudt:iec61360Code "0112/2///62720#UAA059" ;
   qudt:isScalingOf unit:C ;
   qudt:prefix prefix:Micro ;
-  qudt:symbol "μC" ;
+  qudt:symbol "µC" ;
   qudt:ucumCode "uC"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B86" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -14154,6 +14848,7 @@ unit:MicroC-PER-M2
   qudt:hasQuantityKind quantitykind:ElectricChargePerArea ;
   qudt:iec61360Code "0112/2///62720#UAA060" ;
   qudt:plainTextDescription "0.000001-fold of the SI derived unit coulomb divided by the power of the SI base unit metre with the exponent 2" ;
+  qudt:symbol "μC/m²" ;
   qudt:ucumCode "uC.m-2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B88" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -14167,6 +14862,7 @@ unit:MicroC-PER-M3
   qudt:hasQuantityKind quantitykind:ElectricChargeDensity ;
   qudt:iec61360Code "0112/2///62720#UAA061" ;
   qudt:plainTextDescription "0.000001-fold of the SI derived unit coulomb divided by the power of the SI base unit metre with the exponent 3" ;
+  qudt:symbol "μC/m³" ;
   qudt:ucumCode "uC.m-3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B87" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -14201,7 +14897,7 @@ unit:MicroFARAD
   qudt:iec61360Code "0112/2///62720#UAA063" ;
   qudt:isScalingOf unit:FARAD ;
   qudt:prefix prefix:Micro ;
-  qudt:symbol "μF" ;
+  qudt:symbol "µF" ;
   qudt:ucumCode "uF"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "4O" ;
   qudt:unitOfSystem sou:SI ;
@@ -14215,6 +14911,7 @@ unit:MicroFARAD-PER-KiloM
   qudt:hasQuantityKind quantitykind:Permittivity ;
   qudt:iec61360Code "0112/2///62720#UAA064" ;
   qudt:plainTextDescription "0.000001-fold of the SI derived unit farad divided by the 1,000-fold of the SI base unit metre" ;
+  qudt:symbol "μF/km" ;
   qudt:ucumCode "uF.km-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H28" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -14228,6 +14925,7 @@ unit:MicroFARAD-PER-M
   qudt:hasQuantityKind quantitykind:Permittivity ;
   qudt:iec61360Code "0112/2///62720#UAA065" ;
   qudt:plainTextDescription "0.000001-fold of the SI derived unit farad divided by the SI base unit metre" ;
+  qudt:symbol "μF/m" ;
   qudt:ucumCode "uF.m-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B89" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -14253,6 +14951,7 @@ unit:MicroG-PER-CentiM2
   qudt:hasDimensionVector qkdv:A0E0L-2I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:MassPerArea ;
   qudt:plainTextDescription "A unit of mass per area, equivalent to 0.01 grammes per square metre" ;
+  qudt:symbol "µg/cm²" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Microgram per square centimetre"@en ;
 .
@@ -14261,6 +14960,7 @@ unit:MicroGAL-PER-M
   dcterms:description "A rate of change of one millionth part of a unit of gravitational acceleration equal to one centimetre per second per second over a distance of one metre."@en ;
   qudt:conversionMultiplier 0.00000001 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-2D0 ;
+  qudt:symbol "µGal/m" ;
   qudt:ucumCode "uGal.m-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "MicroGals per metre"@en ;
@@ -14274,6 +14974,7 @@ unit:MicroGM
   qudt:isScalingOf unit:KiloGM ;
   qudt:plainTextDescription "0.000000001-fold of the SI base unit kilogram" ;
   qudt:prefix prefix:Micro ;
+  qudt:symbol "μg" ;
   qudt:ucumCode "ug"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "MC" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -14287,6 +14988,7 @@ unit:MicroGM-PER-GM
   qudt:hasQuantityKind quantitykind:MassRatio ;
   qudt:qkdvDenominator qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:qkdvNumerator qkdv:A0E0L0I0M1H0T0D0 ;
+  qudt:symbol "µg/g" ;
   qudt:ucumCode "ug.g-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Micrograms per gram"@en ;
@@ -14300,6 +15002,7 @@ unit:MicroGM-PER-KiloGM
   qudt:plainTextDescription "mass ratio as 0.000000001-fold of the SI base unit kilogram divided by the SI base unit kilogram" ;
   qudt:qkdvDenominator qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:qkdvNumerator qkdv:A0E0L0I0M1H0T0D0 ;
+  qudt:symbol "μg/kg" ;
   qudt:ucumCode "ug.kg-1"^^qudt:UCUMcs ;
   qudt:ucumCode "ug/kg"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J33" ;
@@ -14313,6 +15016,7 @@ unit:MicroGM-PER-L
   qudt:hasQuantityKind quantitykind:MassDensity ;
   qudt:iec61360Code "0112/2///62720#UAA084" ;
   qudt:plainTextDescription "0.000000001-fold of the SI base unit kilogram divided by the unit litre" ;
+  qudt:symbol "μg/L" ;
   qudt:ucumCode "ug.L-1"^^qudt:UCUMcs ;
   qudt:ucumCode "ug/L"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H29" ;
@@ -14325,6 +15029,7 @@ unit:MicroGM-PER-L-HR
   dcterms:description "A rate of change of mass of a measurand equivalent to 10^-9 kilogram (the SI unit of mass) per litre volume of matrix over a period of 1 hour."@en ;
   qudt:conversionMultiplier 0.000000000277777777777778 ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H0T-1D0 ;
+  qudt:symbol "µg/(L⋅hr)" ;
   qudt:ucumCode "ug.L-1.h-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Micrograms per litre per hour"@en ;
@@ -14333,6 +15038,7 @@ unit:MicroGM-PER-M2-DAY
   a qudt:Unit ;
   qudt:conversionMultiplier 0.0000000000000115740740740741 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M1H0T-1D0 ;
+  qudt:symbol "µg/(m²⋅day)" ;
   qudt:ucumCode "ug.m-2.d-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Micrograms per square metre per day"@en ;
@@ -14344,6 +15050,7 @@ unit:MicroGM-PER-M3
   qudt:hasQuantityKind quantitykind:MassDensity ;
   qudt:iec61360Code "0112/2///62720#UAA085" ;
   qudt:plainTextDescription "0.000000001-fold of the SI base unit kilogram divided by the power of the SI base unit metre with the exponent 3" ;
+  qudt:symbol "μg/m³" ;
   qudt:ucumCode "ug.m-3"^^qudt:UCUMcs ;
   qudt:ucumCode "ug/m3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "GQ" ;
@@ -14355,6 +15062,7 @@ unit:MicroGM-PER-M3-HR
   a qudt:Unit ;
   qudt:conversionMultiplier 0.000000000000277777777777778 ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H0T-1D0 ;
+  qudt:symbol "µg/(m³⋅day)" ;
   qudt:ucumCode "ug.m-3.h-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Micrograms per cubic metre per hour"@en ;
@@ -14366,6 +15074,7 @@ unit:MicroGM-PER-MilliL
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:MassConcentration ;
   qudt:hasQuantityKind quantitykind:MassDensity ;
+  qudt:symbol "µg/mL" ;
   qudt:ucumCode "ug.mL-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Micrograms per millilitre"@en ;
@@ -14399,7 +15108,7 @@ unit:MicroH
   qudt:iec61360Code "0112/2///62720#UAA066" ;
   qudt:isScalingOf unit:H ;
   qudt:prefix prefix:Micro ;
-  qudt:symbol "μH" ;
+  qudt:symbol "µH" ;
   qudt:ucumCode "uH"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B90" ;
   qudt:unitOfSystem sou:SI ;
@@ -14413,6 +15122,7 @@ unit:MicroH-PER-KiloOHM
   qudt:hasQuantityKind quantitykind:Time ;
   qudt:iec61360Code "0112/2///62720#UAA068" ;
   qudt:plainTextDescription "0.000001-fold of the SI derived unit henry divided by the 1,000-fold of the SI derived unit ohm" ;
+  qudt:symbol "µH/kΩ" ;
   qudt:ucumCode "uH.kOhm-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G98" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -14425,6 +15135,7 @@ unit:MicroH-PER-M
   qudt:hasQuantityKind quantitykind:Permeability ;
   qudt:iec61360Code "0112/2///62720#UAA069" ;
   qudt:plainTextDescription "0.000001-fold of the SI derived unit henry divided by the SI base unit metre" ;
+  qudt:symbol "μH/m" ;
   qudt:ucumCode "uH.m-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B91" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -14438,6 +15149,7 @@ unit:MicroH-PER-OHM
   qudt:hasQuantityKind quantitykind:Time ;
   qudt:iec61360Code "0112/2///62720#UAA067" ;
   qudt:plainTextDescription "0.000001-fold of the SI derived unit henry divided by the SI derived unit ohm" ;
+  qudt:symbol "µH/Ω" ;
   qudt:ucumCode "uH.Ohm-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G99" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -14469,6 +15181,7 @@ unit:MicroJ
   qudt:isScalingOf unit:J ;
   qudt:plainTextDescription "0.000001-fold of the SI derived unit joule" ;
   qudt:prefix prefix:Micro ;
+  qudt:symbol "µJ" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Micro Joule"@en ;
   rdfs:label "Micro Joule"@en-us ;
@@ -14481,6 +15194,7 @@ unit:MicroL
   qudt:hasQuantityKind quantitykind:Volume ;
   qudt:iec61360Code "0112/2///62720#UAA088" ;
   qudt:plainTextDescription "0.000001-fold of the unit litre" ;
+  qudt:symbol "μL" ;
   qudt:ucumCode "uL"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "4G" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -14494,6 +15208,7 @@ unit:MicroL-PER-L
   qudt:hasQuantityKind quantitykind:VolumeFraction ;
   qudt:iec61360Code "0112/2///62720#UAA089" ;
   qudt:plainTextDescription "volume ratio as 0.000001-fold of the unit litre divided by the unit litre" ;
+  qudt:symbol "μL/L" ;
   qudt:ucumCode "uL.L-1"^^qudt:UCUMcs ;
   qudt:ucumCode "uL/L"^^qudt:UCUMcs ;
   qudt:udunitsCode "ppmv" ;
@@ -14514,7 +15229,7 @@ unit:MicroM
   qudt:informativeReference "http://en.wikipedia.org/wiki/Micrometer?oldid=491270437"^^xsd:anyURI ;
   qudt:isScalingOf unit:M ;
   qudt:prefix prefix:Micro ;
-  qudt:symbol "㎛" ;
+  qudt:symbol "µm" ;
   qudt:ucumCode "um"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "4H" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -14528,6 +15243,7 @@ unit:MicroM-PER-K
   qudt:hasQuantityKind quantitykind:LinearThermalExpansion ;
   qudt:iec61360Code "0112/2///62720#UAA091" ;
   qudt:plainTextDescription "0.000001-fold of the SI base unit metre divided by the SI base unit kelvin" ;
+  qudt:symbol "μm/K" ;
   qudt:ucumCode "um.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F50" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -14538,6 +15254,7 @@ unit:MicroM-PER-L-DAY
   a qudt:Unit ;
   qudt:conversionMultiplier 0.0000000115740740740741 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T-1D0 ;
+  qudt:symbol "µm/(L⋅day)" ;
   qudt:ucumCode "um.L-1.d-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Micromoles per litre per day"@en ;
@@ -14546,6 +15263,7 @@ unit:MicroM-PER-MilliL
   a qudt:Unit ;
   qudt:conversionMultiplier 0.000001 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T0D0 ;
+  qudt:symbol "µm/mL" ;
   qudt:ucumCode "um2.mL-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Square microns per millilitre"@en ;
@@ -14557,6 +15275,7 @@ unit:MicroM-PER-N
   qudt:hasDimensionVector qkdv:A0E0L0I0M-1H0T2D0 ;
   qudt:hasQuantityKind quantitykind:LinearCompressibility ;
   qudt:plainTextDescription "Micro metres measured per Newton" ;
+  qudt:symbol "µJ/N" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Micro meter per Newton"@en-us ;
   rdfs:label "Micro metre per Newton"@en ;
@@ -14571,6 +15290,7 @@ unit:MicroM2
   qudt:isScalingOf unit:M2 ;
   qudt:plainTextDescription "0.000000000001-fold of the power of the SI base unit metre with the exponent 2" ;
   qudt:prefix prefix:Micro ;
+  qudt:symbol "μm²" ;
   qudt:ucumCode "um2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H30" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -14584,6 +15304,7 @@ unit:MicroM3
   qudt:hasQuantityKind quantitykind:Volume ;
   qudt:isScalingOf unit:M3 ;
   qudt:prefix prefix:Micro ;
+  qudt:symbol "µm³" ;
   qudt:ucumCode "um3"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Cubic micrometres (microns)"@en ;
@@ -14595,6 +15316,7 @@ unit:MicroM3-PER-M3
   qudt:hasQuantityKind quantitykind:VolumeFraction ;
   qudt:qkdvDenominator qkdv:A0E0L3I0M0H0T0D0 ;
   qudt:qkdvNumerator qkdv:A0E0L3I0M0H0T0D0 ;
+  qudt:symbol "µm³/m³" ;
   qudt:ucumCode "um3.m-3"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Cubic microns per cubic metre"@en ;
@@ -14606,6 +15328,7 @@ unit:MicroM3-PER-MilliL
   qudt:hasQuantityKind quantitykind:VolumeFraction ;
   qudt:qkdvDenominator qkdv:A0E0L3I0M0H0T0D0 ;
   qudt:qkdvNumerator qkdv:A0E0L3I0M0H0T0D0 ;
+  qudt:symbol "µm³/mL" ;
   qudt:ucumCode "um3.mL-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Cubic microns per millilitre"@en ;
@@ -14619,6 +15342,7 @@ unit:MicroMHO
   qudt:isScalingOf unit:MHO ;
   qudt:plainTextDescription "0.000001-fold of the obsolete unit mho of the electric conductance" ;
   qudt:prefix prefix:Micro ;
+  qudt:symbol "μmho" ;
   qudt:ucumCode "umho"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "NR" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -14633,6 +15357,7 @@ unit:MicroMOL
   qudt:isScalingOf unit:MOL ;
   qudt:plainTextDescription "0.000001-fold of the SI base unit mol" ;
   qudt:prefix prefix:Micro ;
+  qudt:symbol "μmol" ;
   qudt:ucumCode "umol"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "FH" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -14648,6 +15373,7 @@ unit:MicroMOL-PER-GM
   qudt:hasQuantityKind quantitykind:MolalityOfSolute ;
   qudt:isScalingOf unit:MOL-PER-KiloGM ;
   qudt:plainTextDescription "0.000001-fold of the SI base unit mol divided by the 0.001-fold of the SI base unit kilogram" ;
+  qudt:symbol "µmol/g" ;
   qudt:ucumCode "umol.g-1"^^qudt:UCUMcs ;
   qudt:ucumCode "umol/g"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -14657,6 +15383,7 @@ unit:MicroMOL-PER-GM-HR
   a qudt:Unit ;
   qudt:conversionMultiplier 0.000000277777777777778 ;
   qudt:hasDimensionVector qkdv:A1E0L0I0M-1H0T-1D0 ;
+  qudt:symbol "µmol/(g⋅h)" ;
   qudt:ucumCode "umol.g-1.h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "umol/g/h"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -14676,6 +15403,7 @@ unit:MicroMOL-PER-KiloGM
   qudt:conversionMultiplier 0.000001 ;
   qudt:hasDimensionVector qkdv:A1E0L0I0M-1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:AmountOfSubstancePerUnitMass ;
+  qudt:symbol "µmol/kg" ;
   qudt:ucumCode "umol.kg-1"^^qudt:UCUMcs ;
   qudt:ucumCode "umol/kg"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -14687,6 +15415,7 @@ unit:MicroMOL-PER-L
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:AmountOfSubstancePerUnitVolume ;
   qudt:hasQuantityKind quantitykind:Solubility_Water ;
+  qudt:symbol "µmol/L" ;
   qudt:ucumCode "umol.L-1"^^qudt:UCUMcs ;
   qudt:ucumCode "umol/L"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -14696,6 +15425,7 @@ unit:MicroMOL-PER-L-HR
   a qudt:Unit ;
   qudt:conversionMultiplier 0.000000277777777777778 ;
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T-1D0 ;
+  qudt:symbol "µmol/(L⋅hr)" ;
   qudt:ucumCode "umol.L-1.h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "umol/L/h"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -14706,6 +15436,7 @@ unit:MicroMOL-PER-M2
   dcterms:description "One part per 10**6 (million) of the SI unit of quantity of matter (the mole) per SI unit area."@en ;
   qudt:conversionMultiplier 0.000001 ;
   qudt:hasDimensionVector qkdv:A1E0L-2I0M0H0T0D0 ;
+  qudt:symbol "µmol/m²" ;
   qudt:ucumCode "umol.m-2"^^qudt:UCUMcs ;
   qudt:ucumCode "umol/m2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -14715,6 +15446,7 @@ unit:MicroMOL-PER-M2-DAY
   a qudt:Unit ;
   qudt:conversionMultiplier 0.0000000000115740740740741 ;
   qudt:hasDimensionVector qkdv:A1E0L-2I0M0H0T-1D0 ;
+  qudt:symbol "µmol/(m²⋅day)" ;
   qudt:ucumCode "umol.m-2.d-1"^^qudt:UCUMcs ;
   qudt:ucumCode "umol/m2/d"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -14724,6 +15456,7 @@ unit:MicroMOL-PER-M2-HR
   a qudt:Unit ;
   qudt:conversionMultiplier 0.000000000277777777777778 ;
   qudt:hasDimensionVector qkdv:A1E0L-2I0M0H0T-1D0 ;
+  qudt:symbol "µmol/(m²⋅hr)" ;
   qudt:ucumCode "umol.m-2.h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "umol/m2/h"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -14735,6 +15468,7 @@ unit:MicroMOL-PER-M2-SEC
   qudt:conversionMultiplier 0.000001 ;
   qudt:hasDimensionVector qkdv:A1E0L-2I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:PhotosyntheticPhotonFluxDensity ;
+  qudt:symbol "µmol/(m²⋅s)" ;
   qudt:ucumCode "umol.m-2.s-1"^^qudt:UCUMcs ;
   qudt:ucumCode "umol/m2/s"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -14746,6 +15480,7 @@ unit:MicroMOL-PER-MOL
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:qkdvDenominator qkdv:A1E0L0I0M0H0T0D0 ;
   qudt:qkdvNumerator qkdv:A1E0L0I0M0H0T0D0 ;
+  qudt:symbol "µmol/mol" ;
   qudt:ucumCode "umol.mol-1"^^qudt:UCUMcs ;
   qudt:ucumCode "umol/mol"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -14755,6 +15490,7 @@ unit:MicroMOL-PER-MicroMOL-DAY
   a qudt:Unit ;
   qudt:conversionMultiplier 0.0000115740740740741 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
+  qudt:symbol "µmol/(µmol⋅day)" ;
   qudt:ucumCode "umol.umol-1.d-1"^^qudt:UCUMcs ;
   qudt:ucumCode "umol/umol/d"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -14766,6 +15502,7 @@ unit:MicroMOL-PER-SEC
   qudt:conversionMultiplier 0.000001 ;
   qudt:hasDimensionVector qkdv:A1E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:PhotosyntheticPhotonFlux ;
+  qudt:symbol "µmol/s" ;
   qudt:ucumCode "umol.s-1"^^qudt:UCUMcs ;
   qudt:ucumCode "umol/s"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -14780,6 +15517,7 @@ unit:MicroN
   qudt:isScalingOf unit:N ;
   qudt:plainTextDescription "0.000001-fold of the SI derived unit newton" ;
   qudt:prefix prefix:Micro ;
+  qudt:symbol "μN" ;
   qudt:ucumCode "uN"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B92" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -14792,6 +15530,7 @@ unit:MicroN-M
   qudt:hasQuantityKind quantitykind:Torque ;
   qudt:iec61360Code "0112/2///62720#UAA071" ;
   qudt:plainTextDescription "0.000001-fold of the product out of the derived SI newton and the SI base unit metre" ;
+  qudt:symbol "μN⋅m" ;
   qudt:ucumCode "uN.m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B93" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -14807,6 +15546,7 @@ unit:MicroOHM
   qudt:isScalingOf unit:OHM ;
   qudt:plainTextDescription "0.000001-fold of the SI derived unit ohm" ;
   qudt:prefix prefix:Micro ;
+  qudt:symbol "μΩ" ;
   qudt:ucumCode "uOhm"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B94" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -14822,6 +15562,7 @@ unit:MicroPA
   qudt:isScalingOf unit:PA ;
   qudt:plainTextDescription "0.000001-fold of the SI derived unit pascal" ;
   qudt:prefix prefix:Micro ;
+  qudt:symbol "μPa" ;
   qudt:ucumCode "uPa"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B96" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -14834,6 +15575,7 @@ unit:MicroPOISE
   qudt:hasQuantityKind quantitykind:DynamicViscosity ;
   qudt:iec61360Code "0112/2///62720#UAA072" ;
   qudt:plainTextDescription "0.000001-fold of the CGS unit of the dynamic viscosity poise" ;
+  qudt:symbol "μP" ;
   qudt:ucumCode "uP"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J32" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -14849,7 +15591,7 @@ unit:MicroRAD
   qudt:iec61360Code "0112/2///62720#UAA094" ;
   qudt:isScalingOf unit:RAD ;
   qudt:prefix prefix:Micro ;
-  qudt:symbol "μrad" ;
+  qudt:symbol "µrad" ;
   qudt:ucumCode "urad"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B97" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -14864,6 +15606,7 @@ unit:MicroS
   qudt:isScalingOf unit:S ;
   qudt:plainTextDescription "0.000001-fold of the SI derived unit siemens" ;
   qudt:prefix prefix:Micro ;
+  qudt:symbol "μS" ;
   qudt:ucumCode "uS"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B99" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -14876,6 +15619,7 @@ unit:MicroS-PER-CentiM
   qudt:hasQuantityKind quantitykind:Conductivity ;
   qudt:iec61360Code "0112/2///62720#UAA075" ;
   qudt:plainTextDescription "0.000001-fold of the SI derived unit Siemens divided by the 0.01-fold of the SI base unit metre" ;
+  qudt:symbol "μS/cm" ;
   qudt:ucumCode "uS.cm-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G42" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -14889,6 +15633,7 @@ unit:MicroS-PER-M
   qudt:hasQuantityKind quantitykind:Conductivity ;
   qudt:iec61360Code "0112/2///62720#UAA076" ;
   qudt:plainTextDescription "0.000001-fold of the SI derived unit Siemens divided by the SI base unit metre" ;
+  qudt:symbol "μS/m" ;
   qudt:ucumCode "uS.m-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G43" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -14905,7 +15650,7 @@ unit:MicroSEC
   qudt:iec61360Code "0112/2///62720#UAA095" ;
   qudt:isScalingOf unit:SEC ;
   qudt:prefix prefix:Micro ;
-  qudt:symbol "μs" ;
+  qudt:symbol "µs" ;
   qudt:ucumCode "us"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B98" ;
   qudt:unitOfSystem sou:IMPERIAL ;
@@ -14961,6 +15706,7 @@ unit:MicroT
   qudt:isScalingOf unit:T ;
   qudt:plainTextDescription "0.000001-fold of the SI derived unit tesla" ;
   qudt:prefix prefix:Micro ;
+  qudt:symbol "µT" ;
   qudt:ucumCode "uT"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D81" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -14973,7 +15719,7 @@ unit:MicroTORR
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerArea ;
   qudt:hasQuantityKind quantitykind:VaporPressure ;
-  qudt:symbol "μTorr" ;
+  qudt:symbol "µTorr" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "MicroTorr"@en ;
 .
@@ -14986,6 +15732,7 @@ unit:MicroV
   qudt:isScalingOf unit:V ;
   qudt:plainTextDescription "0.000001-fold of the SI derived unit volt" ;
   qudt:prefix prefix:Micro ;
+  qudt:symbol "µV" ;
   qudt:ucumCode "uV"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D82" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -14998,6 +15745,7 @@ unit:MicroV-PER-M
   qudt:hasQuantityKind quantitykind:ElectricFieldStrength ;
   qudt:iec61360Code "0112/2///62720#UAA079" ;
   qudt:plainTextDescription "0.000001-fold of the SI derived unit volt divided by the SI base unit metre" ;
+  qudt:symbol "µV/m" ;
   qudt:ucumCode "uV.m-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C3" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -15014,6 +15762,7 @@ unit:MicroW
   qudt:isScalingOf unit:W ;
   qudt:plainTextDescription "0.000001-fold of the SI derived unit watt" ;
   qudt:prefix prefix:Micro ;
+  qudt:symbol "mW" ;
   qudt:ucumCode "uW"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D80" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -15026,6 +15775,7 @@ unit:MicroW-PER-M2
   qudt:hasQuantityKind quantitykind:PowerPerArea ;
   qudt:iec61360Code "0112/2///62720#UAA081" ;
   qudt:plainTextDescription "0.000001-fold of the SI derived unit watt divided by the power of the SI base unit metre with the exponent 2" ;
+  qudt:symbol "µW/m²" ;
   qudt:ucumCode "uW.m-2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D85" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -15064,6 +15814,7 @@ unit:MilliA-HR
   qudt:hasQuantityKind quantitykind:ElectricCharge ;
   qudt:iec61360Code "0112/2///62720#UAA777" ;
   qudt:plainTextDescription "product of the 0.001-fold of the SI base unit ampere and the unit hour" ;
+  qudt:symbol "µA⋅hr" ;
   qudt:ucumCode "mA.h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E09" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -15077,6 +15828,7 @@ unit:MilliA-PER-IN
   qudt:hasQuantityKind quantitykind:MagneticFieldStrength_H ;
   qudt:iec61360Code "0112/2///62720#UAA778" ;
   qudt:plainTextDescription "0.001-fold of the SI base unit ampere divided by the unit inch according to the Anglo-American and the Imperial system of units" ;
+  qudt:symbol "µA/in" ;
   qudt:ucumCode "mA.[in_i]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F08" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -15090,6 +15842,7 @@ unit:MilliA-PER-MilliM
   qudt:hasQuantityKind quantitykind:MagneticFieldStrength_H ;
   qudt:iec61360Code "0112/2///62720#UAA781" ;
   qudt:plainTextDescription "0.001-fold of the SI base unit ampere  divided by the 0.001-fold of the SI base unit metre" ;
+  qudt:symbol "mA/mm" ;
   qudt:ucumCode "mA.mm-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F76" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -15138,6 +15891,7 @@ unit:MilliBAR-L-PER-SEC
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAA813" ;
   qudt:plainTextDescription "product out of the 0.001-fold of the unit bar and the unit litre divided by the SI base unit second" ;
+  qudt:symbol "mbar⋅L/s" ;
   qudt:ucumCode "mbar.L.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F95" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -15151,6 +15905,7 @@ unit:MilliBAR-M3-PER-SEC
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAA327" ;
   qudt:plainTextDescription "product of the unit bar and the power of the SI base unit metre with the exponent 3 divided by the SI base unit second" ;
+  qudt:symbol "mbar⋅m³/s" ;
   qudt:ucumCode "mbar.m3.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F96" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -15164,6 +15919,7 @@ unit:MilliBAR-PER-BAR
   qudt:hasQuantityKind quantitykind:PressureRatio ;
   qudt:iec61360Code "0112/2///62720#UAA812" ;
   qudt:plainTextDescription "0.01-fold of the unit bar divided by the unit bar" ;
+  qudt:symbol "mbar/bar" ;
   qudt:ucumCode "mbar.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F04" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -15176,6 +15932,7 @@ unit:MilliBAR-PER-K
   qudt:hasQuantityKind quantitykind:VolumetricHeatCapacity ;
   qudt:iec61360Code "0112/2///62720#UAA811" ;
   qudt:plainTextDescription "0.001-fold of the unit bar divided by the unit temperature kelvin" ;
+  qudt:symbol "mbar/K" ;
   qudt:ucumCode "mbar.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F84" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -15187,6 +15944,7 @@ unit:MilliBQ-PER-GM
   qudt:conversionMultiplier 1.0 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M-1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:SpecificActivity ;
+  qudt:symbol "mBq/g" ;
   qudt:ucumCode "mBq.g-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Millibecquerels per gram"@en ;
@@ -15197,6 +15955,7 @@ unit:MilliBQ-PER-KiloGM
   qudt:conversionMultiplier 0.001 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M-1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:SpecificActivity ;
+  qudt:symbol "mBq/kg" ;
   qudt:ucumCode "mBq.kg-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Millibecquerels per kilogram"@en ;
@@ -15207,6 +15966,7 @@ unit:MilliBQ-PER-L
   qudt:conversionMultiplier 1.0 ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:ActivityConcentration ;
+  qudt:symbol "mBq/L" ;
   qudt:ucumCode "mBq.L-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Millibecquerels per litre"@en ;
@@ -15216,6 +15976,7 @@ unit:MilliBQ-PER-M2-DAY
   dcterms:description "One radioactive disintegration per thousand seconds in material passing through an area of one square metre during a period of one day (86400 seconds)."@en ;
   qudt:conversionMultiplier 0.0000000115740740740741 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T-2D0 ;
+  qudt:symbol "mBq/(m²⋅day)" ;
   qudt:ucumCode "mBq.m-2.d-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Millibecquerels per square metre per day"@en ;
@@ -15245,6 +16006,7 @@ unit:MilliC-PER-KiloGM
   qudt:hasQuantityKind quantitykind:ElectricChargePerMass ;
   qudt:iec61360Code "0112/2///62720#UAA783" ;
   qudt:plainTextDescription "0.001-fold of the SI derived unit coulomb divided by the SI base unit kilogram" ;
+  qudt:symbol "mC/kg" ;
   qudt:ucumCode "mC.kg-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C8" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -15257,6 +16019,7 @@ unit:MilliC-PER-M2
   qudt:hasQuantityKind quantitykind:ElectricChargePerArea ;
   qudt:iec61360Code "0112/2///62720#UAA784" ;
   qudt:plainTextDescription "0.001-fold of the SI derived unit coulomb divided by the power of the SI base unit metre with the exponent 2" ;
+  qudt:symbol "mC/m²" ;
   qudt:ucumCode "mC.m-2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D89" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -15270,6 +16033,7 @@ unit:MilliC-PER-M3
   qudt:hasQuantityKind quantitykind:ElectricChargeVolumeDensity ;
   qudt:iec61360Code "0112/2///62720#UAA785" ;
   qudt:plainTextDescription "0.001-fold of the SI derived unit coulomb divided by the power of the SI base unit metre with the exponent 3" ;
+  qudt:symbol "mC/m³" ;
   qudt:ucumCode "mC.m-3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D88" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -15283,6 +16047,7 @@ unit:MilliCi
   qudt:hasQuantityKind quantitykind:Activity ;
   qudt:iec61360Code "0112/2///62720#UAA786" ;
   qudt:plainTextDescription "0.001-fold of the SI derived unit curie" ;
+  qudt:symbol "mCi" ;
   qudt:ucumCode "mCi"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "MCU" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -15305,6 +16070,7 @@ unit:MilliDEG_C
   qudt:informativeReference "http://en.wikipedia.org/wiki/Celsius?oldid=494152178"^^xsd:anyURI ;
   qudt:isScalingOf unit:DEG_C ;
   qudt:latexDefinition "millieDegree Celsius"^^qudt:LatexString ;
+  qudt:symbol "m°C" ;
   qudt:ucumCode "mCel"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Millidegree Celsius"@en ;
@@ -15318,6 +16084,7 @@ unit:MilliFARAD
   qudt:isScalingOf unit:FARAD ;
   qudt:plainTextDescription "0.001-fold of the SI derived unit farad" ;
   qudt:prefix prefix:Milli ;
+  qudt:symbol "mF" ;
   qudt:ucumCode "mF"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C10" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -15342,6 +16109,7 @@ unit:MilliGAL
   qudt:hasQuantityKind quantitykind:Acceleration ;
   qudt:iec61360Code "0112/2///62720#UAB043" ;
   qudt:plainTextDescription "0.001-fold of the unit of acceleration called gal according to the CGS system of units" ;
+  qudt:symbol "mgal" ;
   qudt:ucumCode "mGal"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C11" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -15352,6 +16120,7 @@ unit:MilliGAL-PER-MO
   dcterms:description "A rate of change of one millionth part of a unit of gravitational acceleration equal to one centimetre per second per second over a time duration of 30.4375 days or 2629800 seconds."@en ;
   qudt:conversionMultiplier 0.000000000380257053768347 ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T-3D0 ;
+  qudt:symbol "mgal/mo" ;
   qudt:ucumCode "mGal.mo-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "MilliGals per month"@en ;
@@ -15365,6 +16134,7 @@ unit:MilliGM
   qudt:isScalingOf unit:KiloGM ;
   qudt:plainTextDescription "0.000001-fold of the SI base unit kilogram" ;
   qudt:prefix prefix:Milli ;
+  qudt:symbol "mg" ;
   qudt:ucumCode "mg"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "MGM" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -15377,6 +16147,7 @@ unit:MilliGM-PER-CentiM2
   qudt:hasQuantityKind quantitykind:MassPerArea ;
   qudt:iec61360Code "0112/2///62720#UAA818" ;
   qudt:plainTextDescription "0.000001-fold of the SI base unit kilogram divided by the 0.0001-fold of the power of the SI base unit metre with the exponent 2" ;
+  qudt:symbol "mg/cm²" ;
   qudt:ucumCode "mg.cm-2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H63" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -15390,6 +16161,7 @@ unit:MilliGM-PER-DAY
   qudt:hasQuantityKind quantitykind:MassFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA819" ;
   qudt:plainTextDescription "0.000001-fold of the SI base unit kilogram divided by the unit day" ;
+  qudt:symbol "mg/day" ;
   qudt:ucumCode "mg.d-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F32" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -15404,6 +16176,7 @@ unit:MilliGM-PER-DeciL
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:BloodGlucoseLevel_Mass ;
   qudt:hasQuantityKind quantitykind:Density ;
+  qudt:symbol "mg/L" ;
   qudt:ucumCode "mg.dL-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "milligrams per decilitre"@en ;
@@ -15418,6 +16191,7 @@ unit:MilliGM-PER-GM
   qudt:plainTextDescription "0.000001-fold of the SI base unit kilogram divided by the 0.001-fold of the SI base unit kilogram" ;
   qudt:qkdvDenominator qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:qkdvNumerator qkdv:A0E0L0I0M1H0T0D0 ;
+  qudt:symbol "mg/gm" ;
   qudt:ucumCode "mg.g-1"^^qudt:UCUMcs ;
   qudt:ucumCode "mg/g"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H64" ;
@@ -15442,6 +16216,7 @@ unit:MilliGM-PER-HR
   qudt:hasQuantityKind quantitykind:MassFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA823" ;
   qudt:plainTextDescription "0.000001-fold of the SI base unit kilogram divided by the unit hour" ;
+  qudt:symbol "mg/hr" ;
   qudt:ucumCode "mg.h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "4M" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -15456,6 +16231,7 @@ unit:MilliGM-PER-KiloGM
   qudt:plainTextDescription "0.000001-fold of the SI base unit kilogram divided by the SI base unit kilogram" ;
   qudt:qkdvDenominator qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:qkdvNumerator qkdv:A0E0L0I0M1H0T0D0 ;
+  qudt:symbol "mg/kg" ;
   qudt:ucumCode "mg.kg-1"^^qudt:UCUMcs ;
   qudt:ucumCode "mg/kg"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "NA" ;
@@ -15469,6 +16245,7 @@ unit:MilliGM-PER-L
   qudt:hasQuantityKind quantitykind:MassDensity ;
   qudt:iec61360Code "0112/2///62720#UAA827" ;
   qudt:plainTextDescription "0.000001-fold of the SI base unit kilogram divided by the unit litre" ;
+  qudt:symbol "mg/L" ;
   qudt:ucumCode "mg.L-1"^^qudt:UCUMcs ;
   qudt:ucumCode "mg/L"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M1" ;
@@ -15483,6 +16260,7 @@ unit:MilliGM-PER-M
   qudt:hasQuantityKind quantitykind:MassPerLength ;
   qudt:iec61360Code "0112/2///62720#UAA828" ;
   qudt:plainTextDescription "0.000001-fold of the SI base unit kilogram divided by the SI base unit metre" ;
+  qudt:symbol "mg/m" ;
   qudt:ucumCode "mg.m-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C12" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -15496,6 +16274,7 @@ unit:MilliGM-PER-M2
   qudt:hasQuantityKind quantitykind:MassPerArea ;
   qudt:iec61360Code "0112/2///62720#UAA829" ;
   qudt:plainTextDescription "0.000001-fold of the SI base unit kilogram divided by the power of the SI base unit metre with the exponent 2" ;
+  qudt:symbol "mg/m²" ;
   qudt:ucumCode "mg.m-2"^^qudt:UCUMcs ;
   qudt:ucumCode "mg/m2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "GO" ;
@@ -15508,6 +16287,7 @@ unit:MilliGM-PER-M2-DAY
   qudt:conversionMultiplier 0.0000000000115740740740741 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:MassPerAreaTime ;
+  qudt:symbol "mg/(m²⋅day)" ;
   qudt:ucumCode "mg.m-2.d-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Milligrams per square metre per day"@en ;
@@ -15517,6 +16297,7 @@ unit:MilliGM-PER-M2-HR
   qudt:conversionMultiplier 0.000000000277777777777778 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:MassPerAreaTime ;
+  qudt:symbol "mg/(m²⋅hr)" ;
   qudt:ucumCode "mg.m-2.h-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Milligrams per square metre per hour"@en ;
@@ -15526,6 +16307,7 @@ unit:MilliGM-PER-M2-SEC
   qudt:conversionMultiplier 0.000001 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:MassPerAreaTime ;
+  qudt:symbol "mg/(m²⋅s)" ;
   qudt:ucumCode "mg.m-2.s-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Milligrams per square metre per second"@en ;
@@ -15537,6 +16319,7 @@ unit:MilliGM-PER-M3
   qudt:hasQuantityKind quantitykind:MassDensity ;
   qudt:iec61360Code "0112/2///62720#UAA830" ;
   qudt:plainTextDescription "0.000001-fold of the SI base unit kilogram divided by the power of the SI base unit metre with the exponent 3" ;
+  qudt:symbol "mg/m³" ;
   qudt:ucumCode "mg.m-3"^^qudt:UCUMcs ;
   qudt:ucumCode "mg/m3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "GP" ;
@@ -15548,6 +16331,7 @@ unit:MilliGM-PER-M3-DAY
   a qudt:Unit ;
   qudt:conversionMultiplier 0.0000000000115740740740741 ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H0T-1D0 ;
+  qudt:symbol "mg/(m³⋅day)" ;
   qudt:ucumCode "mg.m-3.d-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Milligrams per cubic metre per day"@en ;
@@ -15556,6 +16340,7 @@ unit:MilliGM-PER-M3-HR
   a qudt:Unit ;
   qudt:conversionMultiplier 0.000000000277777777777778 ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H0T-1D0 ;
+  qudt:symbol "mg/(m³⋅hr)" ;
   qudt:ucumCode "mg.m-3.h-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Milligrams per cubic metre per hour"@en ;
@@ -15564,6 +16349,7 @@ unit:MilliGM-PER-M3-SEC
   a qudt:Unit ;
   qudt:conversionMultiplier 0.000001 ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H0T-1D0 ;
+  qudt:symbol "mg/(m³⋅s)" ;
   qudt:ucumCode "mg.m-3.s-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Milligrams per cubic metre per second"@en ;
@@ -15575,6 +16361,7 @@ unit:MilliGM-PER-MIN
   qudt:hasQuantityKind quantitykind:MassFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA833" ;
   qudt:plainTextDescription "0.000001-fold of the SI base unit kilogram divided by the unit minute" ;
+  qudt:symbol "mg/min" ;
   qudt:ucumCode "mg/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F33" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -15601,6 +16388,7 @@ unit:MilliGM-PER-SEC
   qudt:hasQuantityKind quantitykind:MassFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA836" ;
   qudt:plainTextDescription "0.000001-fold of the SI base unit kilogram divided by the SI base unit second" ;
+  qudt:symbol "mg/s" ;
   qudt:ucumCode "mg/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F34" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -15615,6 +16403,7 @@ unit:MilliGRAY
   qudt:isScalingOf unit:GRAY ;
   qudt:plainTextDescription "0.001-fold of the SI derived unit gray" ;
   qudt:prefix prefix:Milli ;
+  qudt:symbol "mGy" ;
   qudt:ucumCode "mGy"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C13" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -15645,6 +16434,7 @@ unit:MilliH-PER-KiloOHM
   qudt:hasQuantityKind quantitykind:Time ;
   qudt:iec61360Code "0112/2///62720#UAA791" ;
   qudt:plainTextDescription "0.001-fold of the SI derived unit henry divided by the 1 000-fold of the SI derived unit ohm" ;
+  qudt:symbol "mH/kΩ" ;
   qudt:ucumCode "mH.kOhm-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H05" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -15657,6 +16447,7 @@ unit:MilliH-PER-OHM
   qudt:hasQuantityKind quantitykind:Time ;
   qudt:iec61360Code "0112/2///62720#UAA790" ;
   qudt:plainTextDescription "0.001-fold of the SI derived unit henry divided by the SI derived unit ohm" ;
+  qudt:symbol "mH/Ω" ;
   qudt:ucumCode "mH.Ohm-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H06" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -15669,6 +16460,7 @@ unit:MilliIN
   qudt:hasQuantityKind quantitykind:Length ;
   qudt:iec61360Code "0112/2///62720#UAA841" ;
   qudt:plainTextDescription "0.001-fold of the unit inch according to the Anglo-American and Imperial system of units" ;
+  qudt:symbol "mil" ;
   qudt:ucumCode "m[in_i]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "77" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -15685,6 +16477,7 @@ unit:MilliJ
   qudt:isScalingOf unit:J ;
   qudt:plainTextDescription "0.001-fold of the SI derived unit joule" ;
   qudt:prefix prefix:Milli ;
+  qudt:symbol "mJ" ;
   qudt:ucumCode "mJ"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C15" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -15697,6 +16490,7 @@ unit:MilliL
   qudt:hasQuantityKind quantitykind:Volume ;
   qudt:iec61360Code "0112/2///62720#UAA844" ;
   qudt:plainTextDescription "0.001-fold of the unit litre" ;
+  qudt:symbol "mL" ;
   qudt:ucumCode "mL"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "MLT" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -15710,6 +16504,7 @@ unit:MilliL-PER-CentiM2-MIN
   qudt:hasQuantityKind quantitykind:VolumetricFlux ;
   qudt:iec61360Code "0112/2///62720#UAA858" ;
   qudt:plainTextDescription "quotient of the 0.001-fold of the unit litre and the unit minute divided by the 0.0001-fold of the power of the SI base unit metre with the exponent 2" ;
+  qudt:symbol "mL/(cm²⋅min)" ;
   qudt:ucumCode "mL.cm-2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "35" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -15723,6 +16518,7 @@ unit:MilliL-PER-CentiM2-SEC
   qudt:hasQuantityKind quantitykind:VolumetricFlux ;
   qudt:iec61360Code "0112/2///62720#UAB085" ;
   qudt:plainTextDescription "unit of the volume flow rate millilitre divided by second related to the transfer area as 0.0001-fold of the power of the SI base unit metre by exponent 2" ;
+  qudt:symbol "mL/(cm²⋅s)" ;
   qudt:ucumCode "mL.cm-2.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "35" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -15736,6 +16532,7 @@ unit:MilliL-PER-DAY
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA847" ;
   qudt:plainTextDescription "0.001-fold of the unit litre divided by the unit day" ;
+  qudt:symbol "mL/day" ;
   qudt:ucumCode "mL.d-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G54" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -15749,6 +16546,7 @@ unit:MilliL-PER-HR
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA850" ;
   qudt:plainTextDescription "0.001-fold of the unit litre divided by the unit hour" ;
+  qudt:symbol "mL/hr" ;
   qudt:ucumCode "mL.h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G55" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -15762,6 +16560,7 @@ unit:MilliL-PER-K
   qudt:hasQuantityKind quantitykind:VolumeThermalExpansion ;
   qudt:iec61360Code "0112/2///62720#UAA845" ;
   qudt:plainTextDescription "0.001-fold of the unit litre divided by the SI base unit kelvin" ;
+  qudt:symbol "mL/K" ;
   qudt:ucumCode "mL.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G30" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -15775,6 +16574,7 @@ unit:MilliL-PER-KiloGM
   qudt:hasQuantityKind quantitykind:SpecificVolume ;
   qudt:iec61360Code "0112/2///62720#UAB095" ;
   qudt:plainTextDescription "0.001-fold of the unit of the volume litre divided by the SI base unit kilogram" ;
+  qudt:symbol "mL/kg" ;
   qudt:ucumCode "mL.kg-1"^^qudt:UCUMcs ;
   qudt:ucumCode "mL/kg"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "KX" ;
@@ -15789,6 +16589,7 @@ unit:MilliL-PER-L
   qudt:hasQuantityKind quantitykind:VolumeFraction ;
   qudt:iec61360Code "0112/2///62720#UAA853" ;
   qudt:plainTextDescription "volume ratio consisting of the 0.001-fold of the unit litre divided by the unit litre" ;
+  qudt:symbol "mL/L" ;
   qudt:ucumCode "mL.L-1"^^qudt:UCUMcs ;
   qudt:ucumCode "mL/L"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L19" ;
@@ -15800,6 +16601,7 @@ unit:MilliL-PER-M2-DAY
   a qudt:Unit ;
   qudt:conversionMultiplier 0.0000000000115740740740741 ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T-1D0 ;
+  qudt:symbol "mL/(m²⋅day)" ;
   qudt:ucumCode "mL.m-2.d-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Millilitres per square metre per day"@en ;
@@ -15811,6 +16613,7 @@ unit:MilliL-PER-M3
   qudt:hasQuantityKind quantitykind:VolumeFraction ;
   qudt:iec61360Code "0112/2///62720#UAA854" ;
   qudt:plainTextDescription "0.001-fold of the unit litre divided by the power of the SI base unit metre with the exponent 3" ;
+  qudt:symbol "mL/m³" ;
   qudt:ucumCode "mL.m-3"^^qudt:UCUMcs ;
   qudt:ucumCode "mL/m3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H65" ;
@@ -15825,6 +16628,7 @@ unit:MilliL-PER-MIN
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA855" ;
   qudt:plainTextDescription "0.001-fold of the unit litre divided by the unit minute" ;
+  qudt:symbol "mL/min" ;
   qudt:ucumCode "mL.min-1"^^qudt:UCUMcs ;
   qudt:ucumCode "mL/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "41" ;
@@ -15839,6 +16643,7 @@ unit:MilliL-PER-SEC
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA859" ;
   qudt:plainTextDescription "0.001-fold of the unit litre divided by the SI base unit second" ;
+  qudt:symbol "mL/s" ;
   qudt:ucumCode "mL.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "40" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -15858,7 +16663,7 @@ unit:MilliM
   qudt:informativeReference "http://en.wikipedia.org/wiki/Millimetre?oldid=493032457"^^xsd:anyURI ;
   qudt:isScalingOf unit:M ;
   qudt:prefix prefix:Milli ;
-  qudt:symbol "㎜" ;
+  qudt:symbol "mm" ;
   qudt:ucumCode "mm"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "MMT" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -15874,7 +16679,7 @@ unit:MilliM-PER-DAY
   qudt:hasQuantityKind quantitykind:Velocity ;
   qudt:informativeReference "https://www.wmo.int/pages/prog/www/IMOP/CIMO-Guide.html"^^xsd:anyURI ;
   qudt:plainTextDescription "A measure of change in depth over time for a specific area, typically used to express precipitation intensity or evaporation (the amount of liquid water evaporated per unit of time from the area)" ;
-  qudt:symbol "mm/d" ;
+  qudt:symbol "mm/day" ;
   qudt:ucumCode "mm.d-1"^^qudt:UCUMcs ;
   qudt:ucumCode "mm/d"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -15888,6 +16693,7 @@ unit:MilliM-PER-HR
   qudt:hasQuantityKind quantitykind:Velocity ;
   qudt:iec61360Code "0112/2///62720#UAA866" ;
   qudt:plainTextDescription "0001-fold of the SI base unit metre divided by the unit hour" ;
+  qudt:symbol "mm/hr" ;
   qudt:ucumCode "mm.h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "mm/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H67" ;
@@ -15902,6 +16708,7 @@ unit:MilliM-PER-K
   qudt:hasQuantityKind quantitykind:LinearThermalExpansion ;
   qudt:iec61360Code "0112/2///62720#UAA864" ;
   qudt:plainTextDescription "0.001-fold of the SI base unit metre divided by the SI base unit kelvin" ;
+  qudt:symbol "mm/K" ;
   qudt:ucumCode "mm.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F53" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -15915,6 +16722,7 @@ unit:MilliM-PER-MIN
   qudt:hasQuantityKind quantitykind:Velocity ;
   qudt:iec61360Code "0112/2///62720#UAB378" ;
   qudt:plainTextDescription "0.001-fold of the SI base unit metre divided by the unit minute" ;
+  qudt:symbol "mm/min" ;
   qudt:ucumCode "mm.min-1"^^qudt:UCUMcs ;
   qudt:ucumCode "mm/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H81" ;
@@ -15929,6 +16737,7 @@ unit:MilliM-PER-SEC
   qudt:hasQuantityKind quantitykind:Velocity ;
   qudt:iec61360Code "0112/2///62720#UAA867" ;
   qudt:plainTextDescription "0.001-fold of the SI base unit metre divided by the SI base unit second" ;
+  qudt:symbol "mm/s" ;
   qudt:ucumCode "mm.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C16" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -15942,6 +16751,7 @@ unit:MilliM-PER-YR
   qudt:hasQuantityKind quantitykind:Velocity ;
   qudt:iec61360Code "0112/2///62720#UAA868" ;
   qudt:plainTextDescription "0.001-fold of the SI base unit metre divided by the unit year" ;
+  qudt:symbol "mm/yr" ;
   qudt:ucumCode "mm.a-1"^^qudt:UCUMcs ;
   qudt:ucumCode "mm/a"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H66" ;
@@ -15958,7 +16768,7 @@ unit:MilliM2
   qudt:isScalingOf unit:M2 ;
   qudt:plainTextDescription "0.000001-fold of the power of the SI base unit metre with the exponent 2" ;
   qudt:prefix prefix:Milli ;
-  qudt:symbol "㎟" ;
+  qudt:symbol "mm²" ;
   qudt:ucumCode "mm2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "MMK" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -15972,6 +16782,7 @@ unit:MilliM2-PER-SEC
   qudt:hasQuantityKind quantitykind:AreaPerTime ;
   qudt:iec61360Code "0112/2///62720#UAA872" ;
   qudt:plainTextDescription "0.000001-fold of the power of the SI base unit metre with the exponent 2 divided by the SI base unit second" ;
+  qudt:symbol "mm²/s" ;
   qudt:ucumCode "mm2.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C17" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -15990,6 +16801,7 @@ unit:MilliM3
   qudt:iec61360Code "0112/2///62720#UAA873" ;
   qudt:isScalingOf unit:M3 ;
   qudt:prefix prefix:Milli ;
+  qudt:symbol "mm³" ;
   qudt:ucumCode "mm3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "MMQ" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -16003,6 +16815,7 @@ unit:MilliM3-PER-M3
   qudt:hasQuantityKind quantitykind:VolumeFraction ;
   qudt:iec61360Code "0112/2///62720#UAA874" ;
   qudt:plainTextDescription "volume ratio consisting of the 0.000000001-fold of the power of the SI base unit metre with the exponent 3 divided by the power of the SI base unit metre with the exponent 3" ;
+  qudt:symbol "mm³/m³" ;
   qudt:ucumCode "mm3.m-3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L21" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -16019,6 +16832,7 @@ unit:MilliM4
   qudt:isScalingOf unit:M4 ;
   qudt:plainTextDescription "0.001-fold of the power of the SI base unit metre with the exponent 4" ;
   qudt:prefix prefix:Milli ;
+  qudt:symbol "mm⁴" ;
   qudt:ucumCode "mm4"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G77" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -16034,6 +16848,7 @@ unit:MilliMOL
   qudt:isScalingOf unit:MOL ;
   qudt:plainTextDescription "0.001-fold of the SI base unit mol" ;
   qudt:prefix prefix:Milli ;
+  qudt:symbol "mmol" ;
   qudt:ucumCode "mmol"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C18" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -16047,6 +16862,7 @@ unit:MilliMOL-PER-GM
   qudt:hasQuantityKind quantitykind:IonicStrength ;
   qudt:iec61360Code "0112/2///62720#UAA878" ;
   qudt:plainTextDescription "0.001-fold of the SI base unit mol divided by the 0.001-fold of the SI base unit kilogram" ;
+  qudt:symbol "mmol/g" ;
   qudt:ucumCode "mmol.g-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H68" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -16060,6 +16876,7 @@ unit:MilliMOL-PER-KiloGM
   qudt:hasQuantityKind quantitykind:IonicStrength ;
   qudt:iec61360Code "0112/2///62720#UAA879" ;
   qudt:plainTextDescription "0.001-fold of the SI base unit mol divided by the SI base unit kilogram" ;
+  qudt:symbol "mmol/kg" ;
   qudt:ucumCode "mmol.kg-1"^^qudt:UCUMcs ;
   qudt:ucumCode "mmol/kg"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D87" ;
@@ -16076,6 +16893,7 @@ unit:MilliMOL-PER-L
   qudt:hasQuantityKind quantitykind:AmountOfSubstancePerUnitVolume ;
   qudt:hasQuantityKind quantitykind:BloodGlucoseLevel ;
   qudt:hasQuantityKind quantitykind:Solubility_Water ;
+  qudt:symbol "mmo/L" ;
   qudt:ucumCode "mmol.L-1"^^qudt:UCUMcs ;
   qudt:ucumCode "mmol/L"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M33" ;
@@ -16088,6 +16906,7 @@ unit:MilliMOL-PER-M2
   dcterms:description "Unavailable."@en ;
   qudt:conversionMultiplier 0.001 ;
   qudt:hasDimensionVector qkdv:A1E0L-2I0M0H0T0D0 ;
+  qudt:symbol "mmol/m²" ;
   qudt:ucumCode "mmol.m-2"^^qudt:UCUMcs ;
   qudt:udunitsCode "DU" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -16097,6 +16916,7 @@ unit:MilliMOL-PER-M2-DAY
   a qudt:Unit ;
   qudt:conversionMultiplier 0.0000000115740740740741 ;
   qudt:hasDimensionVector qkdv:A1E0L-2I0M0H0T-1D0 ;
+  qudt:symbol "mmol/(m²⋅day)" ;
   qudt:ucumCode "mmol.m-2.d-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Millimoles per square metre per day"@en ;
@@ -16105,6 +16925,7 @@ unit:MilliMOL-PER-M2-SEC
   a qudt:Unit ;
   qudt:conversionMultiplier 0.001 ;
   qudt:hasDimensionVector qkdv:A1E0L-2I0M0H0T-1D0 ;
+  qudt:symbol "µg/(m²⋅s)" ;
   qudt:ucumCode "mmol.m-2.s-1"^^qudt:UCUMcs ;
   qudt:ucumCode "mmol/m2/s1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -16117,6 +16938,7 @@ unit:MilliMOL-PER-M3
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:AmountOfSubstancePerUnitVolume ;
   qudt:hasQuantityKind quantitykind:Solubility_Water ;
+  qudt:symbol "mmol/m³" ;
   qudt:ucumCode "mmol.m-3"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Millimoles per cubic metre"@en ;
@@ -16126,6 +16948,7 @@ unit:MilliMOL-PER-M3-DAY
   dcterms:description "Unavailable."@en ;
   qudt:conversionMultiplier 0.0000000115740740740741 ;
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T-1D0 ;
+  qudt:symbol "mmol/(m³⋅day)" ;
   qudt:ucumCode "mmol.m-3.d-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Millimoles per cubic metre per day"@en ;
@@ -16136,6 +16959,7 @@ unit:MilliMOL-PER-MOL
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:qkdvDenominator qkdv:A1E0L0I0M0H0T0D0 ;
   qudt:qkdvNumerator qkdv:A1E0L0I0M0H0T0D0 ;
+  qudt:symbol "mmol/mol" ;
   qudt:ucumCode "mmol.mol-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Millimoles per mole"@en ;
@@ -16148,6 +16972,7 @@ unit:MilliM_H2O
   qudt:hasQuantityKind quantitykind:VaporPressure ;
   qudt:iec61360Code "0112/2///62720#UAA875" ;
   qudt:plainTextDescription "unit of pressure - 1 mmH2O is the static pressure exerted by a water column with a height of 1 mm" ;
+  qudt:symbol "mmH₂0" ;
   qudt:ucumCode "mm[H2O]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "HP" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -16163,7 +16988,7 @@ unit:MilliM_HG
   qudt:hasQuantityKind quantitykind:ForcePerArea ;
   qudt:hasQuantityKind quantitykind:VaporPressure ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Torr?oldid=495199381"^^xsd:anyURI ;
-  qudt:symbol "mm Hg" ;
+  qudt:symbol "mmHg" ;
   qudt:ucumCode "mm[Hg]"^^qudt:UCUMcs ;
   qudt:udunitsCode "mmHg" ;
   qudt:udunitsCode "mm_Hg" ;
@@ -16197,6 +17022,7 @@ unit:MilliN
   qudt:isScalingOf unit:N ;
   qudt:plainTextDescription "0.001-fold of the SI derived unit newton" ;
   qudt:prefix prefix:Milli ;
+  qudt:symbol "mN" ;
   qudt:ucumCode "mN"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C20" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -16209,6 +17035,7 @@ unit:MilliN-M
   qudt:hasQuantityKind quantitykind:Torque ;
   qudt:iec61360Code "0112/2///62720#UAA794" ;
   qudt:plainTextDescription "0.001-fold of the product of the SI derived unit newton and the SI base unit metre" ;
+  qudt:symbol "mN⋅m" ;
   qudt:ucumCode "mN.m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D83" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -16222,6 +17049,7 @@ unit:MilliN-PER-M
   qudt:hasQuantityKind quantitykind:ForcePerLength ;
   qudt:iec61360Code "0112/2///62720#UAA795" ;
   qudt:plainTextDescription "0.001-fold of the SI derived unit newton divided by the SI base unit metre" ;
+  qudt:symbol "mN/m" ;
   qudt:ucumCode "mN.m-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C22" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -16237,6 +17065,7 @@ unit:MilliOHM
   qudt:isScalingOf unit:OHM ;
   qudt:plainTextDescription "0.001-fold of the SI derived unit ohm" ;
   qudt:prefix prefix:Milli ;
+  qudt:symbol "mΩ" ;
   qudt:ucumCode "mOhm"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E45" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -16252,6 +17081,7 @@ unit:MilliPA
   qudt:isScalingOf unit:PA ;
   qudt:plainTextDescription "0.001-fold of the SI derived unit pascal" ;
   qudt:prefix prefix:Milli ;
+  qudt:symbol "mPa" ;
   qudt:ucumCode "mPa"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "74" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -16264,6 +17094,7 @@ unit:MilliPA-SEC
   qudt:hasQuantityKind quantitykind:DynamicViscosity ;
   qudt:iec61360Code "0112/2///62720#UAA797" ;
   qudt:plainTextDescription "0.001-fold of the product of the SI derived unit pascal and the SI base unit second" ;
+  qudt:symbol "mPa⋅s" ;
   qudt:ucumCode "mPa.s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C24" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -16276,6 +17107,7 @@ unit:MilliPA-SEC-PER-BAR
   qudt:hasQuantityKind quantitykind:Time ;
   qudt:iec61360Code "0112/2///62720#UAA799" ;
   qudt:plainTextDescription "0.001-fold of the product of the SI derived unit pascal and the SI base unit second divided by the unit of the pressure bar" ;
+  qudt:symbol "mPa⋅s/bar" ;
   qudt:ucumCode "mPa.s.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L16" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -16290,6 +17122,7 @@ unit:MilliR
   qudt:iec61360Code "0112/2///62720#UAB056" ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Roentgen_(unit)"^^xsd:anyURI ;
   qudt:plainTextDescription "0.001-fold of the unit roentgen." ;
+  qudt:symbol "mR" ;
   qudt:ucumCode "mR"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "2Y" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -16316,6 +17149,7 @@ unit:MilliRAD_R-PER-HR
   dcterms:description "One thousandth part of an absorbed ionizing radiation dose equal to 100 ergs per gram of irradiated material received per hour."@en ;
   qudt:conversionMultiplier 0.000000277777777777778 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-3D0 ;
+  qudt:symbol "mrad/hr" ;
   qudt:ucumCode "mRAD.h-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Millirads per hour"@en ;
@@ -16329,6 +17163,7 @@ unit:MilliR_man
   qudt:iec61360Code "0112/2///62720#UAB056" ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Roentgen_equivalent_man"^^xsd:anyURI ;
   qudt:plainTextDescription "The roentgen equivalent man (or rem) is a CGS unit of equivalent dose, effective dose, and committed dose, which are measures of the health effect of low levels of ionizing radiation on the human body." ;
+  qudt:symbol "mrem" ;
   qudt:ucumCode "mREM"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L31" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -16343,6 +17178,7 @@ unit:MilliS
   qudt:isScalingOf unit:S ;
   qudt:plainTextDescription "0.001-fold of the SI derived unit siemens" ;
   qudt:prefix prefix:Milli ;
+  qudt:symbol "mS" ;
   qudt:ucumCode "mS"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C27" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -16355,6 +17191,7 @@ unit:MilliS-PER-CentiM
   qudt:hasQuantityKind quantitykind:Conductivity ;
   qudt:iec61360Code "0112/2///62720#UAA801" ;
   qudt:plainTextDescription "0.001-fold of the SI derived unit Siemens divided by the 0.01-fold of the SI base unit metre" ;
+  qudt:symbol "mS/cm" ;
   qudt:ucumCode "mS.cm-1"^^qudt:UCUMcs ;
   qudt:ucumCode "mS/cm"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H61" ;
@@ -16367,6 +17204,7 @@ unit:MilliS-PER-M
   qudt:conversionMultiplier 0.001 ;
   qudt:hasDimensionVector qkdv:A0E2L-3I0M-1H0T3D0 ;
   qudt:hasQuantityKind quantitykind:Conductivity ;
+  qudt:symbol "mS/m" ;
   qudt:ucumCode "mS.m-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "MilliSiemens per metre"@en ;
@@ -16401,6 +17239,7 @@ unit:MilliSV
   qudt:isScalingOf unit:SV ;
   qudt:plainTextDescription "0.001-fold of the SI derived unit sievert" ;
   qudt:prefix prefix:Milli ;
+  qudt:symbol "mSv" ;
   qudt:ucumCode "mSv"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C28" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -16415,6 +17254,7 @@ unit:MilliT
   qudt:isScalingOf unit:T ;
   qudt:plainTextDescription "0.001-fold of the SI derived unit tesla" ;
   qudt:prefix prefix:Milli ;
+  qudt:symbol "mT" ;
   qudt:ucumCode "mT"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C29" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -16440,6 +17280,7 @@ unit:MilliV
   qudt:isScalingOf unit:V ;
   qudt:plainTextDescription "0,001-fold of the SI derived unit volt" ;
   qudt:prefix prefix:Milli ;
+  qudt:symbol "mV" ;
   qudt:ucumCode "mV"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "2Z" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -16452,6 +17293,7 @@ unit:MilliV-PER-M
   qudt:hasQuantityKind quantitykind:ElectricFieldStrength ;
   qudt:iec61360Code "0112/2///62720#UAA805" ;
   qudt:plainTextDescription "0.000001-fold of the SI derived unit volt divided by the SI base unit metre" ;
+  qudt:symbol "mV/m" ;
   qudt:ucumCode "mV.m-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C30" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -16465,6 +17307,7 @@ unit:MilliV-PER-MIN
   qudt:hasQuantityKind quantitykind:PowerPerElectricCharge ;
   qudt:iec61360Code "0112/2///62720#UAA806" ;
   qudt:plainTextDescription "0.001-fold of the SI derived unit volt divided by the unit minute" ;
+  qudt:symbol "mV/min" ;
   qudt:ucumCode "mV.min-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H62" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -16477,6 +17320,7 @@ unit:MilliW
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:isScalingOf unit:W ;
   qudt:prefix prefix:Milli ;
+  qudt:symbol "mW" ;
   qudt:ucumCode "mW"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "MilliW"@en ;
@@ -16485,6 +17329,7 @@ unit:MilliW-PER-CentiM2-MicroM-SR
   a qudt:Unit ;
   qudt:conversionMultiplier 10000000.0 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-3D0 ;
+  qudt:symbol "mW/(cm⋅µm⋅sr)" ;
   qudt:ucumCode "mW.cm-2.um-1.sr-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Milliwatts per square centimetre per micrometre per steradian"@en ;
@@ -16496,6 +17341,7 @@ unit:MilliW-PER-M2
   qudt:hasQuantityKind quantitykind:PowerPerArea ;
   qudt:iec61360Code "0112/2///62720#UAA808" ;
   qudt:plainTextDescription "0.001-fold of the SI derived unit weber divided by the power of the SI base unit metre with the exponent 2" ;
+  qudt:symbol "mW/m²" ;
   qudt:ucumCode "mW.m-2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C32" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -16506,6 +17352,7 @@ unit:MilliW-PER-M2-NanoM
   a qudt:Unit ;
   qudt:conversionMultiplier 1000000.0 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-3D0 ;
+  qudt:symbol "mW/(cm⋅nm)" ;
   qudt:ucumCode "mW.m-2.nm-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Milliwatts per square metre per nanometre"@en ;
@@ -16514,6 +17361,7 @@ unit:MilliW-PER-M2-NanoM-SR
   a qudt:Unit ;
   qudt:conversionMultiplier 1000000.0 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-3D0 ;
+  qudt:symbol "mW/(cm⋅nm⋅sr)" ;
   qudt:ucumCode "mW.m-2.nm-1.sr-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Milliwatts per square metre per nanometre per steradian"@en ;
@@ -16527,6 +17375,7 @@ unit:MilliWB
   qudt:isScalingOf unit:WB ;
   qudt:plainTextDescription "0.001-fold of the SI derived unit weber" ;
   qudt:prefix prefix:Milli ;
+  qudt:symbol "mWb" ;
   qudt:ucumCode "mWb"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C33" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -16601,6 +17450,7 @@ unit:N-CentiM
   qudt:hasQuantityKind quantitykind:Torque ;
   qudt:iec61360Code "0112/2///62720#UAA237" ;
   qudt:plainTextDescription "product of the SI derived unit newton and the 0.01-fold of the SI base unit metre" ;
+  qudt:symbol "N⋅cm" ;
   qudt:ucumCode "N.cm"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F88" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -16622,7 +17472,7 @@ unit:N-M
   qudt:iec61360Code "0112/2///62720#UAA239" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Newton_metre?oldid=493923333"^^xsd:anyURI ;
   qudt:siUnitsExpression "N.m" ;
-  qudt:symbol "N m" ;
+  qudt:symbol "N⋅m" ;
   qudt:ucumCode "N.m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "NU" ;
   qudt:unitOfSystem sou:SI ;
@@ -16638,6 +17488,7 @@ unit:N-M-PER-A
   qudt:hasQuantityKind quantitykind:MagneticFlux ;
   qudt:iec61360Code "0112/2///62720#UAA241" ;
   qudt:plainTextDescription "product of the SI derived unit newton and the SI base unit metre divided by the SI base unit ampere" ;
+  qudt:symbol "N⋅m/A" ;
   qudt:ucumCode "N.m.A-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F90" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -16651,6 +17502,7 @@ unit:N-M-PER-KiloGM
   qudt:hasQuantityKind quantitykind:SpecificEnergy ;
   qudt:iec61360Code "0112/2///62720#UAB490" ;
   qudt:plainTextDescription "product of the derived SI unit newton and the SI base unit metre divided by the SI base unit kilogram" ;
+  qudt:symbol "N⋅m/kg" ;
   qudt:ucumCode "N.m.kg-1"^^qudt:UCUMcs ;
   qudt:udunitsCode "gp" ;
   qudt:uneceCommonCode "G19" ;
@@ -16665,6 +17517,7 @@ unit:N-M-PER-M
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:TorquePerLength ;
   qudt:plainTextDescription "This is the SI unit for the rolling resistance, which is equivalent to drag force in newton" ;
+  qudt:symbol "N⋅m/m" ;
   qudt:uneceCommonCode "Q27" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Newton meter per meter"@en-us ;
@@ -16679,6 +17532,7 @@ unit:N-M-PER-M2
   qudt:hasQuantityKind quantitykind:ForcePerLength ;
   qudt:iec61360Code "0112/2///62720#UAA244" ;
   qudt:plainTextDescription "product of the SI derived unit newton and the SI base unit metre divided by the power of the SI base unit metre with the exponent 2" ;
+  qudt:symbol "N⋅m/m²" ;
   qudt:ucumCode "N.m.m-2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H86" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -16692,6 +17546,7 @@ unit:N-M-PER-RAD
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:TorquePerAngle ;
   qudt:plainTextDescription "Newton Meter per Radian is the SI unit for Torsion Constant" ;
+  qudt:symbol "N⋅m/rad" ;
   qudt:uneceCommonCode "M93" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Newton meter per radian"@en-us ;
@@ -16711,7 +17566,7 @@ unit:N-M-SEC
   qudt:informativeReference "http://en.wikipedia.org/wiki/SI_derived_unit"^^xsd:anyURI ;
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31889"^^xsd:anyURI ;
   qudt:siUnitsExpression "N.m.sec" ;
-  qudt:symbol "N-m-sec" ;
+  qudt:symbol "N⋅m⋅s" ;
   qudt:ucumCode "N.m.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C53" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -16725,6 +17580,7 @@ unit:N-M-SEC-PER-M
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:LinearMomentum ;
   qudt:plainTextDescription "Newton metre seconds measured per metre" ;
+  qudt:symbol "N⋅m⋅s/m" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Newton meter seconds per meter"@en-us ;
   rdfs:label "Newton metre seconds per metre"@en ;
@@ -16737,6 +17593,7 @@ unit:N-M-SEC-PER-RAD
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:AngularMomentumPerAngle ;
   qudt:plainTextDescription "Newton metre seconds measured per radian" ;
+  qudt:symbol "N⋅m⋅s/rad" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Newton meter seconds per radian"@en-us ;
   rdfs:label "Newton metre seconds per radian"@en ;
@@ -16749,6 +17606,7 @@ unit:N-M2-PER-A
   qudt:exactMatch unit:WB-M ;
   qudt:hasDimensionVector qkdv:A0E-1L3I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:MagneticDipoleMoment ;
+  qudt:symbol "N⋅m²/A" ;
   qudt:ucumCode "N.m2.A-1"^^qudt:UCUMcs ;
   qudt:ucumCode "N.m2/A"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P49" ;
@@ -16763,6 +17621,7 @@ unit:N-M2-PER-KiloGM2
   qudt:hasDimensionVector qkdv:A0E0L3I0M-1H0T-2D0 ;
   qudt:iec61360Code "0112/2///62720#UAB491" ;
   qudt:plainTextDescription "unit of gravitational constant as product of the derived SI unit newton, the power of the SI base unit metre with the exponent 2 divided by the power of the SI base unit kilogram with the exponent 2" ;
+  qudt:symbol "N⋅m²/kg²" ;
   qudt:ucumCode "N.m.kg-2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C54" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -16776,6 +17635,7 @@ unit:N-PER-A
   qudt:hasQuantityKind quantitykind:MagneticFluxPerUnitLength ;
   qudt:iec61360Code "0112/2///62720#UAA236" ;
   qudt:plainTextDescription "SI derived unit newton divided by the SI base unit ampere" ;
+  qudt:symbol "N/A" ;
   qudt:ucumCode "N.A-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H40" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -16791,6 +17651,7 @@ unit:N-PER-C
   qudt:expression "\\(N/C\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E-1L1I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerElectricCharge ;
+  qudt:symbol "N/C" ;
   qudt:ucumCode "N.C-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Newton per Coulomb"@en ;
@@ -16802,6 +17663,7 @@ unit:N-PER-CentiM
   qudt:hasQuantityKind quantitykind:ForcePerLength ;
   qudt:iec61360Code "0112/2///62720#UAA238" ;
   qudt:plainTextDescription "SI derived unit newton divided by the 0.01-fold of the SI base unit metre" ;
+  qudt:symbol "N/cm" ;
   qudt:ucumCode "N.cm-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M23" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -16816,6 +17678,7 @@ unit:N-PER-CentiM2
   qudt:hasQuantityKind quantitykind:VaporPressure ;
   qudt:iec61360Code "0112/2///62720#UAB183" ;
   qudt:plainTextDescription "derived SI unit newton divided by the 0.0001-fold of the power of the SI base unit metre by exponent 2" ;
+  qudt:symbol "N/cm²" ;
   qudt:ucumCode "N.cm-2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E01" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -16832,6 +17695,7 @@ unit:N-PER-KiloGM
   qudt:expression "\\(N/kg\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ThrustToMassRatio ;
+  qudt:symbol "N/kg" ;
   qudt:ucumCode "N.kg-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Newton per Kilogram"@en ;
@@ -16847,6 +17711,7 @@ unit:N-PER-M
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerLength ;
   qudt:iec61360Code "0112/2///62720#UAA246" ;
+  qudt:symbol "N/m" ;
   qudt:ucumCode "N.m-1"^^qudt:UCUMcs ;
   qudt:ucumCode "N/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "4P" ;
@@ -16881,6 +17746,7 @@ unit:N-PER-M3
   a qudt:Unit ;
   qudt:conversionMultiplier 1.0 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M1H0T-2D0 ;
+  qudt:symbol "N/m³" ;
   qudt:ucumCode "N.m-3"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Newtons per cubic metre"@en ;
@@ -16892,6 +17758,7 @@ unit:N-PER-MilliM
   qudt:hasQuantityKind quantitykind:ForcePerLength ;
   qudt:iec61360Code "0112/2///62720#UAA249" ;
   qudt:plainTextDescription "SI derived unit newton divided by the 0.001-fold of the SI base unit metre" ;
+  qudt:symbol "N/mm" ;
   qudt:ucumCode "N.mm-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F47" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -16906,6 +17773,7 @@ unit:N-PER-MilliM2
   qudt:hasQuantityKind quantitykind:VaporPressure ;
   qudt:iec61360Code "0112/2///62720#UAA250" ;
   qudt:plainTextDescription "SI derived unit newton divided by the 0.000001-fold of the power of the SI base unit metre with the exponent 2" ;
+  qudt:symbol "N/mm²" ;
   qudt:ucumCode "N.mm-2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C56" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -16919,6 +17787,7 @@ unit:N-PER-RAD
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerAngle ;
   qudt:plainTextDescription "A one-newton force applied for one angle/torsional torque" ;
+  qudt:symbol "N/rad" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Newton per radian"@en ;
   rdfs:label "Newton per radian"@en-us ;
@@ -16931,6 +17800,7 @@ unit:N-SEC
   qudt:hasQuantityKind quantitykind:LinearMomentum ;
   qudt:iec61360Code "0112/2///62720#UAA251" ;
   qudt:plainTextDescription "product of the SI derived unit newton and the SI base unit second" ;
+  qudt:symbol "N⋅s" ;
   qudt:ucumCode "N.s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C57" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -16946,6 +17816,7 @@ unit:N-SEC-PER-M
   qudt:hasQuantityKind quantitykind:MassPerTime ;
   qudt:iec61360Code "0112/2///62720#UAA252" ;
   qudt:plainTextDescription "Newton second measured per metre" ;
+  qudt:symbol "N⋅s/m" ;
   qudt:ucumCode "N.s.m-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C58" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -16963,6 +17834,7 @@ unit:N-SEC-PER-M3
   qudt:hasDimensionVector qkdv:A0E0L-2I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:SpecificAcousticImpedance ;
   qudt:latexSymbol "\\(N \\cdot s \\cdot m^{-3}\\)"^^qudt:LatexString ;
+  qudt:symbol "N⋅s/m³" ;
   qudt:ucumCode "N.s.m-3"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Newton second per Cubic Meter"@en-us ;
@@ -16975,6 +17847,7 @@ unit:N-SEC-PER-RAD
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:MomentumPerAngle ;
   qudt:plainTextDescription "Newton seconds measured per radian" ;
+  qudt:symbol "N⋅s/rad" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Newton seconds per radian"@en ;
   rdfs:label "Newton seconds per radian"@en-us ;
@@ -17001,6 +17874,7 @@ unit:NAT-PER-SEC
   qudt:hasQuantityKind quantitykind:InformationEntropy ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Nat?oldid=474010287"^^xsd:anyURI ;
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31898"^^xsd:anyURI ;
+  qudt:symbol "nat/s" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Nat per Second"@en ;
 .
@@ -17066,6 +17940,7 @@ unit:NUM-PER-CentiM-KiloYR
   a qudt:Unit ;
   qudt:conversionMultiplier 0.000000316880878140289 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T-1D0 ;
+  qudt:symbol "/(cm⋅1000 yr)" ;
   qudt:ucumCode "{#}.cm-2.ka-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Number per square centimetre per thousand years"@en ;
@@ -17074,6 +17949,7 @@ unit:NUM-PER-GM
   a qudt:Unit ;
   qudt:conversionMultiplier 1000.0 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M-1H0T0D0 ;
+  qudt:symbol "/g" ;
   qudt:ucumCode "{#}.g-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Number per gram"@en ;
@@ -17084,6 +17960,7 @@ unit:NUM-PER-HA
   qudt:conversionMultiplier 1000000.0 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:ParticleFluence ;
+  qudt:symbol "/ha" ;
   qudt:ucumCode "{#}.har-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Number per hectare"@en ;
@@ -17093,6 +17970,7 @@ unit:NUM-PER-HR
   qudt:conversionMultiplier 0.000277777777777778 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Frequency ;
+  qudt:symbol "/hr" ;
   qudt:ucumCode "{#}.h-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Number per hour"@en ;
@@ -17103,6 +17981,7 @@ unit:NUM-PER-HectoGM
   dcterms:description "Count of an entity or phenomenon occurrence in one 10th of the SI unit of mass (kilogram)."@en ;
   qudt:conversionMultiplier 10.0 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M-1H0T0D0 ;
+  qudt:symbol "/hg" ;
   qudt:ucumCode "{#}.hg-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Number per 100 grams"@en ;
@@ -17112,6 +17991,7 @@ unit:NUM-PER-KiloM2
   qudt:conversionMultiplier 0.000001 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:ParticleFluence ;
+  qudt:symbol "/km²" ;
   qudt:ucumCode "{#}.km-2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Number per square kilometre"@en ;
@@ -17121,6 +18001,7 @@ unit:NUM-PER-L
   qudt:conversionMultiplier 1000.0 ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:NumberDensity ;
+  qudt:symbol "/L" ;
   qudt:ucumCode "{#}.L-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Number per litre"@en ;
@@ -17130,6 +18011,7 @@ unit:NUM-PER-M
   dcterms:description "Unavailable."@en ;
   qudt:conversionMultiplier 1.0 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T0D0 ;
+  qudt:symbol "/m" ;
   qudt:ucumCode "{#}.m-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Number per metre"@en ;
@@ -17139,6 +18021,7 @@ unit:NUM-PER-M2
   qudt:conversionMultiplier 1.0 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:ParticleFluence ;
+  qudt:symbol "/m²" ;
   qudt:ucumCode "{#}.m-2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Number per square metre"@en ;
@@ -17148,6 +18031,7 @@ unit:NUM-PER-M2-DAY
   qudt:conversionMultiplier 0.0000115740740740741 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Flux ;
+  qudt:symbol "/(m²⋅day)" ;
   qudt:ucumCode "{#}.m-2.d-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Number per square metre per day"@en ;
@@ -17157,6 +18041,7 @@ unit:NUM-PER-M3
   qudt:conversionMultiplier 1.0 ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:NumberDensity ;
+  qudt:symbol "/m³" ;
   qudt:ucumCode "{#}.m-3"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Number per cubic metre"@en ;
@@ -17166,6 +18051,7 @@ unit:NUM-PER-MicroL
   qudt:conversionMultiplier 1000000000.0 ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:NumberDensity ;
+  qudt:symbol "/µL" ;
   qudt:ucumCode "{#}.uL-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Number per microlitre"@en ;
@@ -17175,6 +18061,7 @@ unit:NUM-PER-MilliGM
   dcterms:description "Count of an entity or phenomenon occurrence in one millionth of the SI unit of mass (kilogram)."@en ;
   qudt:conversionMultiplier 1000000.0 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M-1H0T0D0 ;
+  qudt:symbol "/mg" ;
   qudt:ucumCode "{#}.mg-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Number per milligram"@en ;
@@ -17184,6 +18071,7 @@ unit:NUM-PER-NanoL
   qudt:conversionMultiplier 2147483647.0 ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:NumberDensity ;
+  qudt:symbol "/nL" ;
   qudt:ucumCode "{#}.nL-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Number per nanolitre"@en ;
@@ -17193,6 +18081,7 @@ unit:NUM-PER-SEC
   qudt:conversionMultiplier 1.0 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Frequency ;
+  qudt:symbol "/s" ;
   qudt:ucumCode "{#}.s-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Counts per second"@en ;
@@ -17204,6 +18093,7 @@ unit:NUM-PER-YR
   qudt:expression "\\(\\#/yr\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Frequency ;
+  qudt:symbol "#/yr" ;
   qudt:ucumCode "{#}.a-1"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:CGS ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -17267,6 +18157,7 @@ unit:NanoBQ-PER-L
   qudt:conversionMultiplier 0.000001 ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:ActivityConcentration ;
+  qudt:symbol "nBq/L" ;
   qudt:ucumCode "nBq.L-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Nanobecquerels per litre"@en ;
@@ -17316,6 +18207,7 @@ unit:NanoFARAD-PER-M
   qudt:hasQuantityKind quantitykind:Permittivity ;
   qudt:iec61360Code "0112/2///62720#UAA904" ;
   qudt:plainTextDescription "0.000000001-fold of the SI derived unit farad divided by the SI base unit metre" ;
+  qudt:symbol "nF/m" ;
   qudt:ucumCode "nF.m-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C42" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -17330,6 +18222,7 @@ unit:NanoGM
   qudt:hasQuantityKind quantitykind:Mass ;
   qudt:isScalingOf unit:KiloGM ;
   qudt:prefix prefix:Nano ;
+  qudt:symbol "ng" ;
   qudt:ucumCode "ng"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Nanograms"@en ;
@@ -17339,6 +18232,7 @@ unit:NanoGM-PER-DAY
   qudt:conversionMultiplier 0.0000000000000000115740740740741 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:MassPerTime ;
+  qudt:symbol "ng/day" ;
   qudt:ucumCode "ng.d-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Nanograms per day"@en ;
@@ -17352,6 +18246,7 @@ unit:NanoGM-PER-KiloGM
   qudt:plainTextDescription "mass ratio consisting of the 0.000000000001-fold of the SI base unit kilogram divided by the SI base unit kilogram" ;
   qudt:qkdvDenominator qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:qkdvNumerator qkdv:A0E0L0I0M1H0T0D0 ;
+  qudt:symbol "ng/Kg" ;
   qudt:ucumCode "ng.kg-1"^^qudt:UCUMcs ;
   qudt:ucumCode "ng/kg"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L32" ;
@@ -17363,6 +18258,7 @@ unit:NanoGM-PER-L
   qudt:conversionMultiplier 0.000000001 ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:MassDensity ;
+  qudt:symbol "ng/L" ;
   qudt:ucumCode "ng.L-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Nanograms per litre"@en ;
@@ -17374,6 +18270,7 @@ unit:NanoGM-PER-M3
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:MassDensity ;
   qudt:plainTextDescription "0.000000000001‬-fold of the SI base unit kilogram divided by the power of the SI base unit metre with the exponent 3" ;
+  qudt:symbol "ng/m³" ;
   qudt:ucumCode "ng.m-3"^^qudt:UCUMcs ;
   rdfs:comment "\"Derived from GM-PER-M3 which exists in QUDT\"" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -17385,6 +18282,7 @@ unit:NanoGM-PER-MicroL
   qudt:conversionMultiplier 0.001 ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:MassDensity ;
+  qudt:symbol "ng/µL" ;
   qudt:ucumCode "ng.uL-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Nanograms per microlitre"@en ;
@@ -17396,6 +18294,7 @@ unit:NanoGM-PER-MilliL
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:MassConcentration ;
   qudt:hasQuantityKind quantitykind:MassDensity ;
+  qudt:symbol "ng/mL" ;
   qudt:ucumCode "ng.mL-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Nanograms per millilitre"@en ;
@@ -17410,6 +18309,7 @@ unit:NanoH
   qudt:isScalingOf unit:H ;
   qudt:plainTextDescription "0.000000001-fold of the SI derived unit henry" ;
   qudt:prefix prefix:Nano ;
+  qudt:symbol "nH" ;
   qudt:ucumCode "nH"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C43" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -17422,6 +18322,7 @@ unit:NanoH-PER-M
   qudt:hasQuantityKind quantitykind:Permeability ;
   qudt:iec61360Code "0112/2///62720#UAA906" ;
   qudt:plainTextDescription "0.000000001-fold of the SI derived unit henry divided by the SI base unit metre" ;
+  qudt:symbol "nH/m" ;
   qudt:ucumCode "nH.m-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C44" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -17434,6 +18335,7 @@ unit:NanoL
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Volume ;
   qudt:plainTextDescription "0.000000001-fold of the unit litre" ;
+  qudt:symbol "nL" ;
   qudt:ucumCode "nL"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "Q34" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -17449,7 +18351,7 @@ unit:NanoM
   qudt:isScalingOf unit:M ;
   qudt:plainTextDescription "0.000000001-fold of the SI base unit metre" ;
   qudt:prefix prefix:Nano ;
-  qudt:symbol "㎚" ;
+  qudt:symbol "nM" ;
   qudt:ucumCode "nm"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C45" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -17466,6 +18368,7 @@ unit:NanoM2
   qudt:isScalingOf unit:M2 ;
   qudt:plainTextDescription "A unit of area equal to that of a square, of sides 1nm" ;
   qudt:prefix prefix:Nano ;
+  qudt:symbol "nm²" ;
   qudt:ucumCode "nm2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Square Nanometer"@en-us ;
@@ -17475,6 +18378,7 @@ unit:NanoMOL-PER-CentiM3-HR
   a qudt:Unit ;
   qudt:conversionMultiplier 0.000000277777777777778 ;
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T-1D0 ;
+  qudt:symbol "nmol/(cm³⋅hr)" ;
   qudt:ucumCode "nmol.cm-3.h-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Nanomoles per cubic centimetre per hour"@en ;
@@ -17492,6 +18396,7 @@ unit:NanoMOL-PER-KiloGM
   qudt:conversionMultiplier 0.000000001 ;
   qudt:hasDimensionVector qkdv:A1E0L0I0M-1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:AmountOfSubstancePerUnitMass ;
+  qudt:symbol "nmol/kg" ;
   qudt:ucumCode "nmol.kg-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Nanomoles per kilogram"@en ;
@@ -17511,6 +18416,7 @@ unit:NanoMOL-PER-L-DAY
   a qudt:Unit ;
   qudt:conversionMultiplier 0.0000000000115740740740741 ;
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T-1D0 ;
+  qudt:symbol "nmol/(L⋅day)" ;
   qudt:ucumCode "nmol.L-1.d-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Nanomoles per litre per day"@en ;
@@ -17519,6 +18425,7 @@ unit:NanoMOL-PER-L-HR
   a qudt:Unit ;
   qudt:conversionMultiplier 0.000000000277777777777778 ;
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T-1D0 ;
+  qudt:symbol "nmol/(L⋅hr)" ;
   qudt:ucumCode "nmol.L-1.h-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Nanomoles per litre per hour"@en ;
@@ -17527,6 +18434,7 @@ unit:NanoMOL-PER-M2-DAY
   a qudt:Unit ;
   qudt:conversionMultiplier 0.0000000000000115740740740741 ;
   qudt:hasDimensionVector qkdv:A1E0L-2I0M0H0T-1D0 ;
+  qudt:symbol "nmol/(m²⋅day)" ;
   qudt:ucumCode "nmol.m-2.d-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Nanomoles per square metre per day"@en ;
@@ -17535,6 +18443,7 @@ unit:NanoMOL-PER-MicroGM-HR
   a qudt:Unit ;
   qudt:conversionMultiplier 0.000277777777777778 ;
   qudt:hasDimensionVector qkdv:A1E0L0I0M-1H0T-1D0 ;
+  qudt:symbol "nmol/(µg⋅hr)" ;
   qudt:ucumCode "nmol.ug-1.h-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Nanomoles per microgram per hour"@en ;
@@ -17546,6 +18455,7 @@ unit:NanoMOL-PER-MicroMOL
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:qkdvDenominator qkdv:A1E0L0I0M0H0T0D0 ;
   qudt:qkdvNumerator qkdv:A1E0L0I0M0H0T0D0 ;
+  qudt:symbol "nmol/µmol" ;
   qudt:ucumCode "nmol.umol-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Nanomoles per micromole"@en ;
@@ -17555,6 +18465,7 @@ unit:NanoMOL-PER-MicroMOL-DAY
   dcterms:description "Unavailable."@en ;
   qudt:conversionMultiplier 0.0000000115740740740741 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D1 ;
+  qudt:symbol "nmol/(µmol⋅day)" ;
   qudt:ucumCode "nmol.umol-1.d-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Nanomoles per micromole per day"@en ;
@@ -17566,6 +18477,7 @@ unit:NanoS-PER-CentiM
   qudt:hasQuantityKind quantitykind:Conductivity ;
   qudt:iec61360Code "0112/2///62720#UAA907" ;
   qudt:plainTextDescription "0.000000001-fold of the SI derived unit Siemens by the 0.01 fol of the SI base unit metre" ;
+  qudt:symbol "nS/cm" ;
   qudt:ucumCode "nS.cm-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G44" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -17579,6 +18491,7 @@ unit:NanoS-PER-M
   qudt:hasQuantityKind quantitykind:Conductivity ;
   qudt:iec61360Code "0112/2///62720#UAA908" ;
   qudt:plainTextDescription "0.000000001-fold of the SI derived unit Siemens divided by the SI base unit metre" ;
+  qudt:symbol "nS/m" ;
   qudt:ucumCode "nS.m-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G45" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -17613,6 +18526,7 @@ unit:NanoT
   qudt:isScalingOf unit:T ;
   qudt:plainTextDescription "0.000000001-fold of the SI derived unit tesla" ;
   qudt:prefix prefix:Nano ;
+  qudt:symbol "nT" ;
   qudt:ucumCode "nT"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C48" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -17628,6 +18542,7 @@ unit:NanoW
   qudt:isScalingOf unit:W ;
   qudt:plainTextDescription "0.000000001-fold of the SI derived unit watt" ;
   qudt:prefix prefix:Nano ;
+  qudt:symbol "nW" ;
   qudt:ucumCode "nW"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C49" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -17805,6 +18720,7 @@ unit:OERSTED-CentiM
   qudt:expression "\\(Oe-cm\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E1L0I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:MagnetomotiveForce ;
+  qudt:symbol "Oe⋅cm" ;
   qudt:ucumCode "Oe.cm"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:CGS ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -17841,6 +18757,7 @@ unit:OHM-M
   qudt:hasQuantityKind quantitykind:Resistivity ;
   qudt:iec61360Code "0112/2///62720#UAA020" ;
   qudt:informativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
+  qudt:symbol "Ω⋅m" ;
   qudt:ucumCode "Ohm.m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C61" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -17852,7 +18769,7 @@ unit:OHM-M2-PER-M
   qudt:conversionMultiplier 1.0 ;
   qudt:hasDimensionVector qkdv:A0E-2L3I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:Resistivity ;
-  qudt:symbol "Ohm-m2/m" ;
+  qudt:symbol "Ω⋅m²/m" ;
   qudt:ucumCode "Ohm2.m.m-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Ohm Square Meter per Meter"@en-us ;
@@ -17884,7 +18801,7 @@ unit:OHM_Stat
   qudt:informativeReference "http://whatis.techtarget.com/definition/statohm-stat-W"^^xsd:anyURI ;
   qudt:latexSymbol "\\(stat\\Omega\\)"^^qudt:LatexString ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/statohm> ;
-  qudt:symbol "stat Ω " ;
+  qudt:symbol "statΩ" ;
   qudt:unitOfSystem sou:CGS ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Statohm"@en ;
@@ -17897,7 +18814,7 @@ unit:OZ
   qudt:definedUnitOfSystem sou:USCS ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Mass ;
-  qudt:symbol "ozm" ;
+  qudt:symbol "oz" ;
   qudt:ucumCode "[oz_av]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "ONZ" ;
   qudt:unitOfSystem sou:IMPERIAL ;
@@ -17911,6 +18828,7 @@ unit:OZ-FT
   qudt:hasQuantityKind quantitykind:LengthMass ;
   qudt:iec61360Code "0112/2///62720#UAB133" ;
   qudt:plainTextDescription "unit of the unbalance as a product of avoirdupois ounce according to  the avoirdupois system of units and foot according to the Anglo-American and Imperial system of units" ;
+  qudt:symbol "oz⋅ft" ;
   qudt:ucumCode "[oz_av].[ft_i]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "4R" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -17923,6 +18841,7 @@ unit:OZ-IN
   qudt:hasQuantityKind quantitykind:LengthMass ;
   qudt:iec61360Code "0112/2///62720#UAB132" ;
   qudt:plainTextDescription "unit of the unbalance as a product of avoirdupois ounce according to  the avoirdupois system of units and inch according to the Anglo-American and Imperial system of units" ;
+  qudt:symbol "oz⋅in" ;
   qudt:ucumCode "[oz_av].[in_i]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "4Q" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -17935,6 +18854,7 @@ unit:OZ-PER-DAY
   qudt:hasQuantityKind quantitykind:MassFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA919" ;
   qudt:plainTextDescription "traditional unit of the mass avoirdupois ounce according to the avoirdupois system of units divided by the unit for time day" ;
+  qudt:symbol "oz/day" ;
   qudt:ucumCode "[oz_av].d-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L33" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -17949,6 +18869,7 @@ unit:OZ-PER-FT2
   qudt:expression "oz/ft^{2}" ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:MassPerArea ;
+  qudt:symbol "oz/ft²{US}" ;
   qudt:ucumCode "[oz_av].[sft_i]-1"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:IMPERIAL ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -17962,6 +18883,7 @@ unit:OZ-PER-GAL
   qudt:expression "oz/gal" ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Density ;
+  qudt:symbol "oz/gal{US}" ;
   qudt:ucumCode "[oz_av].[gal_br]-1"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:IMPERIAL ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -17974,6 +18896,7 @@ unit:OZ-PER-GAL_UK
   qudt:hasQuantityKind quantitykind:MassDensity ;
   qudt:iec61360Code "0112/2///62720#UAA923" ;
   qudt:plainTextDescription "unit of the density according to the Imperial system of units" ;
+  qudt:symbol "oz/gal{UK}" ;
   qudt:ucumCode "[oz_av].[gal_br]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L37" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -17989,6 +18912,7 @@ unit:OZ-PER-GAL_US
   qudt:iec61360Code "0112/2///62720#UAA924" ;
   qudt:informativeReference "https://cdd.iec.ch/cdd/iec61360/iec61360.nsf/Units/0112-2---62720%23UAA924"^^xsd:anyURI ;
   qudt:plainTextDescription "unit of the density according to the Anglo-American system of units" ;
+  qudt:symbol "oz/gal{US}" ;
   qudt:ucumCode "[oz_av].[gal_us]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L38" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -18001,6 +18925,7 @@ unit:OZ-PER-HR
   qudt:hasQuantityKind quantitykind:MassFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA920" ;
   qudt:plainTextDescription "traditional unit of the mass avoirdupois ounce according to the avoirdupois system of units divided by the unit for time hour" ;
+  qudt:symbol "oz/hr" ;
   qudt:ucumCode "[oz_av].h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L34" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -18015,6 +18940,7 @@ unit:OZ-PER-IN3
   qudt:expression "oz/in^{3}" ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Density ;
+  qudt:symbol "oz/in³{US}" ;
   qudt:ucumCode "[oz_av].[cin_i]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L39" ;
   qudt:unitOfSystem sou:IMPERIAL ;
@@ -18028,6 +18954,7 @@ unit:OZ-PER-MIN
   qudt:hasQuantityKind quantitykind:MassFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA921" ;
   qudt:plainTextDescription "traditional unit of the mass avoirdupois ounce according to the avoirdupois system of units divided by the unit for time minute" ;
+  qudt:symbol "oz/min" ;
   qudt:ucumCode "[oz_av].min-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L35" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -18040,6 +18967,7 @@ unit:OZ-PER-SEC
   qudt:hasQuantityKind quantitykind:MassFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA922" ;
   qudt:plainTextDescription "traditional unit of the mass avoirdupois ounce according to the avoirdupois system of units divided by the SI base unit second" ;
+  qudt:symbol "oz/s" ;
   qudt:ucumCode "[oz_av].s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L36" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -18054,6 +18982,7 @@ unit:OZ-PER-YD2
   qudt:expression "oz/yd^{2}" ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:MassPerArea ;
+  qudt:symbol "oz/yd³{US}" ;
   qudt:ucumCode "[oz_av].[syd_i]-1"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:IMPERIAL ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -18066,6 +18995,7 @@ unit:OZ-PER-YD3
   qudt:hasQuantityKind quantitykind:MassDensity ;
   qudt:iec61360Code "0112/2///62720#UAA918" ;
   qudt:plainTextDescription "unit ounce  according to the avoirdupois system of units divided by the power of the unit yard according to the Anglo-American and the Imperial system of units with the exponent 3" ;
+  qudt:symbol "oz/yd³" ;
   qudt:ucumCode "[oz_av].[cyd_i]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G32" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -18095,6 +19025,7 @@ unit:OZ_F-IN
   qudt:definedUnitOfSystem sou:USCS ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Torque ;
+  qudt:symbol "ozf⋅in" ;
   qudt:ucumCode "[ozf_av].[in_i]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L41" ;
   qudt:unitOfSystem sou:IMPERIAL ;
@@ -18108,7 +19039,7 @@ unit:OZ_TROY
   qudt:definedUnitOfSystem sou:USCS ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Mass ;
-  qudt:symbol "oz" ;
+  qudt:symbol "oz{Troy}" ;
   qudt:ucumCode "[oz_tr]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "APZ" ;
   qudt:unitOfSystem sou:CGS ;
@@ -18123,6 +19054,7 @@ unit:OZ_VOL_UK
   qudt:hasQuantityKind quantitykind:Volume ;
   qudt:iec61360Code "0112/2///62720#UAA431" ;
   qudt:plainTextDescription "unit of the volume for fluids according to the Imperial system of units" ;
+  qudt:symbol "oz{UK}" ;
   qudt:ucumCode "[foz_br]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "OZI" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -18135,6 +19067,7 @@ unit:OZ_VOL_UK-PER-DAY
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA432" ;
   qudt:plainTextDescription "unit of the volume fluid ounce (UK) for fluids according to the Imperial system of units divided by the unit for time day" ;
+  qudt:symbol "oz{UK}/day" ;
   qudt:ucumCode "[foz_br].d-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J95" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -18147,6 +19080,7 @@ unit:OZ_VOL_UK-PER-HR
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA433" ;
   qudt:plainTextDescription "unit of the volume fluid ounce (UK) for fluids according to the Imperial system of units divided by the unit for time hour" ;
+  qudt:symbol "oz{UK}/hr" ;
   qudt:ucumCode "[foz_br].h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J96" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -18159,6 +19093,7 @@ unit:OZ_VOL_UK-PER-MIN
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA434" ;
   qudt:plainTextDescription "unit of the volume fluid ounce (UK) for fluids according to the Imperial system of units divided by the unit for time minute" ;
+  qudt:symbol "oz{UK}/min" ;
   qudt:ucumCode "[foz_br].min-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J97" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -18171,6 +19106,7 @@ unit:OZ_VOL_UK-PER-SEC
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA435" ;
   qudt:plainTextDescription "unit of the volume fluid ounce (UK) for fluids according to the Imperial system of units divided by the SI base unit second" ;
+  qudt:symbol "oz{UK}/s" ;
   qudt:ucumCode "[foz_br].s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J98" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -18183,10 +19119,9 @@ unit:OZ_VOL_US
   qudt:definedUnitOfSystem sou:USCS ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:LiquidVolume ;
-  qudt:symbol "oz" ;
+  qudt:symbol "fl oz{US}" ;
   qudt:ucumCode "[foz_us]"^^qudt:UCUMcs ;
-  qudt:udunitsCode "floz" ;
-  qudt:udunitsCode "oz" ;
+  qudt:udunitsCode "fl oz" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "US Liquid Ounce"@en ;
 .
@@ -18197,6 +19132,7 @@ unit:OZ_VOL_US-PER-DAY
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA436" ;
   qudt:plainTextDescription "unit of the volume fluid ounce (US) for fluids according to the Anglo-American system of units divided by unit for time day" ;
+  qudt:symbol "oz{US}/day" ;
   qudt:ucumCode "[foz_us].d-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J99" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -18209,6 +19145,7 @@ unit:OZ_VOL_US-PER-HR
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA437" ;
   qudt:plainTextDescription "unit of the volume fluid ounce (US) for fluids according to the Anglo-American system of units divided by the unit for time hour" ;
+  qudt:symbol "oz{US}/hr" ;
   qudt:ucumCode "[foz_us].h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K10" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -18221,6 +19158,7 @@ unit:OZ_VOL_US-PER-MIN
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA438" ;
   qudt:plainTextDescription "unit of the volume fluid ounce (US) for fluids according to the Anglo-American system of units divided by the unit for time minute" ;
+  qudt:symbol "oz{US}/min" ;
   qudt:ucumCode "[foz_us].min-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K11" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -18233,6 +19171,7 @@ unit:OZ_VOL_US-PER-SEC
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA439" ;
   qudt:plainTextDescription "unit of the volume fluid ounce (US) for fluids according to the Anglo-American system of units divided by the SI base unit second" ;
+  qudt:symbol "oz{US}/s" ;
   qudt:ucumCode "[foz_us].s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K12" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -18299,6 +19238,7 @@ unit:PA-L-PER-SEC
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAA261" ;
   qudt:plainTextDescription "product out of the SI derived unit pascal and the unit litre divided by the SI base unit second" ;
+  qudt:symbol "Pa⋅L/s" ;
   qudt:ucumCode "Pa.L.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F99" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -18309,6 +19249,7 @@ unit:PA-M
   a qudt:Unit ;
   qudt:conversionMultiplier 1.0 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-2D0 ;
+  qudt:symbol "Pa⋅m" ;
   qudt:ucumCode "Pa.m"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Pascal metres"@en ;
@@ -18317,6 +19258,7 @@ unit:PA-M-PER-SEC
   a qudt:Unit ;
   qudt:conversionMultiplier 1.0 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-3D0 ;
+  qudt:symbol "Pa⋅m/s" ;
   qudt:ucumCode "Pa.m.s-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Pascal metres per second"@en ;
@@ -18325,6 +19267,7 @@ unit:PA-M-PER-SEC2
   a qudt:Unit ;
   qudt:conversionMultiplier 1.0 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-4D0 ;
+  qudt:symbol "Pa⋅m/s²" ;
   qudt:ucumCode "Pa.m.s-2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Pascal metres per square second"@en ;
@@ -18336,6 +19279,7 @@ unit:PA-M3-PER-SEC
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAA264" ;
   qudt:plainTextDescription "product out of the SI derived unit pascal and the power of the SI base unit metre with the exponent 3 divided by the SI base unit second" ;
+  qudt:symbol "Pa⋅m³/s" ;
   qudt:ucumCode "Pa.m3.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G01" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -18349,6 +19293,7 @@ unit:PA-PER-BAR
   qudt:hasQuantityKind quantitykind:PressureRatio ;
   qudt:iec61360Code "0112/2///62720#UAA260" ;
   qudt:plainTextDescription "SI derived unit pascal divided by the unit bar" ;
+  qudt:symbol "Pa/bar" ;
   qudt:ucumCode "Pa.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F07" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -18362,6 +19307,7 @@ unit:PA-PER-HR
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerAreaTime ;
   qudt:isScalingOf unit:PA-PER-MIN ;
+  qudt:symbol "P/hr" ;
   qudt:ucumCode "Pa.h-1"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:CGS ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -18373,6 +19319,7 @@ unit:PA-PER-K
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H-1T-2D0 ;
   qudt:hasQuantityKind quantitykind:PressureCoefficient ;
   qudt:iec61360Code "0112/2///62720#UAA259" ;
+  qudt:symbol "P/K" ;
   qudt:ucumCode "Pa.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C64" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -18385,6 +19332,7 @@ unit:PA-PER-M
   qudt:hasQuantityKind quantitykind:SpectralRadiantEnergyDensity ;
   qudt:iec61360Code "0112/2///62720#UAA262" ;
   qudt:plainTextDescription "SI derived unit pascal divided by the SI base unit metre" ;
+  qudt:symbol "Pa/m" ;
   qudt:ucumCode "Pa.m-1"^^qudt:UCUMcs ;
   qudt:ucumCode "Pa/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H42" ;
@@ -18400,6 +19348,7 @@ unit:PA-PER-MIN
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerAreaTime ;
   qudt:isScalingOf unit:PA-PER-SEC ;
+  qudt:symbol "P/min" ;
   qudt:ucumCode "Pa.min-1"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:CGS ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -18413,6 +19362,7 @@ unit:PA-PER-SEC
   qudt:expression "\\(P / s\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerAreaTime ;
+  qudt:symbol "P/s" ;
   qudt:ucumCode "Pa.s-1"^^qudt:UCUMcs ;
   qudt:ucumCode "Pa/s"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -18430,6 +19380,7 @@ unit:PA-SEC
   qudt:hasQuantityKind quantitykind:DynamicViscosity ;
   qudt:iec61360Code "0112/2///62720#UAA265" ;
   qudt:siUnitsExpression "Pa.s" ;
+  qudt:symbol "Pa⋅s" ;
   qudt:ucumCode "Pa.s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C65" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -18442,6 +19393,7 @@ unit:PA-SEC-PER-BAR
   qudt:hasQuantityKind quantitykind:Time ;
   qudt:iec61360Code "0112/2///62720#UAA267" ;
   qudt:plainTextDescription "product out of the SI derived unit pascal and the SI base unit second divided by the unit bar" ;
+  qudt:symbol "Pa⋅s/bar" ;
   qudt:ucumCode "Pa.s.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H07" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -18458,6 +19410,7 @@ unit:PA-SEC-PER-M
   qudt:iec61360Code "0112/2///62720#UAA268" ;
   qudt:informativeReference "http://www.efunda.com/glossary/units/units--specific_acoustic_impedance--pascal_second_per_meter.cfm"^^xsd:anyURI ;
   qudt:siUnitsExpression "Pa.s/m" ;
+  qudt:symbol "Pa⋅s/m" ;
   qudt:ucumCode "P.s.m-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C67" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -18474,6 +19427,7 @@ unit:PA-SEC-PER-M3
   qudt:iec61360Code "0112/2///62720#UAA263" ;
   qudt:informativeReference "http://www.efunda.com/glossary/units/units--acoustic_impedance--pascal_second_per_cubic_meter.cfm"^^xsd:anyURI ;
   qudt:siUnitsExpression "Pa.s/m3" ;
+  qudt:symbol "Pa⋅s/m³" ;
   qudt:ucumCode "Pa.s.m-3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C66" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -18484,6 +19438,7 @@ unit:PA2-PER-SEC2
   a qudt:Unit ;
   qudt:conversionMultiplier 1.0 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M2H0T-6D0 ;
+  qudt:symbol "Pa²⋅m/s²" ;
   qudt:ucumCode "Pa2.s-2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Square pascal per square second"@en ;
@@ -18499,6 +19454,7 @@ unit:PA2-SEC
   qudt:iec61360Code "0112/2///62720#UAB339" ;
   qudt:informativeReference "http://www.efunda.com/glossary/units/units--specific_acoustic_impedance--pascal_second_per_meter.cfm"^^xsd:anyURI ;
   qudt:siUnitsExpression "Pa2.s" ;
+  qudt:symbol "Pa²⋅s" ;
   qudt:ucumCode "Pa2.s"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Square Pascal Second"@en ;
@@ -18523,7 +19479,7 @@ unit:PARSEC
   qudt:hasQuantityKind quantitykind:Length ;
   qudt:iec61360Code "0112/2///62720#UAB067" ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/parsec> ;
-  qudt:symbol "㍶" ;
+  qudt:symbol "pc" ;
   qudt:ucumCode "pc"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C63" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -18537,7 +19493,7 @@ unit:PCA
   qudt:hasQuantityKind quantitykind:Length ;
   qudt:iec61360Code "0112/2///62720#UAB606" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Pica?oldid=458102937"^^xsd:anyURI ;
-  qudt:symbol "PCA" ;
+  qudt:symbol "pc" ;
   qudt:ucumCode "[pca]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "R1" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -18574,6 +19530,7 @@ unit:PDL-PER-FT2
   qudt:hasQuantityKind quantitykind:VaporPressure ;
   qudt:iec61360Code "0112/2///62720#UAB243" ;
   qudt:informativeReference "http://www.efunda.com/glossary/units/units--pressure--poundal_per_square_foot.cfm"^^xsd:anyURI ;
+  qudt:symbol "pdl/ft²" ;
   qudt:ucumCode "[lb_av].[ft_i].s-2.[sft_i]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "N21" ;
   qudt:unitOfSystem sou:IMPERIAL ;
@@ -18587,6 +19544,7 @@ unit:PER-ANGSTROM
   qudt:hasQuantityKind quantitykind:InverseLength ;
   qudt:iec61360Code "0112/2///62720#UAB058" ;
   qudt:plainTextDescription "reciprocal of the unit angstrom" ;
+  qudt:symbol "/Å" ;
   qudt:ucumCode "Ao-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C85" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -18600,6 +19558,7 @@ unit:PER-BAR
   qudt:hasQuantityKind quantitykind:InversePressure ;
   qudt:iec61360Code "0112/2///62720#UAA328" ;
   qudt:plainTextDescription "reciprocal of the metrical unit with the name bar" ;
+  qudt:symbol "/bar" ;
   qudt:ucumCode "bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F58" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -18612,6 +19571,7 @@ unit:PER-CentiM
   qudt:hasQuantityKind quantitykind:InverseLength ;
   qudt:iec61360Code "0112/2///62720#UAA382" ;
   qudt:plainTextDescription "reciprocal of the 0.01-fold of the SI base unit metre" ;
+  qudt:symbol "/cm" ;
   qudt:ucumCode "/cm"^^qudt:UCUMcs ;
   qudt:ucumCode "cm-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E90" ;
@@ -18626,6 +19586,7 @@ unit:PER-CentiM3
   qudt:hasQuantityKind quantitykind:InverseVolume ;
   qudt:iec61360Code "0112/2///62720#UAA383" ;
   qudt:plainTextDescription "reciprocal of the 0.000001-fold of the power of the SI base unit metre with the exponent 3" ;
+  qudt:symbol "/cm³" ;
   qudt:ucumCode "cm-3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H50" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -18639,6 +19600,7 @@ unit:PER-DAY
   qudt:hasQuantityKind quantitykind:Frequency ;
   qudt:iec61360Code "0112/2///62720#UAA408" ;
   qudt:plainTextDescription "reciprocal of the unit day" ;
+  qudt:symbol "/day" ;
   qudt:ucumCode "/d"^^qudt:UCUMcs ;
   qudt:ucumCode "d-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E91" ;
@@ -18652,6 +19614,7 @@ unit:PER-FT3
   qudt:hasQuantityKind quantitykind:InverseVolume ;
   qudt:iec61360Code "0112/2///62720#UAA453" ;
   qudt:plainTextDescription "reciprocal value of the power of the unit foot according to the Anglo-American and the Imperial system of units with the exponent 3" ;
+  qudt:symbol "/ft³" ;
   qudt:ucumCode "[cft_i]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K20" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -18661,6 +19624,7 @@ unit:PER-GM
   a qudt:Unit ;
   qudt:conversionMultiplier 1000.0 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M-1H0T0D0 ;
+  qudt:symbol "/g" ;
   qudt:ucumCode "g-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Reciprocal gram"@en ;
@@ -18672,6 +19636,7 @@ unit:PER-GigaEV2
   qudt:expression "\\(/GeV^2\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L-4I0M-2H0T4D0 ;
   qudt:hasQuantityKind quantitykind:InverseSquareEnergy ;
+  qudt:symbol "/GeV²" ;
   qudt:ucumCode "GeV-2"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:CGS ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -18680,6 +19645,7 @@ unit:PER-GigaEV2
 unit:PER-H
   a qudt:Unit ;
   qudt:hasDimensionVector qkdv:A0E2L-2I0M-1H0T2D0 ;
+  qudt:symbol "/H" ;
   qudt:ucumCode "H-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C89" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -18693,6 +19659,7 @@ unit:PER-HR
   qudt:expression "\\(m^{-1}\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Frequency ;
+  qudt:symbol "/hr" ;
   qudt:ucumCode "/h"^^qudt:UCUMcs ;
   qudt:ucumCode "h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H10" ;
@@ -18706,6 +19673,7 @@ unit:PER-IN3
   qudt:hasQuantityKind quantitykind:InverseVolume ;
   qudt:iec61360Code "0112/2///62720#UAA546" ;
   qudt:plainTextDescription "reciprocal value of the power of the unit inch according to the Anglo-American and the Imperial system of units with the exponent 3" ;
+  qudt:symbol "/in³" ;
   qudt:ucumCode "[cin_i]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K49" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -18717,6 +19685,7 @@ unit:PER-J-M3
   qudt:hasDimensionVector qkdv:A0E0L1I0M-1H0T2D0 ;
   qudt:hasQuantityKind quantitykind:EnergyDensityOfStates ;
   qudt:informativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
+  qudt:symbol "/(J⋅m³)" ;
   qudt:ucumCode "J-1.m-3"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Reciprocal Joule Cubic Meter"@en-us ;
@@ -18732,6 +19701,7 @@ unit:PER-K
   qudt:hasQuantityKind quantitykind:InverseTemperature ;
   qudt:hasQuantityKind quantitykind:LinearExpansionCoefficient ;
   qudt:hasQuantityKind quantitykind:RelativePressureCoefficient ;
+  qudt:symbol "/K" ;
   qudt:ucumCode "K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C91" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -18753,6 +19723,7 @@ unit:PER-KiloM
   qudt:hasQuantityKind quantitykind:LinearIonization ;
   qudt:hasQuantityKind quantitykind:PhaseCoefficient ;
   qudt:hasQuantityKind quantitykind:PropagationCoefficient ;
+  qudt:symbol "/km" ;
   qudt:ucumCode "/km"^^qudt:UCUMcs ;
   qudt:ucumCode "km-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -18766,6 +19737,7 @@ unit:PER-KiloV-A-HR
   qudt:hasQuantityKind quantitykind:InverseEnergy ;
   qudt:iec61360Code "0112/2///62720#UAA098" ;
   qudt:plainTextDescription "reciprocal of the 1,000-fold of the product of the SI derived unit volt and the SI base unit ampere and the unit hour" ;
+  qudt:symbol "/(kV⋅A⋅hr)" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Reciprocal Kilovolt Ampere Hour"@en ;
 .
@@ -18776,6 +19748,7 @@ unit:PER-L
   qudt:hasQuantityKind quantitykind:InverseVolume ;
   qudt:iec61360Code "0112/2///62720#UAA667" ;
   qudt:plainTextDescription "reciprocal value of the unit litre" ;
+  qudt:symbol "/L" ;
   qudt:ucumCode "L-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K63" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -18798,6 +19771,7 @@ unit:PER-M
   qudt:hasQuantityKind quantitykind:LinearIonization ;
   qudt:hasQuantityKind quantitykind:PhaseCoefficient ;
   qudt:hasQuantityKind quantitykind:PropagationCoefficient ;
+  qudt:symbol "/m" ;
   qudt:ucumCode "/m"^^qudt:UCUMcs ;
   qudt:ucumCode "m-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C92" ;
@@ -18813,6 +19787,7 @@ unit:PER-M-K
   qudt:expression "\\(/m.k\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H-1T0D0 ;
   qudt:hasQuantityKind quantitykind:InverseLengthTemperature ;
+  qudt:symbol "/(m⋅K)" ;
   qudt:ucumCode "m-1.K-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Reciprocal Meter Kelvin"@en-us ;
@@ -18822,6 +19797,7 @@ unit:PER-M-NanoM
   a qudt:Unit ;
   qudt:conversionMultiplier 1000000000.0 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T0D0 ;
+  qudt:symbol "/(m⋅nm)" ;
   qudt:ucumCode "m-1.nm-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Reciprocal metre per nanometre"@en ;
@@ -18830,6 +19806,7 @@ unit:PER-M-NanoM-SR
   a qudt:Unit ;
   qudt:conversionMultiplier 1000000000.0 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T0D0 ;
+  qudt:symbol "/(m⋅nm⋅sr)" ;
   qudt:ucumCode "m-1.nm-1.sr-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Reciprocal metre per nanometre per steradian"@en ;
@@ -18838,6 +19815,7 @@ unit:PER-M-SEC
   a qudt:Unit ;
   qudt:conversionMultiplier 1.0 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T-1D0 ;
+  qudt:symbol "/(m⋅s)" ;
   qudt:ucumCode "m-1.s-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Reciprocal metre per second"@en ;
@@ -18846,6 +19824,7 @@ unit:PER-M-SR
   a qudt:Unit ;
   qudt:conversionMultiplier 1.0 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T0D0 ;
+  qudt:symbol "/(m⋅sr)" ;
   qudt:ucumCode "m-1.sr-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Reciprocal metre per steradian"@en ;
@@ -18859,7 +19838,7 @@ unit:PER-M2
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:ParticleFluence ;
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
-  qudt:symbol "m^{-2}" ;
+  qudt:symbol "/m²" ;
   qudt:ucumCode "/m2"^^qudt:UCUMcs ;
   qudt:ucumCode "m-2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C93" ;
@@ -18876,6 +19855,7 @@ unit:PER-M2-SEC
   qudt:hasQuantityKind quantitykind:Flux ;
   qudt:hasQuantityKind quantitykind:ParticleFluenceRate ;
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:symbol "/(m²⋅s)" ;
   qudt:ucumCode "m-2.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B81" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -18892,6 +19872,7 @@ unit:PER-M3
   qudt:hasDimensionVector qkdv:A0E0L-3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:InverseVolume ;
   qudt:hasQuantityKind quantitykind:NumberDensity ;
+  qudt:symbol "/m³" ;
   qudt:ucumCode "/m3"^^qudt:UCUMcs ;
   qudt:ucumCode "m-3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C86" ;
@@ -18908,6 +19889,7 @@ unit:PER-M3-SEC
   qudt:hasQuantityKind quantitykind:ParticleSourceDensity ;
   qudt:hasQuantityKind quantitykind:Slowing-DownDensity ;
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:symbol "/(m³⋅s)" ;
   qudt:ucumCode "m-3.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C87" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -18924,6 +19906,7 @@ unit:PER-MILLE-PER-PSI
   qudt:hasQuantityKind quantitykind:IsothermalCompressibility ;
   qudt:iec61360Code "0112/2///62720#UAA016" ;
   qudt:plainTextDescription "thousandth divided by the composed unit for pressure (pound-force per square inch)" ;
+  qudt:symbol "/ksi" ;
   qudt:uneceCommonCode "J12" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Reciprocal Mille Per Psi"@en ;
@@ -18936,6 +19919,7 @@ unit:PER-MIN
   qudt:expression "\\(m^{-1}\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Frequency ;
+  qudt:symbol "/min" ;
   qudt:ucumCode "/min"^^qudt:UCUMcs ;
   qudt:ucumCode "min-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C94" ;
@@ -18949,6 +19933,7 @@ unit:PER-MO
   qudt:hasQuantityKind quantitykind:Frequency ;
   qudt:iec61360Code "0112/2///62720#UAA881" ;
   qudt:plainTextDescription "reciprocal of the unit month" ;
+  qudt:symbol "/month" ;
   qudt:ucumCode "mo-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H11" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -18964,6 +19949,7 @@ unit:PER-MOL
   qudt:expression "\\(/mol\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A-1E0L0I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:InverseAmountOfSubstance ;
+  qudt:symbol "/mol" ;
   qudt:ucumCode "mol-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C95" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -18985,6 +19971,7 @@ unit:PER-MicroM
   qudt:hasQuantityKind quantitykind:LinearIonization ;
   qudt:hasQuantityKind quantitykind:PhaseCoefficient ;
   qudt:hasQuantityKind quantitykind:PropagationCoefficient ;
+  qudt:symbol "/µm" ;
   qudt:ucumCode "/um"^^qudt:UCUMcs ;
   qudt:ucumCode "um-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -18996,6 +19983,7 @@ unit:PER-MicroMOL-L
   dcterms:description "Units used to describe the sensitivity of detection of a spectrophotometer."@en ;
   qudt:conversionMultiplier 1000000000.0 ;
   qudt:hasDimensionVector qkdv:A-1E0L-3I0M0H0T0D0 ;
+  qudt:symbol "/(mmol⋅L)" ;
   qudt:ucumCode "umol-1.L-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Reciprocal micromole per litre"@en ;
@@ -19016,6 +20004,7 @@ unit:PER-MilliM
   qudt:hasQuantityKind quantitykind:LinearIonization ;
   qudt:hasQuantityKind quantitykind:PhaseCoefficient ;
   qudt:hasQuantityKind quantitykind:PropagationCoefficient ;
+  qudt:symbol "/mm" ;
   qudt:ucumCode "/mm"^^qudt:UCUMcs ;
   qudt:ucumCode "mm-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -19029,6 +20018,7 @@ unit:PER-MilliM3
   qudt:hasQuantityKind quantitykind:InverseVolume ;
   qudt:iec61360Code "0112/2///62720#UAA870" ;
   qudt:plainTextDescription "reciprocal value of the 0.000000001-fold of the power of the SI base unit metre with the exponent 3" ;
+  qudt:symbol "/mm³" ;
   qudt:ucumCode "mm-3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L20" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -19040,6 +20030,7 @@ unit:PER-MilliSEC
   qudt:conversionMultiplier 1000.0 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Frequency ;
+  qudt:symbol "/ms" ;
   qudt:ucumCode "ms-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Reciprocal millisecond"@en ;
@@ -19060,6 +20051,7 @@ unit:PER-NanoM
   qudt:hasQuantityKind quantitykind:LinearIonization ;
   qudt:hasQuantityKind quantitykind:PhaseCoefficient ;
   qudt:hasQuantityKind quantitykind:PropagationCoefficient ;
+  qudt:symbol "/nm" ;
   qudt:ucumCode "/nm"^^qudt:UCUMcs ;
   qudt:ucumCode "nm-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -19079,6 +20071,7 @@ unit:PER-PA
   qudt:hasQuantityKind quantitykind:IsothermalCompressibility ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Pascal?oldid=492989202"^^xsd:anyURI ;
   qudt:siUnitsExpression "m^2/N" ;
+  qudt:symbol "/Pa" ;
   qudt:ucumCode "Pa-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C96" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -19088,6 +20081,7 @@ unit:PER-PA-SEC
   a qudt:Unit ;
   qudt:conversionMultiplier 1.0 ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M-1H0T1D0 ;
+  qudt:symbol "/(Pa⋅s)" ;
   qudt:ucumCode "Pa-1.s-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Reciprocal Pascal per second"@en ;
@@ -19099,6 +20093,7 @@ unit:PER-PSI
   qudt:hasQuantityKind quantitykind:InversePressure ;
   qudt:iec61360Code "0112/2///62720#UAA709" ;
   qudt:plainTextDescription "reciprocal value of the composed unit for pressure (pound-force per square inch)" ;
+  qudt:symbol "/psi" ;
   qudt:ucumCode "[psi]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K93" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -19120,6 +20115,7 @@ unit:PER-PicoM
   qudt:hasQuantityKind quantitykind:LinearIonization ;
   qudt:hasQuantityKind quantitykind:PhaseCoefficient ;
   qudt:hasQuantityKind quantitykind:PropagationCoefficient ;
+  qudt:symbol "/pm" ;
   qudt:ucumCode "/pm"^^qudt:UCUMcs ;
   qudt:ucumCode "pm-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -19136,6 +20132,7 @@ unit:PER-PlanckMass2
   qudt:informativeReference "http://en.wikipedia.org/wiki/Planck_mass?oldid=493648632"^^xsd:anyURI ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Planck_units"^^xsd:anyURI ;
   qudt:latexDefinition "\\(m_P = \\sqrt{\\frac{ \\hbar c^3}{G}} \\approx 1.2209 \\times 10^{19} GeV/c^2 = 2.17651(13) \\times 10^{-8}\\), where \\(c\\) is the speed of light in a vacuum, \\(\\hbar\\) is the reduced Planck's constant, and \\(G\\) is the gravitational constant. The two digits enclosed by parentheses are the estimated standard error associated with the reported numerical value."^^qudt:LatexString ;
+  qudt:symbol "/mₚ²" ;
   qudt:unitOfSystem sou:PLANCK ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Inverse Square Planck Mass"@en ;
@@ -19150,6 +20147,7 @@ unit:PER-SEC
   qudt:exactMatch unit:HZ ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Frequency ;
+  qudt:symbol "/s" ;
   qudt:ucumCode "/s"^^qudt:UCUMcs ;
   qudt:ucumCode "s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C97" ;
@@ -19164,6 +20162,7 @@ unit:PER-SEC-M2
   qudt:expression "\\(per-sec-m^2\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Flux ;
+  qudt:symbol "/s⋅m²" ;
   qudt:ucumCode "/(s1.m2)"^^qudt:UCUMcs ;
   qudt:ucumCode "s-1.m-2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -19177,6 +20176,7 @@ unit:PER-SEC-M2-SR
   qudt:expression "\\(/sec-m^2-sr\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:PhotonRadiance ;
+  qudt:symbol "/s⋅m²⋅sr" ;
   qudt:ucumCode "/(s.m2.sr)"^^qudt:UCUMcs ;
   qudt:ucumCode "s-1.m-2.sr-1"^^qudt:UCUMcs ;
   rdfs:comment "It is not clear this unit is ever used. [Editor]" ;
@@ -19192,6 +20192,7 @@ unit:PER-SEC-SR
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:PhotonIntensity ;
   qudt:hasQuantityKind quantitykind:TemporalSummationFunction ;
+  qudt:symbol "/s⋅sr" ;
   qudt:ucumCode "/(s.sr)"^^qudt:UCUMcs ;
   qudt:ucumCode "s-1.sr-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -19201,6 +20202,7 @@ unit:PER-SEC2
   a qudt:Unit ;
   qudt:conversionMultiplier 1.0 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-2D0 ;
+  qudt:symbol "/s²" ;
   qudt:ucumCode "s-2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Reciprocal square second"@en ;
@@ -19209,6 +20211,7 @@ unit:PER-SR
   a qudt:Unit ;
   qudt:conversionMultiplier 1.0 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
+  qudt:symbol "/sr" ;
   qudt:ucumCode "sr-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Reciprocal steradian"@en ;
@@ -19221,6 +20224,7 @@ unit:PER-T-M
   qudt:hasDimensionVector qkdv:A0E1L-1I0M-1H0T2D0 ;
   qudt:hasQuantityKind quantitykind:MagneticReluctivity ;
   qudt:latexSymbol "\\(m^{-1} \\cdot T^{-1}\\)"^^qudt:LatexString ;
+  qudt:symbol "/t⋅m" ;
   qudt:ucumCode "T-1.m-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Reciprocal Tesla Meter"@en-us ;
@@ -19234,6 +20238,7 @@ unit:PER-T-SEC
   qudt:expression "\\(/s . T\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E1L0I0M-1H0T1D0 ;
   qudt:hasQuantityKind quantitykind:ElectricChargePerMass ;
+  qudt:symbol "/T⋅s" ;
   qudt:ucumCode "T-1.s-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Reciprocal Tesla Second Unit"@en ;
@@ -19244,6 +20249,7 @@ unit:PER-WB
   qudt:hasDimensionVector qkdv:A0E1L-2I0M-1H0T2D0 ;
   qudt:hasQuantityKind quantitykind:InverseMagneticFlux ;
   qudt:informativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
+  qudt:symbol "/Wb" ;
   qudt:ucumCode "Wb-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Reciprocal Weber"@en ;
@@ -19255,6 +20261,7 @@ unit:PER-WK
   qudt:hasQuantityKind quantitykind:Frequency ;
   qudt:iec61360Code "0112/2///62720#UAA099" ;
   qudt:plainTextDescription "reciprocal of the unit week" ;
+  qudt:symbol "/week" ;
   qudt:ucumCode "wk-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H85" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -19267,6 +20274,7 @@ unit:PER-YD3
   qudt:hasQuantityKind quantitykind:InverseVolume ;
   qudt:iec61360Code "0112/2///62720#UAB033" ;
   qudt:plainTextDescription "reciprocal value of the unit yard according to the Anglo-American and the Imperial system of units with the exponent 3" ;
+  qudt:symbol "/yd³" ;
   qudt:ucumCode "[cyd_i]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M10" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -19279,6 +20287,7 @@ unit:PER-YR
   qudt:hasQuantityKind quantitykind:Frequency ;
   qudt:iec61360Code "0112/2///62720#UAB027" ;
   qudt:plainTextDescription "reciprocal of the unit year" ;
+  qudt:symbol "/yr" ;
   qudt:ucumCode "/a"^^qudt:UCUMcs ;
   qudt:ucumCode "a-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H09" ;
@@ -19315,6 +20324,7 @@ unit:PERCENT-PER-DAY
   qudt:conversionMultiplier 0.0000115740740740741 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Frequency ;
+  qudt:symbol "%/day" ;
   qudt:ucumCode "%.d-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Percent per day"@en ;
@@ -19324,6 +20334,7 @@ unit:PERCENT-PER-HR
   qudt:conversionMultiplier 0.000277777777777778 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Frequency ;
+  qudt:symbol "%/day" ;
   qudt:ucumCode "%.h-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Percent per hour"@en ;
@@ -19332,6 +20343,7 @@ unit:PERCENT-PER-M
   a qudt:Unit ;
   qudt:conversionMultiplier 1.0 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T0D0 ;
+  qudt:symbol "%/m" ;
   qudt:ucumCode "%.m-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H99" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -19343,6 +20355,7 @@ unit:PERCENT-PER-WK
   qudt:conversionMultiplier 0.00000165343915343915 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Frequency ;
+  qudt:symbol "%/wk" ;
   qudt:ucumCode "%.wk-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Percent per week"@en ;
@@ -19353,6 +20366,7 @@ unit:PERCENT_RH
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:RelativeHumidity ;
   qudt:plainTextDescription "Percent relative humidity is the ratio of the partial pressure of water vapor to the equilibrium vapor pressure of water at a given temperature, expressed as a percentage." ;
+  qudt:symbol "%RH" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Percent Relative Humidity"@en ;
 .
@@ -19366,6 +20380,7 @@ unit:PERMEABILITY_EM_REL
   qudt:hasQuantityKind quantitykind:ElectromagneticPermeabilityRatio ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Relative_permeability"^^xsd:anyURI ;
   qudt:latexSymbol "\\(\\mu\\,T\\)"^^qudt:LatexString ;
+  qudt:symbol "μₜ" ;
   qudt:ucumCode "[mu_0]"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Relative Electromagnetic Permeability"@en ;
@@ -19379,6 +20394,7 @@ unit:PERMEABILITY_REL
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:PermeabilityRatio ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Relative_permeability"^^xsd:anyURI ;
+  qudt:symbol "kᵣ" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Relative Permeability"@en ;
 .
@@ -19405,6 +20421,7 @@ unit:PH
   a qudt:Unit ;
   dcterms:description "the negative decadic logarithmus of the concentration of free protons (or hydronium ions) expressed in 1 mol/l."@en ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
+  qudt:symbol "pH" ;
   qudt:ucumCode "[pH]"^^qudt:UCUMcs ;
   rdfs:comment "Unsure about dimensionality of pH; conversion requires a log function not just a multiplier"@en ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -19436,7 +20453,7 @@ unit:PINT
   qudt:definedUnitOfSystem sou:IMPERIAL ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Volume ;
-  qudt:symbol "pi" ;
+  qudt:symbol "pt" ;
   qudt:ucumCode "[pt_br]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "PTI" ;
   qudt:unitOfSystem sou:IMPERIAL ;
@@ -19450,6 +20467,7 @@ unit:PINT_UK
   qudt:hasQuantityKind quantitykind:Volume ;
   qudt:iec61360Code "0112/2///62720#UAA952" ;
   qudt:plainTextDescription "unit of the volume (both for fluids and for dry measures) according to the Imperial system of units" ;
+  qudt:symbol "pt{UK}" ;
   qudt:ucumCode "[pt_br]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "PTI" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -19462,6 +20480,7 @@ unit:PINT_UK-PER-DAY
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA953" ;
   qudt:plainTextDescription "unit of the volume pint (UK) (both for fluids and for dry measures) according to the Imperial system of units divided by the unit for time day" ;
+  qudt:symbol "pt{UK}/day" ;
   qudt:ucumCode "[pt_br].d"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L53" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -19474,6 +20493,7 @@ unit:PINT_UK-PER-HR
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA954" ;
   qudt:plainTextDescription "unit of the volume pint (UK) (both for fluids and for dry measures) according to the Imperial system of units divided by the unit for time hour" ;
+  qudt:symbol "pt{UK}/hr" ;
   qudt:ucumCode "[pt_br].h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L54" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -19486,6 +20506,7 @@ unit:PINT_UK-PER-MIN
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA955" ;
   qudt:plainTextDescription "unit of the volume pint (UK) (both for fluids and for dry measures) according to the Imperial system of units divided by the unit for time minute" ;
+  qudt:symbol "pt{UK}/min" ;
   qudt:ucumCode "[pt_br].min-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L55" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -19498,6 +20519,7 @@ unit:PINT_UK-PER-SEC
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA956" ;
   qudt:plainTextDescription "unit of the volume pint (UK) (both for fluids and for dry measures) according to the Imperial system of units divided by the SI base unit second" ;
+  qudt:symbol "pt{UK}/s" ;
   qudt:ucumCode "[pt_br].s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L56" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -19510,7 +20532,7 @@ unit:PINT_US
   qudt:definedUnitOfSystem sou:USCS ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:LiquidVolume ;
-  qudt:symbol "pt" ;
+  qudt:symbol "pt{US}" ;
   qudt:ucumCode "[pt_us]"^^qudt:UCUMcs ;
   qudt:udunitsCode "pt" ;
   qudt:uneceCommonCode "PTL" ;
@@ -19524,6 +20546,7 @@ unit:PINT_US-PER-DAY
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA958" ;
   qudt:plainTextDescription "unit of the volume pint (US liquid) according to the Anglo-American system of units divided by the unit for time day" ;
+  qudt:symbol "pt{US}/day" ;
   qudt:ucumCode "[pt_us].d-1"^^qudt:UCUMcs ;
   qudt:udunitsCode "kg" ;
   qudt:uneceCommonCode "L57" ;
@@ -19537,6 +20560,7 @@ unit:PINT_US-PER-HR
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA959" ;
   qudt:plainTextDescription "unit of the volume pint (US liquid) according to the Anglo-American system of units divided by the unit for time hour" ;
+  qudt:symbol "pt{US}/hr" ;
   qudt:ucumCode "[pt_us].h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L58" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -19549,6 +20573,7 @@ unit:PINT_US-PER-MIN
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA960" ;
   qudt:plainTextDescription "unit of the volume pint (US liquid) according to the Anglo-American system of units divided by the unit for time minute" ;
+  qudt:symbol "pt{US}/min" ;
   qudt:ucumCode "[pt_us].min-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L59" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -19561,6 +20586,7 @@ unit:PINT_US-PER-SEC
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA961" ;
   qudt:plainTextDescription "unit of the volume pint (US liquid) according to the Anglo-American system of units divided by the SI base unit second" ;
+  qudt:symbol "pt{US}/s" ;
   qudt:ucumCode "[pt_us].s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L60" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -19573,7 +20599,7 @@ unit:PINT_US_DRY
   qudt:definedUnitOfSystem sou:USCS ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:DryVolume ;
-  qudt:symbol "dry_pt" ;
+  qudt:symbol "pt{US Dry}" ;
   qudt:ucumCode "[dpt_us]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "PTD" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -19586,6 +20612,7 @@ unit:PK_UK
   qudt:hasQuantityKind quantitykind:Volume ;
   qudt:iec61360Code "0112/2///62720#UAA939" ;
   qudt:plainTextDescription "unit of the volume according to the Imperial system of units" ;
+  qudt:symbol "peck{UK}" ;
   qudt:ucumCode "[pk_br]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L43" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -19598,6 +20625,7 @@ unit:PK_UK-PER-DAY
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA940" ;
   qudt:plainTextDescription "unit of the volume peck (UK) according to the Imperial system of units divided by the unit for time day" ;
+  qudt:symbol "peck{UK}/day" ;
   qudt:ucumCode "[pk_br].d-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L44" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -19610,6 +20638,7 @@ unit:PK_UK-PER-HR
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA941" ;
   qudt:plainTextDescription "unit of the volume peck (UK) according to the Imperial system of units divided by the unit for time hour" ;
+  qudt:symbol "peck{UK}/hr" ;
   qudt:ucumCode "[pk_br].h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L45" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -19622,6 +20651,7 @@ unit:PK_UK-PER-MIN
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA942" ;
   qudt:plainTextDescription "unit of the volume peck (UK) according to the Imperial system of units divided by the unit for time minute" ;
+  qudt:symbol "peck{UK}/min" ;
   qudt:ucumCode "[pk_br].min-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L46" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -19634,6 +20664,7 @@ unit:PK_UK-PER-SEC
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA943" ;
   qudt:plainTextDescription "unit of the volume peck (UK) according to the Imperial system of units divided by the SI base unit second" ;
+  qudt:symbol "peck{UK}/s" ;
   qudt:ucumCode "[pk_br].s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L47" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -19646,7 +20677,7 @@ unit:PK_US_DRY
   qudt:definedUnitOfSystem sou:USCS ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:DryVolume ;
-  qudt:symbol "pk" ;
+  qudt:symbol "peck{US Dry}" ;
   qudt:ucumCode "[pk_us]"^^qudt:UCUMcs ;
   qudt:udunitsCode "pk" ;
   qudt:uneceCommonCode "PY" ;
@@ -19661,6 +20692,7 @@ unit:PK_US_DRY-PER-DAY
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA944" ;
   qudt:plainTextDescription "unit of the volume peck (US dry) as dry measure according to the Anglo-American system of units divided by the unit for time day" ;
+  qudt:symbol "peck{US}/day" ;
   qudt:ucumCode "[pk_us].d-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L48" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -19673,6 +20705,7 @@ unit:PK_US_DRY-PER-HR
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA945" ;
   qudt:plainTextDescription "unit of the volume peck (US dry) as dry measure according to the Anglo-American system of units divided by the unit for time hour" ;
+  qudt:symbol "peck{US}/hr" ;
   qudt:ucumCode "[pk_us].h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L49" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -19685,6 +20718,7 @@ unit:PK_US_DRY-PER-MIN
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA946" ;
   qudt:plainTextDescription "unit of the volume peck (US dry) as dry measure according to the Anglo-American system of units divided by the unit for time minute" ;
+  qudt:symbol "peck{US}/min" ;
   qudt:ucumCode "[pk_us].min-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L50" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -19697,6 +20731,7 @@ unit:PK_US_DRY-PER-SEC
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA947" ;
   qudt:plainTextDescription "unit of the volume peck (US dry) as dry measure according to the Anglo-American system of units divided by the SI base unit second" ;
+  qudt:symbol "peck{US}/s" ;
   qudt:ucumCode "[pk_us].s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L51" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -19728,6 +20763,7 @@ unit:POISE-PER-BAR
   qudt:hasQuantityKind quantitykind:Time ;
   qudt:iec61360Code "0112/2///62720#UAA257" ;
   qudt:plainTextDescription "CGS unit poise divided by the unit bar" ;
+  qudt:symbol "P/bar" ;
   qudt:ucumCode "P.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F06" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -19740,7 +20776,7 @@ unit:PPB
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:DimensionlessRatio ;
   qudt:informativeReference "http://aurora.regenstrief.org/~ucum/ucum.html#section-Derived-Unit-Atoms"^^xsd:anyURI ;
-  qudt:symbol "ppb" ;
+  qudt:symbol "PPB" ;
   qudt:ucumCode "[ppb]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "61" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -19754,7 +20790,7 @@ unit:PPM
   qudt:hasQuantityKind quantitykind:DimensionlessRatio ;
   qudt:informativeReference "http://aurora.regenstrief.org/~ucum/ucum.html#section-Derived-Unit-Atoms"^^xsd:anyURI ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/partsPerMillion> ;
-  qudt:symbol "ppm" ;
+  qudt:symbol "PPM" ;
   qudt:ucumCode "[ppm]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "59" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -19780,6 +20816,7 @@ unit:PPTH-PER-HR
   a qudt:Unit ;
   qudt:conversionMultiplier 0.000000277777777777778 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
+  qudt:symbol "‰/hr" ;
   qudt:ucumCode "[ppth].h-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Parts per thousand per hour"@en ;
@@ -19791,7 +20828,7 @@ unit:PPTR
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:DimensionlessRatio ;
   qudt:informativeReference "http://aurora.regenstrief.org/~ucum/ucum.html#section-Derived-Unit-Atoms"^^xsd:anyURI ;
-  qudt:symbol "pptr" ;
+  qudt:symbol "PPTR" ;
   qudt:ucumCode "[pptr]"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Parts per trillion"@en ;
@@ -19800,6 +20837,7 @@ unit:PPTR_VOL
   a qudt:Unit ;
   qudt:conversionMultiplier 0.000000000001 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
+  qudt:symbol "pptr" ;
   qudt:ucumCode "[pptr]{vol}"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Parts per trillion by volume"@en ;
@@ -19814,6 +20852,7 @@ unit:PSI
   qudt:hasQuantityKind quantitykind:ForcePerArea ;
   qudt:hasQuantityKind quantitykind:VaporPressure ;
   qudt:plainTextDescription "Pounds of force per square inch, the unit for pressure as a compounded unit pound-force according to the Anglo-American system of units divided by the power of the unit Inch according to the Anglo-American and Imperial system of units by exponent 2" ;
+  qudt:symbol "psi" ;
   qudt:ucumCode "[psi]"^^qudt:UCUMcs ;
   qudt:udunitsCode "psi" ;
   qudt:uneceCommonCode "PS" ;
@@ -19828,6 +20867,7 @@ unit:PSI-IN3-PER-SEC
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAA703" ;
   qudt:plainTextDescription "product of the composed unit for pressure (pound-force per square inch) and the composed unit for volume flow (cubic inch per second)" ;
+  qudt:symbol "psi⋅in³/s" ;
   qudt:ucumCode "[psi].[cin_i].s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K87" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -19840,6 +20880,7 @@ unit:PSI-L-PER-SEC
   qudt:hasQuantityKind quantitykind:PowerPerArea ;
   qudt:iec61360Code "0112/2///62720#UAA704" ;
   qudt:plainTextDescription "product of the composed unit for pressure (pound-force per square inch) and the composed unit for volume flow (litre per second)" ;
+  qudt:symbol "psi⋅L³/s" ;
   qudt:ucumCode "[psi].L.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K88" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -19853,6 +20894,7 @@ unit:PSI-M3-PER-SEC
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAA705" ;
   qudt:plainTextDescription "product of the composed unit for pressure (pound-force per square inch) and the composed unit for volume flow (cubic metre per second)" ;
+  qudt:symbol "psi⋅m³/s" ;
   qudt:ucumCode "[psi].m3.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K89" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -19866,6 +20908,7 @@ unit:PSI-PER-PSI
   qudt:hasQuantityKind quantitykind:PressureRatio ;
   qudt:iec61360Code "0112/2///62720#UAA951" ;
   qudt:plainTextDescription "composed unit for pressure (pound-force per square inch) divided by the composed unit for pressure (pound-force per square inch)" ;
+  qudt:symbol "psi/psi" ;
   qudt:ucumCode "[psi].[psi]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L52" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -19878,6 +20921,7 @@ unit:PSI-YD3-PER-SEC
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAA706" ;
   qudt:plainTextDescription "product of the composed unit for pressure (pound-force per square inch) and the square inch) and the composed unit for volume flow (cubic yard per second)" ;
+  qudt:symbol "psi⋅yd³/s" ;
   qudt:ucumCode "[psi].[cyd_i].s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K90" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -19888,6 +20932,7 @@ unit:PSU
   dcterms:description "Practical salinity scale 1978 (PSS-78) is used for ionic content of seawater determined by electrical conductivity. Salinities measured using PSS-78 do not have units, but are approximately scaled to parts-per-thousand for the valid range. The suffix psu or PSU (denoting practical salinity unit) is sometimes added to PSS-78 measurement values. The addition of PSU as a unit after the value is \"formally incorrect and strongly discouraged\"." ;
   dcterms:source <https://unesdoc.unesco.org/ark:/48223/pf0000047932> ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
+  qudt:symbol "PSU" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Practical salinity unit" ;
   rdfs:seeAlso unit:PPTH ;
@@ -19979,6 +21024,7 @@ unit:Pennyweight
   qudt:hasQuantityKind quantitykind:Mass ;
   qudt:iec61360Code "0112/2///62720#UAB182" ;
   qudt:plainTextDescription "non SI-conforming unit of mass which comes from the Anglo-American Troy or Apothecaries' Weight System of units according to NIST of 1 pwt = 1.555174 10^3 kg" ;
+  qudt:symbol "dwt" ;
   qudt:ucumCode "[pwt_tr]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "DWT" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -20027,6 +21073,7 @@ unit:PetaJ
   qudt:isScalingOf unit:J ;
   qudt:plainTextDescription "1,000,000,000,000,000-fold of the derived SI unit joule" ;
   qudt:prefix prefix:Peta ;
+  qudt:symbol "PJ" ;
   qudt:ucumCode "PJ"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C68" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -20063,6 +21110,7 @@ unit:PicoA-PER-MicroMOL-L
   a qudt:Unit ;
   qudt:conversionMultiplier 0.001 ;
   qudt:hasDimensionVector qkdv:A-1E1L-3I0M0H0T0D0 ;
+  qudt:symbol "pA/(mmol⋅L)" ;
   qudt:ucumCode "pA.umol-1.L-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Picoamps per micromole per litre"@en ;
@@ -20112,6 +21160,7 @@ unit:PicoFARAD-PER-M
   qudt:hasQuantityKind quantitykind:Permittivity ;
   qudt:iec61360Code "0112/2///62720#UAA931" ;
   qudt:plainTextDescription "0.000000000001-fold of the SI derived unit farad divided by the SI base unit metre" ;
+  qudt:symbol "pF/m" ;
   qudt:ucumCode "pF.m-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C72" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -20126,6 +21175,7 @@ unit:PicoGM
   qudt:hasQuantityKind quantitykind:Mass ;
   qudt:isScalingOf unit:KiloGM ;
   qudt:prefix prefix:Pico ;
+  qudt:symbol "pg" ;
   qudt:ucumCode "pg"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Picograms"@en ;
@@ -20138,6 +21188,7 @@ unit:PicoGM-PER-GM
   qudt:hasQuantityKind quantitykind:MassRatio ;
   qudt:qkdvDenominator qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:qkdvNumerator qkdv:A0E0L0I0M1H0T0D0 ;
+  qudt:symbol "pg/g" ;
   qudt:ucumCode "pg.g-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Picograms per gram"@en ;
@@ -20150,6 +21201,7 @@ unit:PicoGM-PER-KiloGM
   qudt:hasQuantityKind quantitykind:MassRatio ;
   qudt:qkdvDenominator qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:qkdvNumerator qkdv:A0E0L0I0M1H0T0D0 ;
+  qudt:symbol "pg/kg" ;
   qudt:ucumCode "pg.kg-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Picograms per kilogram"@en ;
@@ -20160,6 +21212,7 @@ unit:PicoGM-PER-L
   qudt:conversionMultiplier 0.000000000001 ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:MassDensity ;
+  qudt:symbol "pg/L" ;
   qudt:ucumCode "pg.L-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Picofarad Per Meter"@en-us ;
@@ -20173,6 +21226,7 @@ unit:PicoGM-PER-MilliL
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:MassConcentration ;
   qudt:hasQuantityKind quantitykind:MassDensity ;
+  qudt:symbol "pg/mL" ;
   qudt:ucumCode "pg.mL-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Picograms per millilitre"@en ;
@@ -20186,6 +21240,7 @@ unit:PicoH
   qudt:isScalingOf unit:H ;
   qudt:plainTextDescription "0.000000000001-fold of the SI derived unit henry" ;
   qudt:prefix prefix:Pico ;
+  qudt:symbol "pH" ;
   qudt:ucumCode "pH"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C73" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -20197,6 +21252,7 @@ unit:PicoL
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Volume ;
   qudt:plainTextDescription "0.000000000001-fold of the unit litre" ;
+  qudt:symbol "pL" ;
   qudt:ucumCode "pL"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "Q33" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -20212,6 +21268,7 @@ unit:PicoM
   qudt:isScalingOf unit:M ;
   qudt:plainTextDescription "0.000000000001-fold of the SI base unit metre" ;
   qudt:prefix prefix:Pico ;
+  qudt:symbol "pM" ;
   qudt:ucumCode "pm"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C52" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -20223,6 +21280,7 @@ unit:PicoMOL-PER-KiloGM
   qudt:conversionMultiplier 0.000000000001 ;
   qudt:hasDimensionVector qkdv:A1E0L0I0M-1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:AmountOfSubstancePerUnitMass ;
+  qudt:symbol "pmol/kg" ;
   qudt:ucumCode "pmol.kg-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Picomoles per kilogram"@en ;
@@ -20233,6 +21291,7 @@ unit:PicoMOL-PER-L
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:AmountOfSubstancePerUnitVolume ;
   qudt:hasQuantityKind quantitykind:Solubility_Water ;
+  qudt:symbol "pmol/L" ;
   qudt:ucumCode "pmol.L-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Picomoles per litre"@en ;
@@ -20242,6 +21301,7 @@ unit:PicoMOL-PER-L-DAY
   dcterms:description "A change in the quantity of matter of 10^-12 moles in the SI unit of volume scaled by 10^-3 over a period of 86400 seconds."@en ;
   qudt:conversionMultiplier 0.0000000000000115740740740741 ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H0T-1D0 ;
+  qudt:symbol "pmol/day" ;
   qudt:ucumCode "pmol.L-1.d-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Picomoles per litre per day"@en ;
@@ -20251,6 +21311,7 @@ unit:PicoMOL-PER-L-HR
   dcterms:description "A change in the quantity of matter of 10^-12 moles in the SI unit of volume scaled by 10^-3 over a period of 3600 seconds."@en ;
   qudt:conversionMultiplier 0.000000000000277777777777778 ;
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T-1D0 ;
+  qudt:symbol "pmol/(L⋅hr)" ;
   qudt:ucumCode "pmol.L-1.h-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Picomoles per litre per hour"@en ;
@@ -20259,6 +21320,7 @@ unit:PicoMOL-PER-M-W-SEC
   a qudt:Unit ;
   qudt:conversionMultiplier 0.000000000001 ;
   qudt:hasDimensionVector qkdv:A1E0L-3I0M-1H0T2D0 ;
+  qudt:symbol "pmol/(m⋅W⋅s)" ;
   qudt:ucumCode "pmol.m-1.W-1.s-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Picomoles per metre per watt per second"@en ;
@@ -20267,6 +21329,7 @@ unit:PicoMOL-PER-M2-DAY
   a qudt:Unit ;
   qudt:conversionMultiplier 0.0000000000000000115740740740741 ;
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T-1D0 ;
+  qudt:symbol "pmol/(m²⋅day)" ;
   qudt:ucumCode "pmol.m-2.d-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Picomoles per square metre per day"@en ;
@@ -20277,6 +21340,7 @@ unit:PicoMOL-PER-M3
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:AmountOfSubstancePerUnitVolume ;
   qudt:hasQuantityKind quantitykind:Solubility_Water ;
+  qudt:symbol "pmol/m³" ;
   qudt:ucumCode "pmol.m-3"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Picomoles per cubic metre"@en ;
@@ -20285,6 +21349,7 @@ unit:PicoMOL-PER-M3-SEC
   a qudt:Unit ;
   qudt:conversionMultiplier 0.000000000001 ;
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T-1D0 ;
+  qudt:symbol "pmol/(m³⋅s)" ;
   qudt:ucumCode "pmol.m-3.s-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Picomoles per cubic metre per second"@en ;
@@ -20297,6 +21362,7 @@ unit:PicoPA-PER-KiloM
   qudt:hasQuantityKind quantitykind:ForcePerLength ;
   qudt:iec61360Code "0112/2///62720#UAA933" ;
   qudt:plainTextDescription "0.000000000001-fold of the SI derived unit pascal divided by the 1 000-fold of the SI base unit metre" ;
+  qudt:symbol "pPa/km" ;
   qudt:ucumCode "pPa.km-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H69" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -20310,6 +21376,7 @@ unit:PicoS-PER-M
   qudt:hasQuantityKind quantitykind:Conductivity ;
   qudt:iec61360Code "0112/2///62720#UAA934" ;
   qudt:plainTextDescription "0.000000000001-fold of the SI derived unit Siemens divided by the SI base unit metre" ;
+  qudt:symbol "pS/m" ;
   qudt:ucumCode "pS.m-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L42" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -20325,6 +21392,7 @@ unit:PicoSEC
   qudt:isScalingOf unit:SEC ;
   qudt:plainTextDescription "0.000000000001-fold of the SI base unit second" ;
   qudt:prefix prefix:Pico ;
+  qudt:symbol "ps" ;
   qudt:ucumCode "ps"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H70" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -20340,6 +21408,7 @@ unit:PicoW
   qudt:isScalingOf unit:W ;
   qudt:plainTextDescription "0.000000000001-fold of the SI derived unit watt" ;
   qudt:prefix prefix:Pico ;
+  qudt:symbol "pW" ;
   qudt:ucumCode "pW"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C75" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -20350,6 +21419,7 @@ unit:PicoW-PER-CentiM2-L
   dcterms:description "The power (scaled by 10^-12) per SI unit of area (scaled by 10^-4) produced per SI unit of volume (scaled by 10^-3)."@en ;
   qudt:conversionMultiplier 0.00001 ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H0T-3D0 ;
+  qudt:symbol "pW/(cm²⋅L)" ;
   qudt:ucumCode "pW.cm-2.L-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Picowatts per square centimetre per litre"@en ;
@@ -20361,6 +21431,7 @@ unit:PicoW-PER-M2
   qudt:hasQuantityKind quantitykind:PowerPerArea ;
   qudt:iec61360Code "0112/2///62720#UAA936" ;
   qudt:plainTextDescription "0.000000000001-fold of the SI derived unit watt divided by the power of the SI base unit metre with the exponent 2" ;
+  qudt:symbol "pW/m²" ;
   qudt:ucumCode "pW.m-2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C76" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -20373,6 +21444,7 @@ unit:PlanckArea
   qudt:derivedUnitOfSystem sou:PLANCK ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Area ;
+  qudt:symbol "planckarea" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Planck Area"@en ;
 .
@@ -20384,6 +21456,7 @@ unit:PlanckCharge
   qudt:hasQuantityKind quantitykind:ElectricCharge ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Planck_units"^^xsd:anyURI ;
   qudt:latexSymbol "\\(Q_P\\)"^^qudt:LatexString ;
+  qudt:symbol "planckcharge" ;
   qudt:unitOfSystem sou:PLANCK ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Planck Charge"@en ;
@@ -20397,6 +21470,7 @@ unit:PlanckCurrent
   qudt:hasDimensionVector qkdv:A0E1L0I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:ElectricCurrent ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Planck_current?oldid=493640689"^^xsd:anyURI ;
+  qudt:symbol "planckcurrent" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Planck Current"@en ;
 .
@@ -20406,6 +21480,7 @@ unit:PlanckCurrentDensity
   qudt:derivedUnitOfSystem sou:PLANCK ;
   qudt:hasDimensionVector qkdv:A0E1L-2I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:ElectricCurrentDensity ;
+  qudt:symbol "planckcurrentdensity" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Planck Current Density"@en ;
 .
@@ -20418,6 +21493,7 @@ unit:PlanckDensity
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Density ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Planck_density?oldid=493642128"^^xsd:anyURI ;
+  qudt:symbol "planckdensity" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Planck Density"@en ;
 .
@@ -20444,6 +21520,7 @@ unit:PlanckForce
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Force ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Planck_force?oldid=493643031"^^xsd:anyURI ;
+  qudt:symbol "planckforce" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Planck Force"@en ;
 .
@@ -20455,6 +21532,7 @@ unit:PlanckFrequency
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Frequency ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Planck_angular_frequency?oldid=493641308"^^xsd:anyURI ;
+  qudt:symbol "planckfrequency" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Planck Frequency"@en ;
 .
@@ -20463,6 +21541,7 @@ unit:PlanckFrequency_Ang
   qudt:dbpediaMatch "http://dbpedia.org/resource/Planck_angular_frequency"^^xsd:anyURI ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:AngularVelocity ;
+  qudt:symbol "planckangularfrequency" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Planck Angular Frequency"@en ;
 .
@@ -20475,7 +21554,7 @@ unit:PlanckImpedance
   qudt:hasQuantityKind quantitykind:Resistance ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Planck_impedance"^^xsd:anyURI ;
   qudt:latexDefinition "\\(Z_P = \\frac{V_P}{I_P}= \\frac{1}{4\\pi\\epsilon_0c}=\\frac{\\mu_oc}{4\\pi}=\\frac{Z_0}{4\\pi}=29.9792458\\Omega\\)\\where \\(V_P\\) is the Planck voltage, \\(I_P\\) is the Planck current, \\(c\\) is the speed of light in a vacuum, \\(\\epsilon_0\\) is the permittivity of free space, \\(\\mu_0\\) is the permeability of free space, and \\(Z_0\\) is the impedance of free space."^^qudt:LatexString ;
-  qudt:symbol "ZP" ;
+  qudt:symbol "Zₚ" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Planck Impedance"@en ;
 .
@@ -20490,6 +21569,7 @@ unit:PlanckLength
   qudt:informativeReference "https://en.wikipedia.org/wiki/Planck_units"^^xsd:anyURI ;
   qudt:latexDefinition "\\(\\ell_P = \\sqrt{\\frac{ \\hbar G}{c^3}} \\approx 1.616199(97)) \\times 10^{-35} m\\), where \\(c\\) is the speed of light in a vacuum, \\(\\hbar\\) is the reduced Planck's constant, and \\(G\\) is the gravitational constant. The two digits enclosed by parentheses are the estimated standard error associated with the reported numerical value."^^qudt:LatexString ;
   qudt:latexSymbol "\\(\\ell_P\\)"^^qudt:LatexString ;
+  qudt:symbol "plancklength" ;
   qudt:unitOfSystem sou:PLANCK ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Planck Length"@en ;
@@ -20505,6 +21585,7 @@ unit:PlanckMass
   qudt:informativeReference "https://en.wikipedia.org/wiki/Planck_units"^^xsd:anyURI ;
   qudt:latexDefinition "\\(m_P = \\sqrt{\\frac{ \\hbar c^3}{G}} \\approx 1.2209 \\times 10^{19} GeV/c^2 = 2.17651(13) \\times 10^{-8}\\), where \\(c\\) is the speed of light in a vacuum, \\(\\hbar\\) is the reduced Planck's constant, and \\(G\\) is the gravitational constant. The two digits enclosed by parentheses are the estimated standard error associated with the reported numerical value."^^qudt:LatexString ;
   qudt:latexSymbol "\\(m_P\\)"^^qudt:LatexString ;
+  qudt:symbol "planckmass" ;
   qudt:unitOfSystem sou:PLANCK ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Planck Mass"@en ;
@@ -20518,6 +21599,7 @@ unit:PlanckMomentum
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:LinearMomentum ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Planck_momentum?oldid=493644981"^^xsd:anyURI ;
+  qudt:symbol "planckmomentum" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Planck Momentum"@en ;
 .
@@ -20531,6 +21613,7 @@ unit:PlanckPower
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Planck_power?oldid=493642483"^^xsd:anyURI ;
   qudt:latexDefinition "\\(P_p = {\\frac{ c^5}{G}}\\), where \\(c\\) is the speed of light in a vacuum, and \\(G\\) is the gravitational constant."^^qudt:LatexString ;
+  qudt:symbol "planckpower" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Planck Power"@en ;
 .
@@ -20543,6 +21626,7 @@ unit:PlanckPressure
   qudt:hasQuantityKind quantitykind:ForcePerArea ;
   qudt:hasQuantityKind quantitykind:VaporPressure ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Planck_pressure?oldid=493640883"^^xsd:anyURI ;
+  qudt:symbol "planckpressure" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Planck Pressure"@en ;
 .
@@ -20555,6 +21639,7 @@ unit:PlanckTemperature
   qudt:hasQuantityKind quantitykind:Temperature ;
   qudt:hasQuantityKind quantitykind:ThermodynamicTemperature ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Planck_units"^^xsd:anyURI ;
+  qudt:symbol "plancktemperature" ;
   qudt:unitOfSystem sou:PLANCK ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "PlanckTemperature"@en ;
@@ -20569,6 +21654,7 @@ unit:PlanckTime
   qudt:informativeReference "http://en.wikipedia.org/wiki/Planck_time?oldid=495362103"^^xsd:anyURI ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Planck_units"^^xsd:anyURI ;
   qudt:latexSymbol "\\(t_P\\)"^^qudt:LatexString ;
+  qudt:symbol "tₚ" ;
   qudt:unitOfSystem sou:PLANCK ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Planck Time"@en ;
@@ -20579,6 +21665,7 @@ unit:PlanckVolt
   qudt:derivedUnitOfSystem sou:PLANCK ;
   qudt:hasDimensionVector qkdv:A0E-1L2I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:EnergyPerElectricCharge ;
+  qudt:symbol "Vₚ" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Planck Volt"@en ;
 .
@@ -20588,6 +21675,7 @@ unit:PlanckVolume
   qudt:derivedUnitOfSystem sou:PLANCK ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Volume ;
+  qudt:symbol "l³ₚ" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Planck Volume"@en ;
 .
@@ -20635,6 +21723,7 @@ unit:QT_UK
   qudt:hasQuantityKind quantitykind:Volume ;
   qudt:iec61360Code "0112/2///62720#UAA963" ;
   qudt:plainTextDescription "unit of the volume for fluids according to the Imperial system of units" ;
+  qudt:symbol "qt{UK}" ;
   qudt:ucumCode "[qt_br]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "QTI" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -20647,6 +21736,7 @@ unit:QT_UK-PER-DAY
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA710" ;
   qudt:plainTextDescription "unit of the volume quart (UK liquid) for fluids according to the Imperial system of units divided by the unit for time day" ;
+  qudt:symbol "qt{UK}/day" ;
   qudt:ucumCode "[qt_br].d-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K94" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -20659,6 +21749,7 @@ unit:QT_UK-PER-HR
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA711" ;
   qudt:plainTextDescription "unit of the volume quart (UK liquid) for fluids according to the Imperial system of units divided by the unit for time hour" ;
+  qudt:symbol "qt{UK}/hr" ;
   qudt:ucumCode "[qt_br].h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K95" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -20671,6 +21762,7 @@ unit:QT_UK-PER-MIN
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA712" ;
   qudt:plainTextDescription "unit of the volume quart (UK liquid) for fluids according to the Imperial system of units divided by the unit for time minute" ;
+  qudt:symbol "qt{UK}/min" ;
   qudt:ucumCode "[qt_br].min-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K96" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -20683,6 +21775,7 @@ unit:QT_UK-PER-SEC
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA713" ;
   qudt:plainTextDescription "unit of the volume quart (UK liquid) for fluids according to the Imperial system of units divided by the SI base unit second" ;
+  qudt:symbol "qt{UK}/s" ;
   qudt:ucumCode "[qt_br].h-1.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K97" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -20709,6 +21802,7 @@ unit:QT_US-PER-DAY
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA714" ;
   qudt:plainTextDescription "unit fo the volume quart (US liquid) for fluids according to the Anglo-American system of units divided by the unit for time day" ;
+  qudt:symbol "qt{US}/day" ;
   qudt:ucumCode "[qt_us].d-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K98" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -20721,6 +21815,7 @@ unit:QT_US-PER-HR
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA715" ;
   qudt:plainTextDescription "unit fo the volume quart (US liquid) for fluids according to the Anglo-American system of units divided by the unit for time hour" ;
+  qudt:symbol "qt{US}/hr" ;
   qudt:ucumCode "[qt_us].h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K99" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -20733,6 +21828,7 @@ unit:QT_US-PER-MIN
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA716" ;
   qudt:plainTextDescription "unit fo the volume quart (US liquid) for fluids according to the Anglo-American system of units divided by the unit for time minute" ;
+  qudt:symbol "qt{US}/min" ;
   qudt:ucumCode "[qt_us].min-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L10" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -20745,6 +21841,7 @@ unit:QT_US-PER-SEC
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA717" ;
   qudt:plainTextDescription "unit fo the volume quart (US liquid) for fluids according to the Anglo-American system of units divided by the SI base unit second" ;
+  qudt:symbol "qt{US}/s" ;
   qudt:ucumCode "[qt_us].s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L11" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -20757,7 +21854,7 @@ unit:QT_US_DRY
   qudt:definedUnitOfSystem sou:USCS ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:DryVolume ;
-  qudt:symbol "dry_qt" ;
+  qudt:symbol "qt{US Dry}" ;
   qudt:ucumCode "[dqt_us]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "QTD" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -20798,6 +21895,7 @@ unit:Quarter_UK
   qudt:hasQuantityKind quantitykind:Mass ;
   qudt:iec61360Code "0112/2///62720#UAB202" ;
   qudt:plainTextDescription "unit of the mass according to the avoirdupois system of units: 1 qr. l. = 28 lb" ;
+  qudt:symbol "quarter" ;
   qudt:ucumCode "28.[lb_av]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "QTR" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -20864,6 +21962,7 @@ unit:RAD-M2-PER-KiloGM
   qudt:hasDimensionVector qkdv:A0E0L2I0M-1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:SpecificOpticalRotatoryPower ;
   qudt:iec61360Code "0112/2///62720#UAB162" ;
+  qudt:symbol "rad⋅m²/kg" ;
   qudt:ucumCode "rad.m2.kg-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C83" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -20876,6 +21975,7 @@ unit:RAD-M2-PER-MOL
   qudt:hasDimensionVector qkdv:A-1E0L2I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:MolarOpticalRotatoryPower ;
   qudt:iec61360Code "0112/2///62720#UAB161" ;
+  qudt:symbol "rad⋅m²/mol" ;
   qudt:ucumCode "rad.m-2.mol-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C82" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -20889,6 +21989,7 @@ unit:RAD-PER-HR
   qudt:expression "\\(rad/h\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:AngularVelocity ;
+  qudt:symbol "rad/h" ;
   qudt:ucumCode "rad.h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "rad/h"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -20905,6 +22006,7 @@ unit:RAD-PER-M
   qudt:hasQuantityKind quantitykind:FermiAngularWavenumber ;
   qudt:iec61360Code "0112/2///62720#UAA967" ;
   qudt:informativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
+  qudt:symbol "rad/m" ;
   qudt:ucumCode "rad.m-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C84" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -20919,6 +22021,7 @@ unit:RAD-PER-MIN
   qudt:expression "\\(rad/m\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:AngularVelocity ;
+  qudt:symbol "rad/min" ;
   qudt:ucumCode "rad.min-1"^^qudt:UCUMcs ;
   qudt:ucumCode "rad/min"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -20935,6 +22038,7 @@ unit:RAD-PER-SEC
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:AngularVelocity ;
   qudt:iec61360Code "0112/2///62720#UAA968" ;
+  qudt:symbol "rad/s" ;
   qudt:ucumCode "rad.s-1"^^qudt:UCUMcs ;
   qudt:ucumCode "rad/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "2A" ;
@@ -20952,6 +22056,7 @@ unit:RAD-PER-SEC2
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:AngularAcceleration ;
   qudt:iec61360Code "0112/2///62720#UAA969" ;
+  qudt:symbol "rad/s²" ;
   qudt:ucumCode "rad.s-2"^^qudt:UCUMcs ;
   qudt:ucumCode "rad/s2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "2B" ;
@@ -20982,6 +22087,7 @@ unit:RAYL
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:SpecificAcousticImpedance ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Rayl?oldid=433570842"^^xsd:anyURI ;
+  qudt:symbol "rayl" ;
   qudt:unitOfSystem sou:CGS ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Rayl"@en ;
@@ -21024,6 +22130,7 @@ unit:REV-PER-HR
   qudt:expression "\\(rev/h\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:AngularVelocity ;
+  qudt:symbol "rev/h" ;
   qudt:ucumCode "{#}.h-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Revolution per Hour"@en ;
@@ -21037,6 +22144,7 @@ unit:REV-PER-MIN
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:AngularVelocity ;
   qudt:iec61360Code "0112/2///62720#UAB231" ;
+  qudt:symbol "rev/min" ;
   qudt:ucumCode "{#}.min-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M46" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -21050,6 +22158,7 @@ unit:REV-PER-SEC
   qudt:expression "\\(rev/s\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:AngularVelocity ;
+  qudt:symbol "rev/s" ;
   qudt:ucumCode "{#}.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "RPS" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -21062,6 +22171,7 @@ unit:REV-PER-SEC2
   qudt:expression "\\(rev/s2\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:AngularAcceleration ;
+  qudt:symbol "rev/s²" ;
   qudt:ucumCode "{#}.s-2"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:CGS ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -21079,6 +22189,7 @@ unit:ROD
   qudt:hasQuantityKind quantitykind:Length ;
   qudt:iec61360Code "0112/2///62720#UAA970" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Rod?oldid=492590086"^^xsd:anyURI ;
+  qudt:symbol "rod" ;
   qudt:ucumCode "[rd_br]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F49" ;
   qudt:unitOfSystem sou:IMPERIAL ;
@@ -21221,6 +22332,7 @@ unit:S-M2-PER-MOL
   qudt:hasDimensionVector qkdv:A0E2L-3I0M-1H0T3D0 ;
   qudt:hasQuantityKind quantitykind:MolarConductivity ;
   qudt:iec61360Code "0112/2///62720#UAA280" ;
+  qudt:symbol "s⋅m²/mol" ;
   qudt:ucumCode "S.m2.mol-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D12" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -21234,6 +22346,7 @@ unit:S-PER-CentiM
   qudt:hasQuantityKind quantitykind:Conductivity ;
   qudt:iec61360Code "0112/2///62720#UAA278" ;
   qudt:plainTextDescription "SI derived unit Siemens divided by the 0.01-fold of the SI base unit metre" ;
+  qudt:symbol "S/cm" ;
   qudt:ucumCode "S.cm-2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H43" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -21249,6 +22362,7 @@ unit:S-PER-M
   qudt:hasQuantityKind quantitykind:ElectrolyticConductivity ;
   qudt:iec61360Code "0112/2///62720#UAA279" ;
   qudt:plainTextDescription "SI derived unit siemens divided by the SI base unit metre" ;
+  qudt:symbol "s/m" ;
   qudt:ucumCode "S.m-1"^^qudt:UCUMcs ;
   qudt:ucumCode "S/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D10" ;
@@ -21262,6 +22376,7 @@ unit:SAMPLE-PER-SEC
   qudt:expression "\\(sample-per-sec\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Frequency ;
+  qudt:symbol "sample/s" ;
   qudt:ucumCode "s-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Sample per second"@en ;
@@ -21299,6 +22414,7 @@ unit:SEC-FT2
   qudt:expression "\\(s-ft^2\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:AreaTime ;
+  qudt:symbol "s⋅ft²" ;
   qudt:ucumCode "s.[ft_i]2"^^qudt:UCUMcs ;
   qudt:ucumCode "s.[sft_i]"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:IMPERIAL ;
@@ -21309,6 +22425,7 @@ unit:SEC-PER-M
   a qudt:Unit ;
   qudt:conversionMultiplier 1.0 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T1D0 ;
+  qudt:symbol "s/m" ;
   qudt:ucumCode "s.m-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Seconds per metre"@en ;
@@ -21320,6 +22437,7 @@ unit:SEC-PER-RAD-M3
   qudt:hasQuantityKind quantitykind:DensityOfStates ;
   qudt:iec61360Code "0112/2///62720#UAB352" ;
   qudt:informativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
+  qudt:symbol "s/rad⋅m³" ;
   qudt:ucumCode "s.rad-1.m-3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "Q22" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -21337,6 +22455,7 @@ unit:SEC2
   qudt:expression "\\(s^2\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T2D0 ;
   qudt:hasQuantityKind quantitykind:TimeSquared ;
+  qudt:symbol "s²" ;
   qudt:ucumCode "s2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Square Second"@en ;
@@ -21351,7 +22470,7 @@ unit:SH
   qudt:iec61360Code "0112/2///62720#UAB226" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Shake?oldid=494796779"^^xsd:anyURI ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/shake> ;
-  qudt:symbol "Sh" ;
+  qudt:symbol "shake" ;
   qudt:ucumCode "10.ns"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M56" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -21368,6 +22487,7 @@ unit:SHANNON
   qudt:informativeReference "http://en.wikipedia.org/wiki/Ban_(information)"^^xsd:anyURI ;
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31898"^^xsd:anyURI ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/shannon> ;
+  qudt:symbol "Sh" ;
   qudt:uneceCommonCode "Q14" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Shannon"@en ;
@@ -21382,6 +22502,7 @@ unit:SHANNON-PER-SEC
   qudt:iec61360Code "0112/2///62720#UAB346" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Ban_(information)"^^xsd:anyURI ;
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31898"^^xsd:anyURI ;
+  qudt:symbol "Sh/s" ;
   qudt:uneceCommonCode "Q17" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Shannon per Second"@en ;
@@ -21410,6 +22531,7 @@ unit:SLUG-PER-DAY
   qudt:hasQuantityKind quantitykind:MassFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA979" ;
   qudt:plainTextDescription "unit slug for mass according to an English engineering system divided by the unit day" ;
+  qudt:symbol "slug/day" ;
   qudt:uneceCommonCode "L63" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Slug Per Day"@en ;
@@ -21422,6 +22544,7 @@ unit:SLUG-PER-FT
   qudt:expression "\\(slug/ft\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:MassPerLength ;
+  qudt:symbol "slug/ft" ;
   qudt:unitOfSystem sou:IMPERIAL ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Slug per Foot"@en ;
@@ -21435,6 +22558,7 @@ unit:SLUG-PER-FT-SEC
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:DynamicViscosity ;
   qudt:iec61360Code "0112/2///62720#UAA980" ;
+  qudt:symbol "slug/(ft⋅s)" ;
   qudt:uneceCommonCode "L64" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Slug per Foot Second"@en ;
@@ -21447,6 +22571,7 @@ unit:SLUG-PER-FT2
   qudt:expression "\\(slug/ft^{2}\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:MassPerArea ;
+  qudt:symbol "slug/ft²" ;
   qudt:unitOfSystem sou:IMPERIAL ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Slug per Square Foot"@en ;
@@ -21460,6 +22585,7 @@ unit:SLUG-PER-FT3
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Density ;
   qudt:iec61360Code "0112/2///62720#UAA981" ;
+  qudt:symbol "slug/ft³" ;
   qudt:uneceCommonCode "L65" ;
   qudt:unitOfSystem sou:IMPERIAL ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -21472,6 +22598,7 @@ unit:SLUG-PER-HR
   qudt:hasQuantityKind quantitykind:MassFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA982" ;
   qudt:plainTextDescription "unit slug for mass slug according to the English engineering system divided by the unit hour" ;
+  qudt:symbol "slug/hr" ;
   qudt:uneceCommonCode "L66" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Slug Per Hour"@en ;
@@ -21483,6 +22610,7 @@ unit:SLUG-PER-MIN
   qudt:hasQuantityKind quantitykind:MassFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA983" ;
   qudt:plainTextDescription "unit slug for the mass according to the English engineering system divided by the unit minute" ;
+  qudt:symbol "slug/min" ;
   qudt:uneceCommonCode "L67" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Slug Per Minute"@en ;
@@ -21497,6 +22625,7 @@ unit:SLUG-PER-SEC
   qudt:hasQuantityKind quantitykind:MassFlowRate ;
   qudt:hasQuantityKind quantitykind:MassPerTime ;
   qudt:iec61360Code "0112/2///62720#UAA984" ;
+  qudt:symbol "slug/s" ;
   qudt:uneceCommonCode "L68" ;
   qudt:unitOfSystem sou:IMPERIAL ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -21537,7 +22666,6 @@ unit:ST
   qudt:latexDefinition "\\((cm^2/s\\))"^^qudt:LatexString ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/stokes> ;
   qudt:symbol "St" ;
-  qudt:symbol "v" ;
   qudt:ucumCode "St"^^qudt:UCUMcs ;
   qudt:udunitsCode "St" ;
   qudt:uneceCommonCode "91" ;
@@ -21587,6 +22715,7 @@ unit:SUSCEPTIBILITY_ELEC
   qudt:hasQuantityKind quantitykind:Dimensionless ;
   qudt:latexDefinition "\\chi_{\\text{e}} = \\frac{{\\mathbf P}}{\\varepsilon_0{\\mathbf E}}"^^qudt:LatexString ;
   qudt:plainTextDescription "Electric susceptibility is a dimensionless proportionality constant that indicates the degree of polarization of a dielectric material in response to an applied electric field. Here P = epsilon_0 * chi_e * E. Where epsilon_0 is the electric permittivity of free space (electric constant), P is the polarization density of the material chi_e is the electric susceptibility and E is the electric field." ;
+  qudt:symbol "χ" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Electric Susceptibility Unit" ;
 .
@@ -21598,6 +22727,7 @@ unit:SUSCEPTIBILITY_MAG
   qudt:hasQuantityKind quantitykind:Dimensionless ;
   qudt:latexDefinition "\\chi_\\text{v} = \\frac{\\mathbf{M}}{\\mathbf{H}}"^^qudt:LatexString ;
   qudt:plainTextDescription "Magnetic susceptibility is a dimensionless proportionality constant that indicates the degree of magnetization of a material in response to an applied magnetic field. Here M = chi * H. Where M is the magnetization of the material (the magnetic dipole moment per unit volume), measured in amperes per meter, and H is the magnetic field strength, also measured in amperes per meter. Chi is therefore a dimensionless quantity." ;
+  qudt:symbol "χ" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Magnetic Susceptibility Unit" ;
 .
@@ -21881,6 +23011,7 @@ unit:Standard
   qudt:hasQuantityKind quantitykind:Volume ;
   qudt:iec61360Code "0112/2///62720#UAB116" ;
   qudt:plainTextDescription "non SI-conform unit of the volume of readily finished wood material : 1 standard = 1,980 board feet or approximate 4.672 cubic metre" ;
+  qudt:symbol "standard" ;
   qudt:ucumCode "1980.[bf_i]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "WSD" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -21893,6 +23024,7 @@ unit:Stone_UK
   qudt:hasQuantityKind quantitykind:Mass ;
   qudt:iec61360Code "0112/2///62720#UAB081" ;
   qudt:plainTextDescription "unit of the mass which is commonly used for the determination of the weight of living beings regarding to the conversion to the avoirdupois system of units: 1 st = 14 lb (av)" ;
+  qudt:symbol "st{UK}" ;
   qudt:ucumCode "[stone_av]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "STI" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -21993,6 +23125,7 @@ unit:T-M
   a qudt:Unit ;
   qudt:hasDimensionVector qkdv:A0E-1L1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:MagneticFluxPerUnitLength ;
+  qudt:symbol "T⋅m" ;
   qudt:ucumCode "T.m"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "T-M"@en ;
@@ -22001,6 +23134,7 @@ unit:T-SEC
   a qudt:Unit ;
   qudt:hasDimensionVector qkdv:A0E-1L0I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:MassPerElectricCharge ;
+  qudt:symbol "T⋅s" ;
   qudt:ucumCode "T.s"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "T-SEC"@en ;
@@ -22063,6 +23197,7 @@ unit:THM_EEC
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Energy ;
   qudt:hasQuantityKind quantitykind:ThermalEnergy ;
+  qudt:symbol "thm{EEC}" ;
   qudt:ucumCode "100000.[Btu_IT]"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "THM_EEC"@en ;
@@ -22075,7 +23210,7 @@ unit:THM_US
   qudt:hasQuantityKind quantitykind:Energy ;
   qudt:hasQuantityKind quantitykind:ThermalEnergy ;
   qudt:informativeReference "http://www.convertunits.com/info/therm%2B%5BU.S.%5D"^^xsd:anyURI ;
-  qudt:symbol "thm" ;
+  qudt:symbol "thm{US}" ;
   qudt:ucumCode "100000.[Btu_59]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "N72" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -22100,6 +23235,7 @@ unit:TONNE
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Mass ;
   qudt:plainTextDescription "1,000-fold of the SI base unit kilogram" ;
+  qudt:symbol "t" ;
   qudt:ucumCode "t"^^qudt:UCUMcs ;
   qudt:udunitsCode "t" ;
   qudt:uneceCommonCode "TNE" ;
@@ -22115,6 +23251,7 @@ unit:TONNE-PER-DAY
   qudt:hasQuantityKind quantitykind:MassFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA991" ;
   qudt:plainTextDescription "metric unit tonne divided by the unit for time day" ;
+  qudt:symbol "t/day" ;
   qudt:ucumCode "t.d-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L71" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -22154,6 +23291,7 @@ unit:TONNE-PER-HR
   qudt:hasQuantityKind quantitykind:MassFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAB994" ;
   qudt:plainTextDescription "unit tonne divided by the unit for time hour" ;
+  qudt:symbol "t/hr" ;
   qudt:ucumCode "t.h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E18" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -22168,6 +23306,7 @@ unit:TONNE-PER-M3
   qudt:hasQuantityKind quantitykind:MassDensity ;
   qudt:iec61360Code "0112/2///62720#UAA997" ;
   qudt:plainTextDescription "unit tonne divided by the power of the SI base unit metre with the exponent 3" ;
+  qudt:symbol "t/m³" ;
   qudt:ucumCode "t.m-3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D41" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -22183,6 +23322,7 @@ unit:TONNE-PER-MIN
   qudt:hasQuantityKind quantitykind:MassFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAB000" ;
   qudt:plainTextDescription "unit tonne divided by the unit for time minute" ;
+  qudt:symbol "t/min" ;
   qudt:ucumCode "t.min-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L78" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -22197,6 +23337,7 @@ unit:TONNE-PER-SEC
   qudt:hasQuantityKind quantitykind:MassFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAB003" ;
   qudt:plainTextDescription "unit tonne divided by the SI base unit second" ;
+  qudt:symbol "t/s" ;
   qudt:ucumCode "t.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L81" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -22227,6 +23368,7 @@ unit:TON_FG
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Ton_of_refrigeration?oldid=494342824"^^xsd:anyURI ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/tonOfRefrigeration> ;
+  qudt:symbol "t/fg" ;
   qudt:unitOfSystem sou:CGS ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Ton of Refrigeration"@en ;
@@ -22238,6 +23380,7 @@ unit:TON_F_US
   qudt:hasQuantityKind quantitykind:Force ;
   qudt:iec61360Code "0112/2///62720#UAB021" ;
   qudt:plainTextDescription "unit of the force according to the American system of units" ;
+  qudt:symbol "tonf{us}" ;
   qudt:ucumCode "[stonf_av]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L94" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -22253,7 +23396,7 @@ unit:TON_LONG
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Mass ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Long_ton"^^xsd:anyURI ;
-  qudt:symbol "ton" ;
+  qudt:symbol "t{long}" ;
   qudt:ucumCode "[lton_av]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "LTN" ;
   qudt:unitOfSystem sou:IMPERIAL ;
@@ -22270,6 +23413,7 @@ unit:TON_LONG-PER-YD3
   qudt:expression "\\(ton/yd^3\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Density ;
+  qudt:symbol "t{long}/yd³" ;
   qudt:ucumCode "[lton_av]/[cyd_i]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L92" ;
   qudt:unitOfSystem sou:IMPERIAL ;
@@ -22287,7 +23431,7 @@ unit:TON_Metric
   qudt:hasQuantityKind quantitykind:Mass ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Tonne?oldid=492526238"^^xsd:anyURI ;
   qudt:plainTextDescription "1,000-fold of the SI base unit kilogram" ;
-  qudt:symbol "mT" ;
+  qudt:symbol "t" ;
   qudt:ucumCode "t"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "TNE" ;
   qudt:unitOfSystem sou:CGS ;
@@ -22305,6 +23449,7 @@ unit:TON_Metric-PER-DAY
   qudt:hasQuantityKind quantitykind:MassFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA991" ;
   qudt:plainTextDescription "metric unit ton divided by the unit for time day" ;
+  qudt:symbol "t/day" ;
   qudt:ucumCode "t.d-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L71" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -22333,6 +23478,7 @@ unit:TON_Metric-PER-HR
   qudt:hasQuantityKind quantitykind:MassFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAB994" ;
   qudt:plainTextDescription "unit tonne divided by the unit for time hour" ;
+  qudt:symbol "t/hr" ;
   qudt:ucumCode "t.h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E18" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -22347,6 +23493,7 @@ unit:TON_Metric-PER-M3
   qudt:hasQuantityKind quantitykind:MassDensity ;
   qudt:iec61360Code "0112/2///62720#UAA997" ;
   qudt:plainTextDescription "unit tonne divided by the power of the SI base unit metre with the exponent 3" ;
+  qudt:symbol "t/m³" ;
   qudt:ucumCode "t.m-3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D41" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -22362,6 +23509,7 @@ unit:TON_Metric-PER-MIN
   qudt:hasQuantityKind quantitykind:MassFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAB000" ;
   qudt:plainTextDescription "unit ton divided by the unit for time minute" ;
+  qudt:symbol "t/min" ;
   qudt:ucumCode "t.min-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L78" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -22376,6 +23524,7 @@ unit:TON_Metric-PER-SEC
   qudt:hasQuantityKind quantitykind:MassFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAB003" ;
   qudt:plainTextDescription "unit ton divided by the SI base unit second" ;
+  qudt:symbol "t/s" ;
   qudt:ucumCode "t.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L81" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -22389,6 +23538,7 @@ unit:TON_SHIPPING_US
   qudt:hasQuantityKind quantitykind:Volume ;
   qudt:iec61360Code "0112/2///62720#UAB011" ;
   qudt:plainTextDescription "traditional unit for volume of cargo, especially in shipping" ;
+  qudt:symbol "MTON" ;
   qudt:uneceCommonCode "L86" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Ton (US Shipping)"@en ;
@@ -22402,7 +23552,7 @@ unit:TON_SHORT
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Mass ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Short_ton"^^xsd:anyURI ;
-  qudt:symbol "ton" ;
+  qudt:symbol "ton{short}" ;
   qudt:ucumCode "[ston_av]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "STN" ;
   qudt:unitOfSystem sou:CGS ;
@@ -22421,6 +23571,7 @@ unit:TON_SHORT-PER-HR
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:MassFlowRate ;
   qudt:hasQuantityKind quantitykind:MassPerTime ;
+  qudt:symbol "ton/hr" ;
   qudt:ucumCode "[ston_av].h-1"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:IMPERIAL ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -22437,6 +23588,7 @@ unit:TON_SHORT-PER-YD3
   qudt:expression "\\(ton/yd^3\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Density ;
+  qudt:symbol "ton{short}/yd³" ;
   qudt:ucumCode "[ston_av].[cyd_i]-1"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:IMPERIAL ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -22452,6 +23604,7 @@ unit:TON_UK
   qudt:iec61360Code "0112/2///62720#UAB008" ;
   qudt:iec61360Code "0112/2///62720#UAB009" ;
   qudt:plainTextDescription "traditional Imperial unit for volume of cargo, especially in the shipping sector" ;
+  qudt:symbol "ton{UK}" ;
   qudt:ucumCode "[lton_av]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L84" ;
   qudt:uneceCommonCode "LTN" ;
@@ -22466,6 +23619,7 @@ unit:TON_UK-PER-DAY
   qudt:hasQuantityKind quantitykind:MassFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAB010" ;
   qudt:plainTextDescription "unit British ton according to the Imperial system of units divided by the unit day" ;
+  qudt:symbol "t{long}/day" ;
   qudt:ucumCode "[lton_av].d-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L85" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -22479,6 +23633,7 @@ unit:TON_UK-PER-YD3
   qudt:hasQuantityKind quantitykind:MassDensity ;
   qudt:iec61360Code "0112/2///62720#UAB018" ;
   qudt:plainTextDescription "unit of the density according the Imperial system of units" ;
+  qudt:symbol "t{long}/yd³" ;
   qudt:ucumCode "[lton_av].[cyd_i]-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Long Ton (UK) Per Cubic Yard"@en ;
@@ -22492,6 +23647,7 @@ unit:TON_US
   qudt:hasQuantityKind quantitykind:Mass ;
   qudt:iec61360Code "0112/2///62720#UAB012" ;
   qudt:plainTextDescription "unit of the mass according to the Anglo-American system of units" ;
+  qudt:symbol "ton{US}" ;
   qudt:ucumCode "[ston_av]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "STN" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -22505,6 +23661,7 @@ unit:TON_US-PER-DAY
   qudt:hasQuantityKind quantitykind:MassFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAB014" ;
   qudt:plainTextDescription "unit American ton according to the Anglo-American system of units divided by the unit day" ;
+  qudt:symbol "ton{US}/day" ;
   qudt:ucumCode "[ston_av].d-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L88" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -22519,6 +23676,7 @@ unit:TON_US-PER-HR
   qudt:iec61360Code "0112/2///62720#UAA994" ;
   qudt:iec61360Code "0112/2///62720#UAB019" ;
   qudt:plainTextDescription "unit ton divided by the unit for time hour" ;
+  qudt:symbol "ton{US}/hr" ;
   qudt:ucumCode "[ston_av].h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "4W" ;
   qudt:uneceCommonCode "E18" ;
@@ -22534,6 +23692,7 @@ unit:TON_US-PER-YD3
   qudt:hasQuantityKind quantitykind:MassDensity ;
   qudt:iec61360Code "0112/2///62720#UAB020" ;
   qudt:plainTextDescription "unit of the density according to the Anglo-American system of units" ;
+  qudt:symbol "ton{US}/yd³" ;
   qudt:ucumCode "[ston_av].[cyd_i]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L93" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -22678,6 +23837,7 @@ unit:TeraHZ
   qudt:isScalingOf unit:HZ ;
   qudt:plainTextDescription "1 000 000 000 000-fold of the SI derived unit hertz" ;
   qudt:prefix prefix:Tera ;
+  qudt:symbol "THz" ;
   qudt:ucumCode "THz"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D29" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -22692,6 +23852,7 @@ unit:TeraJ
   qudt:isScalingOf unit:J ;
   qudt:plainTextDescription "1 000 000 000 000-fold of the SI derived unit joule" ;
   qudt:prefix prefix:Tera ;
+  qudt:symbol "TJ" ;
   qudt:ucumCode "TJ"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D30" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -22706,6 +23867,7 @@ unit:TeraOHM
   qudt:isScalingOf unit:OHM ;
   qudt:plainTextDescription "1,000,000,000,000-fold of the SI derived unit ohm" ;
   qudt:prefix prefix:Tera ;
+  qudt:symbol "TΩ" ;
   qudt:ucumCode "TOhm"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H44" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -22721,6 +23883,7 @@ unit:TeraW
   qudt:isScalingOf unit:W ;
   qudt:plainTextDescription "1,000,000,000,000-fold of the SI derived unit watt" ;
   qudt:prefix prefix:Tera ;
+  qudt:symbol "TW" ;
   qudt:ucumCode "TW"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D31" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -22733,6 +23896,7 @@ unit:TeraW-HR
   qudt:hasQuantityKind quantitykind:Energy ;
   qudt:iec61360Code "0112/2///62720#UAA290" ;
   qudt:plainTextDescription "1,000,000,000,000-fold of the product of the SI derived unit watt and the unit hour" ;
+  qudt:symbol "TW⋅hr" ;
   qudt:ucumCode "TW/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D32" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -22745,6 +23909,7 @@ unit:TonEnergy
   qudt:expression "\\(t/lbf\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Energy ;
+  qudt:symbol "t/lbf" ;
   qudt:ucumCode "Gcal"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:CGS ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -22922,7 +24087,7 @@ unit:UNITLESS
   qudt:hasQuantityKind quantitykind:Transmittance ;
   qudt:hasQuantityKind quantitykind:TransmittanceDensity ;
   qudt:hasQuantityKind quantitykind:Turns ;
-  qudt:symbol "U" ;
+  qudt:symbol "unitless" ;
   qudt:unitOfSystem sou:CGS ;
   qudt:unitOfSystem sou:IMPERIAL ;
   qudt:unitOfSystem sou:SI ;
@@ -23006,6 +24171,7 @@ unit:UnitPole
   qudt:hasQuantityKind quantitykind:MagneticFlux ;
   qudt:iec61360Code "0112/2///62720#UAB214" ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/unitPole> ;
+  qudt:symbol "pole" ;
   qudt:uneceCommonCode "P53" ;
   qudt:unitOfSystem sou:CGS ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -23064,6 +24230,7 @@ unit:V-A
   qudt:hasQuantityKind quantitykind:NonActivePower ;
   qudt:iec61360Code "0112/2///62720#UAA298" ;
   qudt:plainTextDescription "product of the SI derived unit volt and the SI base unit ampere" ;
+  qudt:symbol "V⋅A" ;
   qudt:ucumCode "V.A"^^qudt:UCUMcs ;
   qudt:udunitsCode "VA" ;
   qudt:uneceCommonCode "D46" ;
@@ -23076,6 +24243,7 @@ unit:V-A-HR
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Energy ;
   qudt:plainTextDescription "product of the unit for apparent by ampere and the unit hour" ;
+  qudt:symbol "V⋅A⋅hr" ;
   qudt:ucumCode "V.A.h"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Volt Ampere Hour"@en ;
@@ -23087,6 +24255,7 @@ unit:V-A_Reactive
   qudt:hasQuantityKind quantitykind:ReactivePower ;
   qudt:iec61360Code "0112/2///62720#UAB023" ;
   qudt:plainTextDescription "unit with special name for reactive power" ;
+  qudt:symbol "V⋅A{Reactive}" ;
   qudt:ucumCode "V.A{reactive}"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D44" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -23098,6 +24267,7 @@ unit:V-A_Reactive-HR
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Energy ;
   qudt:plainTextDescription "product of the unit volt ampere reactive and the unit hour" ;
+  qudt:symbol "V⋅A{reactive}⋅hr" ;
   qudt:ucumCode "V.A{reactive}.h"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Volt Ampere Reactive Hour"@en ;
@@ -23106,6 +24276,7 @@ unit:V-M
   a qudt:Unit ;
   qudt:hasDimensionVector qkdv:A0E-1L3I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:ElectricFlux ;
+  qudt:symbol "V⋅m" ;
   qudt:ucumCode "V.m"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "V-M"@en ;
@@ -23117,6 +24288,7 @@ unit:V-PER-CentiM
   qudt:hasQuantityKind quantitykind:ElectricFieldStrength ;
   qudt:iec61360Code "0112/2///62720#UAB054" ;
   qudt:plainTextDescription "derived SI unit volt divided by the 0.01-fold of the SI base unit metre" ;
+  qudt:symbol "V/cm" ;
   qudt:ucumCode "V.cm-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D47" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -23130,6 +24302,7 @@ unit:V-PER-IN
   qudt:hasQuantityKind quantitykind:ElectricFieldStrength ;
   qudt:iec61360Code "0112/2///62720#UAA300" ;
   qudt:plainTextDescription "SI derived unit volt divided by the unit inch according to the Anglo-American and the Imperial system of units" ;
+  qudt:symbol "V/in" ;
   qudt:ucumCode "V.[in_i]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H23" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -23143,6 +24316,7 @@ unit:V-PER-K
   qudt:hasQuantityKind quantitykind:ThomsonCoefficient ;
   qudt:iec61360Code "0112/2///62720#UAB173" ;
   qudt:informativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
+  qudt:symbol "V/K" ;
   qudt:ucumCode "V.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D48" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -23161,6 +24335,7 @@ unit:V-PER-M
   qudt:hasQuantityKind quantitykind:ElectricFieldStrength ;
   qudt:iec61360Code "0112/2///62720#UAA301" ;
   qudt:informativeReference "http://www.efunda.com/glossary/units/units--electric_field_strength--volt_per_meter.cfm"^^xsd:anyURI ;
+  qudt:symbol "V/m" ;
   qudt:ucumCode "V.m-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D50" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -23176,6 +24351,7 @@ unit:V-PER-M2
   qudt:hasDimensionVector qkdv:A0E-1L0I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:EnergyPerAreaElectricCharge ;
   qudt:informativeReference "http://www.funtrivia.com/en/subtopics/Physical-Quantities-310909.html"^^xsd:anyURI ;
+  qudt:symbol "V/m²" ;
   qudt:ucumCode "V.m-2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Volt per Square Meter"@en-us ;
@@ -23188,6 +24364,7 @@ unit:V-PER-MicroSEC
   qudt:hasQuantityKind quantitykind:PowerPerElectricCharge ;
   qudt:iec61360Code "0112/2///62720#UAA297" ;
   qudt:plainTextDescription "SI derived unit volt divided by the 0.000001-fold of the SI base unit second" ;
+  qudt:symbol "V/µs" ;
   qudt:ucumCode "V.us-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H24" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -23200,6 +24377,7 @@ unit:V-PER-MilliM
   qudt:hasQuantityKind quantitykind:ElectricFieldStrength ;
   qudt:iec61360Code "0112/2///62720#UAA302" ;
   qudt:plainTextDescription "SI derived unit volt divided by the 0.001-fold of the SI base unit metre" ;
+  qudt:symbol "V/mm" ;
   qudt:ucumCode "V.mm-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D51" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -23217,6 +24395,7 @@ unit:V-PER-SEC
   qudt:iec61360Code "0112/2///62720#UAA304" ;
   qudt:informativeReference "http://www.oxfordreference.com/view/10.1093/acref/9780198605225.001.0001/acref-9780198605225-e-1512"^^xsd:anyURI ;
   qudt:informativeReference "http://www.thefreedictionary.com/Webers"^^xsd:anyURI ;
+  qudt:symbol "V/s" ;
   qudt:ucumCode "V.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H46" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -23231,6 +24410,7 @@ unit:V-SEC-PER-M
   qudt:hasQuantityKind quantitykind:ScalarMagneticPotential ;
   qudt:iec61360Code "0112/2///62720#UAA303" ;
   qudt:plainTextDescription "product of the SI derived unit volt and the SI base unit second divided by the SI base unit metre" ;
+  qudt:symbol "V⋅s/m" ;
   qudt:ucumCode "V.s.m-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H45" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -23244,6 +24424,7 @@ unit:V2-PER-K2
   qudt:hasQuantityKind quantitykind:LorenzCoefficient ;
   qudt:iec61360Code "0112/2///62720#UAB172" ;
   qudt:informativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
+  qudt:symbol "V²/K²" ;
   qudt:ucumCode "V2.K-2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D45" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -23292,6 +24473,7 @@ unit:V_Ab-SEC
   qudt:hasDimensionVector qkdv:A0E-1L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:MagneticFlux ;
   qudt:informativeReference "http://www.oxfordreference.com/view/10.1093/acref/9780198605225.001.0001/acref-9780198605225-e-820"^^xsd:anyURI ;
+  qudt:symbol "abv⋅s" ;
   qudt:ucumCode "10.nV.s"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:CGS ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -23318,6 +24500,7 @@ unit:V_Stat-CentiM
   qudt:expression "\\(statvolt-centimeter\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E-1L3I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:ElectricFlux ;
+  qudt:symbol "statV⋅cm" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "V_Stat-CentiM"@en ;
 .
@@ -23331,6 +24514,7 @@ The abvolt is another option for a unit of voltage in the cgs system."""^^rdf:HT
   qudt:hasQuantityKind quantitykind:ElectricField ;
   qudt:hasQuantityKind quantitykind:ElectricFieldStrength ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Statvolt"^^xsd:anyURI ;
+  qudt:symbol "statV/cm" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Statvolt per Centimeter"@en-us ;
   rdfs:label "Statvolt per Centimetre"@en ;
@@ -23399,7 +24583,7 @@ unit:W-HR
   qudt:conversionMultiplier 3600.0 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Energy ;
-  qudt:symbol "W-hr" ;
+  qudt:symbol "W⋅hr" ;
   qudt:ucumCode "W.h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "WHR" ;
   qudt:unitOfSystem sou:CGS ;
@@ -23412,7 +24596,7 @@ unit:W-HR-PER-M3
   qudt:conversionMultiplier 3600.0 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:EnergyDensity ;
-  qudt:symbol "W-hr/m3" ;
+  qudt:symbol "W⋅hr/m³" ;
   qudt:ucumCode "W.h.m-3"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:CGS ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -23424,6 +24608,7 @@ unit:W-M-PER-M2-SR
   dcterms:description "The power per unit area of radiation of a given wavenumber illuminating a target at a given incident angle."@en ;
   qudt:conversionMultiplier 1.0 ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H0T-3D0 ;
+  qudt:symbol "W⋅m/m²⋅sr" ;
   qudt:ucumCode "W.m-2.m.sr-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Watts per square metre per inverse metre per steradian"@en ;
@@ -23433,6 +24618,7 @@ unit:W-M2
   qudt:conversionMultiplier 1.0 ;
   qudt:hasDimensionVector qkdv:A0E0L4I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:PowerArea ;
+  qudt:symbol "W⋅m²" ;
   qudt:ucumCode "W.m2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "W-M2"@en ;
@@ -23441,6 +24627,7 @@ unit:W-M2-PER-SR
   a qudt:Unit ;
   qudt:hasDimensionVector qkdv:A0E0L4I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:PowerAreaPerSolidAngle ;
+  qudt:symbol "W⋅m²/sr" ;
   qudt:ucumCode "W.m2.sr-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "W-M2-PER-SR"@en ;
@@ -23453,6 +24640,7 @@ unit:W-PER-CentiM2
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:PowerPerArea ;
   qudt:iec61360Code "0112/2///62720#UAB224" ;
+  qudt:symbol "W/cm²" ;
   qudt:ucumCode "W.cm-2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "N48" ;
   qudt:unitOfSystem sou:CGS ;
@@ -23467,6 +24655,7 @@ unit:W-PER-FT2
   qudt:expression "\\(W/ft^{2}\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:PowerPerArea ;
+  qudt:symbol "W/ft²" ;
   qudt:ucumCode "W.[sft_i]-1"^^qudt:UCUMcs ;
   qudt:unitOfSystem sou:USCS ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -23480,6 +24669,7 @@ unit:W-PER-IN2
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:PowerPerArea ;
   qudt:iec61360Code "0112/2///62720#UAB225" ;
+  qudt:symbol "W/in²" ;
   qudt:ucumCode "W.[sin_i]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "N49" ;
   qudt:unitOfSystem sou:USCS ;
@@ -23495,6 +24685,7 @@ unit:W-PER-K
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H-1T-3D0 ;
   qudt:hasQuantityKind quantitykind:ThermalConductance ;
   qudt:iec61360Code "0112/2///62720#UAA307" ;
+  qudt:symbol "w/K" ;
   qudt:ucumCode "W.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D52" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -23507,6 +24698,7 @@ unit:W-PER-KiloGM
   qudt:hasQuantityKind quantitykind:AbsorbedDoseRate ;
   qudt:iec61360Code "0112/2///62720#UAA316" ;
   qudt:plainTextDescription "SI derived unit watt divided by the SI base unit kilogram" ;
+  qudt:symbol "W/kg" ;
   qudt:ucumCode "W.kg-1"^^qudt:UCUMcs ;
   qudt:ucumCode "W/kg"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "WA" ;
@@ -23517,6 +24709,7 @@ unit:W-PER-M
   a qudt:Unit ;
   qudt:conversionMultiplier 1.0 ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H0T-3D0 ;
+  qudt:symbol "W/m" ;
   qudt:ucumCode "W.m-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H74" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -23534,6 +24727,7 @@ unit:W-PER-M-K
   qudt:iec61360Code "0112/2///62720#UAA309" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Thermal_conductivity"^^xsd:anyURI ;
   qudt:latexSymbol "\\(W \\cdot m^{-1} \\cdot K^{-1}\\)"^^qudt:LatexString ;
+  qudt:symbol "W/(m⋅K)" ;
   qudt:ucumCode "W.m-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D53" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -23553,6 +24747,7 @@ unit:W-PER-M2
   qudt:hasQuantityKind quantitykind:PoyntingVector ;
   qudt:iec61360Code "0112/2///62720#UAA310" ;
   qudt:informativeReference "http://www.efunda.com/glossary/units/units--energy_flux--watt_per_square_meter.cfm"^^xsd:anyURI ;
+  qudt:symbol "W/m²" ;
   qudt:ucumCode "W.m-2"^^qudt:UCUMcs ;
   qudt:ucumCode "W/m2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D54" ;
@@ -23573,6 +24768,7 @@ unit:W-PER-M2-K
   qudt:hasQuantityKind quantitykind:CombinedNonEvaporativeHeatTransferCoefficient ;
   qudt:hasQuantityKind quantitykind:SurfaceCoefficientOfHeatTransfer ;
   qudt:iec61360Code "0112/2///62720#UAA311" ;
+  qudt:symbol "W/(m²⋅K)" ;
   qudt:ucumCode "W.m-2.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D55" ;
   qudt:unitOfSystem sou:SI ;
@@ -23588,6 +24784,7 @@ unit:W-PER-M2-K4
   qudt:expression "\\(W/(m^2.K^4)\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H-4T-3D0 ;
   qudt:hasQuantityKind quantitykind:PowerPerAreaQuarticTemperature ;
+  qudt:symbol "W/(m²⋅K⁴)" ;
   qudt:ucumCode "W.m-2.K-4"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Watt per Square Meter Quartic Kelvin"@en-us ;
@@ -23597,6 +24794,7 @@ unit:W-PER-M2-M
   a qudt:Unit ;
   qudt:conversionMultiplier 1.0 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-3D0 ;
+  qudt:symbol "W/m²⋅m" ;
   qudt:ucumCode "W.m-2.m-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Watts per square metre per metre"@en ;
@@ -23605,6 +24803,7 @@ unit:W-PER-M2-M-SR
   a qudt:Unit ;
   qudt:conversionMultiplier 1.0 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-3D0 ;
+  qudt:symbol "W/m²⋅m⋅sr" ;
   qudt:ucumCode "W.m-2.m-1.sr-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Watts per square metre per metre per steradian"@en ;
@@ -23613,6 +24812,7 @@ unit:W-PER-M2-NanoM
   a qudt:Unit ;
   qudt:conversionMultiplier 1000000000.0 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-3D0 ;
+  qudt:symbol "W/m²⋅nm" ;
   qudt:ucumCode "W.m-2.nm-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Watts per square metre per nanometre"@en ;
@@ -23621,6 +24821,7 @@ unit:W-PER-M2-NanoM-SR
   a qudt:Unit ;
   qudt:conversionMultiplier 1000000000.0 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-3D0 ;
+  qudt:symbol "W/m²⋅nm⋅sr" ;
   qudt:ucumCode "W.m-2.nm-1.sr-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Watts per square metre per nanometre per steradian"@en ;
@@ -23634,6 +24835,7 @@ unit:W-PER-M2-PA
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:EvaporativeHeatTransferCoefficient ;
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=43012"^^xsd:anyURI ;
+  qudt:symbol "W/(m²⋅pa)" ;
   qudt:ucumCode "W.m-2.Pa-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Watt per Square Meter Pascal"@en-us ;
@@ -23652,6 +24854,7 @@ unit:W-PER-M2-SR
   qudt:informativeReference "http://asd-www.larc.nasa.gov/Instrument/ceres_units.html"^^xsd:anyURI ;
   qudt:informativeReference "http://www.efunda.com/glossary/units/units--radiance--watt_per_square_meter_per_steradian.cfm"^^xsd:anyURI ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Radiance"^^xsd:anyURI ;
+  qudt:symbol "W/(m²⋅sr)" ;
   qudt:ucumCode "W.m-2.sr-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D58" ;
   qudt:unitOfSystem sou:SI ;
@@ -23666,6 +24869,7 @@ unit:W-PER-M3
   qudt:hasQuantityKind quantitykind:ForcePerAreaTime ;
   qudt:iec61360Code "0112/2///62720#UAA312" ;
   qudt:plainTextDescription "SI derived unit watt divided by the power of the SI base unit metre with the exponent 3" ;
+  qudt:symbol "W/m³" ;
   qudt:ucumCode "W.m-3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H47" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -23683,6 +24887,7 @@ unit:W-PER-SR
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:RadiantIntensity ;
   qudt:iec61360Code "0112/2///62720#UAA314" ;
+  qudt:symbol "W/sr" ;
   qudt:ucumCode "W.sr-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D57" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -23695,6 +24900,7 @@ unit:W-SEC
   qudt:hasQuantityKind quantitykind:Energy ;
   qudt:iec61360Code "0112/2///62720#UAA313" ;
   qudt:plainTextDescription "product of the SI derived unit watt and SI base unit second" ;
+  qudt:symbol "W⋅s" ;
   qudt:ucumCode "W.s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J55" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -23705,6 +24911,7 @@ unit:W-SEC-PER-M2
   qudt:conversionMultiplier 1.0 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:EnergyPerArea ;
+  qudt:symbol "W⋅s/m²" ;
   qudt:ucumCode "W.s.m-2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Watt seconds per square metre"@en ;
@@ -23739,7 +24946,7 @@ unit:WB-M
   qudt:hasQuantityKind quantitykind:MagneticDipoleMoment ;
   qudt:iec61360Code "0112/2///62720#UAB333" ;
   qudt:informativeReference "http://www.simetric.co.uk/siderived.htm"^^xsd:anyURI ;
-  qudt:symbol "WbM" ;
+  qudt:symbol "Wb⋅m" ;
   qudt:ucumCode "Wb.m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P50" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -23754,6 +24961,7 @@ unit:WB-PER-M
   qudt:hasQuantityKind quantitykind:MagneticVectorPotential ;
   qudt:iec61360Code "0112/2///62720#UAA318" ;
   qudt:plainTextDescription "SI derived unit weber divided by the SI base unit metre" ;
+  qudt:symbol "Wb/m" ;
   qudt:ucumCode "Wb.m-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D59" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -23767,6 +24975,7 @@ unit:WB-PER-MilliM
   qudt:hasQuantityKind quantitykind:MagneticVectorPotential ;
   qudt:iec61360Code "0112/2///62720#UAB074" ;
   qudt:plainTextDescription "derived SI unit weber divided by the 0.001-fold of the SI base unit metre" ;
+  qudt:symbol "Wb/mm" ;
   qudt:ucumCode "Wb.mm-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D60" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -23867,6 +25076,7 @@ unit:YD-PER-DEG_F
   qudt:hasQuantityKind quantitykind:LinearThermalExpansion ;
   qudt:iec61360Code "0112/2///62720#UAB031" ;
   qudt:plainTextDescription "unit yard according to the Anglo-American and the Imperial system of units divided by the unit for temperature degree Fahrenheit" ;
+  qudt:symbol "yd/°F" ;
   qudt:ucumCode "[yd_i].[degF]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L98" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -23883,6 +25093,7 @@ unit:YD2
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Area ;
   qudt:iec61360Code "0112/2///62720#UAB034" ;
+  qudt:symbol "sqyd" ;
   qudt:ucumCode "[syd_i]"^^qudt:UCUMcs ;
   qudt:ucumCode "[yd_i]2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "YDK" ;
@@ -23902,6 +25113,7 @@ unit:YD3
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Volume ;
   qudt:iec61360Code "0112/2///62720#UAB035" ;
+  qudt:symbol "yd³" ;
   qudt:ucumCode "[cyd_i]"^^qudt:UCUMcs ;
   qudt:ucumCode "[yd_i]3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "YDQ" ;
@@ -23917,6 +25129,7 @@ unit:YD3-PER-DAY
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAB037" ;
   qudt:plainTextDescription "power of the unit yard according to the Anglo-American and the Imperial system of units with the exponent 3 divided by the unit for time day" ;
+  qudt:symbol "yd³/day" ;
   qudt:ucumCode "[cyd_i].d-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M12" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -23929,6 +25142,7 @@ unit:YD3-PER-DEG_F
   qudt:hasQuantityKind quantitykind:VolumeThermalExpansion ;
   qudt:iec61360Code "0112/2///62720#UAB036" ;
   qudt:plainTextDescription "power of the unit yard according to the Anglo-American and the Imperial system of units with the exponent 3 divided by the unit for temperature degree Fahrenheit" ;
+  qudt:symbol "yd³/°F" ;
   qudt:ucumCode "[cyd_i].[degF]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M11" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -23941,6 +25155,7 @@ unit:YD3-PER-HR
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAB038" ;
   qudt:plainTextDescription "power of the unit yard according to the Anglo-American and the Imperial system of units with the exponent 3 divided by the unit for the time hour" ;
+  qudt:symbol "yd³/hr" ;
   qudt:ucumCode "[cyd_i].h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M13" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -23958,6 +25173,7 @@ unit:YD3-PER-MIN
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
   qudt:iec61360Code "0112/2///62720#UAB040" ;
+  qudt:symbol "yd³/min" ;
   qudt:ucumCode "[cyd_i].min-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[cyd_i]/min"^^qudt:UCUMcs ;
   qudt:ucumCode "[yd_i]3.min-1"^^qudt:UCUMcs ;
@@ -23974,6 +25190,7 @@ unit:YD3-PER-SEC
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAB041" ;
   qudt:plainTextDescription "power of the unit and the Anglo-American and Imperial system of units with the exponent 3 divided by the SI base unit second" ;
+  qudt:symbol "yd³/s" ;
   qudt:ucumCode "[cyd_i].s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M16" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -23988,7 +25205,7 @@ unit:YR
   qudt:iec61360Code "0112/2///62720#UAB026" ;
   qudt:informativeReference "http://www.oxfordreference.com/view/10.1093/acref/9780198605225.001.0001/acref-9780198605225-e-1533?rskey=b94Fd6"^^xsd:anyURI ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/year> ;
-  qudt:symbol "a" ;
+  qudt:symbol "yr" ;
   qudt:ucumCode "a"^^qudt:UCUMcs ;
   qudt:udunitsCode "yr" ;
   qudt:uneceCommonCode "ANN" ;
@@ -24002,6 +25219,7 @@ unit:YR_Common
   qudt:hasQuantityKind quantitykind:Time ;
   qudt:iec61360Code "0112/2///62720#UAB025" ;
   qudt:plainTextDescription "31,536,000-fold of the SI base unit second according a common year with 365 days" ;
+  qudt:symbol "yr" ;
   qudt:uneceCommonCode "L95" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Common Year"@en ;
@@ -24013,7 +25231,7 @@ unit:YR_Sidereal
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Time ;
   qudt:iec61360Code "0112/2///62720#UAB028" ;
-  qudt:symbol "yr" ;
+  qudt:symbol "yr{sidereal}" ;
   qudt:uneceCommonCode "L96" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Sidereal Year"@en ;
@@ -24026,7 +25244,7 @@ unit:YR_TROPICAL
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Time ;
   qudt:iec61360Code "0112/2///62720#UAB029" ;
-  qudt:symbol "a_{t}" ;
+  qudt:symbol "yr{tropical}" ;
   qudt:ucumCode "a_t"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D42" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -24181,6 +25399,7 @@ unit:failures-in-time
   qudt:hasQuantityKind quantitykind:Frequency ;
   qudt:iec61360Code "0112/2///62720#UAB403" ;
   qudt:plainTextDescription "unit of failure rate" ;
+  qudt:symbol "failures/s" ;
   qudt:ucumCode "s-1{failures}"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "FIT" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -18265,11 +18265,11 @@ unit:NanoGM-PER-L
 .
 unit:NanoGM-PER-M3
   a qudt:Unit ;
-  dcterms:description "\"0.000000000001‬-fold of the SI base unit kilogram divided by the power of the SI base unit metre with the exponent 3\""^^rdf:HTML ;
+  dcterms:description "\"0.000000000001-fold of the SI base unit kilogram divided by the power of the SI base unit metre with the exponent 3\""^^rdf:HTML ;
   qudt:conversionMultiplier 0.000000000001 ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:MassDensity ;
-  qudt:plainTextDescription "0.000000000001‬-fold of the SI base unit kilogram divided by the power of the SI base unit metre with the exponent 3" ;
+  qudt:plainTextDescription "0.000000000001-fold of the SI base unit kilogram divided by the power of the SI base unit metre with the exponent 3" ;
   qudt:symbol "ng/m³" ;
   qudt:ucumCode "ng.m-3"^^qudt:UCUMcs ;
   rdfs:comment "\"Derived from GM-PER-M3 which exists in QUDT\"" ;


### PR DESCRIPTION
I saw the reference to adding Unicode symbols in the release notes and another pull request related to it by @fennibay (#567). We also have a desire for having human readable symbols for units for use in our applications, and rendering TeX is not always convenient. This includes a fairly standardized set of about 1500 Unicode representations of units. They look like the following for `unit:BTU_IT-PER-FT2-HR-DEG_F`: Btu{IT}/(hr⋅ft²⋅°F)

Note that the [the Unicode symbols linked to in the other PR](https://unicode-table.com/en/sets/unit-symbols/) are currently _NOT_ used in this PR to ensure appearance would be consistent (unlike the g/㎏ example used in the other PR where the two g's look different on my browser). If desired, I can certainly modify this PR to use those Unicode symbols where applicable.

Also, note that a large majority of unit symbols not updated here are for currency units.