### PR TITLE
 Made dimensionExponentFor... no longer subProperty of dimensionExponent

### DIFF
--- a/schema/SCHEMA_QUDT-v2.1.ttl
+++ b/schema/SCHEMA_QUDT-v2.1.ttl
@@ -2181,50 +2181,41 @@ qudt:dimensionExponent
   a owl:DatatypeProperty ;
   rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
   rdfs:label "dimension exponent" ;
-  rdfs:range dtype:numericUnion ;
 .
 qudt:dimensionExponentForAmountOfSubstance
   a owl:DatatypeProperty ;
   rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
   rdfs:label "dimension exponent for amount of substance" ;
-  rdfs:subPropertyOf qudt:dimensionExponent ;
 .
 qudt:dimensionExponentForElectricCurrent
   a owl:DatatypeProperty ;
   rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
   rdfs:label "dimension exponent for electric current" ;
-  rdfs:range xsd:integer ;
-  rdfs:subPropertyOf qudt:dimensionExponent ;
 .
 qudt:dimensionExponentForLength
   a owl:DatatypeProperty ;
   rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
   rdfs:label "dimension exponent for length" ;
-  rdfs:subPropertyOf qudt:dimensionExponent ;
 .
 qudt:dimensionExponentForLuminousIntensity
   a owl:DatatypeProperty ;
   rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
   rdfs:label "dimension exponent for luminous intensity" ;
-  rdfs:subPropertyOf qudt:dimensionExponent ;
 .
 qudt:dimensionExponentForMass
   a owl:DatatypeProperty ;
   rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
   rdfs:label "dimension exponent for mass" ;
-  rdfs:subPropertyOf qudt:dimensionExponent ;
 .
 qudt:dimensionExponentForThermodynamicTemperature
   a owl:DatatypeProperty ;
   rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
   rdfs:label "dimension exponent for thermodynamic temperature" ;
-  rdfs:subPropertyOf qudt:dimensionExponent ;
 .
 qudt:dimensionExponentForTime
   a owl:DatatypeProperty ;
   rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
   rdfs:label "dimension exponent for time" ;
-  rdfs:subPropertyOf qudt:dimensionExponent ;
 .
 qudt:dimensionInverse
   a owl:FunctionalProperty ;
@@ -2245,7 +2236,6 @@ qudt:dimensionlessExponent
   a owl:DatatypeProperty ;
   rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
   rdfs:label "dimensionless exponent" ;
-  rdfs:subPropertyOf qudt:dimensionExponent ;
 .
 qudt:element
   a owl:ObjectProperty ;

--- a/schema/shacl/SCHEMA_QUDT_NoOWL-v2.1.ttl
+++ b/schema/shacl/SCHEMA_QUDT_NoOWL-v2.1.ttl
@@ -2546,43 +2546,36 @@ qudt:dimensionExponentForAmountOfSubstance
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/2.1/schema/shacl/qudt> ;
   rdfs:label "dimension exponent for amount of substance" ;
-  rdfs:subPropertyOf qudt:dimensionExponent ;
 .
 qudt:dimensionExponentForElectricCurrent
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/2.1/schema/shacl/qudt> ;
   rdfs:label "dimension exponent for electric current" ;
-  rdfs:subPropertyOf qudt:dimensionExponent ;
 .
 qudt:dimensionExponentForLength
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/2.1/schema/shacl/qudt> ;
   rdfs:label "dimension exponent for length" ;
-  rdfs:subPropertyOf qudt:dimensionExponent ;
 .
 qudt:dimensionExponentForLuminousIntensity
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/2.1/schema/shacl/qudt> ;
   rdfs:label "dimension exponent for luminous intensity" ;
-  rdfs:subPropertyOf qudt:dimensionExponent ;
 .
 qudt:dimensionExponentForMass
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/2.1/schema/shacl/qudt> ;
   rdfs:label "dimension exponent for mass" ;
-  rdfs:subPropertyOf qudt:dimensionExponent ;
 .
 qudt:dimensionExponentForThermodynamicTemperature
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/2.1/schema/shacl/qudt> ;
   rdfs:label "dimension exponent for thermodynamic temperature" ;
-  rdfs:subPropertyOf qudt:dimensionExponent ;
 .
 qudt:dimensionExponentForTime
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/2.1/schema/shacl/qudt> ;
   rdfs:label "dimension exponent for time" ;
-  rdfs:subPropertyOf qudt:dimensionExponent ;
 .
 qudt:dimensionInverse
   a rdf:Property ;
@@ -2598,7 +2591,6 @@ qudt:dimensionlessExponent
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/2.1/schema/shacl/qudt> ;
   rdfs:label "dimensionless exponent" ;
-  rdfs:subPropertyOf qudt:dimensionExponent ;
 .
 qudt:element
   a rdf:Property ;


### PR DESCRIPTION
This was because it should not follow that dimensionExponent has all the values of its subProperties, which would be implied by rdfs:subPropertyOf.