### PR TITLE
Remove qudt:SymbolAndExpressionDisjointPropertiesConstraint

### DIFF
--- a/schema/shacl/SHACL-SCHEMA-SUPPLEMENT_QUDT-v2.1.ttl
+++ b/schema/shacl/SHACL-SCHEMA-SUPPLEMENT_QUDT-v2.1.ttl
@@ -98,13 +98,6 @@ qudt:Concept-dcterms_description
   sh:name "dcterms description" ;
   sh:order "60"^^xsd:decimal ;
 .
-qudt:Concept-rdfs_isDefinedBy
-  a sh:PropertyShape ;
-  sh:path rdfs:isDefinedBy ;
-  rdfs:isDefinedBy <http://qudt.org/2.1/schema/shacl/overlay/qudt> ;
-  sh:group qudt:IdentifiersAndDescriptionsPropertyGroup ;
-  sh:order "200"^^xsd:decimal ;
-.
 qudt:Concept-qudt_abbreviation
   rdfs:isDefinedBy <http://qudt.org/2.1/schema/shacl/overlay/qudt> ;
   sh:group qudt:IdentifiersAndDescriptionsPropertyGroup ;
@@ -121,15 +114,20 @@ qudt:Concept-qudt_description
   sh:name "full description" ;
   sh:order "60"^^xsd:decimal ;
 .
+qudt:Concept-qudt_guidance
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/shacl/overlay/qudt> ;
+  sh:group qudt:IdentifiersAndDescriptionsPropertyGroup ;
+  sh:order "60"^^xsd:decimal ;
+.
 qudt:Concept-qudt_hasRule
   rdfs:isDefinedBy <http://qudt.org/2.1/schema/shacl/overlay/qudt> ;
   sh:group qudt:IdentifiersAndDescriptionsPropertyGroup ;
   sh:order "95"^^xsd:decimal ;
 .
-qudt:Concept-qudt_guidance
+qudt:Concept-qudt_id
   rdfs:isDefinedBy <http://qudt.org/2.1/schema/shacl/overlay/qudt> ;
   sh:group qudt:IdentifiersAndDescriptionsPropertyGroup ;
-  sh:order "60"^^xsd:decimal ;
+  sh:order "40"^^xsd:decimal ;
 .
 qudt:Concept-qudt_plainTextDescription
   rdfs:isDefinedBy <http://qudt.org/2.1/schema/shacl/overlay/qudt> ;
@@ -144,6 +142,13 @@ qudt:Concept-rdf_type
   sh:minCount 1 ;
   sh:name "type" ;
   sh:order "10"^^xsd:decimal ;
+.
+qudt:Concept-rdfs_isDefinedBy
+  a sh:PropertyShape ;
+  sh:path rdfs:isDefinedBy ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/shacl/overlay/qudt> ;
+  sh:group qudt:IdentifiersAndDescriptionsPropertyGroup ;
+  sh:order "200"^^xsd:decimal ;
 .
 qudt:Concept-rdfs_label
   a sh:PropertyShape ;
@@ -410,25 +415,6 @@ qudt:Rule-qudt_example
   rdfs:isDefinedBy <http://qudt.org/2.1/schema/shacl/overlay/qudt> ;
   sh:or qudt:HTMLOrStringOrLangStringOrLatexString ;
 .
-qudt:SymbolAndExpressionDisjointPropertiesConstraint
-  a sh:NodeShape ;
-  rdfs:isDefinedBy <http://qudt.org/2.1/schema/shacl/overlay/qudt> ;
-  rdfs:label "Symbol and expression disjoint properties constraint" ;
-  sh:sparql [
-      a sh:SPARQLConstraint ;
-      rdfs:comment "Checks that a unit or quantitykind does not have both a symbol and an expression" ;
-      sh:message "Resource '{$this}' of type '{?myType}' must not have both the symbol '{?symbol}' and the expression '{?expression}'." ;
-      sh:prefixes <http://qudt.org/2.1/schema/shacl/overlay/qudt> ;
-      sh:select """SELECT $this ?myType ?symbol ?expression
-WHERE {
-	$this qudt:symbol ?symbol .
-	$this qudt:expression ?expression .
-    $this a ?myType 
-} """ ;
-    ] ;
-  sh:targetClass qudt:QuantityKind ;
-  sh:targetClass qudt:Unit ;
-.
 qudt:UniqueSymbolTypeRestrictedPropertyConstraint
   a sh:NodeShape ;
   rdfs:isDefinedBy <http://qudt.org/2.1/schema/shacl/overlay/qudt> ;
@@ -493,11 +479,6 @@ qudt:Unit-qudt_hasQuantityKind
   rdfs:isDefinedBy <http://qudt.org/2.1/schema/shacl/overlay/qudt> ;
   sh:group qudt:PropertiesGroup ;
   sh:name "quantity kind" ;
-  sh:order "40"^^xsd:decimal ;
-.
-qudt:Concept-qudt_id
-  rdfs:isDefinedBy <http://qudt.org/2.1/schema/shacl/overlay/qudt> ;
-  sh:group qudt:IdentifiersAndDescriptionsPropertyGroup ;
   sh:order "40"^^xsd:decimal ;
 .
 qudt:Unit-qudt_iec61360Code


### PR DESCRIPTION
Remove a SPARQL constraint which prevents Units and Quantity Kinds from having both a qudt:symbol and qudt:expression. Also, reorder some other resources in the file due to TBC serialization. Resolves #605.