### PR TITLE
Add ISO 4217 currencyCodes and currencyNumber

### DIFF
--- a/schema/SCHEMA_QUDT-v2.1.ttl
+++ b/schema/SCHEMA_QUDT-v2.1.ttl
@@ -2134,6 +2134,24 @@ qudt:currencyExponent
   rdfs:label "currency exponent" ;
   rdfs:range xsd:integer ;
 .
+qudt:currencyCode
+    a owl:DatatypeProperty ;
+    a owl:FunctionalProperty ;
+    dcterms:description "Alphabetic Currency Code as defined by ISO 4217. For example, US Dollar has the code 'USD'."^^rdf:HTML ;
+    rdfs:seeAlso "https://en.wikipedia.org/wiki/ISO_4217"^^xsd:anyURI ;
+    rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+    rdfs:label "currency code" ;
+    rdfs:range xsd:string ;
+.
+qudt:currencyNumber
+    a owl:DatatypeProperty ;
+    a owl:FunctionalProperty ;
+    dcterms:description "Numeric currency Code as defined by ISO 4217. For example, US Dollar has the number 840."^^rdf:HTML ;
+    rdfs:seeAlso "https://en.wikipedia.org/wiki/ISO_4217"^^xsd:anyURI ;
+    rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+    rdfs:label "currency number" ;
+    rdfs:range xsd:positiveInteger  ;
+.
 qudt:dataEncoding
   a owl:ObjectProperty ;
   rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -25718,3 +25718,567 @@ a qudt:DerivedUnit ;
   rdfs:label "Kilogram per Square Meter Square Second"@en-us ;
   rdfs:label "Kilogram per Square Metre Square Second"@en ;
 .
