### PR TITLE
Add currency symbols for a subset of QUDT currency units.

### DIFF
--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -26128,3 +26128,52 @@ THE UCUM TABLE (IN ALL FORMATS), UCUM DEFINITIONS, AND SPECIFICATION ARE PROVIDE
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "All Units Ontology Version 2.1.24" ;
 .
+
+unit:MexicanPeso qudt:symbol "$" .
+unit:PoundSterling qudt:symbol "£" .
+unit:JapaneseYen qudt:symbol "¥" .
+unit:YuanRenminbi qudt:symbol "¥" .
+unit:AMD qudt:symbol "֏" .
+unit:THB qudt:symbol "฿" .
+unit:SouthKoreanWon qudt:symbol "₩" .
+unit:NewIsraeliShekel qudt:symbol "₪" .
+unit:Euro qudt:symbol "€" .
+unit:PhilippinePeso qudt:symbol "₱" .
+unit:Hryvnia qudt:symbol "₴" .
+unit:IndianRupee qudt:symbol "₹" .
+unit:NewTurkishLira qudt:symbol "₺" .
+unit:AZN qudt:symbol "₼" .
+unit:RussianRuble qudt:symbol "₽" .
+unit:Lari qudt:symbol "₾" .
+unit:SaudiRiyal qudt:symbol "﷼" .
+unit:AUD qudt:symbol "$" .
+unit:CAD qudt:symbol "$" .
+unit:SwissFranc qudt:symbol "CHF" .
+unit:ChileanPeso qudt:symbol "$" .
+unit:ColombianPeso qudt:symbol "$" .
+unit:Denar qudt:symbol "ден" .
+unit:SerbianDinar qudt:symbol "дин" .
+unit:Forint qudt:symbol "Ft" .
+unit:HongKongDollar qudt:symbol "$" .
+unit:CzechKoruna qudt:symbol "Kč" .
+unit:ConvertibleMark qudt:symbol "KM" .
+unit:DanishKrone qudt:symbol "kr" .
+unit:NorwegianKrone qudt:symbol "kr" .
+unit:SwedishKrona qudt:symbol "kr" .
+unit:IcelandKrona qudt:symbol "kr" .
+unit:Lek qudt:symbol "L" .
+unit:MoldovanLeu qudt:symbol "L" .
+unit:RomanianNeLeu qudt:symbol "L" .
+unit:NewTaiwanDollar qudt:symbol "$" .
+unit:NewZealandDollar qudt:symbol "$" .
+unit:SouthAfricanRand qudt:symbol "R" .
+unit:BrazilianReal qudt:symbol "$" .
+unit:BYR qudt:symbol "Rbl" .
+unit:MalaysianRinggit qudt:symbol "RM" .
+unit:Rupiah qudt:symbol "Rp" .
+unit:SingaporeDollar qudt:symbol "$" .
+unit:SlovakKoruna qudt:symbol "Sk" .
+unit:USDollar qudt:symbol "$" .
+unit:Zloty qudt:symbol "zł" .
+unit:BulgarianLev qudt:symbol "лв." .
+unit:UAEDirham qudt:symbol "د.إ" .


### PR DESCRIPTION
There are edge cases. Many currencies have multiple symbols, e.g. Mexican Peso, which can be '$' or 'Mex$'. In this commit, there is only one symbol per currency unit. The decision was made based on the first sentence of the abstract of the respective Wikipedia article (e.g. https://en.wikipedia.org/wiki/Mexican_peso, which states 'The Mexican peso (symbol: $; code: MXN) is the currency of Mexico.')

Actual work done by @clemensjur - thanks!

Fixes #657 