### PR TITLE
Adds qudt:conversionMultipliers for a few units

### DIFF
--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -5202,6 +5202,7 @@ unit:DeciS-PER-M
 .
 unit:DeciTONNE
   a qudt:Unit ;
+  qudt:conversionMultiplier 100.0 ;
   qudt:exactMatch unit:DeciTON_Metric ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Mass ;
@@ -5213,7 +5214,7 @@ unit:DeciTONNE
 .
 unit:DeciTON_Metric
   a qudt:Unit ;
-  qudt:conversionMultiplier 1.02 ;
+  qudt:conversionMultiplier 100.0 ;
   qudt:exactMatch unit:DeciTONNE ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Mass ;
@@ -5575,6 +5576,7 @@ where, \\(e\\) is the elementary charge, \\(\\epsilon_0\\) is the electric const
 .
 unit:EarthMass
   a qudt:Unit ;
+  qudt:conversionMultiplier 5972400000000000000000000.0 ;
   dcterms:description "Earth mass (\\(M_{\\oplus}\\)) is the unit of mass equal to that of the Earth. In SI Units, \\(1 M_{\\oplus} = 5.9722 \\times 1024 kg\\). Earth mass is often used to describe masses of rocky terrestrial planets. The four terrestrial planets of the Solar System, Mercury, Venus, Earth, and Mars, have masses of 0.055, 0.815, 1.000, and 0.107 Earth masses respectively."^^qudt:LatexString ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Earth_mass"^^xsd:anyURI ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T0D0 ;
@@ -11323,6 +11325,7 @@ unit:KiloSEC
 .
 unit:KiloTONNE
   a qudt:Unit ;
+  qudt:conversionMultiplier 1000000.0 ;
   qudt:exactMatch unit:KiloTON_Metric ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:symbol "kt" ;
@@ -11333,7 +11336,7 @@ unit:KiloTONNE
 .
 unit:KiloTON_Metric
   a qudt:Unit ;
-  qudt:conversionMultiplier 907184.7 ;
+  qudt:conversionMultiplier 1000000.0 ;
   qudt:exactMatch unit:KiloTONNE ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Mass ;
@@ -12568,6 +12571,7 @@ unit:Loti
 .
 unit:LunarMass
   a qudt:Unit ;
+  qudt:conversionMultiplier 73460000000000000000000.0 ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Moon"^^xsd:anyURI ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Mass ;
@@ -14688,6 +14692,7 @@ unit:MegaV-PER-M
 .
 unit:MegaW
   a qudt:Unit ;
+  qudt:conversionMultiplier 1000000.0 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:ActivePower ;
   qudt:hasQuantityKind quantitykind:Power ;
@@ -17339,6 +17344,7 @@ unit:MilliV-PER-MIN
 .
 unit:MilliW
   a qudt:Unit ;
+  qudt:conversionMultiplier 0.001 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:ActivePower ;
   qudt:hasQuantityKind quantitykind:Power ;
@@ -18116,6 +18122,7 @@ unit:NUM-PER-SEC
 unit:NUM-PER-YR
   a qudt:DerivedUnit ;
   a qudt:Unit ;
+  qudt:conversionMultiplier 0.00000003168808781402895023702689684893655 ;
   dcterms:description "\"Number per Year\" is a unit for  'Frequency' expressed as \\(\\#/yr\\)."^^qudt:LatexString ;
   qudt:expression "\\(\\#/yr\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
@@ -22921,6 +22928,7 @@ unit:SlovakKoruna
 .
 unit:SolarMass
   a qudt:Unit ;
+  qudt:conversionMultiplier 1988500000000000000000000000000 ;
   dcterms:description "The astronomical unit of mass is the solar mass.The symbol \\(S\\) is often used in astronomy to refer to this unit, although \\(M_{\\odot}\\) is also common. The solar mass, \\(1.98892 \\time 1030 kg\\), is a standard way to express mass in astronomy, used to describe the masses of other stars and galaxies. It is equal to the mass of the Sun, about 333,000 times the mass of the Earth or 1,048 times the mass of Jupiter. In practice, the masses of celestial bodies appear in the dynamics of the solar system only through the products GM, where G is the constant of gravitation."^^qudt:LatexString ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Solar_mass"^^xsd:anyURI ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T0D0 ;


### PR DESCRIPTION
Addresses #591 - adds/corrects a few qudt:conversionMultiplier triples

Units:
- MilliW (added)
- MegaW (added)
- DeciTONNE (added), DeciTON_Metric: (corrected)
- KiloTONNE (added), KiloTON_Metric: (corrected)
- EarthMass, LunarMass, SolarMass (added, taken from: https://nssdc.gsfc.nasa.gov/planetary/factsheet/ and https://nssdc.gsfc.nasa.gov/planetary/factsheet/sunfact.html and https://nssdc.gsfc.nasa.gov/planetary/factsheet/moonfact.html

                                               -