+
+unit:CroatianKuna  qudt:currencyCode  "HRK" ;
+                   qudt:currencyNumber  191 .
+
+unit:Rupiah  qudt:currencyCode  "IDR" ;
+             qudt:currencyNumber  360 .
+
+unit:SurinamDollar  qudt:currencyCode  "SRD" ;
+                    qudt:currencyNumber  968 .
+
+unit:VenezuelanBolvar
+    qudt:currencyCode    "VES" ;
+    qudt:currencyNumber  928 .
+
+unit:BYR  qudt:currencyCode  "BYN" ;
+          qudt:currencyNumber  933 .
+
+unit:UruguayPeso  qudt:currencyCode  "UYU" ;
+                  qudt:currencyNumber  858 .
+
+unit:Hryvnia  qudt:currencyCode  "UAH" ;
+              qudt:currencyNumber  980 .
+
+unit:NorwegianKrone  qudt:currencyCode  "NOK" ;
+                     qudt:currencyNumber  578 .
+
+unit:Zloty  qudt:currencyCode  "PLN" ;
+            qudt:currencyNumber  985 .
+
+unit:Manat  qudt:currencyCode  "TMT" ;
+            qudt:currencyNumber  934 .
+
+unit:SouthKoreanWon  qudt:currencyCode  "KRW" ;
+                     qudt:currencyNumber  410 .
+
+unit:ConvertibleMark  qudt:currencyCode
+                                           "BAM" ;
+                      qudt:currencyNumber  977 .
+
+unit:NorthKoreanWon  qudt:currencyCode  "KPW" ;
+                     qudt:currencyNumber  408 .
+
+unit:DanishKrone  qudt:currencyCode  "DKK" ;
+                  qudt:currencyNumber  208 .
+
+unit:IcelandKrona  qudt:currencyCode  "ISK" ;
+                   qudt:currencyNumber  352 .
+
+unit:EuropeanUnitOfAccount9
+    qudt:currencyCode    "XBC" ;
+    qudt:currencyNumber  957 .
+
+unit:NewTurkishLira  qudt:currencyCode  "TRY" ;
+                     qudt:currencyNumber  949 .
+
+unit:USDollar-SameDay
+    qudt:currencyCode    "USS" ;
+    qudt:currencyNumber  998 .
+
+unit:SeychellesRupee  qudt:currencyCode
+                                           "SCR" ;
+                      qudt:currencyNumber  690 .
+
+unit:Somoni  qudt:currencyCode  "TJS" ;
+             qudt:currencyNumber  972 .
+
+unit:BBD  qudt:currencyCode  "BBD" ;
+          qudt:currencyNumber  052 .
+
+unit:Quetzal  qudt:currencyCode  "GTQ" ;
+              qudt:currencyNumber  320 .
+
+unit:GuyanaDollar  qudt:currencyCode  "GYD" ;
+                   qudt:currencyNumber  328 .
+
+unit:AFN  qudt:currencyCode  "AFN" ;
+          qudt:currencyNumber  971 .
+
+unit:RomanianNeLeu  qudt:currencyCode  "RON" ;
+                    qudt:currencyNumber  946 .
+
+unit:GoldFranc  qudt:currencyCode  "XFO" .
+
+unit:RussianRuble  qudt:currencyCode  "RUB" ;
+                   qudt:currencyNumber  643 .
+
+unit:Rufiyaa  qudt:currencyCode  "MVR" ;
+              qudt:currencyNumber  462 .
+
+unit:KenyanShilling  qudt:currencyCode  "KES" ;
+                     qudt:currencyNumber  404 .
+
+unit:TunisianDinar  qudt:currencyCode  "TND" ;
+                    qudt:currencyNumber  788 .
+
+unit:HaitiGourde  qudt:currencyCode  "HTG" ;
+                  qudt:currencyNumber  332 .
+
+unit:Boliviano  qudt:currencyCode  "BOB" ;
+                qudt:currencyNumber  068 .
+
+unit:AWG  qudt:currencyCode  "AWG" ;
+          qudt:currencyNumber  533 .
+
+unit:FrancCongolais  qudt:currencyCode  "CDF" ;
+                     qudt:currencyNumber  976 .
+
+unit:LithuanianLitas  qudt:currencyCode
+                                           "LTL" ;
+                      qudt:currencyNumber  440 .
+
+unit:SaudiRiyal  qudt:currencyCode  "SAR" ;
+                 qudt:currencyNumber  682 .
+
+unit:CaymanIslandsDollar
+    qudt:currencyCode    "KYD" ;
+    qudt:currencyNumber  136 .
+
+unit:Cedi  qudt:currencyCode  "GHS" ;
+           qudt:currencyNumber  936 .
+
+unit:Loti  qudt:currencyCode  "LSL" ;
+           qudt:currencyNumber  426 .
+
+unit:EthiopianBirr  qudt:currencyCode  "ETB" ;
+                    qudt:currencyNumber  230 .
+
+unit:CostaRicanColon  qudt:currencyCode
+                                           "CRC" ;
+                      qudt:currencyNumber  188 .
+
+unit:PakistanRupee  qudt:currencyCode  "PKR" ;
+                    qudt:currencyNumber  586 .
+
+unit:UnidadDeValorReal
+    qudt:currencyCode    "COU" ;
+    qudt:currencyNumber  970 .
+
+unit:MalagasyAriary  qudt:currencyCode  "MGA" ;
+                     qudt:currencyNumber  969 .
+
+unit:SpecialDrawingRights
+    qudt:currencyCode    "XDR" ;
+    qudt:currencyNumber  960 .
+
+unit:BermudaDollar  qudt:currencyCode  "BMD" ;
+                    qudt:currencyNumber  060 .
+
+unit:YemeniRial  qudt:currencyCode  "YER" ;
+                 qudt:currencyNumber  886 .
+
+unit:SwedishKrona  qudt:currencyCode  "SEK" ;
+                   qudt:currencyNumber  752 .
+
+unit:UzbekistanSom  qudt:currencyCode  "UZS" ;
+                    qudt:currencyNumber  860 .
+
+unit:AZN  qudt:currencyCode  "AZN" ;
+          qudt:currencyNumber  944 .
+
+unit:SingaporeDollar  qudt:currencyCode
+                                           "SGD" ;
+                      qudt:currencyNumber  702 .
+
+unit:UgandaShilling  qudt:currencyCode  "UGX" ;
+                     qudt:currencyNumber  800 .
+
+unit:Lari  qudt:currencyCode  "GEL" ;
+           qudt:currencyNumber  981 .
+
+unit:Paanga  qudt:currencyCode  "TOP" ;
+             qudt:currencyNumber  776 .
+
+unit:BruneiDollar  qudt:currencyCode  "BND" ;
+                   qudt:currencyNumber  096 .
+
+unit:NewZealandDollar
+    qudt:currencyCode    "NZD" ;
+    qudt:currencyNumber  554 .
+
+unit:Dalasi  qudt:currencyCode  "GMD" ;
+             qudt:currencyNumber  270 .
+
+unit:Forint  qudt:currencyCode  "HUF" ;
+             qudt:currencyNumber  348 .
+
+unit:IndianRupee  qudt:currencyCode  "INR" ;
+                  qudt:currencyNumber  356 .
+
+unit:CAD  qudt:currencyCode  "CAD" ;
+          qudt:currencyNumber  124 .
+
+unit:Metical  qudt:currencyCode  "MZN" ;
+              qudt:currencyNumber  943 .
+
+unit:PoundSterling  qudt:currencyCode  "GBP" ;
+                    qudt:currencyNumber  826 .
+
+unit:WIREuro  qudt:currencyCode  "CHE" ;
+              qudt:currencyNumber  947 .
+
+unit:SudanesePound  qudt:currencyCode  "SDG" ;
+                    qudt:currencyNumber  938 .
+
+unit:UICFranc  qudt:currencyCode  "XFU" .
+
+unit:ColombianPeso  qudt:currencyCode  "COP" ;
+                    qudt:currencyNumber  170 .
+
+unit:FijiDollar  qudt:currencyCode  "FJD" ;
+                 qudt:currencyNumber  242 .
+
+unit:Palladium-OunceTroy
+    qudt:currencyCode    "XPD" ;
+    qudt:currencyNumber  964 .
+
+unit:MexicanPeso  qudt:currencyCode  "MXN" ;
+                  qudt:currencyNumber  484 .
+
+unit:BurundianFranc  qudt:currencyCode  "BIF" ;
+                     qudt:currencyNumber  108 .
+
+unit:MalaysianRinggit
+    qudt:currencyCode    "MYR" ;
+    qudt:currencyNumber  458 .
+
+unit:BolivianMvdol  qudt:currencyCode  "BOV" ;
+                    qudt:currencyNumber  984 .
+
+unit:BulgarianLev  qudt:currencyCode  "BGN" ;
+                   qudt:currencyNumber  975 .
+
+unit:NamibianDollar  qudt:currencyCode  "NAD" ;
+                     qudt:currencyNumber  516 .
+
+unit:SomaliShilling  qudt:currencyCode  "SOS" ;
+                     qudt:currencyNumber  706 .
+
+unit:Som  qudt:currencyCode  "KGS" ;
+          qudt:currencyNumber  417 .
+
+unit:LiberianDollar  qudt:currencyCode  "LRD" ;
+                     qudt:currencyNumber  430 .
+
+unit:SwissFranc  qudt:currencyCode  "CHF" ;
+                 qudt:currencyNumber  756 .
+
+unit:EuropeanCompositeUnit
+    qudt:currencyCode    "XBA" ;
+    qudt:currencyNumber  955 .
+
+unit:Lek  qudt:currencyCode  "ALL" ;
+          qudt:currencyNumber  008 .
+
+unit:Ngultrum  qudt:currencyCode  "BTN" ;
+               qudt:currencyNumber  064 .
+
+unit:AUD  qudt:currencyCode  "AUD" ;
+          qudt:currencyNumber  036 .
+
+unit:IranianRial  qudt:currencyCode  "IRR" ;
+                  qudt:currencyNumber  364 .
+
+unit:Euro  qudt:currencyCode  "EUR" ;
+           qudt:currencyNumber  978 .
+
+unit:MalteseLira  qudt:currencyCode  "MTL" ;
+                  qudt:currencyNumber  470 .
+
+unit:MoroccanDirham  qudt:currencyCode  "MAD" ;
+                     qudt:currencyNumber  504 .
+
+unit:EuropeanMonetaryUnit
+    qudt:currencyCode    "XBB" ;
+    qudt:currencyNumber  956 .
+
+unit:CordobaOro  qudt:currencyCode  "NIO" ;
+                 qudt:currencyNumber  558 .
+
+unit:LaoKip  qudt:currencyCode  "LAK" ;
+             qudt:currencyNumber  418 .
+
+unit:Vatu  qudt:currencyCode  "VUV" ;
+           qudt:currencyNumber  548 .
+
+unit:SerbianDinar  qudt:currencyCode  "RSD" ;
+                   qudt:currencyNumber  941 .
+
+unit:Lilangeni  qudt:currencyCode  "SZL" ;
+                qudt:currencyNumber  748 .
+
+unit:Riel  qudt:currencyCode  "KHR" ;
+           qudt:currencyNumber  116 .
+
+unit:USDollar-NextDay
+    qudt:currencyCode    "USN" ;
+    qudt:currencyNumber  997 .
+
+unit:YuanRenminbi  qudt:currencyCode  "CNY" ;
+                   qudt:currencyNumber  156 .
+
+unit:UAEDirham  qudt:currencyCode  "AED" ;
+                qudt:currencyNumber  784 .
+
+unit:GuineaFranc  qudt:currencyCode  "GNF" ;
+                  qudt:currencyNumber  324 .
+
+unit:LibyanDinar  qudt:currencyCode  "LYD" ;
+                  qudt:currencyNumber  434 .
+
+unit:EgyptianPound  qudt:currencyCode  "EGP" ;
+                    qudt:currencyNumber  818 .
+
+unit:LatvianLats  qudt:currencyCode  "LVL" ;
+                  qudt:currencyNumber  428 .
+
+unit:NewTaiwanDollar  qudt:currencyCode
+                                           "TWD" ;
+                      qudt:currencyNumber  901 .
+
+unit:DZD  qudt:currencyCode  "DZD" ;
+          qudt:currencyNumber  012 .
+
+unit:CubanPeso  qudt:currencyCode  "CUP" ;
+                qudt:currencyNumber  192 .
+
+unit:NewIsraeliShekel
+    qudt:currencyCode    "ILS" ;
+    qudt:currencyNumber  376 .
+
+unit:XAF  qudt:currencyCode  "XAF" ;
+          qudt:currencyNumber  950 .
+
+unit:Kina  qudt:currencyCode  "PGK" ;
+           qudt:currencyNumber  598 .
+
+unit:VietnameseDong  qudt:currencyCode  "VND" ;
+                     qudt:currencyNumber  704 .
+
+unit:MauritiusRupee  qudt:currencyCode  "MUR" ;
+                     qudt:currencyNumber  480 .
+
+unit:CzechKoruna  qudt:currencyCode  "CZK" ;
+                  qudt:currencyNumber  203 .
+
+unit:ChileanPeso  qudt:currencyCode  "CLP" ;
+                  qudt:currencyNumber  152 .
+
+unit:Naira  qudt:currencyCode  "NGN" ;
+            qudt:currencyNumber  566 .
+
+unit:MoldovanLeu  qudt:currencyCode  "MDL" ;
+                  qudt:currencyNumber  498 .
+
+unit:Silver-OunceTroy
+    qudt:currencyCode    "XAG" ;
+    qudt:currencyNumber  961 .
+
+unit:THB  qudt:currencyCode  "THB" ;
+          qudt:currencyNumber  764 .
+
+unit:SolomonIslandsDollar
+    qudt:currencyCode    "SBD" ;
+    qudt:currencyNumber  090 .
+
+unit:MalawiKwacha  qudt:currencyCode  "MWK" ;
+                   qudt:currencyNumber  454 .
+
+unit:WIRFranc  qudt:currencyCode  "CHW" ;
+               qudt:currencyNumber  948 .
+
+unit:JapaneseYen  qudt:currencyCode  "JPY" ;
+                  qudt:currencyNumber  392 .
+
+unit:Kyat  qudt:currencyCode  "MMK" ;
+           qudt:currencyNumber  104 .
+
+unit:CapeVerdeEscudo  qudt:currencyCode
+                                           "CVE" ;
+                      qudt:currencyNumber  132 .
+
+unit:XPF  qudt:currencyCode  "XPF" ;
+          qudt:currencyNumber  953 .
+
+unit:NuevoSol  qudt:currencyCode  "PEN" ;
+               qudt:currencyNumber  604 .
+
+unit:IraqiDinar  qudt:currencyCode  "IQD" ;
+                 qudt:currencyNumber  368 .
+
+unit:FalklandIslandsPound
+    qudt:currencyCode    "FKP" ;
+    qudt:currencyNumber  238 .
+
+unit:Kwanza  qudt:currencyCode  "AOA" ;
+             qudt:currencyNumber  973 .
+
+unit:JordanianDinar  qudt:currencyCode  "JOD" ;
+                     qudt:currencyNumber  400 .
+
+unit:TrinidadAndTobagoDollar
+    qudt:currencyCode    "TTD" ;
+    qudt:currencyNumber  780 .
+
+unit:BrazilianReal  qudt:currencyCode  "BRL" ;
+                    qudt:currencyNumber  986 .
+
+unit:Pataca  qudt:currencyCode  "MOP" ;
+             qudt:currencyNumber  446 .
+
+unit:CyprusPound  qudt:currencyCode  "CYP" ;
+                  qudt:currencyNumber  196 .
+
+unit:Guarani  qudt:currencyCode  "PYG" ;
+              qudt:currencyNumber  600 .
+
+unit:SouthAfricanRand
+    qudt:currencyCode    "ZAR" ;
+    qudt:currencyNumber  710 .
+
+unit:MexicanUnidadDeInversion
+    qudt:currencyCode    "MXV" ;
+    qudt:currencyNumber  979 .
+
+unit:SaintHelenaPound
+    qudt:currencyCode    "SHP" ;
+    qudt:currencyNumber  654 .
+
+unit:OmaniRial  qudt:currencyCode  "OMR" ;
+                qudt:currencyNumber  512 .
+
+unit:Lempira  qudt:currencyCode  "HNL" ;
+              qudt:currencyNumber  340 .
+
+unit:ZambianKwacha  qudt:currencyCode  "ZMW" ;
+                    qudt:currencyNumber  967 .
+
+unit:ARS  qudt:currencyCode  "ARS" ;
+          qudt:currencyNumber  032 .
+
+unit:Platinum-OunceTroy
+    qudt:currencyCode    "XPT" ;
+    qudt:currencyNumber  962 .
+
+unit:NetherlandsAntillianGuilder
+    qudt:currencyCode    "ANG" ;
+    qudt:currencyNumber  532 .
+
+unit:ComoroFranc  qudt:currencyCode  "KMF" ;
+                  qudt:currencyNumber  174 .
+
+unit:Leone  qudt:currencyCode  "SLE" ;
+            qudt:currencyNumber  925 .
+
+unit:NepaleseRupee  qudt:currencyCode  "NPR" ;
+                    qudt:currencyNumber  524 .
+
+unit:Kroon  qudt:currencyCode  "EEK" ;
+            qudt:currencyNumber  233 .
+
+unit:DominicanPeso  qudt:currencyCode  "DOP" ;
+                    qudt:currencyNumber  214 .
+
+unit:EastCaribbeanDollar
+    qudt:currencyCode    "XCD" ;
+    qudt:currencyNumber  951 .
+
+unit:BDT  qudt:currencyCode  "BDT" ;
+          qudt:currencyNumber  050 .
+
+unit:PhilippinePeso  qudt:currencyCode  "PHP" ;
+                     qudt:currencyNumber  608 .
+
+unit:XOF  qudt:currencyCode  "XOF" ;
+          qudt:currencyNumber  952 .
+
+unit:BelizeDollar  qudt:currencyCode  "BZD" ;
+                   qudt:currencyNumber  084 .
+
+unit:BSD  qudt:currencyCode  "BSD" ;
+          qudt:currencyNumber  044 .
+
+unit:RwandaFranc  qudt:currencyCode  "RWF" ;
+                  qudt:currencyNumber  646 .
+
+unit:ZimbabweDollar  qudt:currencyCode  "ZWL" ;
+                     qudt:currencyNumber  932 .
+
+unit:PAB  qudt:currencyCode  "PAB" ;
+          qudt:currencyNumber  590 .
+
+unit:DjiboutiFranc  qudt:currencyCode  "DJF" ;
+                    qudt:currencyNumber  262 .
+
+unit:Gold-OunceTroy  qudt:currencyCode  "XAU" ;
+                     qudt:currencyNumber  959 .
+
+unit:SamoanTala  qudt:currencyCode  "WST" ;
+                 qudt:currencyNumber  882 .
+
+unit:GibraltarPound  qudt:currencyCode  "GIP" ;
+                     qudt:currencyNumber  292 .
+
+unit:Pula  qudt:currencyCode  "BWP" ;
+           qudt:currencyNumber  072 .
+
+unit:USDollar  qudt:currencyCode  "USD" ;
+               qudt:currencyNumber  840 .
+
+unit:Dobra  qudt:currencyCode  "STN" ;
+            qudt:currencyNumber  930 .
+
+unit:Tenge  qudt:currencyCode  "KZT" ;
+            qudt:currencyNumber  398 .
+
+unit:Nakfa  qudt:currencyCode  "ERN" ;
+            qudt:currencyNumber  232 .
+
+unit:Denar  qudt:currencyCode  "MKD" ;
+            qudt:currencyNumber  807 .
+
+unit:EuropeanUnitOfAccount17
+    qudt:currencyCode    "XBD" ;
+    qudt:currencyNumber  958 .
+
+unit:JamaicanDollar  qudt:currencyCode  "JMD" ;
+                     qudt:currencyNumber  388 .
+
+unit:SlovakKoruna  qudt:currencyCode  "SKK" ;
+                   qudt:currencyNumber  703 .
+
+unit:HongKongDollar  qudt:currencyCode  "HKD" ;
+                     qudt:currencyNumber  344 .
+
+unit:KuwaitiDinar  qudt:currencyCode  "KWD" ;
+                   qudt:currencyNumber  414 .
+
+unit:BHD  qudt:currencyCode  "BHD" ;
+          qudt:currencyNumber  048 .
+
+unit:QatariRial  qudt:currencyCode  "QAR" ;
+                 qudt:currencyNumber  634 .
+
+unit:SyrianPound  qudt:currencyCode  "SYP" ;
+                  qudt:currencyNumber  760 .
+
+unit:LebanesePound  qudt:currencyCode  "LBP" ;
+                    qudt:currencyNumber  422 .
+
+unit:Ouguiya  qudt:currencyCode  "MRU" ;
+              qudt:currencyNumber  929 .
+
+unit:SriLankaRupee  qudt:currencyCode  "LKR" ;
+                    qudt:currencyNumber  144 .
+
+unit:TanzanianShilling
+    qudt:currencyCode    "TZS" ;
+    qudt:currencyNumber  834 .
+
+unit:AMD  qudt:currencyCode  "AMD" ;
+          qudt:currencyNumber  051 .
+
+unit:UnidadesDeFormento qudt:currencyCode "CLF" ;
+                        qudt:currencyNumber 990 .


