### PR TITLE
Extend the QUDT/IFC mapping

### DIFF
--- a/community/mappings/SSSOM/IFC/qudt-ifc-mapping.tsv
+++ b/community/mappings/SSSOM/IFC/qudt-ifc-mapping.tsv
@@ -30,7 +30,7 @@ unit:V	skos:exactMatch	ifc:VOLT	semapv:ManualMappingCuration
 unit:W	skos:exactMatch	ifc:WATT	semapv:ManualMappingCuration
 unit:WB	skos:exactMatch	ifc:WEBER	semapv:ManualMappingCuration
 qk:AbsorbedDose	skos:exactMatch	ifc:IfcAbsorbedDoseMeasure	semapv:ManualMappingCuration
-qk:AmountOfSubstance	skos:exactMatch ifc:IfcAmountOfSubstanceMeasure	semapv:ManualMappingCuration
+qk:AmountOfSubstance	skos:exactMatch	ifc:IfcAmountOfSubstanceMeasure	semapv:ManualMappingCuration
 qk:Area	skos:exactMatch	ifc:IfcAREAMeasure	semapv:ManualMappingCuration
 qk:DoseEquivalent	skos:exactMatch	ifc:IfcDoseEquivalentMeasure	semapv:ManualMappingCuration
 qk:Capacitance	skos:exactMatch	ifc:IfcElectricCapacitanceMeasure	semapv:ManualMappingCuration
@@ -55,10 +55,10 @@ qk:Power	skos:exactMatch	ifc:IfcPowerMeasure	semapv:ManualMappingCuration
 qk:Pressure	skos:exactMatch	ifc:IfcPressureMeasure	semapv:ManualMappingCuration
 qk:Activity	skos:exactMatch	ifc:IfcRadioActivityMeasure	semapv:ManualMappingCuration
 qk:SolidAngle	skos:exactMatch	ifc:IfcSolidAngleMeasure	semapv:ManualMappingCuration
-qk:ThermodynamicTemperature skos:exactMatch ifc:IfcThermodynamicTemperatureMeasure	semapv:ManualMappingCuration
+qk:ThermodynamicTemperature	skos:exactMatch	ifc:IfcThermodynamicTemperatureMeasure	semapv:ManualMappingCuration
 qk:Time	skos:exactMatch	ifc:IfcTimeMeasure	semapv:ManualMappingCuration
 qk:Volume	skos:exactMatch	ifc:IfcVolumeMeasure	semapv:ManualMappingCuration
-qk:AngularVelocity	skos:exactMatch ifc:IfcAngularVelocityMeasure	semapv:ManualMappingCuration
+qk:AngularVelocity	skos:exactMatch	ifc:IfcAngularVelocityMeasure	semapv:ManualMappingCuration
 qk:SurfaceDensity	skos:exactMatch	ifc:IfcAreaDensityMeasure	semapv:ManualMappingCuration
 qk:PlaneAngle	skos:exactMatch	ifc:IfcCompoundPlaneAngleMeasure	semapv:ManualMappingCuration
 qk:DynamicViscosity	skos:exactMatch	ifc:IfcDynamicViscosityMeasure	semapv:ManualMappingCuration
@@ -113,7 +113,10 @@ qk:WarpingMoment	skos:exactMatch	ifc:IfcWarpingMomentMeasure	semapv:ManualMappin
 qk:DimensionlessRatio	skos:exactMatch	ifc:IfcRatioMeasure	semapv:ManualMappingCuration
 qk:PositiveDimensionlessRatio	skos:exactMatch	ifc:IfcPositiveRatioMeasure	semapv:ManualMappingCuration
 qk:NormalizedDimensionlessRatio	skos:exactMatch	ifc:IfcNormalisedRatioMeasure	semapv:ManualMappingCuration
-qk:Dimensionless	skos:exactMatch	ifc:IfcReal	semapv:ManualMappingCuration
+qk:Dimensionless	skos:exactMatch	ifc:IfcNumericMeasure	semapv:ManualMappingCuration
+qk:NonNegativeLength	skos:exactMatch	ifc:IfcNonNegativeLengthMeasure	semapv:ManualMappingCuration
+qk:PositiveLength	skos:exactMatch	ifc:IfcPositiveLengthMeasure	semapv:ManualMappingCuration
+qk:PositivePlaneAngle	skos:exactMatch	ifc:IfcPositivePlaneAngleMeasure	semapv:ManualMappingCuration
 qk:Count	skos:exactMatch	ifc:IfcCountMeasure	semapv:ManualMappingCuration
 pfx:Nano	skos:exactMatch	ifc:NANO	semapv:ManualMappingCuration
 pfx:Milli	skos:exactMatch	ifc:MILLI	semapv:ManualMappingCuration

--- a/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
+++ b/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
@@ -20377,3 +20377,28 @@ quantitykind:Count
   rdfs:label "Count"@en ;
   skos:broader quantitykind:Dimensionless ;
 .
+quantitykind:PositiveLength
+  a qudt:QuantityKind ;
+  qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T0D0 ;
+  qudt:plainTextDescription "\"PositiveLength\" is a measure of length strictly greater than zero." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Positive Length"@en ;
+  skos:broader quantitykind:NonNegativeLength ;
+.
+quantitykind:NonNegativeLength
+  a qudt:QuantityKind ;
+  qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T0D0 ;
+  qudt:plainTextDescription "\"NonNegativeLength\" is a measure of length greater than or equal to zero." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Positive Length"@en ;
+  skos:broader quantitykind:Length ;
+.
+quantitykind:PositivePlaneAngle
+  a qudt:QuantityKind ;
+  qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
+  qudt:informativeReference "http://www.thefreedictionary.com/plane+angle"^^xsd:anyURI ;
+  qudt:plainTextDescription "A \"PositivePlaneAngle\" is a plane angle strictly greater than zero." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Positive Plane Angle"@en ;
+  skos:broader quantitykind:PlaneAngle ;
+.

--- a/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
+++ b/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
@@ -19173,7 +19173,7 @@ quantitykind:Turns
   qudt:plainTextDescription "\"Turns\" is the number of turns in a winding." ;
   qudt:symbol "N" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Turns"@en
+  rdfs:label "Turns"@en ;
   skos:broader quantitykind:Count ;
 .
 quantitykind:UpperCriticalMagneticFluxDensity


### PR DESCRIPTION
Addresses #626 (the missing quantitykinds mentioned in [this comment](https://github.com/qudt/qudt-public-repo/issues/626#issuecomment-1385614885))

* fixes some whitespace errors in the qudt-ifc mapping tsv file
* adds three quantitykinds that are present in ifc:
  - qk:NonNegativeLength
  - qk:PositiveLength
  - qk:PositivePlaneAngle