### PR TITLE
Add a few units and add fix/some symbols, labels, and conversionMultipliers

### DIFF
--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -14263,11 +14263,11 @@ unit:M3-PER-M2
   qudt:hasQuantityKind quantitykind:VolumePerArea ;
   qudt:plainTextDescription "power of the SI base unit metre with the exponent 3 divided by the power of the SI base unit metre with the exponent 2" ;
   qudt:symbol "m³/m²" ;
-  qudt:ucumCode "m3.m-3"^^qudt:UCUMcs ;
+  qudt:ucumCode "m3.m-2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H60" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
-  rdfs:label "Cubic Meter Per Cubic Meter"@en-us ;
-  rdfs:label "Cubic Metre Per Cubic Metre"@en ;
+  rdfs:label "Cubic Meter Per Square Meter"@en-us ;
+  rdfs:label "Cubic Metre Per Square Metre"@en ;
 .
 unit:M3-PER-M3
   a qudt:Unit ;
@@ -23228,7 +23228,7 @@ unit:PPTM-PER-K
   a qudt:Unit ;
   dcterms:description "Unit for expansion ratios expressed as parts per ten million per Kelvin."^^qudt:LatexString ;
   qudt:conversionMultiplier 0.0000001 ;
-  qudt:expression "\\(PPM/K\\)"^^qudt:LatexString ;
+  qudt:expression "\\(PPTM/K\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H-1T0D0 ;
   qudt:hasQuantityKind quantitykind:ExpansionRatio ;
   qudt:symbol "PPTM/K" ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -547,6 +547,7 @@ unit:ATM-M3-PER-MOL
   qudt:conversionMultiplier 101325.0 ;
   qudt:hasDimensionVector qkdv:A-1E0L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:HenrysLawVolatilityConstant ;
+  qudt:symbol "atm⋅m³/mol" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Atmosphere Cubic Meter per Mole"@en ;
   rdfs:label "Atmosphere Cubic Meter per Mole"@en-us ;
@@ -3036,6 +3037,7 @@ unit:CD-PER-LM
   qudt:conversionMultiplier 1.0 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:LuminousIntensityDistribution ;
+  qudt:symbol "cd/lm" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Candela per Lumen" ;
 .
@@ -3753,10 +3755,11 @@ unit:CentiM3-PER-MOL-SEC
   a qudt:Unit ;
   dcterms:description "A unit that is the 0.000001-fold of the power of the SI base unit metre with the exponent 3 divided by the SI base unit mol multiplied by the SI base unit second."^^qudt:LatexString ;
   qudt:applicableSystem sou:SI ;
-  qudt:conversionMultiplier 1.0 ;
+  qudt:conversionMultiplier 0.000001 ;
   qudt:hasDimensionVector qkdv:A-1E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:AtmosphericHydroxylationRate ;
   qudt:hasQuantityKind quantitykind:SecondOrderReactionRateConstant ;
+  qudt:symbol "cm³/(mol⋅s)" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Cubic Centimeter per Mole Second"@en ;
   rdfs:label "Cubic Centimeter per Mole Second"@en-us ;
@@ -3787,6 +3790,7 @@ unit:CentiMOL
   qudt:hasDimensionVector qkdv:A1E0L0I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:AmountOfSubstance ;
   qudt:hasQuantityKind quantitykind:ExtentOfReaction ;
+  qudt:symbol "cmol" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "CentiMole"@en ;
 .
@@ -3852,6 +3856,7 @@ unit:CentiN
   qudt:conversionMultiplier 0.01 ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Force ;
+  qudt:symbol "cN" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "CentiNewton"@en ;
 .
@@ -4639,6 +4644,7 @@ unit:DEG_F-PER-SEC2
   dcterms:description "\\(\\textit{Degree Fahrenheit per Square Second}\\) is a C.G.S System unit for expressing the acceleration of a temperature expressed as \\(degF / s^2\\)."^^qudt:LatexString ;
   qudt:applicableSystem sou:IMPERIAL ;
   qudt:applicableSystem sou:USCS ;
