### PR TITLE
Fix the ontology IRI of QUDT Sources Vocabulary

### DIFF
--- a/vocab/VOCAB_QUDT-SOURCES-v2.1.ttl
+++ b/vocab/VOCAB_QUDT-SOURCES-v2.1.ttl
@@ -70,19 +70,19 @@ CODATA sponsors the CODATA international conference every two years. [Wikipedia]
   qudt:name "CODATA" ;
   qudt:url "http://en.wikipedia.org/wiki/Committee_on_Data_for_Science_and_Technology"^^xsd:anyURI ;
   qudt:url "http://www.sizes.com/units/codata.htm"^^xsd:anyURI ;
-  rdfs:isDefinedBy <http://qudt.org/2.0/vocab/sources> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/sources> ;
   rdfs:label "CODATA" ;
 .
 qudt:PhysicsForums
   rdf:type org:Organization ;
   qudt:url "http://www.physicsforums.com"^^xsd:anyURI ;
-  rdfs:isDefinedBy <http://qudt.org/2.0/vocab/sources> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/sources> ;
   rdfs:label "Physics Forums" ;
 .
 qudt:Wikipedia
   rdf:type org:Organization ;
   qudt:url "http://wwwwikipedia.com"^^xsd:anyURI ;
-  rdfs:isDefinedBy <http://qudt.org/2.0/vocab/sources> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/sources> ;
   rdfs:label "Wikipedia" ;
 .
 voag:hasCatalogEntry

--- a/vocab/constants/VOCAB_QUDT-CONSTANTS-v2.1.ttl
+++ b/vocab/constants/VOCAB_QUDT-CONSTANTS-v2.1.ttl
@@ -31,7 +31,7 @@
 qudt:PhysicsForums
   a org:Organization ;
   qudt:url "http://www.physicsforums.com"^^xsd:anyURI ;
-  rdfs:isDefinedBy <http://qudt.org/2.0/vocab/sources> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/sources> ;
   rdfs:label "Physics Forums" ;
 .
 constant:AlphaParticleElectronMassRatio


### PR DESCRIPTION
I didn't try to fix the occurrences in `vocab\VOCAB_QUDT-SOURCES-v2.0.ttl` and `vocab\quantitykinds\to-be-deprecated-quantitykinds\VOCAB_QUDT-QUANTITY-KINDS-NIST-CONSTANTS-v2.0.ttl`.