### PR DESCRIPTION
Addresses #612 

Added two properties:
* `qudt:currencyCode`
* `qudt:currencyNumber `

Added these properties to all currency units, except these:
`unit: MillionUSD` and unit:Tugrik` - no matches found in ISO 4217.

In ISO 4217, I found the following (current, not outdated) entries, for which I was not able to find qudt units:
```
COU 	970 	2[9] 	Unidad de Valor Real (UVR) (funds code)[9] 	 Colombia
CUC 	931 	2 	Cuban convertible peso 	 Cuba
KHR 	116 	2 	Cambodian riel 	 Cambodia
MGA 	969 	2[d] 	Malagasy ariary 	 Madagascar
MNT 	496 	2 	Mongolian tögrög 	 Mongolia
SSP 	728 	2 	South Sudanese pound 	 South Sudan
SVC 	222 	2 	Salvadoran colón 	 El Salvador
UYI 	940 	0 	Uruguay Peso en Unidades Indexadas (URUIURUI) (funds code) 	 Uruguay
UYW 	927 	4 	Unidad previsional[19] 	 Uruguay
XPF 	953 	0 	CFP franc (franc Pacifique) 	French territories of the Pacific Ocean:  French Polynesia (PF),  New Caledonia (NC),  Wallis and Futuna (WF)

XSU 	994 	. 	SUCRE 	Unified System for Regional Compensation (SUCRE)[21]
XTS 	963 	. 	Code reserved for testing 	

XUA 	965 	. 	ADB Unit of Account 	African Development Bank[22]
XXX 	999 	. 	No currency 	
```

