### PR TITLE
Add quantitykind 'Count'

### DIFF
--- a/community/mappings/SSSOM/IFC/qudt-ifc-mapping.tsv
+++ b/community/mappings/SSSOM/IFC/qudt-ifc-mapping.tsv
@@ -114,6 +114,7 @@ qk:DimensionlessRatio	skos:exactMatch	ifc:IfcRatioMeasure	semapv:ManualMappingCu
 qk:PositiveDimensionlessRatio	skos:exactMatch	ifc:IfcPositiveRatioMeasure	semapv:ManualMappingCuration
 qk:NormalizedDimensionlessRatio	skos:exactMatch	ifc:IfcNormalisedRatioMeasure	semapv:ManualMappingCuration
 qk:Dimensionless	skos:exactMatch	ifc:IfcReal	semapv:ManualMappingCuration
+qk:Count	skos:exactMatch	ifc:IfcCountMeasure	semapv:ManualMappingCuration
 pfx:Nano	skos:exactMatch	ifc:NANO	semapv:ManualMappingCuration
 pfx:Milli	skos:exactMatch	ifc:MILLI	semapv:ManualMappingCuration
 pfx:Kilo	skos:exactMatch	ifc:KILO	semapv:ManualMappingCuration

--- a/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
+++ b/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
@@ -1350,7 +1350,7 @@ quantitykind:AtomicNumber
   qudt:symbol "Z" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
   rdfs:label "Atomic Number"@en ;
-  skos:broader quantitykind:Dimensionless ;
+  skos:broader quantitykind:Count ;
 .
 quantitykind:AttenuationCoefficient
   a qudt:QuantityKind ;
@@ -10900,7 +10900,7 @@ quantitykind:MassNumber
   qudt:symbol "A" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
   rdfs:label "Mass Number"@en ;
-  skos:broader quantitykind:Dimensionless ;
+  skos:broader quantitykind:Count ;
 .
 quantitykind:MassOfElectricalPowerSupply
   a qudt:QuantityKind ;
@@ -12570,7 +12570,7 @@ quantitykind:NeutronNumber
   qudt:symbol "N" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
   rdfs:label "Neutron Number"@en ;
-  skos:broader quantitykind:Dimensionless ;
+  skos:broader quantitykind:Count ;
 .
 quantitykind:NeutronYieldPerAbsorption
   a qudt:QuantityKind ;
@@ -12939,7 +12939,7 @@ quantitykind:NucleonNumber
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
   rdfs:label "Nucleon number"@en ;
   skos:altLabel "mass-number" ;
-  skos:broader quantitykind:Dimensionless ;
+  skos:broader quantitykind:Count ;
 .
 quantitykind:NumberDensity
   a qudt:QuantityKind ;
@@ -14022,7 +14022,7 @@ quantitykind:Population
   qudt:plainTextDescription "Population typically refers to the number of people in a single area, whether it be a city or town, region, country, continent, or the world, but can also represent the number of any kind of entity." ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
   rdfs:label "Population"@en ;
-  skos:broader quantitykind:Dimensionless ;
+  skos:broader quantitykind:Count ;
 .
 quantitykind:PositionVector
   a qudt:QuantityKind ;
@@ -19173,7 +19173,8 @@ quantitykind:Turns
   qudt:plainTextDescription "\"Turns\" is the number of turns in a winding." ;
   qudt:symbol "N" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Turns"@en ;
+  rdfs:label "Turns"@en
+  skos:broader quantitykind:Count ;
 .
 quantitykind:UpperCriticalMagneticFluxDensity
   a qudt:QuantityKind ;
@@ -20366,4 +20367,13 @@ vaem:GMD_QUDT-QUANTITY-KINDS-ALL
   vaem:withAttributionTo <http://voag.linkedmodel.org/voag/QUDT-Attribution> ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
   rdfs:label "QUDT Quantity Kinds Vocabulary Version 2.1.24" ;
+.
+quantitykind:Count
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "\"Count\" is the value of a count of items." ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Count"@en ;
+  skos:broader quantitykind:Dimensionless ;
 .


### PR DESCRIPTION
* Add qk:Count and set as `skos:broader` where applicable
* Add mapping to IfcCountMeasure
* 
Implements the suggestion in #626 (in [this comment](https://github.com/qudt/qudt-public-repo/issues/626#issuecomment-1385492116)). Contrary to the suggestion, though, only a handful of quantitykinds that have the applicable unit `unit:NUM` are actually counts, so only those (and one or two others I found) were adapted to point to the newly created `qk:Count`

