### PR TITLE
Extend the QUDT/IFC mapping

### DIFF
--- a/community/mappings/SSSOM/IFC/qudt-ifc-mapping.tsv
+++ b/community/mappings/SSSOM/IFC/qudt-ifc-mapping.tsv
@@ -1,112 +1,133 @@
-subject_id	predicate_id	object_id
-unit:A	skos:exactMatch	ifc:AMPERE
-unit:BQ	skos:exactMatch	ifc:BECQUEREL
-unit:CD	skos:exactMatch	ifc:CANDELA
-unit:C	skos:exactMatch	ifc:COULOMB
-unit:M3	skos:exactMatch	ifc:CUBIC_METRE
-unit:DEG_C	skos:exactMatch	ifc:DEGREE_CELSIUS
-unit:F	skos:exactMatch	ifc:FARAD
-unit:GM	skos:exactMatch	ifc:GRAM
-unit:GRAY	skos:exactMatch	ifc:GRAY
-unit:H	skos:exactMatch	ifc:HENRY
-unit:HZ	skos:exactMatch	ifc:HERTZ
-unit:J	skos:exactMatch	ifc:JOULE
-unit:K	skos:exactMatch	ifc:KELVIN
-unit:LM	skos:exactMatch	ifc:LUMEN
-unit:LUX	skos:exactMatch	ifc:LUX
-unit:M	skos:exactMatch	ifc:METRE
-unit:MOL	skos:exactMatch	ifc:MOLE
-unit:N	skos:exactMatch	ifc:NEWTON
-unit:OHM	skos:exactMatch	ifc:OHM
-unit:PA	skos:exactMatch	ifc:PASCAL
-unit:RAD	skos:exactMatch	ifc:RADIAN
-unit:SEC	skos:exactMatch	ifc:SECOND
-unit:S	skos:exactMatch	ifc:SIEMENS
-unit:SV	skos:exactMatch	ifc:SIEVERT
-unit:M2	skos:exactMatch	ifc:SQUARE_METRE
-unit:SR	skos:exactMatch	ifc:STERADIAN
-unit:T	skos:exactMatch	ifc:TESLA
-unit:V	skos:exactMatch	ifc:VOLT
-unit:W	skos:exactMatch	ifc:WATT
-unit:WB	skos:exactMatch	ifc:WEBER
-qk:AbsorbedDose	skos:exactMatch	ifc:IfcAbsorbedDoseMeasure
-qk:AmountOfSubstance	skos:exactMatch ifc:IfcAmountOfSubstanceMeasure
-qk:Area	skos:exactMatch	ifc:IfcAREAMeasure
-qk:DoseEquivalent	skos:exactMatch	ifc:IfcDoseEquivalentMeasure
-qk:Capacitance	skos:exactMatch	ifc:IfcElectricCapacitanceMeasure
-qk:ElectricCharge	skos:exactMatch	ifc:IfcElectricChargeMeasure
-qk:ElectricConductivity	skos:exactMatch	ifc:IfcElectricConductanceMeasure
-qk:ElectricCurrent	skos:exactMatch	ifc:IfcElectricCurrentMeasure
-qk:Resistance	skos:exactMatch	ifc:IfcElectricResistanceMeasure
-qk:Voltage	skos:exactMatch	ifc:IfcElectricVoltageMeasure
-qk:Energy	skos:exactMatch	ifc:IfcEnergyMeasure
-qk:Force	skos:exactMatch	ifc:IfcForceMeasure
-qk:Frequency	skos:exactMatch	ifc:IfcFrequencyMeasure
-qk:Illuminance	skos:exactMatch	ifc:IfcIlluminanceMeasure
-qk:Inductance	skos:exactMatch	ifc:IfcInductanceMeasure
-qk:Length	skos:exactMatch	ifc:IfcLengthMeasure
-qk:LuminousFlux	skos:exactMatch	ifc:IfcLuminousFluxMeasure
-qk:LuminousIntensity	skos:exactMatch	ifc:IfcLuminousIntensityMeasure
-qk:MagneticFluxDensity	skos:exactMatch	ifc:IfcMagneticFluxDensityMeasure
-qk:MagneticFlux	skos:exactMatch	ifc:IfcMagneticFluxMeasure
-qk:Mass	skos:exactMatch	ifc:IfcMassMeasure
-qk:PlaneAngle	skos:exactMatch	ifc:IfcPlaneAngleMeasure
-qk:Power	skos:exactMatch	ifc:IfcPowerMeasure
-qk:Pressure	skos:exactMatch	ifc:IfcPressureMeasure
-qk:Activity	skos:exactMatch	ifc:IfcRadioActivityMeasure
-qk:SolidAngle	skos:exactMatch	ifc:IfcSolidAngleMeasure
-qk:ThermodynamicTemperature skos:exactMatch ifc:IfcThermodynamicTemperatureMeasure
-qk:Time	skos:exactMatch	ifc:IfcTimeMeasure
-qk:Volume	skos:exactMatch	ifc:IfcVolumeMeasure
-qk:AngularVelocity	skos:exactMatch ifc:IfcAngularVelocityMeasure
-qk:SurfaceDensity	skos:exactMatch	ifc:IfcAreaDensityMeasure
-qk:PlaneAngle	skos:exactMatch	ifc:IfcCompoundPlaneAngleMeasure
-qk:DynamicViscosity	skos:exactMatch	ifc:IfcDynamicViscosityMeasure
-qk:HeatFluxDensity	skos:exactMatch	ifc:IfcHeatFluxDensityMeasure
-qk:Frequency	skos:exactMatch	ifc:IfcIntegerCountRateMeasure
-qk:KinematicViscosity	skos:exactMatch	ifc:IfcKinematicViscosityMeasure
-qk:LinearVelocity	skos:exactMatch	ifc:IfcLinearVelocityMeasure
-qk:MassDensity	skos:exactMatch	ifc:IfcMassDensityMeasure
-qk:MassFlowRate	skos:exactMatch	ifc:IfcMassFlowRateMeasure
-qk:MolarMass	skos:exactMatch	ifc:IfcMolecularWeightMeasure
-qk:SpecificHeatCapacity	skos:exactMatch	ifc:IfcSpecificHeatCapacityMeasure
-qk:ThermalConductance	skos:exactMatch	ifc:IfcThermalConductanceMeasure
-qk:ThermalResistance	skos:exactMatch	ifc:IfcThermalResistanceMeasure
-qk:VolumeFlowRate	skos:exactMatch	ifc:IfcVolumetricFlowRateMeasure
-qk:AngularFrequency	skos:exactMatch	ifc:IfcRotationalFrequencyMeasure
-qk:Torque	skos:exactMatch	ifc:IfcTorqueMeasure
-qk:MomentOfInertia	skos:exactMatch	ifc:IfcMomentOfInertiaMeasure
-qk:LinearMomentum	skos:exactMatch	ifc:IfcLinearMomentMeasure
-qk:ModulusOfElasticity	skos:exactMatch	ifc:IfcModulusOfElasticityMeasure
-qk:ShearModulus	skos:exactMatch	ifc:IfcShearModulusMeasure
-qk:Acceleration	skos:exactMatch	ifc:IfcAccelerationMeasure
-qk:Curvature	skos:exactMatch	ifc:IfcCurvatureMeasure
-qk:MassPerLength	skos:exactMatch	ifc:IfcMassPerLengthMeasure
-qk:RotationalMass	skos:exactMatch	ifc:IfcRotationalMassMeasure
-qk:SectionModulus	skos:exactMatch	ifc:IfcSectionModulusMeasure
-qk:SoundPowerLevel	skos:exactMatch	ifc:IfcSoundPowerLevelMeasure
-qk:SoundPower	skos:exactMatch	ifc:IfcSoundPowerMeasure
-qk:SoundPressureLevel	skos:exactMatch	ifc:IfcSoundPressureLevelMeasure
-qk:SoundPressure	skos:exactMatch	ifc:IfcSoundPressureMeasure
-qk:TemperatureRateOfChange	skos:exactMatch	ifc:IfcTemperatureRateOfChangeMeasure
-qk:ThermalExpansionCoefficient	skos:exactMatch	ifc:IfcThermalExpansionCoefficientMeasure
-qk:IsothermalMoistureCapacity	skos:exactMatch	ifc:IfcIsothermalMoistureCapacityMeasure
-qk:MoistureDiffusivity	skos:exactMatch	ifc:IfcMoistureDiffusivityMeasure
-qk:ThermalAdmittance	skos:exactMatch	ifc:IfcThermalAdmittanceMeasure
-qk:ThermalTransmittance	skos:exactMatch	ifc:IfcThermalTransmittanceMeasure
-qk:VaporPermeability	skos:exactMatch	ifc:IfcVaporPermeabilityMeasure
-qk:LinearForce	skos:exactMatch	ifc:IfcLinearForceMeasure
-qk:PlanarForce	skos:exactMatch	ifc:IfcPlanarForceMeasure
-qk:LinearStiffness	skos:exactMatch	ifc:IfcLinearStiffnessMeasure
-qk:RotationalStiffness	skos:exactMatch	ifc:IfcRotationalStiffnessMeasure
-qk:ModulusOfSubgradeReaction	skos:exactMatch	ifc:IfcModulusOfSubgradeReactionMeasure
-qk:HeatingValue	skos:exactMatch	ifc:IfcHeatingValueMeasure
-qk:IonConcentration	skos:exactMatch	ifc:IfcIonConcentrationMeasure
-qk:LuminousIntensityDistribution	skos:exactMatch	ifc:IfcLuminousIntensityDistributionMeasure
-qk:ModulusOfLinearSubgradeReaction	skos:exactMatch	ifc:IfcModulusOfLinearSubgradeReactionMeasure
-qk:ModulusOfRotationalSubgradeReaction	skos:exactMatch	ifc:IfcModulusOfRotationalSubgradeReactionMeasure
-qk:PH	skos:exactMatch	ifc:IfcPHMeasure
-qk:SectionAreaIntegral	skos:exactMatch	ifc:IfcSectionAreaIntegralMeasure
-qk:TemperatureGradient	skos:exactMatch	ifc:IfcTemperatureGradientMeasure
-qk:WarpingConstant	skos:exactMatch	ifc:IfcWarpingConstantMeasure
-qk:WarpingMoment	skos:exactMatch	ifc:IfcWarpingMomentMeasure
+subject_id	predicate_id	object_id	mapping_justification
+unit:A	skos:exactMatch	ifc:AMPERE	semapv:ManualMappingCuration
+unit:BQ	skos:exactMatch	ifc:BECQUEREL	semapv:ManualMappingCuration
+unit:CD	skos:exactMatch	ifc:CANDELA	semapv:ManualMappingCuration
+unit:C	skos:exactMatch	ifc:COULOMB	semapv:ManualMappingCuration
+unit:M3	skos:exactMatch	ifc:CUBIC_METRE	semapv:ManualMappingCuration
+unit:DEG_C	skos:exactMatch	ifc:DEGREE_CELSIUS	semapv:ManualMappingCuration
+unit:F	skos:exactMatch	ifc:FARAD	semapv:ManualMappingCuration
+unit:GM	skos:exactMatch	ifc:GRAM	semapv:ManualMappingCuration
+unit:GRAY	skos:exactMatch	ifc:GRAY	semapv:ManualMappingCuration
+unit:H	skos:exactMatch	ifc:HENRY	semapv:ManualMappingCuration
+unit:HZ	skos:exactMatch	ifc:HERTZ	semapv:ManualMappingCuration
+unit:J	skos:exactMatch	ifc:JOULE	semapv:ManualMappingCuration
+unit:K	skos:exactMatch	ifc:KELVIN	semapv:ManualMappingCuration
+unit:LM	skos:exactMatch	ifc:LUMEN	semapv:ManualMappingCuration
+unit:LUX	skos:exactMatch	ifc:LUX	semapv:ManualMappingCuration
+unit:M	skos:exactMatch	ifc:METRE	semapv:ManualMappingCuration
+unit:MOL	skos:exactMatch	ifc:MOLE	semapv:ManualMappingCuration
+unit:N	skos:exactMatch	ifc:NEWTON	semapv:ManualMappingCuration
+unit:OHM	skos:exactMatch	ifc:OHM	semapv:ManualMappingCuration
+unit:PA	skos:exactMatch	ifc:PASCAL	semapv:ManualMappingCuration
+unit:RAD	skos:exactMatch	ifc:RADIAN	semapv:ManualMappingCuration
+unit:SEC	skos:exactMatch	ifc:SECOND	semapv:ManualMappingCuration
+unit:S	skos:exactMatch	ifc:SIEMENS	semapv:ManualMappingCuration
+unit:SV	skos:exactMatch	ifc:SIEVERT	semapv:ManualMappingCuration
+unit:M2	skos:exactMatch	ifc:SQUARE_METRE	semapv:ManualMappingCuration
+unit:SR	skos:exactMatch	ifc:STERADIAN	semapv:ManualMappingCuration
+unit:T	skos:exactMatch	ifc:TESLA	semapv:ManualMappingCuration
+unit:V	skos:exactMatch	ifc:VOLT	semapv:ManualMappingCuration
+unit:W	skos:exactMatch	ifc:WATT	semapv:ManualMappingCuration
+unit:WB	skos:exactMatch	ifc:WEBER	semapv:ManualMappingCuration
+qk:AbsorbedDose	skos:exactMatch	ifc:IfcAbsorbedDoseMeasure	semapv:ManualMappingCuration
+qk:AmountOfSubstance	skos:exactMatch ifc:IfcAmountOfSubstanceMeasure	semapv:ManualMappingCuration
+qk:Area	skos:exactMatch	ifc:IfcAREAMeasure	semapv:ManualMappingCuration
+qk:DoseEquivalent	skos:exactMatch	ifc:IfcDoseEquivalentMeasure	semapv:ManualMappingCuration
+qk:Capacitance	skos:exactMatch	ifc:IfcElectricCapacitanceMeasure	semapv:ManualMappingCuration
+qk:ElectricCharge	skos:exactMatch	ifc:IfcElectricChargeMeasure	semapv:ManualMappingCuration
+qk:ElectricConductivity	skos:exactMatch	ifc:IfcElectricConductanceMeasure	semapv:ManualMappingCuration
+qk:ElectricCurrent	skos:exactMatch	ifc:IfcElectricCurrentMeasure	semapv:ManualMappingCuration
+qk:Resistance	skos:exactMatch	ifc:IfcElectricResistanceMeasure	semapv:ManualMappingCuration
+qk:Voltage	skos:exactMatch	ifc:IfcElectricVoltageMeasure	semapv:ManualMappingCuration
+qk:Energy	skos:exactMatch	ifc:IfcEnergyMeasure	semapv:ManualMappingCuration
+qk:Force	skos:exactMatch	ifc:IfcForceMeasure	semapv:ManualMappingCuration
+qk:Frequency	skos:exactMatch	ifc:IfcFrequencyMeasure	semapv:ManualMappingCuration
+qk:Illuminance	skos:exactMatch	ifc:IfcIlluminanceMeasure	semapv:ManualMappingCuration
+qk:Inductance	skos:exactMatch	ifc:IfcInductanceMeasure	semapv:ManualMappingCuration
+qk:Length	skos:exactMatch	ifc:IfcLengthMeasure	semapv:ManualMappingCuration
+qk:LuminousFlux	skos:exactMatch	ifc:IfcLuminousFluxMeasure	semapv:ManualMappingCuration
+qk:LuminousIntensity	skos:exactMatch	ifc:IfcLuminousIntensityMeasure	semapv:ManualMappingCuration
+qk:MagneticFluxDensity	skos:exactMatch	ifc:IfcMagneticFluxDensityMeasure	semapv:ManualMappingCuration
+qk:MagneticFlux	skos:exactMatch	ifc:IfcMagneticFluxMeasure	semapv:ManualMappingCuration
+qk:Mass	skos:exactMatch	ifc:IfcMassMeasure	semapv:ManualMappingCuration
+qk:PlaneAngle	skos:exactMatch	ifc:IfcPlaneAngleMeasure	semapv:ManualMappingCuration
+qk:Power	skos:exactMatch	ifc:IfcPowerMeasure	semapv:ManualMappingCuration
+qk:Pressure	skos:exactMatch	ifc:IfcPressureMeasure	semapv:ManualMappingCuration
+qk:Activity	skos:exactMatch	ifc:IfcRadioActivityMeasure	semapv:ManualMappingCuration
+qk:SolidAngle	skos:exactMatch	ifc:IfcSolidAngleMeasure	semapv:ManualMappingCuration
+qk:ThermodynamicTemperature skos:exactMatch ifc:IfcThermodynamicTemperatureMeasure	semapv:ManualMappingCuration
+qk:Time	skos:exactMatch	ifc:IfcTimeMeasure	semapv:ManualMappingCuration
+qk:Volume	skos:exactMatch	ifc:IfcVolumeMeasure	semapv:ManualMappingCuration
+qk:AngularVelocity	skos:exactMatch ifc:IfcAngularVelocityMeasure	semapv:ManualMappingCuration
+qk:SurfaceDensity	skos:exactMatch	ifc:IfcAreaDensityMeasure	semapv:ManualMappingCuration
+qk:PlaneAngle	skos:exactMatch	ifc:IfcCompoundPlaneAngleMeasure	semapv:ManualMappingCuration
+qk:DynamicViscosity	skos:exactMatch	ifc:IfcDynamicViscosityMeasure	semapv:ManualMappingCuration
+qk:HeatFluxDensity	skos:exactMatch	ifc:IfcHeatFluxDensityMeasure	semapv:ManualMappingCuration
+qk:Frequency	skos:exactMatch	ifc:IfcIntegerCountRateMeasure	semapv:ManualMappingCuration
+qk:KinematicViscosity	skos:exactMatch	ifc:IfcKinematicViscosityMeasure	semapv:ManualMappingCuration
+qk:LinearVelocity	skos:exactMatch	ifc:IfcLinearVelocityMeasure	semapv:ManualMappingCuration
+qk:MassDensity	skos:exactMatch	ifc:IfcMassDensityMeasure	semapv:ManualMappingCuration
+qk:MassFlowRate	skos:exactMatch	ifc:IfcMassFlowRateMeasure	semapv:ManualMappingCuration
+qk:MolarMass	skos:exactMatch	ifc:IfcMolecularWeightMeasure	semapv:ManualMappingCuration
+qk:SpecificHeatCapacity	skos:exactMatch	ifc:IfcSpecificHeatCapacityMeasure	semapv:ManualMappingCuration
+qk:ThermalConductance	skos:exactMatch	ifc:IfcThermalConductanceMeasure	semapv:ManualMappingCuration
+qk:ThermalResistance	skos:exactMatch	ifc:IfcThermalResistanceMeasure	semapv:ManualMappingCuration
+qk:VolumeFlowRate	skos:exactMatch	ifc:IfcVolumetricFlowRateMeasure	semapv:ManualMappingCuration
+qk:AngularFrequency	skos:exactMatch	ifc:IfcRotationalFrequencyMeasure	semapv:ManualMappingCuration
+qk:Torque	skos:exactMatch	ifc:IfcTorqueMeasure	semapv:ManualMappingCuration
+qk:MomentOfInertia	skos:exactMatch	ifc:IfcMomentOfInertiaMeasure	semapv:ManualMappingCuration
+qk:LinearMomentum	skos:exactMatch	ifc:IfcLinearMomentMeasure	semapv:ManualMappingCuration
+qk:ModulusOfElasticity	skos:exactMatch	ifc:IfcModulusOfElasticityMeasure	semapv:ManualMappingCuration
+qk:ShearModulus	skos:exactMatch	ifc:IfcShearModulusMeasure	semapv:ManualMappingCuration
+qk:Acceleration	skos:exactMatch	ifc:IfcAccelerationMeasure	semapv:ManualMappingCuration
+qk:Curvature	skos:exactMatch	ifc:IfcCurvatureMeasure	semapv:ManualMappingCuration
+qk:MassPerLength	skos:exactMatch	ifc:IfcMassPerLengthMeasure	semapv:ManualMappingCuration
+qk:RotationalMass	skos:exactMatch	ifc:IfcRotationalMassMeasure	semapv:ManualMappingCuration
+qk:SectionModulus	skos:exactMatch	ifc:IfcSectionModulusMeasure	semapv:ManualMappingCuration
+qk:SoundPowerLevel	skos:exactMatch	ifc:IfcSoundPowerLevelMeasure	semapv:ManualMappingCuration
+qk:SoundPower	skos:exactMatch	ifc:IfcSoundPowerMeasure	semapv:ManualMappingCuration
+qk:SoundPressureLevel	skos:exactMatch	ifc:IfcSoundPressureLevelMeasure	semapv:ManualMappingCuration
+qk:SoundPressure	skos:exactMatch	ifc:IfcSoundPressureMeasure	semapv:ManualMappingCuration
+qk:TemperatureRateOfChange	skos:exactMatch	ifc:IfcTemperatureRateOfChangeMeasure	semapv:ManualMappingCuration
+qk:ThermalExpansionCoefficient	skos:exactMatch	ifc:IfcThermalExpansionCoefficientMeasure	semapv:ManualMappingCuration
+qk:IsothermalMoistureCapacity	skos:exactMatch	ifc:IfcIsothermalMoistureCapacityMeasure	semapv:ManualMappingCuration
+qk:MoistureDiffusivity	skos:exactMatch	ifc:IfcMoistureDiffusivityMeasure	semapv:ManualMappingCuration
+qk:ThermalAdmittance	skos:exactMatch	ifc:IfcThermalAdmittanceMeasure	semapv:ManualMappingCuration
+qk:ThermalTransmittance	skos:exactMatch	ifc:IfcThermalTransmittanceMeasure	semapv:ManualMappingCuration
+qk:VaporPermeability	skos:exactMatch	ifc:IfcVaporPermeabilityMeasure	semapv:ManualMappingCuration
+qk:LinearForce	skos:exactMatch	ifc:IfcLinearForceMeasure	semapv:ManualMappingCuration
+qk:PlanarForce	skos:exactMatch	ifc:IfcPlanarForceMeasure	semapv:ManualMappingCuration
+qk:LinearStiffness	skos:exactMatch	ifc:IfcLinearStiffnessMeasure	semapv:ManualMappingCuration
+qk:RotationalStiffness	skos:exactMatch	ifc:IfcRotationalStiffnessMeasure	semapv:ManualMappingCuration
+qk:ModulusOfSubgradeReaction	skos:exactMatch	ifc:IfcModulusOfSubgradeReactionMeasure	semapv:ManualMappingCuration
+qk:HeatingValue	skos:exactMatch	ifc:IfcHeatingValueMeasure	semapv:ManualMappingCuration
+qk:IonConcentration	skos:exactMatch	ifc:IfcIonConcentrationMeasure	semapv:ManualMappingCuration
+qk:LuminousIntensityDistribution	skos:exactMatch	ifc:IfcLuminousIntensityDistributionMeasure	semapv:ManualMappingCuration
+qk:ModulusOfLinearSubgradeReaction	skos:exactMatch	ifc:IfcModulusOfLinearSubgradeReactionMeasure	semapv:ManualMappingCuration
+qk:ModulusOfRotationalSubgradeReaction	skos:exactMatch	ifc:IfcModulusOfRotationalSubgradeReactionMeasure	semapv:ManualMappingCuration
+qk:PH	skos:exactMatch	ifc:IfcPHMeasure	semapv:ManualMappingCuration
+qk:SectionAreaIntegral	skos:exactMatch	ifc:IfcSectionAreaIntegralMeasure	semapv:ManualMappingCuration
+qk:TemperatureGradient	skos:exactMatch	ifc:IfcTemperatureGradientMeasure	semapv:ManualMappingCuration
+qk:WarpingConstant	skos:exactMatch	ifc:IfcWarpingConstantMeasure	semapv:ManualMappingCuration
+qk:WarpingMoment	skos:exactMatch	ifc:IfcWarpingMomentMeasure	semapv:ManualMappingCuration
+qk:DimensionlessRatio	skos:exactMatch	ifc:IfcRatioMeasure	semapv:ManualMappingCuration
+qk:PositiveDimensionlessRatio	skos:exactMatch	ifc:IfcPositiveRatioMeasure	semapv:ManualMappingCuration
+qk:NormalizedDimensionlessRatio	skos:exactMatch	ifc:IfcNormalisedRatioMeasure	semapv:ManualMappingCuration
+qk:Dimensionless	skos:exactMatch	ifc:IfcReal	semapv:ManualMappingCuration
+pfx:Nano	skos:exactMatch	ifc:NANO	semapv:ManualMappingCuration
+pfx:Milli	skos:exactMatch	ifc:MILLI	semapv:ManualMappingCuration
+pfx:Kilo	skos:exactMatch	ifc:KILO	semapv:ManualMappingCuration
+pfx:Deca	skos:exactMatch	ifc:DECA	semapv:ManualMappingCuration
+pfx:Giga	skos:exactMatch	ifc:GIGA	semapv:ManualMappingCuration
+pfx:Atto	skos:exactMatch	ifc:ATTO	semapv:ManualMappingCuration
+pfx:Centi	skos:exactMatch	ifc:CENTI	semapv:ManualMappingCuration
+pfx:Pico	skos:exactMatch	ifc:PICO	semapv:ManualMappingCuration
+pfx:Femto	skos:exactMatch	ifc:FEMTO	semapv:ManualMappingCuration
+pfx:Deka	skos:exactMatch	ifc:DECA	semapv:ManualMappingCuration
+pfx:Deci	skos:exactMatch	ifc:DECI	semapv:ManualMappingCuration
+pfx:Tera	skos:exactMatch	ifc:TERA	semapv:ManualMappingCuration
+pfx:Peta	skos:exactMatch	ifc:PETA	semapv:ManualMappingCuration
+pfx:Micro	skos:exactMatch	ifc:MICRO	semapv:ManualMappingCuration
+pfx:Exa	skos:exactMatch	ifc:EXA	semapv:ManualMappingCuration
+pfx:Hecto	skos:exactMatch	ifc:HECTO	semapv:ManualMappingCuration
+pfx:Mega	skos:exactMatch	ifc:MEGA	semapv:ManualMappingCuration

