### PR TITLE
Unit and Quantity Kind Additions

### DIFF
--- a/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
+++ b/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
@@ -422,8 +422,8 @@ quantitykind:Adaptation
 quantitykind:Admittance
   a qudt:QuantityKind ;
   dcterms:description "\"Admittance\" is a measure of how easily a circuit or device will allow a current to flow. It is defined as the inverse of the impedance (\\(Z\\)). "^^qudt:LatexString ;
-  qudt:applicableUnit unit:MicroS ;
   qudt:applicableUnit unit:KiloS ;
+  qudt:applicableUnit unit:MicroS ;
   qudt:applicableUnit unit:MilliS ;
   qudt:applicableUnit unit:S ;
   qudt:hasDimensionVector qkdv:A0E2L-2I0M-1H0T3D0 ;

--- a/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
+++ b/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
@@ -3041,6 +3041,7 @@ quantitykind:CubicExpansionCoefficient
   qudt:qkdvNumerator qkdv:A0E0L3I0M0H0T0D0 ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
   rdfs:label "Cubic Expansion Coefficient"@en ;
+  skos:broader quantitykind:ExpansionRatio ;
 .
 quantitykind:CurieTemperature
   a qudt:QuantityKind ;
@@ -8960,8 +8961,11 @@ quantitykind:LinearExpansionCoefficient
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI ;
   qudt:latexDefinition "\\(\\alpha_l = \\frac{1}{l} \\; \\frac{dl}{dT}\\), where \\(l\\) is \\(length\\) and \\(T\\) is thermodynamic temperature."^^qudt:LatexString ;
   qudt:latexSymbol "\\(\\alpha_l\\)"^^qudt:LatexString ;
+  qudt:qkdvDenominator qkdv:A0E0L1I0M0H1T0D0 ;
+  qudt:qkdvNumerator qkdv:A0E0L1I0M0H0T0D0 ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
   rdfs:label "Linear Expansion Coefficient"@en ;
+  skos:broader quantitykind:ExpansionRatio ;
 .
 quantitykind:LinearIonization
   a qudt:QuantityKind ;

--- a/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
+++ b/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
@@ -16056,6 +16056,17 @@ quantitykind:Stress
   rdfs:label "Stress"@en ;
   skos:broader quantitykind:ForcePerArea ;
 .
+quantitykind:StressOpticCoefficient
+  a qudt:QuantityKind ;
+  qudt:hasDimensionVector qkdv:A0E0L1I0M-1H0T2D0 ;
+  qudt:informativeReference "https://en.wikipedia.org/w/index.php?title=Photoelasticity&oldid=1109858854#Experimental_principles"^^xsd:anyURI ;
+  qudt:latexDefinition "When a ray of light passes through a photoelastic material, its electromagnetic wave components are resolved along the two principal stress directions and each component experiences a different refractive index due to the birefringence. The difference in the refractive indices leads to a relative phase retardation between the two components. Assuming a thin specimen made of isotropic materials, where two-dimensional photoelasticity is applicable, the magnitude of the relative retardation is given by the stress-optic law \\(\\Delta ={\\frac {2\\pi t}{\\lambda }}C(\\sigma _{1}-\\sigma _{2})\\), where \\(\\Delta\\) is the induced retardation, \\(C\\) is the stress-optic coefficient, \\(t\\) is the specimen thickness, \\(\\lambda\\) is the vacuum wavelength, and \\(\\sigma_1\\) and \\(\\sigma_2\\) are the first and second principal stresses, respectively."^^qudt:LatexString ;
+  qudt:plainTextDescription "When a ray of light passes through a photoelastic material, its electromagnetic wave components are resolved along the two principal stress directions and each component experiences a different refractive index due to the birefringence. The difference in the refractive indices leads to a relative phase retardation between the two components. Assuming a thin specimen made of isotropic materials, where two-dimensional photoelasticity is applicable, the magnitude of the relative retardation is given by the stress-optic law Δ=((2πt)/λ)C(σ₁-σ₂), where Δ is the induced retardation, C is the stress-optic coefficient, t is the specimen thickness, λ is the vacuum wavelength, and σ₁ and σ₂ are the first and second principal stresses, respectively." ;
+  qudt:qkdvDenominator qkdv:A0E0L0I0M1H0T-2D0 ;
+  qudt:qkdvNumerator qkdv:A0E0L1I0M0H0T0D0 ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Stress-Optic Coefficient"@en ;
+.
 quantitykind:StructuralEfficiency
   a qudt:QuantityKind ;
   qudt:latexSymbol "\\(\\gamma\\)"^^qudt:LatexString ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -19727,9 +19727,8 @@ unit:PER-K
   qudt:conversionMultiplier 1.0 ;
   qudt:expression "\\(/K\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H-1T0D0 ;
-  qudt:hasQuantityKind quantitykind:CubicExpansionCoefficient ;
+  qudt:hasQuantityKind quantitykind:ExpansionRatio ;
   qudt:hasQuantityKind quantitykind:InverseTemperature ;
-  qudt:hasQuantityKind quantitykind:LinearExpansionCoefficient ;
   qudt:hasQuantityKind quantitykind:RelativePressureCoefficient ;
   qudt:symbol "/K" ;
   qudt:ucumCode "K-1"^^qudt:UCUMcs ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -20827,6 +20827,18 @@ unit:PPM
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Parts per million"@en ;
 .