+  qudt:conversionMultiplier 0.5555555555555556 ;
   qudt:definedUnitOfSystem sou:IMPERIAL ;
   qudt:definedUnitOfSystem sou:USCS ;
   qudt:expression "\\(degF / s^2\\)"^^qudt:LatexString ;
@@ -5415,6 +5421,7 @@ unit:DeciN
   qudt:conversionMultiplier 0.1 ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Force ;
+  qudt:symbol "dN" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "DeciNewton"@en ;
 .
@@ -5446,6 +5453,7 @@ unit:DeciS
   qudt:hasDimensionVector qkdv:A0E2L-2I0M-1H0T3D0 ;
   qudt:hasQuantityKind quantitykind:Admittance ;
   qudt:hasQuantityKind quantitykind:Conductance ;
+  qudt:symbol "dS" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "DeciSiemens"@en ;
 .
@@ -6867,6 +6875,7 @@ unit:FemtoGM
   qudt:conversionMultiplier 0.000000000000000001 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Mass ;
+  qudt:symbol "fg" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "FemtoGram"@en ;
 .
@@ -6965,6 +6974,7 @@ unit:FemtoMOL
   qudt:hasDimensionVector qkdv:A1E0L0I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:AmountOfSubstance ;
   qudt:hasQuantityKind quantitykind:ExtentOfReaction ;
+  qudt:symbol "fmol" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "FemtoMole"@en ;
 .
@@ -9937,6 +9947,21 @@ unit:K-PER-SEC
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kelvin per Second"@en ;
 .
+unit:K-PER-SEC2
+  a qudt:Unit ;
+  dcterms:description "\\(\\textbf{Kelvin per Square Second} is a unit for 'Temperature Per Time Squared' expressed as \\(K / s^2\\)."^^qudt:LatexString ;
+  qudt:applicableSystem sou:SI ;
+  qudt:conversionMultiplier 1.0 ;
+  qudt:derivedCoherentUnitOfSystem sou:SI ;
+  qudt:expression "\\(K / s\\)"^^qudt:LatexString ;
+  qudt:hasDimensionVector qkdv:A0E0L0I0M0H1T-2D0 ;
+  qudt:hasQuantityKind quantitykind:TemperaturePerTime_Squared ;
+  qudt:symbol "K/s²" ;
+  qudt:ucumCode "K.s-2"^^qudt:UCUMcs ;
+  qudt:ucumCode "K/s^2"^^qudt:UCUMcs ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Kelvin per Square Second"@en ;
+.
 unit:K-PER-T
   a qudt:Unit ;
   dcterms:description "\\(\\textbf{Kelvin per Tesla} is a unit for 'Temperature Per Magnetic Flux Density' expressed as \\(K T^{-1}\\)."^^qudt:LatexString ;
@@ -11222,6 +11247,7 @@ unit:KiloGM-PER-M2-SEC2
   qudt:conversionMultiplier 1.0 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:PressureLossPerLength ;
+  qudt:symbol "kg/(m²⋅s²)" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kilogram per Square Meter Square Second"@en-us ;
   rdfs:label "Kilogram per Square Metre Square Second"@en ;
@@ -11679,8 +11705,10 @@ unit:KiloLB_F
   a qudt:Unit ;
   qudt:applicableSystem sou:IMPERIAL ;
   qudt:applicableSystem sou:USCS ;
+  qudt:conversionMultiplier 4448.222 ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Force ;
+  qudt:symbol "klbf" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "KiloPound Force"@en ;
 .
@@ -11977,6 +12005,7 @@ unit:KiloN-M2
   qudt:conversionMultiplier 1000.0 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:WarpingMoment ;