--- a/community/mappings/SSSOM/IFC/qudt-ifc-metadata.yml
+++ b/community/mappings/SSSOM/IFC/qudt-ifc-metadata.yml
@@ -6,6 +6,9 @@ object_source: https://standards.buildingsmart.org/IFC/DEV/IFC4/ADD2_TC1/OWL
 subject_source: https://www.wikidata.org/wiki/Q25917172
 curie_map:
   unit: http://qudt.org/vocab/unit/
+  qk: http://qudt.org/vocab/quantitykind/
+  pfx: http://qudt.org/vocab/prefix/
   ifc: https://standards.buildingsmart.org/IFC/DEV/IFC4/ADD2_TC1/OWL#
   wikidata: http://www.wikidata.org/entity/
-  skos: "http://www.w3.org/2004/02/skos/core#"
+  skos: http://www.w3.org/2004/02/skos/core#
+  semapv: https://w3id.org/semapv/vocab/

--- a/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
+++ b/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
@@ -18949,3 +18949,21 @@ vaem:GMD_QUDT-QUANTITY-KINDS-ALL
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
   rdfs:label "QUDT Quantity Kinds Vocabulary Version 2.1.22" ;
 .
+quantitykind:PositiveDimensionlessRatio
+  a qudt:QuantityKind ;
+  qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  qudt:plainTextDescription "A \"Positive Dimensionless Ratio\" is a dimensionless ratio that is greater than zero" ;
+  qudt:informativeReference "https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcpositiveratiomeasure.htm"^^xsd:anyURI ;
+  rdfs:label "Positive Dimensionless Ratio"@en ;
+  skos:broader quantitykind:DimensionlessRatio ;
+.
+quantitykind:NormalizedDimensionlessRatio
+  a qudt:QuantityKind ;
+  qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  qudt:plainTextDescription "A \"Normalized Dimensionless Ratio\" is a dimensionless ratio ranging from 0.0 to 1.0" ;
+  qudt:informativeReference "https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/link/ifcnormalisedratiomeasure.htm"^^xsd:anyURI ;
+  rdfs:label "Positive Dimensionless Ratio"@en ;
+  skos:broader quantitykind:DimensionlessRatio ;
+.


### PR DESCRIPTION
* Adds the mapping_justification property as requested in https://github.com/qudt/qudt-public-repo/issues/604#issuecomment-1329922459_
* Adds prefix mappings
* Adds dimensionless ratio mappings
* Adds two quantitykinds that are present in IFC but not in QUDT