### PR TITLE
Add missing quantitykind:VolumePerArea

### DIFF
--- a/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
+++ b/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
@@ -17821,6 +17821,15 @@ quantitykind:VolumePerUnitTime
   rdfs:label "Volume per Unit Time"@en ;
   owl:sameAs quantitykind:VolumeFlowRate ;
 .
+quantitykind:VolumePerArea
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:M3-PER-HA ;
+  qudt:baseUnitDimensions "\\(L^3/L^2\\)"^^qudt:LatexString ;
+  qudt:baseUnitDimensions "\\(m^3/m^2\\)"^^qudt:LatexString ;
+  qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T0D0 ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Volume per Unit Area"@en ;
+.
 quantitykind:VolumeStrain
   a qudt:QuantityKind ;
   dcterms:description "Volume, or volumetric, Strain, or dilatation (the relative variation of the volume) is the trace of the tensor \\(\\vartheta\\)."^^qudt:LatexString ;


### PR DESCRIPTION
This quantitykind was referenced by unit:M3-PER-HA but not defined(#593). 

This PR addresses this problem.

As [stated in the issue](https://github.com/qudt/qudt-public-repo/issues/593#issuecomment-1290128388), this PR uses the dimension vector `qkdv:A0E0L1I0M0H0T0D0`, but another one might be better. 