+  qudt:symbol "kN⋅m²" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kilo Newton Square Meter"@en-us ;
   rdfs:label "Kilo Newton Square Metre"@en ;
@@ -12393,6 +12422,7 @@ unit:KiloWB
   qudt:conversionMultiplier 1000.0 ;
   qudt:hasDimensionVector qkdv:A0E-1L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:MagneticFlux ;
+  qudt:symbol "kWb" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "KiloWeber"@en ;
 .
@@ -12424,6 +12454,7 @@ unit:KiloYR
   qudt:conversionMultiplier 1000.0 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Time ;
+  qudt:symbol "1000 yr" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "KiloYear"@en ;
 .
@@ -14190,6 +14221,7 @@ unit:M3-PER-KiloGM
   qudt:derivedCoherentUnitOfSystem sou:SI ;
   qudt:expression "\\(m^{3}/kg\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M-1H0T0D0 ;
+  qudt:hasQuantityKind quantitykind:SoilAdsorptionCoefficient ;
   qudt:hasQuantityKind quantitykind:SpecificVolume ;
   qudt:iec61360Code "0112/2///62720#UAA766" ;
   qudt:symbol "m³/kg" ;
@@ -14219,6 +14251,23 @@ unit:M3-PER-KiloGM-SEC2
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Cubic Meter per Kilogram Square Second"@en-us ;
   rdfs:label "Cubic Metre per Kilogram Square Second"@en ;
+.
+unit:M3-PER-M2
+  a qudt:Unit ;
+  qudt:applicableSystem sou:CGS ;
+  qudt:applicableSystem sou:CGS-EMU ;
+  qudt:applicableSystem sou:CGS-GAUSS ;
+  qudt:applicableSystem sou:SI ;
+  qudt:conversionMultiplier 1.0 ;
+  qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T0D0 ;
+  qudt:hasQuantityKind quantitykind:VolumePerArea ;
+  qudt:plainTextDescription "power of the SI base unit metre with the exponent 3 divided by the power of the SI base unit metre with the exponent 2" ;
+  qudt:symbol "m³/m²" ;
+  qudt:ucumCode "m3.m-3"^^qudt:UCUMcs ;
+  qudt:uneceCommonCode "H60" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Cubic Meter Per Cubic Meter"@en-us ;
+  rdfs:label "Cubic Metre Per Cubic Metre"@en ;
 .
 unit:M3-PER-M3
   a qudt:Unit ;
@@ -14274,6 +14323,20 @@ unit:M3-PER-MOL
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Cubic Meter per Mole"@en-us ;
   rdfs:label "Cubic Metre per Mole"@en ;
+.
+unit:M3-PER-MOL-SEC
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "A unit that is the SI base unit metre with the exponent 3 divided by the SI base unit mol multiplied by the SI base unit second."^^qudt:LatexString ;
+  qudt:applicableSystem sou:SI ;
+  qudt:conversionMultiplier 1.0 ;
+  qudt:hasDimensionVector qkdv:A-1E0L3I0M0H0T-1D0 ;
+  qudt:hasQuantityKind quantitykind:AtmosphericHydroxylationRate ;
+  qudt:hasQuantityKind quantitykind:SecondOrderReactionRateConstant ;
+  qudt:symbol "m³/(mol⋅s)" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Cubic Centimeter per Mole Second"@en ;
+  rdfs:label "Cubic Centimeter per Mole Second"@en-us ;
 .
 unit:M3-PER-SEC
   a qudt:DerivedUnit ;
