### PR TITLE
Minor fixes to a few labels, symbols, and a dimension vector

### DIFF
--- a/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
+++ b/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
@@ -11150,7 +11150,7 @@ quantitykind:MolarAbsorptionCoefficient
   a qudt:QuantityKind ;
   qudt:applicableUnit unit:M2-PER-MOL ;
   qudt:exactMatch quantitykind:MolarAttenuationCoefficient ;
-  qudt:hasDimensionVector qkdv:A0E0L2I0M-1H0T0D0 ;
+  qudt:hasDimensionVector qkdv:A-1E0L2I0M0H0T0D0 ;
   qudt:latexDefinition "\\(x = aV_m\\), where \\(a\\) is the linear absorption coefficient and \\(V_m\\) is the molar volume."^^qudt:LatexString ;
   qudt:plainTextDescription "\"Molar Absorption Coefficient\" is a spectrophotometric unit indicating the light a substance absorbs with respect to length, usually centimeters, and concentration, usually moles per liter." ;
   qudt:symbol "x" ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -401,11 +401,11 @@ unit:ANGSTROM3
   qudt:conversionMultiplier 0.0000000000000000000000000000000000000001 ;
   qudt:hasDimensionVector qkdv:A0E2L0I0M-1H0T4D0 ;
   qudt:hasQuantityKind quantitykind:Polarizability ;
-  qudt:symbol "Ã…^3" ;
+  qudt:symbol "Å³" ;
   qudt:unitOfSystem sou:CGS-GAUSS ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
-  rdfs:label "Angstrom^3"@en ;
-  rdfs:label "Angstrom^3"@en-us ;
+  rdfs:label "Cubic Angstrom"@en ;
+  rdfs:label "Cubic Angstrom"@en-us ;
 .
 unit:ARCMIN
   a qudt:DerivedUnit ;
@@ -8097,12 +8097,6 @@ unit:HP
   qudt:unitOfSystem sou:IMPERIAL ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Horsepower"@en ;
-.
-unit:HP-PER-M
-  qudt:symbol "HP{metric}" ;
-.
-unit:HP-PER-V
-  qudt:symbol "HP{electric}" ;
 .
 unit:HP_Boiler
   a qudt:Unit ;


### PR DESCRIPTION
I found a few minor issues while going through some internal updates today:
- Fixed dimension vector of `quantitykind:MolarAbsorptionCoefficient`
- Fixed a couple symbols and labels for consistency
- Removed a couple symbols for 2 units that had been removed.