### PR TITLE
Fix namespace IRI of citation:

### DIFF
--- a/schema/SCHEMA_QUDT-CITATION-v2.1.ttl
+++ b/schema/SCHEMA_QUDT-CITATION-v2.1.ttl
@@ -215,18 +215,6 @@ citation:Citation
     ] ;
   skos:definition "Used to define bibliographic references, compatible with BibTeX and BibLaTeX characteristics" ;
 .
-citation:PubKind
-  a owl:Class ;
-  rdfs:label "Pub kind" ;
-  rdfs:subClassOf <http://qudt.org/schema/qudt/StructuredDatatype> ;
-  rdfs:subClassOf dtype:Enumeration ;
-  rdfs:subClassOf owl:Thing ;
-  rdfs:subClassOf [
-      a owl:Restriction ;
-      owl:allValuesFrom dtype:EnumeratedValue ;
-      owl:onProperty dtype:value ;
-    ] ;
-.
 citation:address
   a owl:DatatypeProperty ;
   rdfs:label "address" ;

--- a/schema/SCHEMA_QUDT-CITATION-v2.1.ttl
+++ b/schema/SCHEMA_QUDT-CITATION-v2.1.ttl
@@ -6,7 +6,7 @@
 # imports: http://www.w3.org/2004/02/skos/core
 # prefix: citation
 
-@prefix citation: <http://qudt.org/2.1/schema/citation#> .
+@prefix citation: <http://qudt.org/schema/citation/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix dtype: <http://www.linkedmodel.org/schema/dtype#> .

--- a/schema/SCHEMA_QUDT-DATATYPE-v2.1.ttl
+++ b/schema/SCHEMA_QUDT-DATATYPE-v2.1.ttl
@@ -54,10 +54,6 @@ dcterms:title
   rdfs:label "title" ;
   rdfs:range xsd:string ;
 .
-<http://qudt.org/2.1/schema/citation#PubKinds>
-  a <http://qudt.org/2.1/schema/citation#PubKind> ;
-  rdfs:label "Pub kinds" ;
-.
 <http://qudt.org/2.1/schema/datatype>
   a owl:Ontology ;
   vaem:hasCatalogEntry voag:QUDT-SchemaCatalogEntry ;

--- a/vocab/VOCAB_QUDT-CITATION-v2.1.ttl
+++ b/vocab/VOCAB_QUDT-CITATION-v2.1.ttl
@@ -5,7 +5,7 @@
 # imports: http://www.linkedmodel.org/schema/vaem
 # imports: http://www.w3.org/2004/02/skos/core
 
-@prefix citation: <http://qudt.org/2.1/schema/citation#> .
+@prefix citation: <http://qudt.org/schema/citation/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix dtype: <http://www.linkedmodel.org/schema/dtype#> .


### PR DESCRIPTION
As discussed in https://github.com/qudt/qudt-public-repo/pull/681, `<http://qudt.org/2.1/schema/citation#>` should be the versionless namespace IRI `<http://qudt.org/schema/citation/>`.

`<http://qudt.org/2.1/schema/citation#PubKinds>` and `<http://qudt.org/2.1/schema/citation#PubKind>` are not referenced anywhere and don't seem to have a clear purpose, so maybe they could just be removed?