@@ -14433,6 +14496,7 @@ unit:MESH
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:InverseLength ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Mesh_(scale)"^^xsd:anyURI ;
+  qudt:symbol "mesh" ;
   qudt:ucumCode "[mesh_i]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "57" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -14775,6 +14839,7 @@ unit:MOHM
   qudt:informativeReference "http://www.oxfordreference.com/view/10.1093/acref/9780198605225.001.0001/acref-9780198605225-e-914"^^xsd:anyURI ;
   qudt:latexDefinition "\\(1\\:{mohm_{cgs}} = 1\\:\\frac {cm} {dyn.s}\\: (=\\:1\\:\\frac s g \\:in\\:base\\:c.g.s.\\:terms)\\)"^^qudt:LatexString ;
   qudt:latexDefinition "\\(1\\:{mohm_{mks}} = 10^{3}\\:\\frac m {N.s}\\:(=\\:10^{3}\\:   \\frac s {kg}\\:in\\:base\\:m.k.s.\\:terms)\\)"^^qudt:LatexString ;
+  qudt:symbol "mohm" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Mohm"@en ;
 .
@@ -15781,6 +15846,7 @@ unit:MegaS
   qudt:hasDimensionVector qkdv:A0E2L-2I0M-1H0T3D0 ;
   qudt:hasQuantityKind quantitykind:Admittance ;
   qudt:hasQuantityKind quantitykind:Conductance ;
+  qudt:symbol "MS" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "MegaSiemens"@en ;
 .
@@ -16741,6 +16807,7 @@ unit:MicroMOL-PER-GM-SEC
   qudt:applicableSystem sou:SI ;
   qudt:conversionMultiplier 0.0001 ;
   qudt:hasDimensionVector qkdv:A1E0L0I0M-1H0T-1D0 ;
+  qudt:symbol "μmol/(g⋅s)" ;
   qudt:ucumCode "umol.g-1.s-1"^^qudt:UCUMcs ;
   qudt:ucumCode "umol/g/s"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -17375,6 +17442,7 @@ unit:MilliBQ
   qudt:conversionMultiplier 0.001 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Activity ;
+  qudt:symbol "mBq" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "MilliBecquerel"@en ;
 .
@@ -17706,6 +17774,7 @@ unit:MilliGM-PER-HA
   qudt:hasQuantityKind quantitykind:MassPerArea ;
   qudt:iec61360Code "0112/2///62720#UAA818" ;
   qudt:plainTextDescription "0.000001-fold of the SI base unit kilogram divided by the 10,0000-fold of the power of the SI base unit metre with the exponent 2" ;
+  qudt:symbol "mg/ha" ;
   qudt:ucumCode "mg.har-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Milligram Per Hectare"@en ;
@@ -17932,6 +18001,7 @@ unit:MilliGM-PER-MilliL
   qudt:hasQuantityKind quantitykind:MassConcentration ;
   qudt:hasQuantityKind quantitykind:MassDensity ;
   qudt:plainTextDescription "0.000001-fold of the SI base unit kilogram divided by the unit millilitre" ;
+  qudt:symbol "mg/mL" ;
   qudt:ucumCode "mg.mL-1"^^qudt:UCUMcs ;
   qudt:ucumCode "mg/mL"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -18846,8 +18916,10 @@ unit:MilliRAD
 unit:MilliRAD_R
   a qudt:Unit ;
   qudt:applicableSystem sou:CGS ;
+  qudt:conversionMultiplier 0.00001 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:AbsorbedDose ;
+  qudt:symbol "mrad" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "MilliRad"@en ;
 .
@@ -19281,6 +19353,7 @@ unit:N-M-PER-M-RAD
   qudt:exactMatch unit:N-PER-RAD ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ModulusOfRotationalSubgradeReaction ;
+  qudt:symbol "N⋅m/(m⋅rad)" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Newton Metre per Metre per Radians" ;
   owl:sameAs unit:N-PER-RAD ;
@@ -19390,6 +19463,7 @@ unit:N-M2
   qudt:conversionMultiplier 1.0 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:WarpingMoment ;
+  qudt:symbol "N⋅m²" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Newton Square Meter"@en-us ;
   rdfs:label "Newton Square Metre"@en ;
@@ -20009,6 +20083,7 @@ unit:NanoBQ
   qudt:conversionMultiplier 0.000000001 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Activity ;