+unit:PPM-PER-K
+  a qudt:Unit ;
+  dcterms:description "Unit for expansion ratios expressed as parts per million per Kelvin."^^qudt:LatexString ;
+  qudt:conversionMultiplier 0.000001 ;
+  qudt:expression "\\(PPM/K\\)"^^qudt:LatexString ;
+  qudt:hasDimensionVector qkdv:A0E0L0I0M0H-1T0D0 ;
+  qudt:hasQuantityKind quantitykind:ExpansionRatio ;
+  qudt:symbol "PPM/K" ;
+  qudt:ucumCode "ppm.K-1"^^qudt:UCUMcs ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Parts Per Million per Kelvin"@en ;
+.
 unit:PPTH
   a qudt:Unit ;
   dcterms:description "Dimensionless unit for concentration. Recommended practice is to use specific units such as \\(ug/l\\)."^^qudt:LatexString ;
@@ -20851,6 +20863,27 @@ unit:PPTH-PER-HR
   qudt:ucumCode "[ppth].h-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Parts per thousand per hour"@en ;
+.
+unit:PPTM
+  a qudt:Unit ;
+  dcterms:description "Dimensionless unit for concentration. Recommended practice is to use specific units such as \\(ug/l\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 0.0000001 ;
+  qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
+  qudt:hasQuantityKind quantitykind:DimensionlessRatio ;
+  qudt:symbol "PPTM" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Parts per Ten Million"@en ;
+.
+unit:PPTM-PER-K
+  a qudt:Unit ;
+  dcterms:description "Unit for expansion ratios expressed as parts per ten million per Kelvin."^^qudt:LatexString ;
+  qudt:conversionMultiplier 0.0000001 ;
+  qudt:expression "\\(PPM/K\\)"^^qudt:LatexString ;
+  qudt:hasDimensionVector qkdv:A0E0L0I0M0H-1T0D0 ;
+  qudt:hasQuantityKind quantitykind:ExpansionRatio ;
+  qudt:symbol "PPM/K" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Parts Per Ten Million per Kelvin"@en ;
 .
 unit:PPTR
   a qudt:Unit ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -18385,6 +18385,34 @@ unit:NanoM
   rdfs:label "Nanometer"@en-us ;
   rdfs:label "Nanometre"@en ;
 .
+unit:NanoM-PER-CentiM-PSI
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  qudt:conversionMultiplier 0.0000000000145037738 ;
+  qudt:hasDimensionVector qkdv:A0E0L1I0M-1H0T2D0 ;
+  qudt:hasQuantityKind quantitykind:StressOpticCoefficient ;
+  qudt:qkdvDenominator qkdv:A0E0L0I0M1H0T-2D0 ;
+  qudt:qkdvNumerator qkdv:A0E0L1I0M0H0T0D0 ;
+  qudt:siUnitsExpression "nm/cm/PSI" ;
+  qudt:symbol "nm/(cm⋅PSI)" ;
+  qudt:ucumCode "nm.cm-1.PSI-1"^^qudt:UCUMcs ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Nanometer Per Centimeter PSI"@en ;
+.
+unit:NanoM-PER-MilliM-MegaPA
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  qudt:conversionMultiplier 0.000000000001 ;
+  qudt:hasDimensionVector qkdv:A0E0L1I0M-1H0T2D0 ;
+  qudt:hasQuantityKind quantitykind:StressOpticCoefficient ;
+  qudt:qkdvDenominator qkdv:A0E0L0I0M1H0T-2D0 ;
+  qudt:qkdvNumerator qkdv:A0E0L1I0M0H0T0D0 ;
+  qudt:siUnitsExpression "nm/mm/MPa" ;
+  qudt:symbol "nm/(mm⋅MPa)" ;
+  qudt:ucumCode "nm.mm-1.MPa-1"^^qudt:UCUMcs ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Nanometer Per Millimeter Megapascal"@en ;
+.
 unit:NanoM2
   a qudt:Unit ;
   qudt:conversionMultiplier 0.000000000000000001 ;
@@ -20098,6 +20126,7 @@ unit:PER-PA
   qudt:hasQuantityKind quantitykind:InversePressure ;
   qudt:hasQuantityKind quantitykind:IsentropicCompressibility ;
   qudt:hasQuantityKind quantitykind:IsothermalCompressibility ;
+  qudt:hasQuantityKind quantitykind:StressOpticCoefficient ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Pascal?oldid=492989202"^^xsd:anyURI ;
   qudt:siUnitsExpression "m^2/N" ;
   qudt:symbol "/Pa" ;
@@ -20120,6 +20149,7 @@ unit:PER-PSI
   qudt:conversionMultiplier 0.0001450377 ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M-1H0T2D0 ;
   qudt:hasQuantityKind quantitykind:InversePressure ;
+  qudt:hasQuantityKind quantitykind:StressOpticCoefficient ;
   qudt:iec61360Code "0112/2///62720#UAA709" ;
   qudt:plainTextDescription "reciprocal value of the composed unit for pressure (pound-force per square inch)" ;
   qudt:symbol "/psi" ;


### PR DESCRIPTION
This includes the following:

- Make `qudt:CubicExpansionCoefficient` and `qudt:LinearExpansionCoefficent` narrower than `qudt:ExpansionRatio` and adjust usages of `qudt:hasQuantityKind` accordingly
- Add two units for `qudt:ExpansionRatio`
- Add one unit for concentration
- Add Stress-Optical Coefficient as a Quantity Kind, set `qudt:hasQuantityKind` to it for 2 existing units, and add 2 additional units for it.