+  qudt:symbol "nBq" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "NanoBecquerel"@en ;
 .
@@ -20343,6 +20418,7 @@ unit:NanoMOL
   qudt:hasDimensionVector qkdv:A1E0L0I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:AmountOfSubstance ;
   qudt:hasQuantityKind quantitykind:ExtentOfReaction ;
+  qudt:symbol "nmol" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "NanoMole"@en ;
 .
@@ -20361,6 +20437,7 @@ unit:NanoMOL-PER-GM-SEC
   qudt:applicableSystem sou:SI ;
   qudt:conversionMultiplier 0.000001 ;
   qudt:hasDimensionVector qkdv:A1E0L0I0M-1H0T-1D0 ;
+  qudt:symbol "nmol/(g⋅s)" ;
   qudt:ucumCode "nmol.g-1.s-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Nanomoles per gram per second"@en ;
@@ -20383,6 +20460,7 @@ unit:NanoMOL-PER-L
   qudt:conversionMultiplier 0.000001 ;
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:AmountOfSubstancePerUnitVolume ;
+  qudt:symbol "nmol/L" ;
   qudt:ucumCode "nmol.L-1"^^qudt:UCUMcs ;
   qudt:ucumCode "nmol/L"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -20462,6 +20540,7 @@ unit:NanoS
   qudt:hasDimensionVector qkdv:A0E2L-2I0M-1H0T3D0 ;
   qudt:hasQuantityKind quantitykind:Admittance ;
   qudt:hasQuantityKind quantitykind:Conductance ;
+  qudt:symbol "nS" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "NanoSiemens"@en ;
 .
@@ -21581,6 +21660,22 @@ unit:PER-DAY
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Reciprocal Day"@en ;
 .
+unit:PER-EV2
+  a qudt:Unit ;
+  dcterms:description "Per Square Electron Volt is a denominator unit with dimensions \\(/eV^2\\)."^^qudt:LatexString ;
+  qudt:applicableSystem sou:CGS ;
+  qudt:applicableSystem sou:CGS-EMU ;
+  qudt:applicableSystem sou:CGS-GAUSS ;
+  qudt:applicableSystem sou:SI ;
+  qudt:conversionMultiplier 38956440500000000000000000000000000000.0 ;
+  qudt:expression "\\(/eV^2\\)"^^qudt:LatexString ;
+  qudt:hasDimensionVector qkdv:A0E0L-4I0M-2H0T4D0 ;
+  qudt:hasQuantityKind quantitykind:InverseEnergy_Squared ;
+  qudt:symbol "/eV²" ;
+  qudt:ucumCode "eV-2"^^qudt:UCUMcs ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Reciprocal Square Electron Volt"@en ;
+.
 unit:PER-FT3
   a qudt:Unit ;
   qudt:applicableSystem sou:IMPERIAL ;
@@ -21692,6 +21787,22 @@ unit:PER-J-M3
   rdfs:label "Reciprocal Joule Cubic Meter"@en-us ;
   rdfs:label "Reciprocal Joule Cubic Metre"@en ;
 .
+unit:PER-J2
+  a qudt:Unit ;
+  dcterms:description "Per Square Joule is a denominator unit with dimensions \\(/eV^2\\)."^^qudt:LatexString ;
+  qudt:applicableSystem sou:CGS ;
+  qudt:applicableSystem sou:CGS-EMU ;
+  qudt:applicableSystem sou:CGS-GAUSS ;
+  qudt:applicableSystem sou:SI ;
+  qudt:conversionMultiplier 1.0 ;
+  qudt:expression "\\(/J^2\\)"^^qudt:LatexString ;
+  qudt:hasDimensionVector qkdv:A0E0L-4I0M-2H0T4D0 ;
+  qudt:hasQuantityKind quantitykind:InverseEnergy_Squared ;
+  qudt:symbol "/J²" ;
+  qudt:ucumCode "J-2"^^qudt:UCUMcs ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Reciprocal Square Joule"@en ;
+.
 unit:PER-K
   a qudt:Unit ;
   dcterms:description "Per Kelvin Unit is a denominator unit with dimensions \\(/k\\)."^^qudt:LatexString ;
@@ -21708,6 +21819,19 @@ unit:PER-K
   qudt:uneceCommonCode "C91" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Reciprocal Kelvin"@en ;
+.
+unit:PER-KiloGM2
+  a qudt:Unit ;
+  dcterms:description "Per Square Kilogram is a denominator unit with dimensions \\(/kg^2\\)."^^qudt:LatexString ;
+  qudt:applicableSystem sou:SI ;
+  qudt:conversionMultiplier 1.0 ;
+  qudt:expression "\\(/kg^2\\)"^^qudt:LatexString ;
+  qudt:hasDimensionVector qkdv:A0E0L0I0M-2H0T0D0 ;
+  qudt:hasQuantityKind quantitykind:InverseMass_Squared ;
+  qudt:symbol "/kg²" ;
+  qudt:ucumCode "kg-2"^^qudt:UCUMcs ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Reciprocal Square Kilogram"@en ;
 .
 unit:PER-KiloM
   a qudt:Unit ;
@@ -22592,8 +22716,9 @@ unit:PERM_Metric
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:VaporPermeability ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Perm_(unit)"^^xsd:anyURI ;
+  qudt:symbol "perm{Metric}" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
-  rdfs:label "U.S. Perm"@en ;
+  rdfs:label "Metric Perm"@en ;
 .
 unit:PERM_US
   a qudt:Unit ;
@@ -22603,6 +22728,7 @@ unit:PERM_US
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:VaporPermeability ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Perm_(unit)"^^xsd:anyURI ;
+  qudt:symbol "perm{US}" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "U.S. Perm"@en ;
 .
@@ -23105,7 +23231,7 @@ unit:PPTM-PER-K
   qudt:expression "\\(PPM/K\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H-1T0D0 ;
   qudt:hasQuantityKind quantitykind:ExpansionRatio ;
-  qudt:symbol "PPM/K" ;
+  qudt:symbol "PPTM/K" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Parts Per Ten Million per Kelvin"@en ;
 .
@@ -23603,6 +23729,7 @@ unit:PicoMOL
   qudt:hasDimensionVector qkdv:A1E0L0I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:AmountOfSubstance ;
   qudt:hasQuantityKind quantitykind:ExtentOfReaction ;
+  qudt:symbol "pmol" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "PicoMole"@en ;
 .
@@ -23707,6 +23834,7 @@ unit:PicoPA
   qudt:hasQuantityKind quantitykind:ModulusOfElasticity ;
   qudt:hasQuantityKind quantitykind:ShearModulus ;
   qudt:hasQuantityKind quantitykind:VaporPressure ;
+  qudt:symbol "pPa" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "PicoPascal"@en ;
 .
@@ -23739,6 +23867,7 @@ unit:PicoS
   qudt:hasDimensionVector qkdv:A0E2L-2I0M-1H0T3D0 ;
   qudt:hasQuantityKind quantitykind:Admittance ;
   qudt:hasQuantityKind quantitykind:Conductance ;
+  qudt:symbol "pS" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "PicoSiemens"@en ;
 .


### PR DESCRIPTION
I have a few tweaks from our upgrade to the most recent release.

This PR includes the following:
- A few additional units
- Addition of a bunch of `qudt:symbol`s where they were missing, as well as fix the one for `unit:PPTM-PER-K`
- Add a couple `qudt:conversionMultiplier`s, as well as fix the one for `unit:CentiM3-PER-MOL-SEC`
- Fix an incorrect label for `unit:PERM_Metric`
- Add a `qudt:hasQuantityKind` statement for a few units