### PR TITLE
Migrating to qudt:hasUnit

### DIFF
--- a/schema/SCHEMA_QUDT-v2.1.ttl
+++ b/schema/SCHEMA_QUDT-v2.1.ttl
@@ -954,6 +954,11 @@ qudt:Quantifiable
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
+      owl:allValuesFrom qudt:Unit ;
+      owl:onProperty qudt:hasUnit ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
       owl:allValuesFrom xsd:double ;
       owl:onProperty qudt:relativeStandardUncertainty ;
     ] ;
@@ -986,6 +991,11 @@ qudt:Quantifiable
       a owl:Restriction ;
       owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onProperty qudt:unit ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:hasUnit ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
@@ -1282,6 +1292,11 @@ qudt:QuantityValue
       a owl:Restriction ;
       owl:cardinality "1"^^xsd:nonNegativeInteger ;
       owl:onProperty qudt:unit ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:cardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:hasUnit ;
     ] ;
 .
 qudt:RatioScale
@@ -2496,7 +2511,6 @@ qudt:hasUnit
   dcterms:description "This property relates a system of units with a unit of measure that is either a) defined by the system, or b) accepted for use by the system and is convertible to a unit of equivalent dimension that is defined by the system. Systems of units may distinguish between base and derived units. Base units are the units which measure the base quantities for the corresponding system of quantities. The base units are used to define units for all other quantities as products of powers of the base units. Such units are called derived units for the system."^^rdf:HTML ;
   rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
   rdfs:label "has unit" ;
-  owl:inverseOf qudt:isUnitOfSystem ;
 .
 qudt:hasUnitSystem
   a owl:FunctionalProperty ;
@@ -2607,7 +2621,6 @@ qudt:isUnitOfSystem
   rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
   rdfs:label "is unit of system" ;
   rdfs:range qudt:SystemOfUnits ;
-  owl:inverseOf qudt:hasUnit ;
 .
 qudt:isoNormativeReference
   a owl:DatatypeProperty ;

--- a/schema/SCHEMA_QUDT-v2.1.ttl
+++ b/schema/SCHEMA_QUDT-v2.1.ttl
@@ -1290,12 +1290,12 @@ qudt:QuantityValue
   rdfs:subClassOf qudt:Quantifiable ;
   rdfs:subClassOf [
       a owl:Restriction ;
-      owl:cardinality "1"^^xsd:nonNegativeInteger ;
+      owl:maxCardinality 1 ;
       owl:onProperty qudt:unit ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
-      owl:cardinality "1"^^xsd:nonNegativeInteger ;
+      owl:maxCardinality 1 ;
       owl:onProperty qudt:hasUnit ;
     ] ;
 .

--- a/schema/shacl/SCHEMA_QUDT_NoOWL-v2.1.ttl
+++ b/schema/shacl/SCHEMA_QUDT_NoOWL-v2.1.ttl
@@ -1191,6 +1191,7 @@ qudt:Quantifiable
   sh:property qudt:Quantifiable-relativeStandardUncertainty ;
   sh:property qudt:Quantifiable-standardUncertainty ;
   sh:property qudt:Quantifiable-unit ;
+  sh:property qudt:Quantifiable-hasUnit ;
   sh:property qudt:Quantifiable-value ;
 .
 qudt:Quantifiable-dataEncoding
@@ -1224,6 +1225,13 @@ qudt:Quantifiable-standardUncertainty
 qudt:Quantifiable-unit
   a sh:PropertyShape ;
   sh:path qudt:unit ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/shacl/qudt> ;
+  sh:class qudt:Unit ;
+  sh:maxCount 1 ;
+.
+qudt:Quantifiable-hasUnit
+  a sh:PropertyShape ;
+  sh:path qudt:hasUnit ;
   rdfs:isDefinedBy <http://qudt.org/2.1/schema/shacl/qudt> ;
   sh:class qudt:Unit ;
   sh:maxCount 1 ;
@@ -1612,6 +1620,7 @@ qudt:QuantityValue
   rdfs:subClassOf qudt:Concept ;
   rdfs:subClassOf qudt:Quantifiable ;
   sh:property qudt:QuantityValue-unit ;
+  sh:property qudt:QuantityValue-hasUnit ;
 .
 qudt:QuantityValue-unit
   a sh:PropertyShape ;
@@ -1620,6 +1629,13 @@ qudt:QuantityValue-unit
   sh:class qudt:Unit ;
   sh:maxCount 1 ;
   sh:minCount 1 ;
+.
+qudt:QuantityValue-hasUnit
+  a sh:PropertyShape ;
+  sh:path qudt:hasUnit ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/shacl/qudt> ;
+  sh:class qudt:Unit ;
+  sh:maxCount 1 ;
 .
 qudt:RatioScale
   a rdfs:Class ;
@@ -2825,7 +2841,7 @@ qudt:hasRule
 .
 qudt:hasUnit
   a rdf:Property ;
-  dcterms:description "This property relates a system of units with a unit of measure that is either a) defined by the system, or b) accepted for use by the system and is convertible to a unit of equivalent dimension that is defined by the system. Systems of units may distinguish between base and derived units. Base units are the units which measure the base quantities for the corresponding system of quantities. The base units are used to define units for all other quantities as products of powers of the base units. Such units are called derived units for the system."^^rdf:HTML ;
+  dcterms:description "This property relates a system of units with a unit of measure that is either a) defined by the system, or b) accepted for use by the system and is convertible to a unit of equivalent dimension that is defined by the system. Systems of units may distinguish between base and derived units. Base units are the units which measure the base quantities for the corresponding system of quantities. The base units are used to define units for all other quantities as products of powers of the base units. Such units are called derived units for the system. Thirdly, c) a reference to the unit of measure of a quantity (variable or constant) of interest"^^rdf:HTML ;
   rdfs:isDefinedBy <http://qudt.org/2.1/schema/shacl/qudt> ;
   rdfs:label "has unit" ;
 .
@@ -3287,6 +3303,8 @@ qudt:uneceCommonCode
 qudt:unit
   a rdf:Property ;
   dcterms:description "A reference to the unit of measure of a quantity (variable or constant) of interest."^^rdf:HTML ;
+  dcterms:isReplacedBy qudt:hasUnit ;
+  qudt:deprecated true ;
   rdfs:isDefinedBy <http://qudt.org/2.1/schema/shacl/qudt> ;
   rdfs:label "unit" ;
 .

--- a/schema/shacl/SCHEMA_QUDT_NoOWL-v2.1.ttl
+++ b/schema/shacl/SCHEMA_QUDT_NoOWL-v2.1.ttl
@@ -1628,7 +1628,6 @@ qudt:QuantityValue-unit
   rdfs:isDefinedBy <http://qudt.org/2.1/schema/shacl/qudt> ;
   sh:class qudt:Unit ;
   sh:maxCount 1 ;
-  sh:minCount 1 ;
 .
 qudt:QuantityValue-hasUnit
   a sh:PropertyShape ;

--- a/schema/shacl/SHACL-SCHEMA-SUPPLEMENT_QUDT-v2.1.ttl
+++ b/schema/shacl/SHACL-SCHEMA-SUPPLEMENT_QUDT-v2.1.ttl
@@ -55,6 +55,11 @@
       sh:namespace "http://www.w3.org/2004/02/skos/core#"^^xsd:anyURI ;
       sh:prefix "skos" ;
     ] ;
+  sh:declare [
+      a sh:PrefixDeclaration ;
+      sh:namespace "http://www.w3.org/1999/02/22-rdf-syntax-ns#"^^xsd:anyURI ;
+      sh:prefix "rdf" ;
+    ] ;
 .
 qudt:AbstractQuantityKind-qudt_latexSymbol
   rdfs:isDefinedBy <http://qudt.org/2.1/schema/shacl/overlay/qudt> ;
@@ -184,18 +189,42 @@ qudt:DeprecationConstraint
   a sh:NodeShape ;
   rdfs:isDefinedBy <http://qudt.org/2.1/schema/shacl/overlay/qudt> ;
   rdfs:label "Warning about use of a deprecated QUDT resource" ;
-  sh:severity sh:Warning ;
+  sh:severity sh:Info ;
   sh:sparql [
       a sh:SPARQLConstraint ;
       rdfs:comment "Warns if a deprecated QUDT resource is used" ;
-      sh:message "Resource, '{?s}' refers to '{$this}' which has been deprecated. Please refer to '{?newq}' instead." ;
+      sh:message "Resource, '{?s}' refers to '{?oldqstr}' which has been deprecated. Please refer to '{?newqstr}' instead." ;
       sh:prefixes <http://qudt.org/2.1/schema/shacl/overlay/qudt> ;
-      sh:select """SELECT ?s $this ?newq
+      sh:select """SELECT ?s $this ?oldqstr ?newqstr
 WHERE {
 $this qudt:deprecated true .
 ?s ?p $this .
 FILTER (!STRSTARTS(STR(?s),'http://qudt.org')) .
 $this dcterms:isReplacedBy ?newq .
+BIND (STR(?newq) AS ?newqstr)
+BIND (STR($this) AS ?oldqstr)
+}""" ;
+    ] ;
+  sh:targetClass qudt:Concept ;
+.
+qudt:DeprecatedPropertyConstraint
+  a sh:NodeShape ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/shacl/overlay/qudt> ;
+  rdfs:label "Warning about use of a deprecated QUDT property" ;
+  sh:severity sh:Info ;
+  sh:sparql [
+      a sh:SPARQLConstraint ;
+      rdfs:comment "Warns if a deprecated QUDT property is used" ;
+      sh:message "Resource, '{$this}' uses the property '{?oldpstr}' which will be deprecated. Please use '{?newpstr}' instead." ;
+      sh:prefixes <http://qudt.org/2.1/schema/shacl/overlay/qudt> ;
+      sh:select """SELECT $this ?p ?oldpstr ?newpstr
+WHERE {
+?p qudt:deprecated true .
+?p a rdf:Property .
+$this ?p ?o .
+?p dcterms:isReplacedBy ?newp .
+BIND (STR(?newp) AS ?newpstr)
+BIND (STR(?p) AS ?oldpstr)
 }""" ;
     ] ;
   sh:targetClass qudt:Concept ;

--- a/vocab/constants/VOCAB_QUDT-CONSTANTS-v2.1.ttl
+++ b/vocab/constants/VOCAB_QUDT-CONSTANTS-v2.1.ttl
@@ -3066,7 +3066,7 @@ constant:ValueForElectronVolt
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:numericValue 1.602176487e-19 ;
   qudt:standardUncertainty 0.000000040e-19 ;
-  qudt:unit unit:J ;
+  qudt:hasUnit unit:J ;
   qudt:value 1.602176634e-19 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?tevj#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron volt" ;
@@ -3075,7 +3075,7 @@ constant:Value_AlphaParticleElectronMassRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000031"^^xsd:double ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value "7294.299537"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?malsme#mid"^^xsd:anyURI ;
   rdfs:label "Value for alpha particle-electron mass ratio" ;
@@ -3085,7 +3085,7 @@ constant:Value_AlphaParticleMass
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:relativeStandardUncertainty 5.0e-8 ;
   qudt:standardUncertainty 0.00000033e-27 ;
-  qudt:unit unit:KiloGM ;
+  qudt:hasUnit unit:KiloGM ;
   qudt:value 6.64465620e-27 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mal#mid"^^xsd:anyURI ;
   rdfs:label "Value for alpha particle mass" ;
@@ -3094,7 +3094,7 @@ constant:Value_AlphaParticleMassEnergyEquivalent
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000030e-10 ;
-  qudt:unit unit:J ;
+  qudt:hasUnit unit:J ;
   qudt:value 5.97191917e-10 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?malc2#mid"^^xsd:anyURI ;
   rdfs:label "Value for alpha particle mass energy equivalent" ;
@@ -3103,7 +3103,7 @@ constant:Value_AlphaParticleMassEnergyEquivalentInMeV
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.000093"^^xsd:double ;
-  qudt:unit unit:MegaEV ;
+  qudt:hasUnit unit:MegaEV ;
   qudt:value "3727.379109"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?malc2mev#mid"^^xsd:anyURI ;
   rdfs:label "Value for alpha particle mass energy equivalent in MeV" ;
@@ -3112,7 +3112,7 @@ constant:Value_AlphaParticleMassInAtomicMassUnit
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.000000000062"^^xsd:double ;
-  qudt:unit unit:U ;
+  qudt:hasUnit unit:U ;
   qudt:value "4.001506179127"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?malu#mid"^^xsd:anyURI ;
   rdfs:label "Value for alpha particle mass in atomic mass unit" ;
@@ -3121,7 +3121,7 @@ constant:Value_AlphaParticleMolarMass
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000000062e-3 ;
-  qudt:unit unit:KiloGM-PER-MOL ;
+  qudt:hasUnit unit:KiloGM-PER-MOL ;
   qudt:value 4.001506179127e-3 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mmal#mid"^^xsd:anyURI ;
   rdfs:label "Value for alpha particle molar mass" ;
@@ -3130,7 +3130,7 @@ constant:Value_AlphaParticleProtonMassRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00000000041"^^xsd:double ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value "3.97259968951"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?malsmp#mid"^^xsd:anyURI ;
   rdfs:label "Value for alpha particle-proton mass ratio" ;
@@ -3139,7 +3139,7 @@ constant:Value_AngstromStar
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000090e-10 ;
-  qudt:unit unit:M ;
+  qudt:hasUnit unit:M ;
   qudt:value 1.00001498e-10 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?angstar#mid"^^xsd:anyURI ;
   rdfs:label "Value for Angstrom star" ;
@@ -3148,7 +3148,7 @@ constant:Value_AtomicMassConstant
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000083e-27 ;
-  qudt:unit unit:KiloGM ;
+  qudt:hasUnit unit:KiloGM ;
   qudt:value 1.660538782e-27 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?u#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic mass constant" ;
@@ -3157,7 +3157,7 @@ constant:Value_AtomicMassConstantEnergyEquivalent
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000074e-10 ;
-  qudt:unit unit:J ;
+  qudt:hasUnit unit:J ;
   qudt:value 1.492417830e-10 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?tuj#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic mass constant energy equivalent" ;
@@ -3166,7 +3166,7 @@ constant:Value_AtomicMassConstantEnergyEquivalentInMeV
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.000023"^^xsd:double ;
-  qudt:unit unit:MegaEV ;
+  qudt:hasUnit unit:MegaEV ;
   qudt:value "931.494028"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?muc2mev#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic mass constant energy equivalent in MeV" ;
@@ -3175,7 +3175,7 @@ constant:Value_AtomicMassUnitElectronVoltRelationship
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000023e6 ;
-  qudt:unit unit:EV ;
+  qudt:hasUnit unit:EV ;
   qudt:value 931.494028e6 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?uev#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic mass unit-electron volt relationship" ;
@@ -3184,7 +3184,7 @@ constant:Value_AtomicMassUnitHartreeRelationship
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000000049e7 ;
-  qudt:unit unit:E_h ;
+  qudt:hasUnit unit:E_h ;
   qudt:value 3.4231777149e7 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?uhr#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic mass unit-hartree relationship" ;
@@ -3193,7 +3193,7 @@ constant:Value_AtomicMassUnitHertzRelationship
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000000032e23 ;
-  qudt:unit unit:HZ ;
+  qudt:hasUnit unit:HZ ;
   qudt:value 2.2523427369e23 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?uhz#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic mass unit-hertz relationship" ;
@@ -3202,7 +3202,7 @@ constant:Value_AtomicMassUnitInverseMeterRelationship
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000011e14 ;
-  qudt:unit unit:PER-M ;
+  qudt:hasUnit unit:PER-M ;
   qudt:value 7.513006671e14 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?uminv#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic mass unit-inverse meter relationship" ;
@@ -3211,7 +3211,7 @@ constant:Value_AtomicMassUnitJouleRelationship
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000074e-10 ;
-  qudt:unit unit:J ;
+  qudt:hasUnit unit:J ;
   qudt:value 1.492417830e-10 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?uj#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic mass unit-joule relationship" ;
@@ -3220,7 +3220,7 @@ constant:Value_AtomicMassUnitKelvinRelationship
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000019e13 ;
-  qudt:unit unit:K ;
+  qudt:hasUnit unit:K ;
   qudt:value 1.0809527e13 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?uk#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic mass unit-kelvin relationship" ;
@@ -3229,7 +3229,7 @@ constant:Value_AtomicMassUnitKilogramRelationship
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000083e-27 ;
-  qudt:unit unit:KiloGM ;
+  qudt:hasUnit unit:KiloGM ;
   qudt:value 1.660538782e-27 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?ukg#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic mass unit-kilogram relationship" ;
@@ -3238,7 +3238,7 @@ constant:Value_AtomicUnitOf1stHyperpolarizability
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000081e-53 ;
-  qudt:unit unit:C3-M-PER-J2 ;
+  qudt:hasUnit unit:C3-M-PER-J2 ;
   qudt:value 3.206361533e-53 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?auhypol#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic unit of 1st hyperpolarizability" ;
@@ -3247,7 +3247,7 @@ constant:Value_AtomicUnitOf2ndHyperpolarizability
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000031e-65 ;
-  qudt:unit unit:C4-M4-PER-J3 ;
+  qudt:hasUnit unit:C4-M4-PER-J3 ;
   qudt:value 6.23538095e-65 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?au2hypol#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic unit of 2nd hyperpolarizability" ;
@@ -3256,7 +3256,7 @@ constant:Value_AtomicUnitOfAction
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000053e-34 ;
-  qudt:unit unit:J-SEC ;
+  qudt:hasUnit unit:J-SEC ;
   qudt:value 1.054571628e-34 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?tthbar#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic unit of action" ;
@@ -3265,7 +3265,7 @@ constant:Value_AtomicUnitOfCharge
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000040e-19 ;
-  qudt:unit unit:C ;
+  qudt:hasUnit unit:C ;
   qudt:value 1.602176487e-19 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?te#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic unit of charge" ;
@@ -3274,7 +3274,7 @@ constant:Value_AtomicUnitOfChargeDensity
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000027e12 ;
-  qudt:unit unit:C-PER-M3 ;
+  qudt:hasUnit unit:C-PER-M3 ;
   qudt:value 1.081202300e12 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?aucd#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic unit of charge density" ;
@@ -3283,7 +3283,7 @@ constant:Value_AtomicUnitOfCurrent
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000017e-3 ;
-  qudt:unit unit:A ;
+  qudt:hasUnit unit:A ;
   qudt:value 6.62361763e-3 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?aucur#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic unit of current" ;
@@ -3292,7 +3292,7 @@ constant:Value_AtomicUnitOfElectricDipoleMoment
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000021e-30 ;
-  qudt:unit unit:C-M ;
+  qudt:hasUnit unit:C-M ;
   qudt:value 8.47835281e-30 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?auedm#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic unit of electric dipole mom." ;
@@ -3301,7 +3301,7 @@ constant:Value_AtomicUnitOfElectricField
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000013e11 ;
-  qudt:unit unit:V-PER-M ;
+  qudt:hasUnit unit:V-PER-M ;
   qudt:value 5.14220632e11 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?auefld#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic unit of electric field" ;
@@ -3310,7 +3310,7 @@ constant:Value_AtomicUnitOfElectricFieldGradient
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000024e21 ;
-  qudt:unit unit:V-PER-M2 ;
+  qudt:hasUnit unit:V-PER-M2 ;
   qudt:value 9.71736166e21 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?auefg#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic unit of electric field gradient" ;
@@ -3319,7 +3319,7 @@ constant:Value_AtomicUnitOfElectricPolarizability
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000000034e-41 ;
-  qudt:unit unit:C2-M-PER-J ;
+  qudt:hasUnit unit:C2-M-PER-J ;
   qudt:value 1.6487772536e-41 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?auepol#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic unit of electric polarizability" ;
@@ -3328,7 +3328,7 @@ constant:Value_AtomicUnitOfElectricPotential
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00000068"^^xsd:double ;
-  qudt:unit unit:V ;
+  qudt:hasUnit unit:V ;
   qudt:value "27.21138386"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?auep#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic unit of electric potential" ;
@@ -3337,7 +3337,7 @@ constant:Value_AtomicUnitOfElectricQuadrupoleMoment
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000011e-40 ;
-  qudt:unit unit:C-M2 ;
+  qudt:hasUnit unit:C-M2 ;
   qudt:value 4.48655107e-40 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?aueqm#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic unit of electric quadrupole moment" ;
@@ -3346,7 +3346,7 @@ constant:Value_AtomicUnitOfEnergy
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000022e-18 ;
-  qudt:unit unit:J ;
+  qudt:hasUnit unit:J ;
   qudt:value 4.35974394e-18 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?thr#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic unit of energy" ;
@@ -3355,7 +3355,7 @@ constant:Value_AtomicUnitOfForce
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000041e-8 ;
-  qudt:unit unit:N ;
+  qudt:hasUnit unit:N ;
   qudt:value 8.23872206e-8 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?auforce#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic unit of force" ;
@@ -3364,7 +3364,7 @@ constant:Value_AtomicUnitOfLength
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000000036e-10 ;
-  qudt:unit unit:M ;
+  qudt:hasUnit unit:M ;
   qudt:value 0.52917720859e-10 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?tbohrrada0#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic unit of length" ;
@@ -3373,7 +3373,7 @@ constant:Value_AtomicUnitOfMagneticDipoleMoment
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000046e-23 ;
-  qudt:unit unit:J-PER-T ;
+  qudt:hasUnit unit:J-PER-T ;
   qudt:value 1.854801830e-23 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?aumdm#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic unit of magnetic dipole moment" ;
@@ -3382,7 +3382,7 @@ constant:Value_AtomicUnitOfMagneticFluxDensity
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000059e5 ;
-  qudt:unit unit:T ;
+  qudt:hasUnit unit:T ;
   qudt:value 2.350517382e5 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?aumfd#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic unit of magnetic flux density" ;
@@ -3391,7 +3391,7 @@ constant:Value_AtomicUnitOfMagnetizability
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000027e-29 ;
-  qudt:unit unit:J-PER-T2 ;
+  qudt:hasUnit unit:J-PER-T2 ;
   qudt:value 7.891036433e-29 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?aumag#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic unit of magnetizability" ;
@@ -3400,7 +3400,7 @@ constant:Value_AtomicUnitOfMass
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000045e-31 ;
-  qudt:unit unit:KiloGM ;
+  qudt:hasUnit unit:KiloGM ;
   qudt:value 9.10938215e-31 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?ttme#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic unit of mass" ;
@@ -3409,7 +3409,7 @@ constant:Value_AtomicUnitOfMomentum
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000099e-24 ;
-  qudt:unit unit:KiloGM-M-PER-SEC ;
+  qudt:hasUnit unit:KiloGM-M-PER-SEC ;
   qudt:value 1.992851565e-24 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?aumom#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic unit of momentum" ;
@@ -3417,7 +3417,7 @@ constant:Value_AtomicUnitOfMomentum
 constant:Value_AtomicUnitOfPermittivity
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
-  qudt:unit unit:FARAD-PER-M ;
+  qudt:hasUnit unit:FARAD-PER-M ;
   qudt:value 1.112650056e-10 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?auperm#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic unit of permittivity" ;
@@ -3426,7 +3426,7 @@ constant:Value_AtomicUnitOfTime
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000000016e-1 ;
-  qudt:unit unit:SEC ;
+  qudt:hasUnit unit:SEC ;
   qudt:value 2.418884326505e-17 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?aut#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic unit of time" ;
@@ -3435,7 +3435,7 @@ constant:Value_AtomicUnitOfVelocity
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000000015e6 ;
-  qudt:unit unit:M-PER-SEC ;
+  qudt:hasUnit unit:M-PER-SEC ;
   qudt:value 2.1876912541e6 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?auvel#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic unit of velocity" ;
@@ -3444,7 +3444,7 @@ constant:Value_AvogadroConstant
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000030e23 ;
-  qudt:unit unit:PER-MOL ;
+  qudt:hasUnit unit:PER-MOL ;
   qudt:value 6.02214179e23 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?na#mid"^^xsd:anyURI ;
   rdfs:label "Value for Avogadro constant" ;
@@ -3453,7 +3453,7 @@ constant:Value_BohrMagneton
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000023e-26 ;
-  qudt:unit unit:J-PER-T ;
+  qudt:hasUnit unit:J-PER-T ;
   qudt:value 927.400915e-26 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mub#mid"^^xsd:anyURI ;
   rdfs:label "Value for Bohr magneton" ;
@@ -3462,7 +3462,7 @@ constant:Value_BohrMagnetonInEVPerT
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000000079e-5 ;
-  qudt:unit unit:EV-PER-T ;
+  qudt:hasUnit unit:EV-PER-T ;
   qudt:value 5.7883817555e-5 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mubev#mid"^^xsd:anyURI ;
   rdfs:label "Value for Bohr magneton in eV per T" ;
@@ -3471,7 +3471,7 @@ constant:Value_BohrMagnetonInHzPerT
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000035e9 ;
-  qudt:unit unit:HZ-PER-T ;
+  qudt:hasUnit unit:HZ-PER-T ;
   qudt:value 13.99624604e9 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mubshhz#mid"^^xsd:anyURI ;
   rdfs:label "Value for Bohr magneton in Hz perT" ;
@@ -3480,7 +3480,7 @@ constant:Value_BohrMagnetonInInverseMetersPerTesla
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000012"^^xsd:double ;
-  qudt:unit unit:PER-T-M ;
+  qudt:hasUnit unit:PER-T-M ;
   qudt:value "46.6864515"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mubshcminv#mid"^^xsd:anyURI ;
   rdfs:label "Value for Bohr magneton in inverse meters per tesla" ;
@@ -3489,7 +3489,7 @@ constant:Value_BohrMagnetonInKPerT
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000012"^^xsd:double ;
-  qudt:unit unit:K-PER-T ;
+  qudt:hasUnit unit:K-PER-T ;
   qudt:value "0.6717131"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mubskk#mid"^^xsd:anyURI ;
   rdfs:label "Value for Bohr magneton in K per T" ;
@@ -3498,7 +3498,7 @@ constant:Value_BohrRadius
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000000036e-10 ;
-  qudt:unit unit:M ;
+  qudt:hasUnit unit:M ;
   qudt:value 0.52917720859e-10 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?bohrrada0#mid"^^xsd:anyURI ;
   rdfs:label "Value for Bohr radius" ;
@@ -3507,7 +3507,7 @@ constant:Value_BoltzmannConstant
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000024e-23 ;
-  qudt:unit unit:J-PER-K ;
+  qudt:hasUnit unit:J-PER-K ;
   qudt:value 1.3806504e-23 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?k#mid"^^xsd:anyURI ;
   rdfs:label "Value for Boltzmann constant" ;
@@ -3516,7 +3516,7 @@ constant:Value_BoltzmannConstantInEVPerK
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000015e-5 ;
-  qudt:unit unit:EV-PER-K ;
+  qudt:hasUnit unit:EV-PER-K ;
   qudt:value 8.617343e-5 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?tkev#mid"^^xsd:anyURI ;
   rdfs:label "Value for Boltzmann constant in eV per K" ;
@@ -3525,7 +3525,7 @@ constant:Value_BoltzmannConstantInHzPerK
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000036e10 ;
-  qudt:unit unit:HZ-PER-K ;
+  qudt:hasUnit unit:HZ-PER-K ;
   qudt:value 2.0836644e10 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?kshhz#mid"^^xsd:anyURI ;
   rdfs:label "Value for Boltzmann constant in Hz per K" ;
@@ -3534,7 +3534,7 @@ constant:Value_BoltzmannConstantInInverseMetersPerKelvin
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00012"^^xsd:double ;
-  qudt:unit unit:PER-M-K ;
+  qudt:hasUnit unit:PER-M-K ;
   qudt:value "69.50356"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?kshcminv#mid"^^xsd:anyURI ;
   rdfs:label "Value for Boltzmann constant in inverse meters per kelvin" ;
@@ -3542,7 +3542,7 @@ constant:Value_BoltzmannConstantInInverseMetersPerKelvin
 constant:Value_CharacteristicImpedanceOfVacuum
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
-  qudt:unit unit:OHM ;
+  qudt:hasUnit unit:OHM ;
   qudt:value "376.730313461"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?z0#mid"^^xsd:anyURI ;
   rdfs:label "Value for characteristic impedance of vacuum" ;
@@ -3551,7 +3551,7 @@ constant:Value_ClassicalElectronRadius
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000000058e-15 ;
-  qudt:unit unit:M ;
+  qudt:hasUnit unit:M ;
   qudt:value 2.8179402894e-15 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?re#mid"^^xsd:anyURI ;
   rdfs:label "Value for classical electron radius" ;
@@ -3560,7 +3560,7 @@ constant:Value_ComptonWavelength
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000000033e-12 ;
-  qudt:unit unit:M ;
+  qudt:hasUnit unit:M ;
   qudt:value 2.4263102175e-12 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?ecomwl#mid"^^xsd:anyURI ;
   rdfs:label "Value for Compton wavelength" ;
@@ -3569,7 +3569,7 @@ constant:Value_ComptonWavelengthOver2Pi
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000053e-15 ;
-  qudt:unit unit:M ;
+  qudt:hasUnit unit:M ;
   qudt:value 386.15926459e-15 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?ecomwlbar#mid"^^xsd:anyURI ;
   rdfs:label "Value for Compton wavelength over 2 pi" ;
@@ -3578,7 +3578,7 @@ constant:Value_ConductanceQuantum
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000000053e-5 ;
-  qudt:unit unit:S ;
+  qudt:hasUnit unit:S ;
   qudt:value 7.7480917004e-5 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?conqu2e2sh#mid"^^xsd:anyURI ;
   rdfs:label "Value for conductance quantum" ;
@@ -3586,7 +3586,7 @@ constant:Value_ConductanceQuantum
 constant:Value_ConventionalValueOfJosephsonConstant
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
-  qudt:unit unit:HZ-PER-V ;
+  qudt:hasUnit unit:HZ-PER-V ;
   qudt:value 483597.9e9 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?kj90#mid"^^xsd:anyURI ;
   rdfs:label "Value for conventional value of Josephson constant" ;
@@ -3594,7 +3594,7 @@ constant:Value_ConventionalValueOfJosephsonConstant
 constant:Value_ConventionalValueOfVonKlitzingConstant
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
-  qudt:unit unit:OHM ;
+  qudt:hasUnit unit:OHM ;
   qudt:value "25812.807"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?rk90#mid"^^xsd:anyURI ;
   rdfs:label "Value for conventional value of von Klitzing constant" ;
@@ -3603,7 +3603,7 @@ constant:Value_CuXUnit
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000028e-13 ;
-  qudt:unit unit:M ;
+  qudt:hasUnit unit:M ;
   qudt:value 1.00207699e-13 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?xucukalph1#mid"^^xsd:anyURI ;
   rdfs:label "Value for Cu x unit" ;
@@ -3612,7 +3612,7 @@ constant:Value_DeuteronElectronMagneticMomentRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000039e-4 ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value -4.664345537e-4 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mudsmuem#mid"^^xsd:anyURI ;
   rdfs:label "Value for deuteron-electron magnetic moment ratio" ;
@@ -3621,7 +3621,7 @@ constant:Value_DeuteronElectronMassRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000016"^^xsd:double ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value "3670.4829654"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mdsme#mid"^^xsd:anyURI ;
   rdfs:label "Value for deuteron-electron mass ratio" ;
@@ -3630,7 +3630,7 @@ constant:Value_DeuteronGFactor
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000000072"^^xsd:double ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value "0.8574382308"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?gdn#mid"^^xsd:anyURI ;
   rdfs:label "Value for deuteron g factor" ;
@@ -3639,7 +3639,7 @@ constant:Value_DeuteronMagneticMoment
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000011e-26 ;
-  qudt:unit unit:J-PER-T ;
+  qudt:hasUnit unit:J-PER-T ;
   qudt:value 0.433073465e-26 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mud#mid"^^xsd:anyURI ;
   rdfs:label "Value for deuteron magnetic moment" ;
@@ -3648,7 +3648,7 @@ constant:Value_DeuteronMagneticMomentToBohrMagnetonRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000000039e-3 ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value 0.4669754556e-3 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mudsmub#mid"^^xsd:anyURI ;
   rdfs:label "Value for deuteron magnetic moment to Bohr magneton ratio" ;
@@ -3657,7 +3657,7 @@ constant:Value_DeuteronMagneticMomentToNuclearMagnetonRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000000072"^^xsd:double ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value "0.8574382308"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mudsmun#mid"^^xsd:anyURI ;
   rdfs:label "Value for deuteron magnetic moment to nuclear magneton ratio" ;
@@ -3666,7 +3666,7 @@ constant:Value_DeuteronMass
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000017e-27 ;
-  qudt:unit unit:KiloGM ;
+  qudt:hasUnit unit:KiloGM ;
   qudt:value 3.34358320e-27 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?md#mid"^^xsd:anyURI ;
   rdfs:label "Value for deuteron mass" ;
@@ -3675,7 +3675,7 @@ constant:Value_DeuteronMassEnergyEquivalent
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000015e-10 ;
-  qudt:unit unit:J ;
+  qudt:hasUnit unit:J ;
   qudt:value 3.00506272e-10 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mdc2#mid"^^xsd:anyURI ;
   rdfs:label "Value for deuteron mass energy equivalent" ;
@@ -3684,7 +3684,7 @@ constant:Value_DeuteronMassEnergyEquivalentInMeV
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.000047"^^xsd:double ;
-  qudt:unit unit:MegaEV ;
+  qudt:hasUnit unit:MegaEV ;
   qudt:value "1875.612793"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mdc2mev#mid"^^xsd:anyURI ;
   rdfs:label "Value for deuteron mass energy equivalent in MeV" ;
@@ -3693,7 +3693,7 @@ constant:Value_DeuteronMassInAtomicMassUnit
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.000000000078"^^xsd:double ;
-  qudt:unit unit:U ;
+  qudt:hasUnit unit:U ;
   qudt:value "2.013553212724"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mdu#mid"^^xsd:anyURI ;
   rdfs:label "Deuteron Mass (amu)" ;
@@ -3702,7 +3702,7 @@ constant:Value_DeuteronMolarMass
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000000078e-3 ;
-  qudt:unit unit:KiloGM-PER-MOL ;
+  qudt:hasUnit unit:KiloGM-PER-MOL ;
   qudt:value 2.013553212724e-3 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mmd#mid"^^xsd:anyURI ;
   rdfs:label "Value for deuteron molar mass" ;
@@ -3711,7 +3711,7 @@ constant:Value_DeuteronNeutronMagneticMomentRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00000011"^^xsd:double ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value "-0.44820652"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mudsmunn#mid"^^xsd:anyURI ;
   rdfs:label "Value for deuteron-neutron magnetic moment ratio" ;
@@ -3720,7 +3720,7 @@ constant:Value_DeuteronProtonMagneticMomentRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000000024"^^xsd:double ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value "0.3070122070"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mudsmup#mid"^^xsd:anyURI ;
   rdfs:label "Value for deuteron-proton magnetic moment ratio" ;
@@ -3729,7 +3729,7 @@ constant:Value_DeuteronProtonMassRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00000000022"^^xsd:double ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value "1.99900750108"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mdsmp#mid"^^xsd:anyURI ;
   rdfs:label "Value for deuteron-proton mass ratio" ;
@@ -3738,7 +3738,7 @@ constant:Value_DeuteronRmsChargeRadius
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0028e-15 ;
-  qudt:unit unit:M ;
+  qudt:hasUnit unit:M ;
   qudt:value 2.1402e-15 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?rd#mid"^^xsd:anyURI ;
   rdfs:label "Value for deuteron rms charge radius" ;
@@ -3746,7 +3746,7 @@ constant:Value_DeuteronRmsChargeRadius
 constant:Value_ElectricConstant
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
-  qudt:unit unit:FARAD-PER-M ;
+  qudt:hasUnit unit:FARAD-PER-M ;
   qudt:value 8.854187817e-12 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?ep0#mid"^^xsd:anyURI ;
   rdfs:label "Value for electric constant" ;
@@ -3755,7 +3755,7 @@ constant:Value_ElectronChargeToMassQuotient
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000044e11 ;
-  qudt:unit unit:C-PER-KiloGM ;
+  qudt:hasUnit unit:C-PER-KiloGM ;
   qudt:value -1.758820150e11 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?esme#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron charge to mass quotient" ;
@@ -3764,7 +3764,7 @@ constant:Value_ElectronDeuteronMagneticMomentRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.000018"^^xsd:double ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value "-2143.923498"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?muemsmud#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron-deuteron magnetic moment ratio" ;
@@ -3773,7 +3773,7 @@ constant:Value_ElectronDeuteronMassRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000000012e-4 ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value 2.7244371093e-4 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mesmd#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron-deuteron mass ratio" ;
@@ -3782,7 +3782,7 @@ constant:Value_ElectronGFactor
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000000000015"^^xsd:double ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value "-2.0023193043622"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?gem#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron g factor" ;
@@ -3791,7 +3791,7 @@ constant:Value_ElectronGyromagneticRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000044e11 ;
-  qudt:unit unit:PER-T-SEC ;
+  qudt:hasUnit unit:PER-T-SEC ;
   qudt:value 1.760859770e11 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?gammae#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron gyromagnetic ratio" ;
@@ -3800,7 +3800,7 @@ constant:Value_ElectronGyromagneticRatioOver2Pi
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00070"^^xsd:double ;
-  qudt:unit unit:MegaHZ-PER-T ;
+  qudt:hasUnit unit:MegaHZ-PER-T ;
   qudt:value "28024.95364"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?gammaebar#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron gyromagnetic ratio over 2 pi" ;
@@ -3809,7 +3809,7 @@ constant:Value_ElectronMagneticMoment
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000023e-26 ;
-  qudt:unit unit:J-PER-T ;
+  qudt:hasUnit unit:J-PER-T ;
   qudt:value -928.476377e-26 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?muem#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron magnetic moment" ;
@@ -3818,7 +3818,7 @@ constant:Value_ElectronMagneticMomentAnomaly
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000000074e-3 ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value 1.15965218111e-3 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?ae#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron magnetic moment anomaly" ;
@@ -3827,7 +3827,7 @@ constant:Value_ElectronMagneticMomentToBohrMagnetonRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00000000000074"^^xsd:double ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value "-1.00115965218111"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?muemsmub#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron magnetic moment to Bohr magneton ratio" ;
@@ -3836,7 +3836,7 @@ constant:Value_ElectronMagneticMomentToNuclearMagnetonRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00000080"^^xsd:double ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value "-1838.28197092"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?muemsmun#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron magnetic moment to nuclear magneton ratio" ;
@@ -3845,7 +3845,7 @@ constant:Value_ElectronMass
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000045e-31 ;
-  qudt:unit unit:KiloGM ;
+  qudt:hasUnit unit:KiloGM ;
   qudt:value 9.10938215e-31 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?me#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron mass" ;
@@ -3854,7 +3854,7 @@ constant:Value_ElectronMassEnergyEquivalent
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000041e-14 ;
-  qudt:unit unit:J ;
+  qudt:hasUnit unit:J ;
   qudt:value 8.18710438e-14 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mec2#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron mass energy equivalent" ;
@@ -3863,7 +3863,7 @@ constant:Value_ElectronMassEnergyEquivalentInMeV
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.000000013"^^xsd:double ;
-  qudt:unit unit:MegaEV ;
+  qudt:hasUnit unit:MegaEV ;
   qudt:value "0.510998910"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mec2mev#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron mass energy equivalent in MeV" ;
@@ -3872,7 +3872,7 @@ constant:Value_ElectronMassInAtomicMassUnit
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000000023e-4 ;
-  qudt:unit unit:U ;
+  qudt:hasUnit unit:U ;
   qudt:value 5.4857990943e-4 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?meu#mid"^^xsd:anyURI ;
   rdfs:label "Electron Mass (amu)" ;
@@ -3881,7 +3881,7 @@ constant:Value_ElectronMolarMass
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000000023e-7 ;
-  qudt:unit unit:KiloGM-PER-MOL ;
+  qudt:hasUnit unit:KiloGM-PER-MOL ;
   qudt:value 5.4857990943e-7 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mme#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron molar mass" ;
@@ -3890,7 +3890,7 @@ constant:Value_ElectronMuonMagneticMomentRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000052"^^xsd:double ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value "206.7669877"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?muemsmumum#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron-muon magnetic moment ratio" ;
@@ -3899,7 +3899,7 @@ constant:Value_ElectronMuonMassRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000012e-3 ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value 4.83633171e-3 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mesmmu#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron-muon mass ratio" ;
@@ -3908,7 +3908,7 @@ constant:Value_ElectronNeutronMagneticMomentRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00023"^^xsd:double ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value "960.92050"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?muemsmunn#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron-neutron magnetic moment ratio" ;
@@ -3917,7 +3917,7 @@ constant:Value_ElectronNeutronMassRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000000033e-4 ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value 5.4386734459e-4 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mesmn#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron-neutron mass ratio" ;
@@ -3926,7 +3926,7 @@ constant:Value_ElectronProtonMagneticMomentRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000054"^^xsd:double ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value "-658.2106848"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?muemsmup#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron-proton magnetic moment ratio" ;
@@ -3935,7 +3935,7 @@ constant:Value_ElectronProtonMassRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000000024e-4 ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value 5.4461702177e-4 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mesmp#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron-proton mass ratio" ;
@@ -3944,7 +3944,7 @@ constant:Value_ElectronTauMassRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00047e-4 ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value 2.87564e-4 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mesmtau#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron-tau mass ratio" ;
@@ -3953,7 +3953,7 @@ constant:Value_ElectronToAlphaParticleMassRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000000058e-4 ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value 1.37093355570e-4 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mesmalpha#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron to alpha particle mass ratio" ;
@@ -3962,7 +3962,7 @@ constant:Value_ElectronToShieldedHelionMagneticMomentRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.000010"^^xsd:double ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value "864.058257"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?muemsmuhp#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron to shielded helion magnetic moment ratio" ;
@@ -3971,7 +3971,7 @@ constant:Value_ElectronToShieldedProtonMagneticMomentRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000072"^^xsd:double ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value "-658.2275971"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?muemsmupp#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron to shielded proton magnetic moment ratio" ;
@@ -3980,7 +3980,7 @@ constant:Value_ElectronVoltAtomicMassUnitRelationship
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000027e-9 ;
-  qudt:unit unit:U ;
+  qudt:hasUnit unit:U ;
   qudt:value 1.073544188e-9 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?evu#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron volt-atomic mass unit relationship" ;
@@ -3989,7 +3989,7 @@ constant:Value_ElectronVoltHartreeRelationship
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000092e-2 ;
-  qudt:unit unit:E_h ;
+  qudt:hasUnit unit:E_h ;
   qudt:value 3.674932540e-2 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?evhr#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron volt-hartree relationship" ;
@@ -3998,7 +3998,7 @@ constant:Value_ElectronVoltHertzRelationship
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000060e14 ;
-  qudt:unit unit:HZ ;
+  qudt:hasUnit unit:HZ ;
   qudt:value 2.417989454e14 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?evhz#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron volt-hertz relationship" ;
@@ -4007,7 +4007,7 @@ constant:Value_ElectronVoltInverseMeterRelationship
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000020e5 ;
-  qudt:unit unit:PER-M ;
+  qudt:hasUnit unit:PER-M ;
   qudt:value 8.06554465e5 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?evminv#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron volt-inverse meter relationship" ;
@@ -4016,7 +4016,7 @@ constant:Value_ElectronVoltJouleRelationship
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000040e-19 ;
-  qudt:unit unit:J ;
+  qudt:hasUnit unit:J ;
   qudt:value 1.602176487e-19 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?evj#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron volt-joule relationship" ;
@@ -4025,7 +4025,7 @@ constant:Value_ElectronVoltKelvinRelationship
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000020e4 ;
-  qudt:unit unit:K ;
+  qudt:hasUnit unit:K ;
   qudt:value 1.1604505e4 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?evk#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron volt-kelvin relationship" ;
@@ -4034,7 +4034,7 @@ constant:Value_ElectronVoltKilogramRelationship
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000044e-36 ;
-  qudt:unit unit:KiloGM ;
+  qudt:hasUnit unit:KiloGM ;
   qudt:value 1.782661758e-36 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?evkg#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron volt-kilogram relationship" ;
@@ -4043,7 +4043,7 @@ constant:Value_ElementaryCharge
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000040e-19 ;
-  qudt:unit unit:C ;
+  qudt:hasUnit unit:C ;
   qudt:value 1.602176487e-19 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?e#mid"^^xsd:anyURI ;
   rdfs:label "Value for elementary charge" ;
@@ -4052,7 +4052,7 @@ constant:Value_ElementaryChargeOverH
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000060e14 ;
-  qudt:unit unit:A-PER-J ;
+  qudt:hasUnit unit:A-PER-J ;
   qudt:value 2.417989454e14 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?esh#mid"^^xsd:anyURI ;
   rdfs:label "Value for elementary charge over h" ;
@@ -4061,14 +4061,14 @@ constant:Value_FaradayConstant
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0024"^^xsd:double ;
-  qudt:unit unit:C-PER-MOL ;
+  qudt:hasUnit unit:C-PER-MOL ;
   qudt:value "96485.3399"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?f#mid"^^xsd:anyURI ;
   rdfs:label "Value for Faraday constant" ;
 .
 constant:Value_FaradayConstantForConventionalElectricCurrent
   a qudt:ConstantValue ;
-  qudt:unit unit:C-PER-MOL ;
+  qudt:hasUnit unit:C-PER-MOL ;
   qudt:value "96485.33212"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?f90#mid"^^xsd:anyURI ;
   rdfs:label "Faraday constant for conventional electric current" ;
@@ -4077,7 +4077,7 @@ constant:Value_FermiCouplingConstant
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00001e-5 ;
-  qudt:unit unit:PER-GigaEV2 ;
+  qudt:hasUnit unit:PER-GigaEV2 ;
   qudt:value 1.16637e-5 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?gf#mid"^^xsd:anyURI ;
   rdfs:label "Value for Fermi coupling constant" ;
@@ -4086,7 +4086,7 @@ constant:Value_FineStructureConstant
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000000050e-3 ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value 7.2973525376e-3 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?alph#mid"^^xsd:anyURI ;
   rdfs:label "Value for fine-structure constant" ;
@@ -4095,7 +4095,7 @@ constant:Value_FirstRadiationConstant
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000019e-16 ;
-  qudt:unit unit:W-M2 ;
+  qudt:hasUnit unit:W-M2 ;
   qudt:value 3.74177118e-16 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?c11strc#mid"^^xsd:anyURI ;
   rdfs:label "Value for first radiation constant" ;
@@ -4104,7 +4104,7 @@ constant:Value_FirstRadiationConstantForSpectralRadiance
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000059e-16 ;
-  qudt:unit unit:W-M2-PER-SR ;
+  qudt:hasUnit unit:W-M2-PER-SR ;
   qudt:value 1.191042759e-16 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?c1l#mid"^^xsd:anyURI ;
   rdfs:label "Value for first radiation constant for spectral radiance" ;
@@ -4112,7 +4112,7 @@ constant:Value_FirstRadiationConstantForSpectralRadiance
 constant:Value_GravitationalConstant
   a qudt:ConstantValue ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Gravitational_constant"^^xsd:anyURI ;
-  qudt:unit unit:N-M2-PER-KiloGM2 ;
+  qudt:hasUnit unit:N-M2-PER-KiloGM2 ;
   qudt:value 6.674e-11 ;
   rdfs:label "Value for gravitational constant" ;
 .
@@ -4120,7 +4120,7 @@ constant:Value_HartreeAtomicMassUnitRelationship
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000000042e-8 ;
-  qudt:unit unit:U ;
+  qudt:hasUnit unit:U ;
   qudt:value 2.9212622986e-8 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?hru#mid"^^xsd:anyURI ;
   rdfs:label "Value for hartree-atomic mass unit relationship" ;
@@ -4129,7 +4129,7 @@ constant:Value_HartreeElectronVoltRelationship
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00000068"^^xsd:double ;
-  qudt:unit unit:EV ;
+  qudt:hasUnit unit:EV ;
   qudt:value "27.21138386"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?hrev#mid"^^xsd:anyURI ;
   rdfs:label "Value for hartree-electron volt relationship" ;
@@ -4138,7 +4138,7 @@ constant:Value_HartreeEnergy
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000022e-18 ;
-  qudt:unit unit:J ;
+  qudt:hasUnit unit:J ;
   qudt:value 4.35974394e-18 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?hr#mid"^^xsd:anyURI ;
   rdfs:label "Value for Hartree energy" ;
@@ -4147,7 +4147,7 @@ constant:Value_HartreeEnergyInEV
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00000068"^^xsd:double ;
-  qudt:unit unit:EV ;
+  qudt:hasUnit unit:EV ;
   qudt:value "27.21138386"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?threv#mid"^^xsd:anyURI ;
   rdfs:label "Value for Hartree energy in eV" ;
@@ -4156,7 +4156,7 @@ constant:Value_HartreeHertzRelationship
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000000044e15 ;
-  qudt:unit unit:HZ ;
+  qudt:hasUnit unit:HZ ;
   qudt:value 6.579683920722e15 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?hrhz#mid"^^xsd:anyURI ;
   rdfs:label "Value for hartree-hertz relationship" ;
@@ -4165,7 +4165,7 @@ constant:Value_HartreeInverseMeterRelationship
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000000015e7 ;
-  qudt:unit unit:PER-M ;
+  qudt:hasUnit unit:PER-M ;
   qudt:value 2.194746313705e7 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?hrminv#mid"^^xsd:anyURI ;
   rdfs:label "Value for hartree-inverse meter relationship" ;
@@ -4174,7 +4174,7 @@ constant:Value_HartreeJouleRelationship
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000022e-18 ;
-  qudt:unit unit:J ;
+  qudt:hasUnit unit:J ;
   qudt:value 4.35974394e-18 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?hrj#mid"^^xsd:anyURI ;
   rdfs:label "Value for hartree-joule relationship" ;
@@ -4183,7 +4183,7 @@ constant:Value_HartreeKelvinRelationship
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000055e5 ;
-  qudt:unit unit:K ;
+  qudt:hasUnit unit:K ;
   qudt:value 3.1577465e5 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?hrk#mid"^^xsd:anyURI ;
   rdfs:label "Value for hartree-kelvin relationship" ;
@@ -4192,7 +4192,7 @@ constant:Value_HartreeKilogramRelationship
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000024e-35 ;
-  qudt:unit unit:KiloGM ;
+  qudt:hasUnit unit:KiloGM ;
   qudt:value 4.85086934e-35 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?hrkg#mid"^^xsd:anyURI ;
   rdfs:label "Value for hartree-kilogram relationship" ;
@@ -4201,7 +4201,7 @@ constant:Value_HelionElectronMassRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000052"^^xsd:double ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value "5495.8852765"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mhsme#mid"^^xsd:anyURI ;
   rdfs:label "Value for helion-electron mass ratio" ;
@@ -4210,7 +4210,7 @@ constant:Value_HelionMass
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000025e-27 ;
-  qudt:unit unit:KiloGM ;
+  qudt:hasUnit unit:KiloGM ;
   qudt:value 5.00641192e-27 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mh#mid"^^xsd:anyURI ;
   rdfs:label "Value for helion mass" ;
@@ -4219,7 +4219,7 @@ constant:Value_HelionMassEnergyEquivalent
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000022e-10 ;
-  qudt:unit unit:J ;
+  qudt:hasUnit unit:J ;
   qudt:value 4.49953864e-10 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mhc2#mid"^^xsd:anyURI ;
   rdfs:label "Value for helion mass energy equivalent" ;
@@ -4228,7 +4228,7 @@ constant:Value_HelionMassEnergyEquivalentInMeV
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.000070"^^xsd:double ;
-  qudt:unit unit:MegaEV ;
+  qudt:hasUnit unit:MegaEV ;
   qudt:value "2808.391383"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mhc2mev#mid"^^xsd:anyURI ;
   rdfs:label "Value for helion mass energy equivalent in MeV" ;
@@ -4237,7 +4237,7 @@ constant:Value_HelionMassInAtomicMassUnit
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000000026"^^xsd:double ;
-  qudt:unit unit:U ;
+  qudt:hasUnit unit:U ;
   qudt:value "3.0149322473"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mhu#mid"^^xsd:anyURI ;
   rdfs:label "Helion Mass (amu)" ;
@@ -4246,7 +4246,7 @@ constant:Value_HelionMolarMass
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000000026e-3 ;
-  qudt:unit unit:KiloGM-PER-MOL ;
+  qudt:hasUnit unit:KiloGM-PER-MOL ;
   qudt:value 3.0149322473e-3 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mmh#mid"^^xsd:anyURI ;
   rdfs:label "Value for helion molar mass" ;
@@ -4255,7 +4255,7 @@ constant:Value_HelionProtonMassRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000000026"^^xsd:double ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value "2.9931526713"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mhsmp#mid"^^xsd:anyURI ;
   rdfs:label "Value for helion-proton mass ratio" ;
@@ -4264,7 +4264,7 @@ constant:Value_HertzAtomicMassUnitRelationship
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000000064e-24 ;
-  qudt:unit unit:U ;
+  qudt:hasUnit unit:U ;
   qudt:value 4.4398216294e-24 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?hzu#mid"^^xsd:anyURI ;
   rdfs:label "Value for hertz-atomic mass unit relationship" ;
@@ -4273,7 +4273,7 @@ constant:Value_HertzElectronVoltRelationship
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000010e-15 ;
-  qudt:unit unit:EV ;
+  qudt:hasUnit unit:EV ;
   qudt:value 4.13566733e-15 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?hzev#mid"^^xsd:anyURI ;
   rdfs:label "Value for hertz-electron volt relationship" ;
@@ -4282,7 +4282,7 @@ constant:Value_HertzHartreeRelationship
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000000010e-1 ;
-  qudt:unit unit:E_h ;
+  qudt:hasUnit unit:E_h ;
   qudt:value 1.519829846006e-16 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?hzhr#mid"^^xsd:anyURI ;
   rdfs:label "Value for hertz-hartree relationship" ;
@@ -4290,7 +4290,7 @@ constant:Value_HertzHartreeRelationship
 constant:Value_HertzInverseMeterRelationship
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
-  qudt:unit unit:PER-M ;
+  qudt:hasUnit unit:PER-M ;
   qudt:value 3.335640951e-9 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?hzminv#mid"^^xsd:anyURI ;
   rdfs:label "Value for hertz-inverse meter relationship" ;
@@ -4299,7 +4299,7 @@ constant:Value_HertzJouleRelationship
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000033e-34 ;
-  qudt:unit unit:J ;
+  qudt:hasUnit unit:J ;
   qudt:value 6.62606896e-34 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?hzj#mid"^^xsd:anyURI ;
   rdfs:label "Value for hertz-joule relationship" ;
@@ -4308,7 +4308,7 @@ constant:Value_HertzKelvinRelationship
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000084e-11 ;
-  qudt:unit unit:K ;
+  qudt:hasUnit unit:K ;
   qudt:value 4.7992374e-11 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?hzk#mid"^^xsd:anyURI ;
   rdfs:label "Value for hertz-kelvin relationship" ;
@@ -4317,7 +4317,7 @@ constant:Value_HertzKilogramRelationship
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000037e-51 ;
-  qudt:unit unit:KiloGM ;
+  qudt:hasUnit unit:KiloGM ;
   qudt:value 7.37249600e-51 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?hzkg#mid"^^xsd:anyURI ;
   rdfs:label "Value for hertz-kilogram relationship" ;
@@ -4326,7 +4326,7 @@ constant:Value_InverseFineStructureConstant
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.000000094"^^xsd:double ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value "137.035999679"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?alphinv#mid"^^xsd:anyURI ;
   rdfs:label "Value for inverse fine-structure constant" ;
@@ -4335,7 +4335,7 @@ constant:Value_InverseMeterAtomicMassUnitRelationship
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000000019e-15 ;
-  qudt:unit unit:U ;
+  qudt:hasUnit unit:U ;
   qudt:value 1.3310250394e-15 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?minvu#mid"^^xsd:anyURI ;
   rdfs:label "Value for inverse meter-atomic mass unit relationship" ;
@@ -4344,7 +4344,7 @@ constant:Value_InverseMeterElectronVoltRelationship
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000031e-6 ;
-  qudt:unit unit:EV ;
+  qudt:hasUnit unit:EV ;
   qudt:value 1.239841875e-6 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?minvev#mid"^^xsd:anyURI ;
   rdfs:label "Value for inverse meter-electron volt relationship" ;
@@ -4353,7 +4353,7 @@ constant:Value_InverseMeterHartreeRelationship
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000000030e-8 ;
-  qudt:unit unit:E_h ;
+  qudt:hasUnit unit:E_h ;
   qudt:value 4.556335252760e-8 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?minvhr#mid"^^xsd:anyURI ;
   rdfs:label "Value for inverse meter-hartree relationship" ;
@@ -4361,7 +4361,7 @@ constant:Value_InverseMeterHartreeRelationship
 constant:Value_InverseMeterHertzRelationship
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
-  qudt:unit unit:HZ ;
+  qudt:hasUnit unit:HZ ;
   qudt:value "299792458"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?minvhz#mid"^^xsd:anyURI ;
   rdfs:label "Value for inverse meter-hertz relationship" ;
@@ -4370,7 +4370,7 @@ constant:Value_InverseMeterJouleRelationship
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000099e-25 ;
-  qudt:unit unit:J ;
+  qudt:hasUnit unit:J ;
   qudt:value 1.986445501e-25 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?minvj#mid"^^xsd:anyURI ;
   rdfs:label "Value for inverse meter-joule relationship" ;
@@ -4379,7 +4379,7 @@ constant:Value_InverseMeterKelvinRelationship
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000025e-2 ;
-  qudt:unit unit:K ;
+  qudt:hasUnit unit:K ;
   qudt:value 1.4387752e-2 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?minvk#mid"^^xsd:anyURI ;
   rdfs:label "Value for inverse meter-kelvin relationship" ;
@@ -4388,7 +4388,7 @@ constant:Value_InverseMeterKilogramRelationship
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000011e-42 ;
-  qudt:unit unit:KiloGM ;
+  qudt:hasUnit unit:KiloGM ;
   qudt:value 2.21021870e-42 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?minvkg#mid"^^xsd:anyURI ;
   rdfs:label "Value for inverse meter-kilogram relationship" ;
@@ -4397,7 +4397,7 @@ constant:Value_InverseOfConductanceQuantum
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000088"^^xsd:double ;
-  qudt:unit unit:OHM ;
+  qudt:hasUnit unit:OHM ;
   qudt:value "12906.4037787"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?invconqu#mid"^^xsd:anyURI ;
   rdfs:label "Value for inverse of conductance quantum" ;
@@ -4406,7 +4406,7 @@ constant:Value_JosephsonConstant
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.012e9 ;
-  qudt:unit unit:HZ-PER-V ;
+  qudt:hasUnit unit:HZ-PER-V ;
   qudt:value 483597.891e9 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?kjos#mid"^^xsd:anyURI ;
   rdfs:label "Value for Josephson constant" ;
@@ -4415,7 +4415,7 @@ constant:Value_JouleAtomicMassUnitRelationship
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000033e9 ;
-  qudt:unit unit:U ;
+  qudt:hasUnit unit:U ;
   qudt:value 6.70053641e9 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?ju#mid"^^xsd:anyURI ;
   rdfs:label "Value for joule-atomic mass unit relationship" ;
@@ -4424,7 +4424,7 @@ constant:Value_JouleElectronVoltRelationship
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000016e18 ;
-  qudt:unit unit:EV ;
+  qudt:hasUnit unit:EV ;
   qudt:value 6.24150965e18 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?jev#mid"^^xsd:anyURI ;
   rdfs:label "Value for joule-electron volt relationship" ;
@@ -4433,7 +4433,7 @@ constant:Value_JouleHartreeRelationship
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000011e17 ;
-  qudt:unit unit:E_h ;
+  qudt:hasUnit unit:E_h ;
   qudt:value 2.29371269e17 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?jhr#mid"^^xsd:anyURI ;
   rdfs:label "Value for joule-hartree relationship" ;
@@ -4442,7 +4442,7 @@ constant:Value_JouleHertzRelationship
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000075e33 ;
-  qudt:unit unit:HZ ;
+  qudt:hasUnit unit:HZ ;
   qudt:value 1.509190450e33 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?jhz#mid"^^xsd:anyURI ;
   rdfs:label "Value for joule-hertz relationship" ;
@@ -4451,7 +4451,7 @@ constant:Value_JouleInverseMeterRelationship
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000025e24 ;
-  qudt:unit unit:PER-M ;
+  qudt:hasUnit unit:PER-M ;
   qudt:value 5.03411747e24 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?jminv#mid"^^xsd:anyURI ;
   rdfs:label "Value for joule-inverse meter relationship" ;
@@ -4460,7 +4460,7 @@ constant:Value_JouleKelvinRelationship
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000013e22 ;
-  qudt:unit unit:K ;
+  qudt:hasUnit unit:K ;
   qudt:value 7.242963e22 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?jk#mid"^^xsd:anyURI ;
   rdfs:label "Value for joule-kelvin relationship" ;
@@ -4468,7 +4468,7 @@ constant:Value_JouleKelvinRelationship
 constant:Value_JouleKilogramRelationship
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
-  qudt:unit unit:KiloGM ;
+  qudt:hasUnit unit:KiloGM ;
   qudt:value 1.112650056e-17 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?jkg#mid"^^xsd:anyURI ;
   rdfs:label "Value for joule-kilogram relationship" ;
@@ -4477,7 +4477,7 @@ constant:Value_KelvinAtomicMassUnitRelationship
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000016e-14 ;
-  qudt:unit unit:U ;
+  qudt:hasUnit unit:U ;
   qudt:value 9.251098e-14 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?ku#mid"^^xsd:anyURI ;
   rdfs:label "Value for kelvin-atomic mass unit relationship" ;
@@ -4486,7 +4486,7 @@ constant:Value_KelvinElectronVoltRelationship
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000015e-5 ;
-  qudt:unit unit:EV ;
+  qudt:hasUnit unit:EV ;
   qudt:value 8.617343e-5 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?kev#mid"^^xsd:anyURI ;
   rdfs:label "Value for kelvin-electron volt relationship" ;
@@ -4495,7 +4495,7 @@ constant:Value_KelvinHartreeRelationship
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000055e-6 ;
-  qudt:unit unit:E_h ;
+  qudt:hasUnit unit:E_h ;
   qudt:value 3.1668153e-6 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?khr#mid"^^xsd:anyURI ;
   rdfs:label "Value for kelvin-hartree relationship" ;
@@ -4504,7 +4504,7 @@ constant:Value_KelvinHertzRelationship
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000036e10 ;
-  qudt:unit unit:HZ ;
+  qudt:hasUnit unit:HZ ;
   qudt:value 2.0836644e10 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?khz#mid"^^xsd:anyURI ;
   rdfs:label "Value for kelvin-hertz relationship" ;
@@ -4513,7 +4513,7 @@ constant:Value_KelvinInverseMeterRelationship
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00012"^^xsd:double ;
-  qudt:unit unit:PER-M ;
+  qudt:hasUnit unit:PER-M ;
   qudt:value "69.50356"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?kminv#mid"^^xsd:anyURI ;
   rdfs:label "Value for kelvin-inverse meter relationship" ;
@@ -4522,7 +4522,7 @@ constant:Value_KelvinJouleRelationship
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000024e-23 ;
-  qudt:unit unit:J ;
+  qudt:hasUnit unit:J ;
   qudt:value 1.3806504e-23 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?kj#mid"^^xsd:anyURI ;
   rdfs:label "Value for kelvin-joule relationship" ;
@@ -4531,7 +4531,7 @@ constant:Value_KelvinKilogramRelationship
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000027e-40 ;
-  qudt:unit unit:KiloGM ;
+  qudt:hasUnit unit:KiloGM ;
   qudt:value 1.5361807e-40 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?kkg#mid"^^xsd:anyURI ;
   rdfs:label "Value for kelvin-kilogram relationship" ;
@@ -4540,7 +4540,7 @@ constant:Value_KilogramAtomicMassUnitRelationship
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000030e26 ;
-  qudt:unit unit:U ;
+  qudt:hasUnit unit:U ;
   qudt:value 6.02214179e26 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?kgu#mid"^^xsd:anyURI ;
   rdfs:label "Value for kilogram-atomic mass unit relationship" ;
@@ -4549,7 +4549,7 @@ constant:Value_KilogramElectronVoltRelationship
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000014e35 ;
-  qudt:unit unit:EV ;
+  qudt:hasUnit unit:EV ;
   qudt:value 5.60958912e35 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?kgev#mid"^^xsd:anyURI ;
   rdfs:label "Value for kilogram-electron volt relationship" ;
@@ -4558,7 +4558,7 @@ constant:Value_KilogramHartreeRelationship
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000010e34 ;
-  qudt:unit unit:E_h ;
+  qudt:hasUnit unit:E_h ;
   qudt:value 2.06148616e34 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?kghr#mid"^^xsd:anyURI ;
   rdfs:label "Value for kilogram-hartree relationship" ;
@@ -4567,7 +4567,7 @@ constant:Value_KilogramHertzRelationship
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000068e50 ;
-  qudt:unit unit:HZ ;
+  qudt:hasUnit unit:HZ ;
   qudt:value 1.356392733e50 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?kghz#mid"^^xsd:anyURI ;
   rdfs:label "Value for kilogram-hertz relationship" ;
@@ -4576,7 +4576,7 @@ constant:Value_KilogramInverseMeterRelationship
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000023e41 ;
-  qudt:unit unit:PER-M ;
+  qudt:hasUnit unit:PER-M ;
   qudt:value 4.52443915e41 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?kgminv#mid"^^xsd:anyURI ;
   rdfs:label "Value for kilogram-inverse meter relationship" ;
@@ -4584,7 +4584,7 @@ constant:Value_KilogramInverseMeterRelationship
 constant:Value_KilogramJouleRelationship
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
-  qudt:unit unit:J ;
+  qudt:hasUnit unit:J ;
   qudt:value 8.987551787e16 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?kgj#mid"^^xsd:anyURI ;
   rdfs:label "Value for kilogram-joule relationship" ;
@@ -4593,7 +4593,7 @@ constant:Value_KilogramKelvinRelationship
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000011e39 ;
-  qudt:unit unit:K ;
+  qudt:hasUnit unit:K ;
   qudt:value 6.509651e39 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?kgk#mid"^^xsd:anyURI ;
   rdfs:label "Value for kilogram-kelvin relationship" ;
@@ -4602,7 +4602,7 @@ constant:Value_LatticeParameterOfSilicon
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000014e-12 ;
-  qudt:unit unit:M ;
+  qudt:hasUnit unit:M ;
   qudt:value 543.102064e-12 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?asil#mid"^^xsd:anyURI ;
   rdfs:label "Value for lattice parameter of silicon" ;
@@ -4611,7 +4611,7 @@ constant:Value_LatticeSpacingOfSilicon
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000050e-12 ;
-  qudt:unit unit:M ;
+  qudt:hasUnit unit:M ;
   qudt:value 192.0155762e-12 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?d220sil#mid"^^xsd:anyURI ;
   rdfs:label "Value for lattice spacing of silicon" ;
@@ -4620,7 +4620,7 @@ constant:Value_LoschmidtConstant
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000047e25 ;
-  qudt:unit unit:PER-M3 ;
+  qudt:hasUnit unit:PER-M3 ;
   qudt:value 2.6867774e25 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?n0#mid"^^xsd:anyURI ;
   rdfs:label "Value for Loschmidt constant 273.15 K 101.325 kPa" ;
@@ -4628,7 +4628,7 @@ constant:Value_LoschmidtConstant
 constant:Value_MagneticConstant
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
-  qudt:unit unit:FARAD-PER-M ;
+  qudt:hasUnit unit:FARAD-PER-M ;
   qudt:value 12.566370614e-7 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mu0#mid"^^xsd:anyURI ;
   rdfs:label "Value for magnetic constant" ;
@@ -4637,7 +4637,7 @@ constant:Value_MagneticFluxQuantum
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000052e-15 ;
-  qudt:unit unit:WB ;
+  qudt:hasUnit unit:WB ;
   qudt:value 2.067833667e-15 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?flxquhs2e#mid"^^xsd:anyURI ;
   rdfs:label "Value for magnetic flux quantum" ;
@@ -4646,7 +4646,7 @@ constant:Value_MoXUnit
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000053e-13 ;
-  qudt:unit unit:M ;
+  qudt:hasUnit unit:M ;
   qudt:value 1.00209955e-13 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?xumokalph1#mid"^^xsd:anyURI ;
   rdfs:label "Value for Mo x unit" ;
@@ -4655,7 +4655,7 @@ constant:Value_MolarGasConstant
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.000015"^^xsd:double ;
-  qudt:unit unit:J-PER-MOL-K ;
+  qudt:hasUnit unit:J-PER-MOL-K ;
   qudt:value "8.31446261815324"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?r#mid"^^xsd:anyURI ;
   rdfs:label "Value for molar gas constant" ;
@@ -4663,7 +4663,7 @@ constant:Value_MolarGasConstant
 constant:Value_MolarMassConstant
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
-  qudt:unit unit:KiloGM-PER-MOL ;
+  qudt:hasUnit unit:KiloGM-PER-MOL ;
   qudt:value 1e-3 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mu#mid"^^xsd:anyURI ;
   rdfs:label "Value for molar mass constant" ;
@@ -4671,7 +4671,7 @@ constant:Value_MolarMassConstant
 constant:Value_MolarMassOfCarbon12
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
-  qudt:unit unit:KiloGM-PER-MOL ;
+  qudt:hasUnit unit:KiloGM-PER-MOL ;
   qudt:value 12e-3 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mm12c#mid"^^xsd:anyURI ;
   rdfs:label "Value for molar mass of carbon-12" ;
@@ -4680,7 +4680,7 @@ constant:Value_MolarPlanckConstant
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000000057e-10 ;
-  qudt:unit unit:J-SEC-PER-MOL ;
+  qudt:hasUnit unit:J-SEC-PER-MOL ;
   qudt:value 3.9903126821e-10 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?nah#mid"^^xsd:anyURI ;
   rdfs:label "Value for molar Planck constant" ;
@@ -4689,7 +4689,7 @@ constant:Value_MolarPlanckConstantTimesC
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00000000017"^^xsd:double ;
-  qudt:unit unit:J-M-PER-MOL ;
+  qudt:hasUnit unit:J-M-PER-MOL ;
   qudt:value "0.11962656472"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?nahc#mid"^^xsd:anyURI ;
   rdfs:label "Value for molar Planck constant times c" ;
@@ -4698,7 +4698,7 @@ constant:Value_MolarVolumeOfIdealGas
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000039e-3 ;
-  qudt:unit unit:M3-PER-MOL ;
+  qudt:hasUnit unit:M3-PER-MOL ;
   qudt:value 22.710981e-3 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mvol#mid"^^xsd:anyURI ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mvolstd#mid"^^xsd:anyURI ;
@@ -4708,7 +4708,7 @@ constant:Value_MolarVolumeOfSilicon
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000011e-6 ;
-  qudt:unit unit:M3-PER-MOL ;
+  qudt:hasUnit unit:M3-PER-MOL ;
   qudt:value 12.0588349e-6 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mvolsil#mid"^^xsd:anyURI ;
   rdfs:label "Value for molar volume of silicon" ;
@@ -4717,7 +4717,7 @@ constant:Value_MuonComptonWavelength
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000030e-15 ;
-  qudt:unit unit:M ;
+  qudt:hasUnit unit:M ;
   qudt:value 11.73444104e-15 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mcomwl#mid"^^xsd:anyURI ;
   rdfs:label "Value for muon Compton wavelength" ;
@@ -4726,7 +4726,7 @@ constant:Value_MuonComptonWavelengthOver2Pi
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000047e-15 ;
-  qudt:unit unit:M ;
+  qudt:hasUnit unit:M ;
   qudt:value 1.867594295e-15 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mcomwlbar#mid"^^xsd:anyURI ;
   rdfs:label "Value for muon Compton wavelength over 2 pi" ;
@@ -4735,7 +4735,7 @@ constant:Value_MuonElectronMassRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000052"^^xsd:double ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value "206.7682823"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mmusme#mid"^^xsd:anyURI ;
   rdfs:label "Value for muon-electron mass ratio" ;
@@ -4744,7 +4744,7 @@ constant:Value_MuonGFactor
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000000012"^^xsd:double ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value "-2.0023318414"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?gmum#mid"^^xsd:anyURI ;
   rdfs:label "Value for muon g factor" ;
@@ -4753,7 +4753,7 @@ constant:Value_MuonMagneticMoment
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000016e-26 ;
-  qudt:unit unit:J-PER-T ;
+  qudt:hasUnit unit:J-PER-T ;
   qudt:value -4.49044786e-26 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mumum#mid"^^xsd:anyURI ;
   rdfs:label "Value for muon magnetic moment" ;
@@ -4762,7 +4762,7 @@ constant:Value_MuonMagneticMomentAnomaly
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000060e-3 ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value 1.16592069e-3 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?amu#mid"^^xsd:anyURI ;
   rdfs:label "Value for muon magnetic moment anomaly" ;
@@ -4771,7 +4771,7 @@ constant:Value_MuonMagneticMomentToBohrMagnetonRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000012e-3 ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value -4.84197049e-3 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mumumsmub#mid"^^xsd:anyURI ;
   rdfs:label "Value for muon magnetic moment to Bohr magneton ratio" ;
@@ -4780,7 +4780,7 @@ constant:Value_MuonMagneticMomentToNuclearMagnetonRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00000023"^^xsd:double ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value "-8.89059705"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mumumsmun#mid"^^xsd:anyURI ;
   rdfs:label "Value for muon magnetic moment to nuclear magneton ratio" ;
@@ -4789,7 +4789,7 @@ constant:Value_MuonMass
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000011e-28 ;
-  qudt:unit unit:KiloGM ;
+  qudt:hasUnit unit:KiloGM ;
   qudt:value 1.88353130e-28 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mmu#mid"^^xsd:anyURI ;
   rdfs:label "Value for muon mass" ;
@@ -4798,7 +4798,7 @@ constant:Value_MuonMassEnergyEquivalent
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000095e-11 ;
-  qudt:unit unit:J ;
+  qudt:hasUnit unit:J ;
   qudt:value 1.692833510e-11 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mmuc2#mid"^^xsd:anyURI ;
   rdfs:label "Value for muon mass energy equivalent" ;
@@ -4807,7 +4807,7 @@ constant:Value_MuonMassEnergyEquivalentInMeV
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000038"^^xsd:double ;
-  qudt:unit unit:MegaEV ;
+  qudt:hasUnit unit:MegaEV ;
   qudt:value "105.6583668"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mmuc2mev#mid"^^xsd:anyURI ;
   rdfs:label "Value for muon mass energy equivalent in MeV" ;
@@ -4816,7 +4816,7 @@ constant:Value_MuonMassInAtomicMassUnit
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000000029"^^xsd:double ;
-  qudt:unit unit:U ;
+  qudt:hasUnit unit:U ;
   qudt:value "0.1134289256"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mmuu#mid"^^xsd:anyURI ;
   rdfs:label "Muon Mass (amu)" ;
@@ -4825,7 +4825,7 @@ constant:Value_MuonMolarMass
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000000029e-3 ;
-  qudt:unit unit:KiloGM-PER-MOL ;
+  qudt:hasUnit unit:KiloGM-PER-MOL ;
   qudt:value 0.1134289256e-3 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mmmu#mid"^^xsd:anyURI ;
   rdfs:label "Value for muon molar mass" ;
@@ -4834,7 +4834,7 @@ constant:Value_MuonNeutronMassRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000000029"^^xsd:double ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value "0.1124545167"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mmusmn#mid"^^xsd:anyURI ;
   rdfs:label "Value for muon-neutron mass ratio" ;
@@ -4843,7 +4843,7 @@ constant:Value_MuonProtonMagneticMomentRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.000000085"^^xsd:double ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value "-3.183345137"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mumumsmup#mid"^^xsd:anyURI ;
   rdfs:label "Value for muon-proton magnetic moment ratio" ;
@@ -4852,7 +4852,7 @@ constant:Value_MuonProtonMassRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000000029"^^xsd:double ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value "0.1126095261"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mmusmp#mid"^^xsd:anyURI ;
   rdfs:label "Value for muon-proton mass ratio" ;
@@ -4861,7 +4861,7 @@ constant:Value_MuonTauMassRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00097e-2 ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value 5.94592e-2 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mmusmtau#mid"^^xsd:anyURI ;
   rdfs:label "Value for muon-tau mass ratio" ;
@@ -4870,7 +4870,7 @@ constant:Value_NaturalUnitOfAction
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000053e-34 ;
-  qudt:unit unit:J-SEC ;
+  qudt:hasUnit unit:J-SEC ;
   qudt:value 1.054571628e-34 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?thbar#mid"^^xsd:anyURI ;
   rdfs:label "Value for natural unit of action" ;
@@ -4879,7 +4879,7 @@ constant:Value_NaturalUnitOfActionInEVS
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000016e-16 ;
-  qudt:unit unit:EV-SEC ;
+  qudt:hasUnit unit:EV-SEC ;
   qudt:value 6.58211899e-16 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?thbarev#mid"^^xsd:anyURI ;
   rdfs:label "Value for natural unit of action in eV s" ;
@@ -4888,7 +4888,7 @@ constant:Value_NaturalUnitOfEnergy
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000041e-14 ;
-  qudt:unit unit:J ;
+  qudt:hasUnit unit:J ;
   qudt:value 8.18710438e-14 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?tmec2#mid"^^xsd:anyURI ;
   rdfs:label "Value for natural unit of energy" ;
@@ -4897,7 +4897,7 @@ constant:Value_NaturalUnitOfEnergyInMeV
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.000000013"^^xsd:double ;
-  qudt:unit unit:MegaEV ;
+  qudt:hasUnit unit:MegaEV ;
   qudt:value "0.510998910"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?tmec2mev#mid"^^xsd:anyURI ;
   rdfs:label "Value for natural unit of energy in MeV" ;
@@ -4906,7 +4906,7 @@ constant:Value_NaturalUnitOfLength
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000053e-15 ;
-  qudt:unit unit:M ;
+  qudt:hasUnit unit:M ;
   qudt:value 386.15926459e-15 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?tecomwlbar#mid"^^xsd:anyURI ;
   rdfs:label "Value for natural unit of length" ;
@@ -4915,7 +4915,7 @@ constant:Value_NaturalUnitOfMass
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000045e-31 ;
-  qudt:unit unit:KiloGM ;
+  qudt:hasUnit unit:KiloGM ;
   qudt:value 9.10938215e-31 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?tme#mid"^^xsd:anyURI ;
   rdfs:label "Value for natural unit of mass" ;
@@ -4924,7 +4924,7 @@ constant:Value_NaturalUnitOfMomentum
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000014e-22 ;
-  qudt:unit unit:KiloGM-M-PER-SEC ;
+  qudt:hasUnit unit:KiloGM-M-PER-SEC ;
   qudt:value 2.73092406e-22 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mec#mid"^^xsd:anyURI ;
   rdfs:label "Value for natural unit of momentum" ;
@@ -4933,7 +4933,7 @@ constant:Value_NaturalUnitOfMomentumInMeVPerC
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.000000013"^^xsd:double ;
-  qudt:unit unit:MegaEV-PER-SpeedOfLight ;
+  qudt:hasUnit unit:MegaEV-PER-SpeedOfLight ;
   qudt:value "0.510998910"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mecmevsc#mid"^^xsd:anyURI ;
   rdfs:label "Value for natural unit of momentum in MeV c^-1" ;
@@ -4942,7 +4942,7 @@ constant:Value_NaturalUnitOfTime
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000000018e-21 ;
-  qudt:unit unit:SEC ;
+  qudt:hasUnit unit:SEC ;
   qudt:value 1.2880886570e-21 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?nut#mid"^^xsd:anyURI ;
   rdfs:label "Value for natural unit of time" ;
@@ -4950,7 +4950,7 @@ constant:Value_NaturalUnitOfTime
 constant:Value_NaturalUnitOfVelocity
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
-  qudt:unit unit:M-PER-SEC ;
+  qudt:hasUnit unit:M-PER-SEC ;
   qudt:value "299792458"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?tc#mid"^^xsd:anyURI ;
   rdfs:label "Value for natural unit of velocity" ;
@@ -4959,7 +4959,7 @@ constant:Value_NeutronComptonWavelength
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000000020e-15 ;
-  qudt:unit unit:M ;
+  qudt:hasUnit unit:M ;
   qudt:value 1.3195908951e-15 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?ncomwl#mid"^^xsd:anyURI ;
   rdfs:label "Value for neutron Compton wavelength" ;
@@ -4968,7 +4968,7 @@ constant:Value_NeutronComptonWavelengthOver2Pi
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000000031e-15 ;
-  qudt:unit unit:M ;
+  qudt:hasUnit unit:M ;
   qudt:value 0.21001941382e-15 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?ncomwlbar#mid"^^xsd:anyURI ;
   rdfs:label "Value for neutron Compton wavelength over 2 pi" ;
@@ -4977,7 +4977,7 @@ constant:Value_NeutronElectronMagneticMomentRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000025e-3 ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value 1.04066882e-3 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?munsmue#mid"^^xsd:anyURI ;
   rdfs:label "Value for neutron-electron magnetic moment ratio" ;
@@ -4986,7 +4986,7 @@ constant:Value_NeutronElectronMassRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000011"^^xsd:double ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value "1838.6836605"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mnsme#mid"^^xsd:anyURI ;
   rdfs:label "Value for neutron-electron mass ratio" ;
@@ -4995,7 +4995,7 @@ constant:Value_NeutronGFactor
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00000090"^^xsd:double ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value "-3.82608545"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?gnn#mid"^^xsd:anyURI ;
   rdfs:label "Value for neutron g factor" ;
@@ -5004,7 +5004,7 @@ constant:Value_NeutronGyromagneticRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000043e8 ;
-  qudt:unit unit:PER-T-SEC ;
+  qudt:hasUnit unit:PER-T-SEC ;
   qudt:value 1.83247185e8 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?gamman#mid"^^xsd:anyURI ;
   rdfs:label "Value for neutron gyromagnetic ratio" ;
@@ -5013,7 +5013,7 @@ constant:Value_NeutronGyromagneticRatioOver2Pi
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000069"^^xsd:double ;
-  qudt:unit unit:MegaHZ-PER-T ;
+  qudt:hasUnit unit:MegaHZ-PER-T ;
   qudt:value "29.1646954"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?gammanbar#mid"^^xsd:anyURI ;
   rdfs:label "Value for neutron gyromagnetic ratio over 2 pi" ;
@@ -5022,7 +5022,7 @@ constant:Value_NeutronMagneticMoment
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000023e-26 ;
-  qudt:unit unit:J-PER-T ;
+  qudt:hasUnit unit:J-PER-T ;
   qudt:value -0.96623641e-26 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?munn#mid"^^xsd:anyURI ;
   rdfs:label "Value for neutron magnetic moment" ;
@@ -5031,7 +5031,7 @@ constant:Value_NeutronMagneticMomentToBohrMagnetonRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000025e-3 ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value -1.04187563e-3 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?munsmub#mid"^^xsd:anyURI ;
   rdfs:label "Value for neutron magnetic moment to Bohr magneton ratio" ;
@@ -5040,7 +5040,7 @@ constant:Value_NeutronMagneticMomentToNuclearMagnetonRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00000045"^^xsd:double ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value "-1.91304273"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?munsmun#mid"^^xsd:anyURI ;
   rdfs:label "Value for neutron magnetic moment to nuclear magneton ratio" ;
@@ -5049,7 +5049,7 @@ constant:Value_NeutronMass
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000084e-27 ;
-  qudt:unit unit:KiloGM ;
+  qudt:hasUnit unit:KiloGM ;
   qudt:value 1.674927211e-27 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mn#mid"^^xsd:anyURI ;
   rdfs:label "Value for neutron mass" ;
@@ -5058,7 +5058,7 @@ constant:Value_NeutronMassEnergyEquivalent
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000075e-10 ;
-  qudt:unit unit:J ;
+  qudt:hasUnit unit:J ;
   qudt:value 1.505349505e-10 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mnc2#mid"^^xsd:anyURI ;
   rdfs:label "Value for neutron mass energy equivalent" ;
@@ -5067,7 +5067,7 @@ constant:Value_NeutronMassEnergyEquivalentInMeV
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.000023"^^xsd:double ;
-  qudt:unit unit:MegaEV ;
+  qudt:hasUnit unit:MegaEV ;
   qudt:value "939.565346"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mnc2mev#mid"^^xsd:anyURI ;
   rdfs:label "Value for neutron mass energy equivalent in MeV" ;
@@ -5076,7 +5076,7 @@ constant:Value_NeutronMassInAtomicMassUnit
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00000000043"^^xsd:double ;
-  qudt:unit unit:U ;
+  qudt:hasUnit unit:U ;
   qudt:value "1.00866491597"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mnu#mid"^^xsd:anyURI ;
   rdfs:label "Neutron Mass (amu)" ;
@@ -5085,7 +5085,7 @@ constant:Value_NeutronMolarMass
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000000043e-3 ;
-  qudt:unit unit:KiloGM-PER-MOL ;
+  qudt:hasUnit unit:KiloGM-PER-MOL ;
   qudt:value 1.00866491597e-3 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mmn#mid"^^xsd:anyURI ;
   rdfs:label "Value for neutron molar mass" ;
@@ -5094,7 +5094,7 @@ constant:Value_NeutronMuonMassRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00000023"^^xsd:double ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value "8.89248409"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mnsmmu#mid"^^xsd:anyURI ;
   rdfs:label "Value for neutron-muon mass ratio" ;
@@ -5103,7 +5103,7 @@ constant:Value_NeutronProtonMagneticMomentRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00000016"^^xsd:double ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value "-0.68497934"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?munsmup#mid"^^xsd:anyURI ;
   rdfs:label "Value for neutron-proton magnetic moment ratio" ;
@@ -5112,7 +5112,7 @@ constant:Value_NeutronProtonMassRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00000000046"^^xsd:double ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value "1.00137841918"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mnsmp#mid"^^xsd:anyURI ;
   rdfs:label "Value for neutron-proton mass ratio" ;
@@ -5121,7 +5121,7 @@ constant:Value_NeutronTauMassRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.000086"^^xsd:double ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value "0.528740"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mnsmtau#mid"^^xsd:anyURI ;
   rdfs:label "Value for neutron-tau mass ratio" ;
@@ -5130,7 +5130,7 @@ constant:Value_NeutronToShieldedProtonMagneticMomentRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00000016"^^xsd:double ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value "-0.68499694"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?munsmupp#mid"^^xsd:anyURI ;
   rdfs:label "Value for neutron to shielded proton magnetic moment ratio" ;
@@ -5140,7 +5140,7 @@ constant:Value_NewtonianConstantOfGravitation
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:relativeStandardUncertainty 2.2e-5 ;
   qudt:standardUncertainty 0.00015e-11 ;
-  qudt:unit unit:M3-PER-KiloGM-SEC2 ;
+  qudt:hasUnit unit:M3-PER-KiloGM-SEC2 ;
   qudt:value 6.67430e-11 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?bg#mid"^^xsd:anyURI ;
   rdfs:label "Value for Newtonian constant of gravitation" ;
@@ -5149,7 +5149,7 @@ constant:Value_NewtonianConstantOfGravitationOverHbarC
   a qudt:ConstantValue ;
   qudt:relativeStandardUncertainty 2.2e-5 ;
   qudt:standardUncertainty 0.00015e-39 ;
-  qudt:unit unit:PER-PlanckMass2 ;
+  qudt:hasUnit unit:PER-PlanckMass2 ;
   qudt:value 6.70883e-39 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?bgspu#mid"^^xsd:anyURI ;
   rdfs:label "Newtonian constant of gravitation over hbar c" ;
@@ -5158,7 +5158,7 @@ constant:Value_NuclearMagneton
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000013e-27 ;
-  qudt:unit unit:J-PER-T ;
+  qudt:hasUnit unit:J-PER-T ;
   qudt:value 5.05078324e-27 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mun#mid"^^xsd:anyURI ;
   rdfs:label "Value for nuclear magneton" ;
@@ -5167,7 +5167,7 @@ constant:Value_NuclearMagnetonInEVPerT
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000000045e-8 ;
-  qudt:unit unit:EV-PER-T ;
+  qudt:hasUnit unit:EV-PER-T ;
   qudt:value 3.1524512326e-8 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?munev#mid"^^xsd:anyURI ;
   rdfs:label "Value for nuclear magneton in eV per T" ;
@@ -5176,7 +5176,7 @@ constant:Value_NuclearMagnetonInInverseMetersPerTesla
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000064e-2 ;
-  qudt:unit unit:PER-T-M ;
+  qudt:hasUnit unit:PER-T-M ;
   qudt:value 2.542623616e-2 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?munshcminv#mid"^^xsd:anyURI ;
   rdfs:label "Value for nuclear magneton in inverse meters per tesla" ;
@@ -5185,7 +5185,7 @@ constant:Value_NuclearMagnetonInKPerT
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000064e-4 ;
-  qudt:unit unit:K-PER-T ;
+  qudt:hasUnit unit:K-PER-T ;
   qudt:value 3.6582637e-4 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?munskk#mid"^^xsd:anyURI ;
   rdfs:label "Value for nuclear magneton in K per T" ;
@@ -5194,7 +5194,7 @@ constant:Value_NuclearMagnetonInMHzPerT
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00000019"^^xsd:double ;
-  qudt:unit unit:MegaHZ-PER-T ;
+  qudt:hasUnit unit:MegaHZ-PER-T ;
   qudt:value "7.62259384"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?munshhz#mid"^^xsd:anyURI ;
   rdfs:label "Value for nuclear magneton in MHz per T" ;
@@ -5202,7 +5202,7 @@ constant:Value_NuclearMagnetonInMHzPerT
 constant:Value_PermittivityOfVacuum
   a qudt:ConstantValue ;
   qudt:relativeStandardUncertainty 1.5e-10 ;
-  qudt:unit unit:FARAD-PER-M ;
+  qudt:hasUnit unit:FARAD-PER-M ;
   qudt:value 6.8541878128e-12 ;
   rdfs:label "Value for permittivity of vacuum" ;
 .
@@ -5210,7 +5210,7 @@ constant:Value_PlanckConstant
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000033e-34 ;
-  qudt:unit unit:J-SEC ;
+  qudt:hasUnit unit:J-SEC ;
   qudt:value 6.62606896e-34 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?h#mid"^^xsd:anyURI ;
   rdfs:label "Value for Planck constant" ;
@@ -5219,7 +5219,7 @@ constant:Value_PlanckConstantInEVS
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000010e-15 ;
-  qudt:unit unit:EV-SEC ;
+  qudt:hasUnit unit:EV-SEC ;
   qudt:value 4.13566733e-15 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?hev#mid"^^xsd:anyURI ;
   rdfs:label "Value for Planck constant in eV s" ;
@@ -5228,7 +5228,7 @@ constant:Value_PlanckConstantOver2Pi
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000053e-34 ;
-  qudt:unit unit:J-SEC ;
+  qudt:hasUnit unit:J-SEC ;
   qudt:value 1.054571628e-34 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?hbar#mid"^^xsd:anyURI ;
   rdfs:label "Value for Planck constant over 2 pi" ;
@@ -5237,7 +5237,7 @@ constant:Value_PlanckConstantOver2PiInEVS
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000016e-16 ;
-  qudt:unit unit:EV-SEC ;
+  qudt:hasUnit unit:EV-SEC ;
   qudt:value 6.58211899e-16 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?hbarev#mid"^^xsd:anyURI ;
   rdfs:label "Value for Planck constant over 2 pi in eV s" ;
@@ -5246,7 +5246,7 @@ constant:Value_PlanckConstantOver2PiTimesCInMeVFm
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000049"^^xsd:double ;
-  qudt:unit unit:MegaEV-FemtoM ;
+  qudt:hasUnit unit:MegaEV-FemtoM ;
   qudt:value "197.3269631"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?hbcmevf#mid"^^xsd:anyURI ;
   rdfs:label "Value for Planck constant over 2 pi times c in MeV fm" ;
@@ -5255,7 +5255,7 @@ constant:Value_PlanckLength
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000081e-35 ;
-  qudt:unit unit:M ;
+  qudt:hasUnit unit:M ;
   qudt:value 1.616252e-35 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?plkl#mid"^^xsd:anyURI ;
   rdfs:label "Value for Planck length" ;
@@ -5264,7 +5264,7 @@ constant:Value_PlanckMass
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00011e-8 ;
-  qudt:unit unit:KiloGM ;
+  qudt:hasUnit unit:KiloGM ;
   qudt:value 2.17644e-8 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?plkm#mid"^^xsd:anyURI ;
   rdfs:label "Value for Planck mass" ;
@@ -5273,7 +5273,7 @@ constant:Value_PlanckMassEnergyEquivalentInGeV
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000061e19 ;
-  qudt:unit unit:GigaEV ;
+  qudt:hasUnit unit:GigaEV ;
   qudt:value 1.220892e19 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?plkmc2gev#mid"^^xsd:anyURI ;
   rdfs:label "Value for Planck mass energy equivalent in GeV" ;
@@ -5282,7 +5282,7 @@ constant:Value_PlanckTemperature
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000071e32 ;
-  qudt:unit unit:K ;
+  qudt:hasUnit unit:K ;
   qudt:value 1.416785e32 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?plktmp#mid"^^xsd:anyURI ;
   rdfs:label "Value for Planck temperature" ;
@@ -5291,7 +5291,7 @@ constant:Value_PlanckTime
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00027e-44 ;
-  qudt:unit unit:SEC ;
+  qudt:hasUnit unit:SEC ;
   qudt:value 5.39124e-44 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?plkt#mid"^^xsd:anyURI ;
   rdfs:label "Value for Planck time" ;
@@ -5300,7 +5300,7 @@ constant:Value_ProtonChargeToMassQuotient
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000024e7 ;
-  qudt:unit unit:C-PER-KiloGM ;
+  qudt:hasUnit unit:C-PER-KiloGM ;
   qudt:value 9.57883392e7 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?esmp#mid"^^xsd:anyURI ;
   rdfs:label "Value for proton charge to mass quotient" ;
@@ -5309,7 +5309,7 @@ constant:Value_ProtonComptonWavelength
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000000019e-15 ;
-  qudt:unit unit:M ;
+  qudt:hasUnit unit:M ;
   qudt:value 1.3214098446e-15 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?pcomwl#mid"^^xsd:anyURI ;
   rdfs:label "Value for proton Compton wavelength" ;
@@ -5318,7 +5318,7 @@ constant:Value_ProtonComptonWavelengthOver2Pi
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000000030e-15 ;
-  qudt:unit unit:M ;
+  qudt:hasUnit unit:M ;
   qudt:value 0.21030890861e-15 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?pcomwlbar#mid"^^xsd:anyURI ;
   rdfs:label "Value for proton Compton wavelength over 2 pi" ;
@@ -5327,7 +5327,7 @@ constant:Value_ProtonElectronMassRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00000080"^^xsd:double ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value "1836.15267247"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mpsme#mid"^^xsd:anyURI ;
   rdfs:label "Value for proton-electron mass ratio" ;
@@ -5336,7 +5336,7 @@ constant:Value_ProtonGFactor
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.000000046"^^xsd:double ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value "5.585694713"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?gp#mid"^^xsd:anyURI ;
   rdfs:label "Value for proton g factor" ;
@@ -5345,7 +5345,7 @@ constant:Value_ProtonGyromagneticRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000070e8 ;
-  qudt:unit unit:PER-T-SEC ;
+  qudt:hasUnit unit:PER-T-SEC ;
   qudt:value 2.675222099e8 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?gammap#mid"^^xsd:anyURI ;
   rdfs:label "Value for proton gyromagnetic ratio" ;
@@ -5354,7 +5354,7 @@ constant:Value_ProtonGyromagneticRatioOver2Pi
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000011"^^xsd:double ;
-  qudt:unit unit:MegaHZ-PER-T ;
+  qudt:hasUnit unit:MegaHZ-PER-T ;
   qudt:value "42.5774821"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?gammapbar#mid"^^xsd:anyURI ;
   rdfs:label "Value for proton gyromagnetic ratio over 2 pi" ;
@@ -5363,7 +5363,7 @@ constant:Value_ProtonMagneticMoment
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000037e-26 ;
-  qudt:unit unit:J-PER-T ;
+  qudt:hasUnit unit:J-PER-T ;
   qudt:value 1.410606662e-26 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mup#mid"^^xsd:anyURI ;
   rdfs:label "Value for proton magnetic moment" ;
@@ -5372,7 +5372,7 @@ constant:Value_ProtonMagneticMomentToBohrMagnetonRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000012e-3 ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value 1.521032209e-3 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mupsmub#mid"^^xsd:anyURI ;
   rdfs:label "Value for proton magnetic moment to Bohr magneton ratio" ;
@@ -5381,7 +5381,7 @@ constant:Value_ProtonMagneticMomentToNuclearMagnetonRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.000000023"^^xsd:double ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value "2.792847356"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mupsmun#mid"^^xsd:anyURI ;
   rdfs:label "Value for proton magnetic moment to nuclear magneton ratio" ;
@@ -5390,7 +5390,7 @@ constant:Value_ProtonMagneticShieldingCorrection
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.014e-6 ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value 25.694e-6 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?sigmapp#mid"^^xsd:anyURI ;
   rdfs:label "Value for proton magnetic shielding correction" ;
@@ -5399,7 +5399,7 @@ constant:Value_ProtonMass
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000083e-27 ;
-  qudt:unit unit:KiloGM ;
+  qudt:hasUnit unit:KiloGM ;
   qudt:value 1.672621637e-27 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mp#mid"^^xsd:anyURI ;
   rdfs:label "Value for proton mass" ;
@@ -5408,7 +5408,7 @@ constant:Value_ProtonMassEnergyEquivalent
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000075e-10 ;
-  qudt:unit unit:J ;
+  qudt:hasUnit unit:J ;
   qudt:value 1.503277359e-10 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mpc2#mid"^^xsd:anyURI ;
   rdfs:label "Value for proton mass energy equivalent" ;
@@ -5417,7 +5417,7 @@ constant:Value_ProtonMassEnergyEquivalentInMeV
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.000023"^^xsd:double ;
-  qudt:unit unit:MegaEV ;
+  qudt:hasUnit unit:MegaEV ;
   qudt:value "938.272013"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mpc2mev#mid"^^xsd:anyURI ;
   rdfs:label "Value for proton mass energy equivalent in MeV" ;
@@ -5426,7 +5426,7 @@ constant:Value_ProtonMassInAtomicMassUnit
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00000000010"^^xsd:double ;
-  qudt:unit unit:U ;
+  qudt:hasUnit unit:U ;
   qudt:value "1.00727646677"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mpu#mid"^^xsd:anyURI ;
   rdfs:label "Proton Mass (amu)" ;
@@ -5435,7 +5435,7 @@ constant:Value_ProtonMolarMass
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000000010e-3 ;
-  qudt:unit unit:KiloGM-PER-MOL ;
+  qudt:hasUnit unit:KiloGM-PER-MOL ;
   qudt:value 1.00727646677e-3 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mmp#mid"^^xsd:anyURI ;
   rdfs:label "Value for proton molar mass" ;
@@ -5444,7 +5444,7 @@ constant:Value_ProtonMuonMassRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00000023"^^xsd:double ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value "8.88024339"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mpsmmu#mid"^^xsd:anyURI ;
   rdfs:label "Value for proton-muon mass ratio" ;
@@ -5453,7 +5453,7 @@ constant:Value_ProtonNeutronMagneticMomentRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00000034"^^xsd:double ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value "-1.45989806"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mupsmunn#mid"^^xsd:anyURI ;
   rdfs:label "Value for proton-neutron magnetic moment ratio" ;
@@ -5462,7 +5462,7 @@ constant:Value_ProtonNeutronMassRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00000000046"^^xsd:double ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value "0.99862347824"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mpsmn#mid"^^xsd:anyURI ;
   rdfs:label "Value for proton-neutron mass ratio" ;
@@ -5471,7 +5471,7 @@ constant:Value_ProtonRmsChargeRadius
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0069e-15 ;
-  qudt:unit unit:M ;
+  qudt:hasUnit unit:M ;
   qudt:value 0.8768e-15 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?rp#mid"^^xsd:anyURI ;
   rdfs:label "Value for proton rms charge radius" ;
@@ -5480,7 +5480,7 @@ constant:Value_ProtonTauMassRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.000086"^^xsd:double ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value "0.528012"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mpsmtau#mid"^^xsd:anyURI ;
   rdfs:label "Value for proton-tau mass ratio" ;
@@ -5489,7 +5489,7 @@ constant:Value_QuantumOfCirculation
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000000050e-4 ;
-  qudt:unit unit:M2-PER-SEC ;
+  qudt:hasUnit unit:M2-PER-SEC ;
   qudt:value 3.6369475199e-4 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?qucirchs2me#mid"^^xsd:anyURI ;
   rdfs:label "Value for quantum of circulation" ;
@@ -5498,7 +5498,7 @@ constant:Value_QuantumOfCirculationTimes2
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000010e-4 ;
-  qudt:unit unit:M2-PER-SEC ;
+  qudt:hasUnit unit:M2-PER-SEC ;
   qudt:value 7.273895040e-4 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?hsme#mid"^^xsd:anyURI ;
   rdfs:label "Value for quantum of circulation times 2" ;
@@ -5507,7 +5507,7 @@ constant:Value_RydbergConstant
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.000073"^^xsd:double ;
-  qudt:unit unit:PER-M ;
+  qudt:hasUnit unit:PER-M ;
   qudt:value "10973731.568527"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?ryd#mid"^^xsd:anyURI ;
   rdfs:label "Value for Rydberg constant" ;
@@ -5516,7 +5516,7 @@ constant:Value_RydbergConstantTimesCInHz
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000000022e15 ;
-  qudt:unit unit:HZ ;
+  qudt:hasUnit unit:HZ ;
   qudt:value 3.289841960361e15 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?rydchz#mid"^^xsd:anyURI ;
   rdfs:label "Value for Rydberg constant times c in Hz" ;
@@ -5525,7 +5525,7 @@ constant:Value_RydbergConstantTimesHcInEV
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00000034"^^xsd:double ;
-  qudt:unit unit:EV ;
+  qudt:hasUnit unit:EV ;
   qudt:value "13.60569193"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?rydhcev#mid"^^xsd:anyURI ;
   rdfs:label "Value for Rydberg constant times hc in eV" ;
@@ -5534,7 +5534,7 @@ constant:Value_RydbergConstantTimesHcInJ
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000011e-18 ;
-  qudt:unit unit:J ;
+  qudt:hasUnit unit:J ;
   qudt:value 2.17987197e-18 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?rydhcj#mid"^^xsd:anyURI ;
   rdfs:label "Value for Rydberg constant times hc in J" ;
@@ -5543,7 +5543,7 @@ constant:Value_SackurTetrodeConstant1K100KPa
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000044"^^xsd:double ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value "-1.1517047"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?s0sr#mid"^^xsd:anyURI ;
   rdfs:label "Value for Sackur-Tetrode constant 1 K 100 kPa" ;
@@ -5552,7 +5552,7 @@ constant:Value_SackurTetrodeConstant1K100KPa
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000044"^^xsd:double ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value "-1.1648677"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?s0srstd#mid"^^xsd:anyURI ;
   rdfs:label "Value for Sackur-Tetrode constant 1 K 101.325 kPa" ;
@@ -5561,7 +5561,7 @@ constant:Value_SecondRadiationConstant
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000025e-2 ;
-  qudt:unit unit:M-K ;
+  qudt:hasUnit unit:M-K ;
   qudt:value 1.4387752e-2 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?c22ndrc#mid"^^xsd:anyURI ;
   rdfs:label "Value for second radiation constant" ;
@@ -5570,7 +5570,7 @@ constant:Value_ShieldedHelionGyromagneticRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000056e8 ;
-  qudt:unit unit:PER-T-SEC ;
+  qudt:hasUnit unit:PER-T-SEC ;
   qudt:value 2.037894730e8 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?gammahp#mid"^^xsd:anyURI ;
   rdfs:label "Value for shielded helion gyromagnetic ratio" ;
@@ -5579,7 +5579,7 @@ constant:Value_ShieldedHelionGyromagneticRatioOver2Pi
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00000090"^^xsd:double ;
-  qudt:unit unit:MegaHZ-PER-T ;
+  qudt:hasUnit unit:MegaHZ-PER-T ;
   qudt:value "32.43410198"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?gammahpbar#mid"^^xsd:anyURI ;
   rdfs:label "Value for shielded helion gyromagnetic ratio over 2 pi" ;
@@ -5588,7 +5588,7 @@ constant:Value_ShieldedHelionMagneticMoment
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000030e-26 ;
-  qudt:unit unit:J-PER-T ;
+  qudt:hasUnit unit:J-PER-T ;
   qudt:value -1.074552982e-26 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?muhp#mid"^^xsd:anyURI ;
   rdfs:label "Value for shielded helion magnetic moment" ;
@@ -5597,7 +5597,7 @@ constant:Value_ShieldedHelionMagneticMomentToBohrMagnetonRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000014e-3 ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value -1.158671471e-3 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?muhpsmub#mid"^^xsd:anyURI ;
   rdfs:label "Value for shielded helion magnetic moment to Bohr magneton ratio" ;
@@ -5606,7 +5606,7 @@ constant:Value_ShieldedHelionMagneticMomentToNuclearMagnetonRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.000000025"^^xsd:double ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value "-2.127497718"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?muhpsmun#mid"^^xsd:anyURI ;
   rdfs:label "Value for shielded helion magnetic moment to nuclear magneton ratio" ;
@@ -5615,7 +5615,7 @@ constant:Value_ShieldedHelionToProtonMagneticMomentRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.000000011"^^xsd:double ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value "-0.761766558"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?muhpsmup#mid"^^xsd:anyURI ;
   rdfs:label "Value for shielded helion to proton magnetic moment ratio" ;
@@ -5624,7 +5624,7 @@ constant:Value_ShieldedHelionToShieldedProtonMagneticMomentRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000000033"^^xsd:double ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value "-0.7617861313"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?muhpsmupp#mid"^^xsd:anyURI ;
   rdfs:label "Value for shielded helion to shielded proton magnetic moment ratio" ;
@@ -5633,7 +5633,7 @@ constant:Value_ShieldedProtonGyromagneticRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000073e8 ;
-  qudt:unit unit:PER-T-SEC ;
+  qudt:hasUnit unit:PER-T-SEC ;
   qudt:value 2.675153362e8 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?gammapp#mid"^^xsd:anyURI ;
   rdfs:label "Value for shielded proton gyromagnetic ratio" ;
@@ -5642,7 +5642,7 @@ constant:Value_ShieldedProtonGyromagneticRatioOver2Pi
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000012"^^xsd:double ;
-  qudt:unit unit:MegaHZ-PER-T ;
+  qudt:hasUnit unit:MegaHZ-PER-T ;
   qudt:value "42.5763881"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?gammappbar#mid"^^xsd:anyURI ;
   rdfs:label "Value for shielded proton gyromagnetic ratio over 2 pi" ;
@@ -5651,7 +5651,7 @@ constant:Value_ShieldedProtonMagneticMoment
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000038e-26 ;
-  qudt:unit unit:J-PER-T ;
+  qudt:hasUnit unit:J-PER-T ;
   qudt:value 1.410570419e-26 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mupp#mid"^^xsd:anyURI ;
   rdfs:label "Value for shielded proton magnetic moment" ;
@@ -5660,7 +5660,7 @@ constant:Value_ShieldedProtonMagneticMomentToBohrMagnetonRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000017e-3 ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value 1.520993128e-3 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?muppsmub#mid"^^xsd:anyURI ;
   rdfs:label "Value for shielded proton magnetic moment to Bohr magneton ratio" ;
@@ -5669,7 +5669,7 @@ constant:Value_ShieldedProtonMagneticMomentToNuclearMagnetonRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.000000030"^^xsd:double ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value "2.792775598"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?muppsmun#mid"^^xsd:anyURI ;
   rdfs:label "Value for shielded proton magnetic moment to nuclear magneton ratio" ;
@@ -5677,7 +5677,7 @@ constant:Value_ShieldedProtonMagneticMomentToNuclearMagnetonRatio
 constant:Value_SpeedOfLight
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
-  qudt:unit unit:M-PER-SEC ;
+  qudt:hasUnit unit:M-PER-SEC ;
   qudt:value "299792458"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?c#mid"^^xsd:anyURI ;
   rdfs:label "Value for velocity of light" ;
@@ -5687,14 +5687,14 @@ constant:Value_SpeedOfLight_Vacuum
   qudt:informativeReference "http://physics.nist.gov/cgi-bin/cuu/Value?c#mid"^^xsd:anyURI ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000000"^^xsd:double ;
-  qudt:unit unit:M-PER-SEC ;
+  qudt:hasUnit unit:M-PER-SEC ;
   qudt:value 2.99792458e8 ;
   rdfs:label "Value for speed of light in a vacuum" ;
 .
 constant:Value_SpeedOfLight_Vacuum_Imperial
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
-  qudt:unit unit:MI-PER-HR ;
+  qudt:hasUnit unit:MI-PER-HR ;
   qudt:value 6.70616629e08 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?c#mid"^^xsd:anyURI ;
   rdfs:label "Value for speed of light in vacuum (Imperial units)" ;
@@ -5702,7 +5702,7 @@ constant:Value_SpeedOfLight_Vacuum_Imperial
 constant:Value_StandardAccelerationOfGravity
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
-  qudt:unit unit:M-PER-SEC2 ;
+  qudt:hasUnit unit:M-PER-SEC2 ;
   qudt:value "9.80665"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?gn#mid"^^xsd:anyURI ;
   rdfs:label "Value for standard acceleration of gravity" ;
@@ -5710,7 +5710,7 @@ constant:Value_StandardAccelerationOfGravity
 constant:Value_StandardAtmosphere
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
-  qudt:unit unit:PA ;
+  qudt:hasUnit unit:PA ;
   qudt:value "101325"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?stdatm#mid"^^xsd:anyURI ;
   rdfs:label "Value for standard atmosphere" ;
@@ -5719,7 +5719,7 @@ constant:Value_StefanBoltzmannConstant
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000040e-8 ;
-  qudt:unit unit:W-PER-M2-K4 ;
+  qudt:hasUnit unit:W-PER-M2-K4 ;
   qudt:value 5.670400e-8 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?sigma#mid"^^xsd:anyURI ;
   rdfs:label "Value for Stefan-Boltzmann Constant" ;
@@ -5728,7 +5728,7 @@ constant:Value_TauComptonWavelength
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00011e-15 ;
-  qudt:unit unit:M ;
+  qudt:hasUnit unit:M ;
   qudt:value 0.69772e-15 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?tcomwl#mid"^^xsd:anyURI ;
   rdfs:label "Value for tau Compton wavelength" ;
@@ -5737,7 +5737,7 @@ constant:Value_TauComptonWavelengthOver2Pi
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000018e-15 ;
-  qudt:unit unit:M ;
+  qudt:hasUnit unit:M ;
   qudt:value 0.111046e-15 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?tcomwlbar#mid"^^xsd:anyURI ;
   rdfs:label "Value for tau Compton wavelength over 2 pi" ;
@@ -5746,7 +5746,7 @@ constant:Value_TauElectronMassRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.57"^^xsd:double ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value "3477.48"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mtausme#mid"^^xsd:anyURI ;
   rdfs:label "Value for tau-electron mass ratio" ;
@@ -5755,7 +5755,7 @@ constant:Value_TauMass
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00052e-27 ;
-  qudt:unit unit:KiloGM ;
+  qudt:hasUnit unit:KiloGM ;
   qudt:value 3.16777e-27 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mtau#mid"^^xsd:anyURI ;
   rdfs:label "Value for tau mass" ;
@@ -5764,7 +5764,7 @@ constant:Value_TauMassEnergyEquivalent
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00046e-10 ;
-  qudt:unit unit:J ;
+  qudt:hasUnit unit:J ;
   qudt:value 2.84705e-10 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mtauc2#mid"^^xsd:anyURI ;
   rdfs:label "Value for tau mass energy equivalent" ;
@@ -5773,7 +5773,7 @@ constant:Value_TauMassEnergyEquivalentInMeV
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.29"^^xsd:double ;
-  qudt:unit unit:MegaEV ;
+  qudt:hasUnit unit:MegaEV ;
   qudt:value "1776.99"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mtauc2mev#mid"^^xsd:anyURI ;
   rdfs:label "Value for tau mass energy equivalent in MeV" ;
@@ -5782,7 +5782,7 @@ constant:Value_TauMassInAtomicMassUnit
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00031"^^xsd:double ;
-  qudt:unit unit:U ;
+  qudt:hasUnit unit:U ;
   qudt:value "1.90768"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mtauu#mid"^^xsd:anyURI ;
   rdfs:label "Tau Mass (amu)" ;
@@ -5791,7 +5791,7 @@ constant:Value_TauMolarMass
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00031e-3 ;
-  qudt:unit unit:KiloGM-PER-MOL ;
+  qudt:hasUnit unit:KiloGM-PER-MOL ;
   qudt:value 1.90768e-3 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mmtau#mid"^^xsd:anyURI ;
   rdfs:label "Value for tau molar mass" ;
@@ -5800,7 +5800,7 @@ constant:Value_TauMuonMassRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0027"^^xsd:double ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value "16.8183"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mtausmmu#mid"^^xsd:anyURI ;
   rdfs:label "Value for tau-muon mass ratio" ;
@@ -5809,7 +5809,7 @@ constant:Value_TauNeutronMassRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00031"^^xsd:double ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value "1.89129"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mtausmn#mid"^^xsd:anyURI ;
   rdfs:label "Value for tau-neutron mass ratio" ;
@@ -5818,7 +5818,7 @@ constant:Value_TauProtonMassRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00031"^^xsd:double ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value "1.89390"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mtausmp#mid"^^xsd:anyURI ;
   rdfs:label "Value for tau-proton mass ratio" ;
@@ -5827,7 +5827,7 @@ constant:Value_ThomsonCrossSection
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000000027e-28 ;
-  qudt:unit unit:M2 ;
+  qudt:hasUnit unit:M2 ;
   qudt:value 0.6652458558e-28 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?sigmae#mid"^^xsd:anyURI ;
   rdfs:label "Value for Thomson cross section" ;
@@ -5836,7 +5836,7 @@ constant:Value_TritonElectronMagneticMomentRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000021e-3 ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value -1.620514423e-3 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mutsmuem#mid"^^xsd:anyURI ;
   rdfs:label "Value for triton-electron magnetic moment ratio" ;
@@ -5845,7 +5845,7 @@ constant:Value_TritonElectronMassRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000051"^^xsd:double ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value "5496.9215269"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mtsme#mid"^^xsd:anyURI ;
   rdfs:label "Value for triton-electron mass ratio" ;
@@ -5854,7 +5854,7 @@ constant:Value_TritonGFactor
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.000000076"^^xsd:double ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value "5.957924896"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?gtn#mid"^^xsd:anyURI ;
   rdfs:label "Value for triton g factor" ;
@@ -5863,7 +5863,7 @@ constant:Value_TritonMagneticMoment
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000042e-26 ;
-  qudt:unit unit:J-PER-T ;
+  qudt:hasUnit unit:J-PER-T ;
   qudt:value 1.504609361e-26 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mut#mid"^^xsd:anyURI ;
   rdfs:label "Value for triton magnetic moment" ;
@@ -5872,7 +5872,7 @@ constant:Value_TritonMagneticMomentToBohrMagnetonRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000021e-3 ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value 1.622393657e-3 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mutsmub#mid"^^xsd:anyURI ;
   rdfs:label "Value for triton magnetic moment to Bohr magneton ratio" ;
@@ -5881,7 +5881,7 @@ constant:Value_TritonMagneticMomentToNuclearMagnetonRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.000000038"^^xsd:double ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value "2.978962448"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mutsmun#mid"^^xsd:anyURI ;
   rdfs:label "Value for triton magnetic moment to nuclear magneton ratio" ;
@@ -5890,7 +5890,7 @@ constant:Value_TritonMass
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000025e-27 ;
-  qudt:unit unit:KiloGM ;
+  qudt:hasUnit unit:KiloGM ;
   qudt:value 5.00735588e-27 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mt#mid"^^xsd:anyURI ;
   rdfs:label "Value for triton mass" ;
@@ -5899,7 +5899,7 @@ constant:Value_TritonMassEnergyEquivalent
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000022e-10 ;
-  qudt:unit unit:J ;
+  qudt:hasUnit unit:J ;
   qudt:value 4.50038703e-10 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mtc2#mid"^^xsd:anyURI ;
   rdfs:label "Value for triton mass energy equivalent" ;
@@ -5908,7 +5908,7 @@ constant:Value_TritonMassEnergyEquivalentInMeV
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.000070"^^xsd:double ;
-  qudt:unit unit:MegaEV ;
+  qudt:hasUnit unit:MegaEV ;
   qudt:value "2808.920906"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mtc2mev#mid"^^xsd:anyURI ;
   rdfs:label "Value for triton mass energy equivalent in MeV" ;
@@ -5917,7 +5917,7 @@ constant:Value_TritonMassInAtomicMassUnit
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000000025"^^xsd:double ;
-  qudt:unit unit:U ;
+  qudt:hasUnit unit:U ;
   qudt:value "3.0155007134"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mtu#mid"^^xsd:anyURI ;
   rdfs:label "Triton Mass (amu)" ;
@@ -5926,7 +5926,7 @@ constant:Value_TritonMolarMass
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000000025e-3 ;
-  qudt:unit unit:KiloGM-PER-MOL ;
+  qudt:hasUnit unit:KiloGM-PER-MOL ;
   qudt:value 3.0155007134e-3 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mmt#mid"^^xsd:anyURI ;
   rdfs:label "Value for triton molar mass" ;
@@ -5935,7 +5935,7 @@ constant:Value_TritonNeutronMagneticMomentRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00000037"^^xsd:double ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value "-1.55718553"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mutsmunn#mid"^^xsd:anyURI ;
   rdfs:label "Value for triton-neutron magnetic moment ratio" ;
@@ -5944,7 +5944,7 @@ constant:Value_TritonProtonMagneticMomentRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.000000010"^^xsd:double ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value "1.066639908"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mutsmup#mid"^^xsd:anyURI ;
   rdfs:label "Value for triton-proton magnetic moment ratio" ;
@@ -5953,7 +5953,7 @@ constant:Value_TritonProtonMassRatio
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000000025"^^xsd:double ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value "2.9937170309"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mtsmp#mid"^^xsd:anyURI ;
   rdfs:label "Value for triton-proton mass ratio" ;
@@ -5962,7 +5962,7 @@ constant:Value_UnifiedAtomicMassUnit
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000083e-27 ;
-  qudt:unit unit:KiloGM ;
+  qudt:hasUnit unit:KiloGM ;
   qudt:value 1.660538782e-27 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?tukg#mid"^^xsd:anyURI ;
   rdfs:label "Value for unified atomic mass unit" ;
@@ -5971,7 +5971,7 @@ constant:Value_VonKlitzingConstant
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.000018"^^xsd:double ;
-  qudt:unit unit:OHM ;
+  qudt:hasUnit unit:OHM ;
   qudt:value "25812.807557"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?rk#mid"^^xsd:anyURI ;
   rdfs:label "Value for von Klitzing constant" ;
@@ -5980,7 +5980,7 @@ constant:Value_WeakMixingAngle
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00056"^^xsd:double ;
-  qudt:unit unit:UNITLESS ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:value "0.22255"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?sin2th#mid"^^xsd:anyURI ;
   rdfs:label "Value for weak mixing angle" ;
@@ -5989,7 +5989,7 @@ constant:Value_WienFrequencyDisplacementLawConstant
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000010e10 ;
-  qudt:unit unit:HZ-PER-K ;
+  qudt:hasUnit unit:HZ-PER-K ;
   qudt:value 5.878933e10 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?bpwien#mid"^^xsd:anyURI ;
   rdfs:label "Value for Wien frequency displacement law constant" ;
@@ -5998,7 +5998,7 @@ constant:Value_WienWavelengthDisplacementLawConstant
   a qudt:ConstantValue ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000051e-3 ;
-  qudt:unit unit:M-K ;
+  qudt:hasUnit unit:M-K ;
   qudt:value 2.8977685e-3 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?bwien#mid"^^xsd:anyURI ;
   rdfs:label "Value for Wien wavelength displacement law constant" ;

--- a/vocab/constants/VOCAB_QUDT-CONSTANTS-v2.1.ttl
+++ b/vocab/constants/VOCAB_QUDT-CONSTANTS-v2.1.ttl
@@ -3063,1005 +3063,1005 @@ Physically, the gas constant is the constant of proportionality that happens to 
 .
 constant:ValueForElectronVolt
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:J ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:numericValue 1.602176487e-19 ;
   qudt:standardUncertainty 0.000000040e-19 ;
-  qudt:hasUnit unit:J ;
   qudt:value 1.602176634e-19 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?tevj#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron volt" ;
 .
 constant:Value_AlphaParticleElectronMassRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000031"^^xsd:double ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value "7294.299537"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?malsme#mid"^^xsd:anyURI ;
   rdfs:label "Value for alpha particle-electron mass ratio" ;
 .
 constant:Value_AlphaParticleMass
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:KiloGM ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:relativeStandardUncertainty 5.0e-8 ;
   qudt:standardUncertainty 0.00000033e-27 ;
-  qudt:hasUnit unit:KiloGM ;
   qudt:value 6.64465620e-27 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mal#mid"^^xsd:anyURI ;
   rdfs:label "Value for alpha particle mass" ;
 .
 constant:Value_AlphaParticleMassEnergyEquivalent
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:J ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000030e-10 ;
-  qudt:hasUnit unit:J ;
   qudt:value 5.97191917e-10 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?malc2#mid"^^xsd:anyURI ;
   rdfs:label "Value for alpha particle mass energy equivalent" ;
 .
 constant:Value_AlphaParticleMassEnergyEquivalentInMeV
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:MegaEV ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.000093"^^xsd:double ;
-  qudt:hasUnit unit:MegaEV ;
   qudt:value "3727.379109"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?malc2mev#mid"^^xsd:anyURI ;
   rdfs:label "Value for alpha particle mass energy equivalent in MeV" ;
 .
 constant:Value_AlphaParticleMassInAtomicMassUnit
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:U ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.000000000062"^^xsd:double ;
-  qudt:hasUnit unit:U ;
   qudt:value "4.001506179127"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?malu#mid"^^xsd:anyURI ;
   rdfs:label "Value for alpha particle mass in atomic mass unit" ;
 .
 constant:Value_AlphaParticleMolarMass
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:KiloGM-PER-MOL ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000000062e-3 ;
-  qudt:hasUnit unit:KiloGM-PER-MOL ;
   qudt:value 4.001506179127e-3 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mmal#mid"^^xsd:anyURI ;
   rdfs:label "Value for alpha particle molar mass" ;
 .
 constant:Value_AlphaParticleProtonMassRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00000000041"^^xsd:double ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value "3.97259968951"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?malsmp#mid"^^xsd:anyURI ;
   rdfs:label "Value for alpha particle-proton mass ratio" ;
 .
 constant:Value_AngstromStar
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:M ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000090e-10 ;
-  qudt:hasUnit unit:M ;
   qudt:value 1.00001498e-10 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?angstar#mid"^^xsd:anyURI ;
   rdfs:label "Value for Angstrom star" ;
 .
 constant:Value_AtomicMassConstant
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:KiloGM ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000083e-27 ;
-  qudt:hasUnit unit:KiloGM ;
   qudt:value 1.660538782e-27 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?u#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic mass constant" ;
 .
 constant:Value_AtomicMassConstantEnergyEquivalent
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:J ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000074e-10 ;
-  qudt:hasUnit unit:J ;
   qudt:value 1.492417830e-10 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?tuj#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic mass constant energy equivalent" ;
 .
 constant:Value_AtomicMassConstantEnergyEquivalentInMeV
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:MegaEV ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.000023"^^xsd:double ;
-  qudt:hasUnit unit:MegaEV ;
   qudt:value "931.494028"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?muc2mev#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic mass constant energy equivalent in MeV" ;
 .
 constant:Value_AtomicMassUnitElectronVoltRelationship
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:EV ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000023e6 ;
-  qudt:hasUnit unit:EV ;
   qudt:value 931.494028e6 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?uev#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic mass unit-electron volt relationship" ;
 .
 constant:Value_AtomicMassUnitHartreeRelationship
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:E_h ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000000049e7 ;
-  qudt:hasUnit unit:E_h ;
   qudt:value 3.4231777149e7 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?uhr#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic mass unit-hartree relationship" ;
 .
 constant:Value_AtomicMassUnitHertzRelationship
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:HZ ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000000032e23 ;
-  qudt:hasUnit unit:HZ ;
   qudt:value 2.2523427369e23 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?uhz#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic mass unit-hertz relationship" ;
 .
 constant:Value_AtomicMassUnitInverseMeterRelationship
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:PER-M ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000011e14 ;
-  qudt:hasUnit unit:PER-M ;
   qudt:value 7.513006671e14 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?uminv#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic mass unit-inverse meter relationship" ;
 .
 constant:Value_AtomicMassUnitJouleRelationship
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:J ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000074e-10 ;
-  qudt:hasUnit unit:J ;
   qudt:value 1.492417830e-10 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?uj#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic mass unit-joule relationship" ;
 .
 constant:Value_AtomicMassUnitKelvinRelationship
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:K ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000019e13 ;
-  qudt:hasUnit unit:K ;
   qudt:value 1.0809527e13 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?uk#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic mass unit-kelvin relationship" ;
 .
 constant:Value_AtomicMassUnitKilogramRelationship
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:KiloGM ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000083e-27 ;
-  qudt:hasUnit unit:KiloGM ;
   qudt:value 1.660538782e-27 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?ukg#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic mass unit-kilogram relationship" ;
 .
 constant:Value_AtomicUnitOf1stHyperpolarizability
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:C3-M-PER-J2 ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000081e-53 ;
-  qudt:hasUnit unit:C3-M-PER-J2 ;
   qudt:value 3.206361533e-53 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?auhypol#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic unit of 1st hyperpolarizability" ;
 .
 constant:Value_AtomicUnitOf2ndHyperpolarizability
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:C4-M4-PER-J3 ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000031e-65 ;
-  qudt:hasUnit unit:C4-M4-PER-J3 ;
   qudt:value 6.23538095e-65 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?au2hypol#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic unit of 2nd hyperpolarizability" ;
 .
 constant:Value_AtomicUnitOfAction
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:J-SEC ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000053e-34 ;
-  qudt:hasUnit unit:J-SEC ;
   qudt:value 1.054571628e-34 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?tthbar#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic unit of action" ;
 .
 constant:Value_AtomicUnitOfCharge
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:C ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000040e-19 ;
-  qudt:hasUnit unit:C ;
   qudt:value 1.602176487e-19 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?te#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic unit of charge" ;
 .
 constant:Value_AtomicUnitOfChargeDensity
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:C-PER-M3 ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000027e12 ;
-  qudt:hasUnit unit:C-PER-M3 ;
   qudt:value 1.081202300e12 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?aucd#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic unit of charge density" ;
 .
 constant:Value_AtomicUnitOfCurrent
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:A ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000017e-3 ;
-  qudt:hasUnit unit:A ;
   qudt:value 6.62361763e-3 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?aucur#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic unit of current" ;
 .
 constant:Value_AtomicUnitOfElectricDipoleMoment
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:C-M ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000021e-30 ;
-  qudt:hasUnit unit:C-M ;
   qudt:value 8.47835281e-30 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?auedm#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic unit of electric dipole mom." ;
 .
 constant:Value_AtomicUnitOfElectricField
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:V-PER-M ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000013e11 ;
-  qudt:hasUnit unit:V-PER-M ;
   qudt:value 5.14220632e11 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?auefld#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic unit of electric field" ;
 .
 constant:Value_AtomicUnitOfElectricFieldGradient
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:V-PER-M2 ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000024e21 ;
-  qudt:hasUnit unit:V-PER-M2 ;
   qudt:value 9.71736166e21 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?auefg#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic unit of electric field gradient" ;
 .
 constant:Value_AtomicUnitOfElectricPolarizability
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:C2-M2-PER-J ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000000034e-41 ;
-  qudt:hasUnit unit:C2-M-PER-J ;
   qudt:value 1.6487772536e-41 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?auepol#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic unit of electric polarizability" ;
 .
 constant:Value_AtomicUnitOfElectricPotential
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:V ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00000068"^^xsd:double ;
-  qudt:hasUnit unit:V ;
   qudt:value "27.21138386"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?auep#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic unit of electric potential" ;
 .
 constant:Value_AtomicUnitOfElectricQuadrupoleMoment
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:C-M2 ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000011e-40 ;
-  qudt:hasUnit unit:C-M2 ;
   qudt:value 4.48655107e-40 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?aueqm#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic unit of electric quadrupole moment" ;
 .
 constant:Value_AtomicUnitOfEnergy
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:J ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000022e-18 ;
-  qudt:hasUnit unit:J ;
   qudt:value 4.35974394e-18 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?thr#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic unit of energy" ;
 .
 constant:Value_AtomicUnitOfForce
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:N ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000041e-8 ;
-  qudt:hasUnit unit:N ;
   qudt:value 8.23872206e-8 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?auforce#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic unit of force" ;
 .
 constant:Value_AtomicUnitOfLength
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:M ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000000036e-10 ;
-  qudt:hasUnit unit:M ;
   qudt:value 0.52917720859e-10 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?tbohrrada0#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic unit of length" ;
 .
 constant:Value_AtomicUnitOfMagneticDipoleMoment
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:J-PER-T ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000046e-23 ;
-  qudt:hasUnit unit:J-PER-T ;
   qudt:value 1.854801830e-23 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?aumdm#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic unit of magnetic dipole moment" ;
 .
 constant:Value_AtomicUnitOfMagneticFluxDensity
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:T ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000059e5 ;
-  qudt:hasUnit unit:T ;
   qudt:value 2.350517382e5 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?aumfd#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic unit of magnetic flux density" ;
 .
 constant:Value_AtomicUnitOfMagnetizability
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:J-PER-T2 ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000027e-29 ;
-  qudt:hasUnit unit:J-PER-T2 ;
   qudt:value 7.891036433e-29 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?aumag#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic unit of magnetizability" ;
 .
 constant:Value_AtomicUnitOfMass
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:KiloGM ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000045e-31 ;
-  qudt:hasUnit unit:KiloGM ;
   qudt:value 9.10938215e-31 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?ttme#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic unit of mass" ;
 .
 constant:Value_AtomicUnitOfMomentum
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:KiloGM-M-PER-SEC ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000099e-24 ;
-  qudt:hasUnit unit:KiloGM-M-PER-SEC ;
   qudt:value 1.992851565e-24 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?aumom#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic unit of momentum" ;
 .
 constant:Value_AtomicUnitOfPermittivity
   a qudt:ConstantValue ;
-  qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:hasUnit unit:FARAD-PER-M ;
+  qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:value 1.112650056e-10 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?auperm#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic unit of permittivity" ;
 .
 constant:Value_AtomicUnitOfTime
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:SEC ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000000016e-1 ;
-  qudt:hasUnit unit:SEC ;
   qudt:value 2.418884326505e-17 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?aut#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic unit of time" ;
 .
 constant:Value_AtomicUnitOfVelocity
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:M-PER-SEC ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000000015e6 ;
-  qudt:hasUnit unit:M-PER-SEC ;
   qudt:value 2.1876912541e6 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?auvel#mid"^^xsd:anyURI ;
   rdfs:label "Value for atomic unit of velocity" ;
 .
 constant:Value_AvogadroConstant
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:PER-MOL ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000030e23 ;
-  qudt:hasUnit unit:PER-MOL ;
   qudt:value 6.02214179e23 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?na#mid"^^xsd:anyURI ;
   rdfs:label "Value for Avogadro constant" ;
 .
 constant:Value_BohrMagneton
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:J-PER-T ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000023e-26 ;
-  qudt:hasUnit unit:J-PER-T ;
   qudt:value 927.400915e-26 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mub#mid"^^xsd:anyURI ;
   rdfs:label "Value for Bohr magneton" ;
 .
 constant:Value_BohrMagnetonInEVPerT
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:EV-PER-T ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000000079e-5 ;
-  qudt:hasUnit unit:EV-PER-T ;
   qudt:value 5.7883817555e-5 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mubev#mid"^^xsd:anyURI ;
   rdfs:label "Value for Bohr magneton in eV per T" ;
 .
 constant:Value_BohrMagnetonInHzPerT
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:HZ-PER-T ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000035e9 ;
-  qudt:hasUnit unit:HZ-PER-T ;
   qudt:value 13.99624604e9 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mubshhz#mid"^^xsd:anyURI ;
   rdfs:label "Value for Bohr magneton in Hz perT" ;
 .
 constant:Value_BohrMagnetonInInverseMetersPerTesla
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:PER-T-M ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000012"^^xsd:double ;
-  qudt:hasUnit unit:PER-T-M ;
   qudt:value "46.6864515"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mubshcminv#mid"^^xsd:anyURI ;
   rdfs:label "Value for Bohr magneton in inverse meters per tesla" ;
 .
 constant:Value_BohrMagnetonInKPerT
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:K-PER-T ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000012"^^xsd:double ;
-  qudt:hasUnit unit:K-PER-T ;
   qudt:value "0.6717131"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mubskk#mid"^^xsd:anyURI ;
   rdfs:label "Value for Bohr magneton in K per T" ;
 .
 constant:Value_BohrRadius
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:M ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000000036e-10 ;
-  qudt:hasUnit unit:M ;
   qudt:value 0.52917720859e-10 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?bohrrada0#mid"^^xsd:anyURI ;
   rdfs:label "Value for Bohr radius" ;
 .
 constant:Value_BoltzmannConstant
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:J-PER-K ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000024e-23 ;
-  qudt:hasUnit unit:J-PER-K ;
   qudt:value 1.3806504e-23 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?k#mid"^^xsd:anyURI ;
   rdfs:label "Value for Boltzmann constant" ;
 .
 constant:Value_BoltzmannConstantInEVPerK
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:EV-PER-K ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000015e-5 ;
-  qudt:hasUnit unit:EV-PER-K ;
   qudt:value 8.617343e-5 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?tkev#mid"^^xsd:anyURI ;
   rdfs:label "Value for Boltzmann constant in eV per K" ;
 .
 constant:Value_BoltzmannConstantInHzPerK
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:HZ-PER-K ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000036e10 ;
-  qudt:hasUnit unit:HZ-PER-K ;
   qudt:value 2.0836644e10 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?kshhz#mid"^^xsd:anyURI ;
   rdfs:label "Value for Boltzmann constant in Hz per K" ;
 .
 constant:Value_BoltzmannConstantInInverseMetersPerKelvin
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:PER-M-K ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00012"^^xsd:double ;
-  qudt:hasUnit unit:PER-M-K ;
   qudt:value "69.50356"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?kshcminv#mid"^^xsd:anyURI ;
   rdfs:label "Value for Boltzmann constant in inverse meters per kelvin" ;
 .
 constant:Value_CharacteristicImpedanceOfVacuum
   a qudt:ConstantValue ;
-  qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:hasUnit unit:OHM ;
+  qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:value "376.730313461"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?z0#mid"^^xsd:anyURI ;
   rdfs:label "Value for characteristic impedance of vacuum" ;
 .
 constant:Value_ClassicalElectronRadius
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:M ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000000058e-15 ;
-  qudt:hasUnit unit:M ;
   qudt:value 2.8179402894e-15 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?re#mid"^^xsd:anyURI ;
   rdfs:label "Value for classical electron radius" ;
 .
 constant:Value_ComptonWavelength
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:M ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000000033e-12 ;
-  qudt:hasUnit unit:M ;
   qudt:value 2.4263102175e-12 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?ecomwl#mid"^^xsd:anyURI ;
   rdfs:label "Value for Compton wavelength" ;
 .
 constant:Value_ComptonWavelengthOver2Pi
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:M ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000053e-15 ;
-  qudt:hasUnit unit:M ;
   qudt:value 386.15926459e-15 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?ecomwlbar#mid"^^xsd:anyURI ;
   rdfs:label "Value for Compton wavelength over 2 pi" ;
 .
 constant:Value_ConductanceQuantum
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:S ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000000053e-5 ;
-  qudt:hasUnit unit:S ;
   qudt:value 7.7480917004e-5 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?conqu2e2sh#mid"^^xsd:anyURI ;
   rdfs:label "Value for conductance quantum" ;
 .
 constant:Value_ConventionalValueOfJosephsonConstant
   a qudt:ConstantValue ;
-  qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:hasUnit unit:HZ-PER-V ;
+  qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:value 483597.9e9 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?kj90#mid"^^xsd:anyURI ;
   rdfs:label "Value for conventional value of Josephson constant" ;
 .
 constant:Value_ConventionalValueOfVonKlitzingConstant
   a qudt:ConstantValue ;
-  qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:hasUnit unit:OHM ;
+  qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:value "25812.807"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?rk90#mid"^^xsd:anyURI ;
   rdfs:label "Value for conventional value of von Klitzing constant" ;
 .
 constant:Value_CuXUnit
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:M ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000028e-13 ;
-  qudt:hasUnit unit:M ;
   qudt:value 1.00207699e-13 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?xucukalph1#mid"^^xsd:anyURI ;
   rdfs:label "Value for Cu x unit" ;
 .
 constant:Value_DeuteronElectronMagneticMomentRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000039e-4 ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value -4.664345537e-4 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mudsmuem#mid"^^xsd:anyURI ;
   rdfs:label "Value for deuteron-electron magnetic moment ratio" ;
 .
 constant:Value_DeuteronElectronMassRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000016"^^xsd:double ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value "3670.4829654"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mdsme#mid"^^xsd:anyURI ;
   rdfs:label "Value for deuteron-electron mass ratio" ;
 .
 constant:Value_DeuteronGFactor
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000000072"^^xsd:double ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value "0.8574382308"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?gdn#mid"^^xsd:anyURI ;
   rdfs:label "Value for deuteron g factor" ;
 .
 constant:Value_DeuteronMagneticMoment
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:J-PER-T ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000011e-26 ;
-  qudt:hasUnit unit:J-PER-T ;
   qudt:value 0.433073465e-26 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mud#mid"^^xsd:anyURI ;
   rdfs:label "Value for deuteron magnetic moment" ;
 .
 constant:Value_DeuteronMagneticMomentToBohrMagnetonRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000000039e-3 ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value 0.4669754556e-3 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mudsmub#mid"^^xsd:anyURI ;
   rdfs:label "Value for deuteron magnetic moment to Bohr magneton ratio" ;
 .
 constant:Value_DeuteronMagneticMomentToNuclearMagnetonRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000000072"^^xsd:double ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value "0.8574382308"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mudsmun#mid"^^xsd:anyURI ;
   rdfs:label "Value for deuteron magnetic moment to nuclear magneton ratio" ;
 .
 constant:Value_DeuteronMass
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:KiloGM ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000017e-27 ;
-  qudt:hasUnit unit:KiloGM ;
   qudt:value 3.34358320e-27 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?md#mid"^^xsd:anyURI ;
   rdfs:label "Value for deuteron mass" ;
 .
 constant:Value_DeuteronMassEnergyEquivalent
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:J ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000015e-10 ;
-  qudt:hasUnit unit:J ;
   qudt:value 3.00506272e-10 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mdc2#mid"^^xsd:anyURI ;
   rdfs:label "Value for deuteron mass energy equivalent" ;
 .
 constant:Value_DeuteronMassEnergyEquivalentInMeV
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:MegaEV ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.000047"^^xsd:double ;
-  qudt:hasUnit unit:MegaEV ;
   qudt:value "1875.612793"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mdc2mev#mid"^^xsd:anyURI ;
   rdfs:label "Value for deuteron mass energy equivalent in MeV" ;
 .
 constant:Value_DeuteronMassInAtomicMassUnit
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:U ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.000000000078"^^xsd:double ;
-  qudt:hasUnit unit:U ;
   qudt:value "2.013553212724"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mdu#mid"^^xsd:anyURI ;
   rdfs:label "Deuteron Mass (amu)" ;
 .
 constant:Value_DeuteronMolarMass
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:KiloGM-PER-MOL ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000000078e-3 ;
-  qudt:hasUnit unit:KiloGM-PER-MOL ;
   qudt:value 2.013553212724e-3 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mmd#mid"^^xsd:anyURI ;
   rdfs:label "Value for deuteron molar mass" ;
 .
 constant:Value_DeuteronNeutronMagneticMomentRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00000011"^^xsd:double ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value "-0.44820652"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mudsmunn#mid"^^xsd:anyURI ;
   rdfs:label "Value for deuteron-neutron magnetic moment ratio" ;
 .
 constant:Value_DeuteronProtonMagneticMomentRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000000024"^^xsd:double ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value "0.3070122070"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mudsmup#mid"^^xsd:anyURI ;
   rdfs:label "Value for deuteron-proton magnetic moment ratio" ;
 .
 constant:Value_DeuteronProtonMassRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00000000022"^^xsd:double ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value "1.99900750108"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mdsmp#mid"^^xsd:anyURI ;
   rdfs:label "Value for deuteron-proton mass ratio" ;
 .
 constant:Value_DeuteronRmsChargeRadius
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:M ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0028e-15 ;
-  qudt:hasUnit unit:M ;
   qudt:value 2.1402e-15 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?rd#mid"^^xsd:anyURI ;
   rdfs:label "Value for deuteron rms charge radius" ;
 .
 constant:Value_ElectricConstant
   a qudt:ConstantValue ;
-  qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:hasUnit unit:FARAD-PER-M ;
+  qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:value 8.854187817e-12 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?ep0#mid"^^xsd:anyURI ;
   rdfs:label "Value for electric constant" ;
 .
 constant:Value_ElectronChargeToMassQuotient
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:C-PER-KiloGM ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000044e11 ;
-  qudt:hasUnit unit:C-PER-KiloGM ;
   qudt:value -1.758820150e11 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?esme#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron charge to mass quotient" ;
 .
 constant:Value_ElectronDeuteronMagneticMomentRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.000018"^^xsd:double ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value "-2143.923498"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?muemsmud#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron-deuteron magnetic moment ratio" ;
 .
 constant:Value_ElectronDeuteronMassRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000000012e-4 ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value 2.7244371093e-4 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mesmd#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron-deuteron mass ratio" ;
 .
 constant:Value_ElectronGFactor
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000000000015"^^xsd:double ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value "-2.0023193043622"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?gem#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron g factor" ;
 .
 constant:Value_ElectronGyromagneticRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:PER-T-SEC ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000044e11 ;
-  qudt:hasUnit unit:PER-T-SEC ;
   qudt:value 1.760859770e11 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?gammae#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron gyromagnetic ratio" ;
 .
 constant:Value_ElectronGyromagneticRatioOver2Pi
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:MegaHZ-PER-T ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00070"^^xsd:double ;
-  qudt:hasUnit unit:MegaHZ-PER-T ;
   qudt:value "28024.95364"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?gammaebar#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron gyromagnetic ratio over 2 pi" ;
 .
 constant:Value_ElectronMagneticMoment
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:J-PER-T ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000023e-26 ;
-  qudt:hasUnit unit:J-PER-T ;
   qudt:value -928.476377e-26 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?muem#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron magnetic moment" ;
 .
 constant:Value_ElectronMagneticMomentAnomaly
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000000074e-3 ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value 1.15965218111e-3 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?ae#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron magnetic moment anomaly" ;
 .
 constant:Value_ElectronMagneticMomentToBohrMagnetonRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00000000000074"^^xsd:double ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value "-1.00115965218111"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?muemsmub#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron magnetic moment to Bohr magneton ratio" ;
 .
 constant:Value_ElectronMagneticMomentToNuclearMagnetonRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00000080"^^xsd:double ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value "-1838.28197092"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?muemsmun#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron magnetic moment to nuclear magneton ratio" ;
 .
 constant:Value_ElectronMass
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:KiloGM ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000045e-31 ;
-  qudt:hasUnit unit:KiloGM ;
   qudt:value 9.10938215e-31 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?me#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron mass" ;
 .
 constant:Value_ElectronMassEnergyEquivalent
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:J ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000041e-14 ;
-  qudt:hasUnit unit:J ;
   qudt:value 8.18710438e-14 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mec2#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron mass energy equivalent" ;
 .
 constant:Value_ElectronMassEnergyEquivalentInMeV
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:MegaEV ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.000000013"^^xsd:double ;
-  qudt:hasUnit unit:MegaEV ;
   qudt:value "0.510998910"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mec2mev#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron mass energy equivalent in MeV" ;
 .
 constant:Value_ElectronMassInAtomicMassUnit
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:U ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000000023e-4 ;
-  qudt:hasUnit unit:U ;
   qudt:value 5.4857990943e-4 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?meu#mid"^^xsd:anyURI ;
   rdfs:label "Electron Mass (amu)" ;
 .
 constant:Value_ElectronMolarMass
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:KiloGM-PER-MOL ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000000023e-7 ;
-  qudt:hasUnit unit:KiloGM-PER-MOL ;
   qudt:value 5.4857990943e-7 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mme#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron molar mass" ;
 .
 constant:Value_ElectronMuonMagneticMomentRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000052"^^xsd:double ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value "206.7669877"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?muemsmumum#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron-muon magnetic moment ratio" ;
 .
 constant:Value_ElectronMuonMassRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000012e-3 ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value 4.83633171e-3 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mesmmu#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron-muon mass ratio" ;
 .
 constant:Value_ElectronNeutronMagneticMomentRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00023"^^xsd:double ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value "960.92050"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?muemsmunn#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron-neutron magnetic moment ratio" ;
 .
 constant:Value_ElectronNeutronMassRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000000033e-4 ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value 5.4386734459e-4 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mesmn#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron-neutron mass ratio" ;
 .
 constant:Value_ElectronProtonMagneticMomentRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000054"^^xsd:double ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value "-658.2106848"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?muemsmup#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron-proton magnetic moment ratio" ;
 .
 constant:Value_ElectronProtonMassRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000000024e-4 ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value 5.4461702177e-4 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mesmp#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron-proton mass ratio" ;
 .
 constant:Value_ElectronTauMassRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00047e-4 ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value 2.87564e-4 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mesmtau#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron-tau mass ratio" ;
 .
 constant:Value_ElectronToAlphaParticleMassRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000000058e-4 ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value 1.37093355570e-4 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mesmalpha#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron to alpha particle mass ratio" ;
 .
 constant:Value_ElectronToShieldedHelionMagneticMomentRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.000010"^^xsd:double ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value "864.058257"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?muemsmuhp#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron to shielded helion magnetic moment ratio" ;
 .
 constant:Value_ElectronToShieldedProtonMagneticMomentRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000072"^^xsd:double ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value "-658.2275971"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?muemsmupp#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron to shielded proton magnetic moment ratio" ;
 .
 constant:Value_ElectronVoltAtomicMassUnitRelationship
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:U ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000027e-9 ;
-  qudt:hasUnit unit:U ;
   qudt:value 1.073544188e-9 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?evu#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron volt-atomic mass unit relationship" ;
 .
 constant:Value_ElectronVoltHartreeRelationship
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:E_h ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000092e-2 ;
-  qudt:hasUnit unit:E_h ;
   qudt:value 3.674932540e-2 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?evhr#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron volt-hartree relationship" ;
 .
 constant:Value_ElectronVoltHertzRelationship
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:HZ ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000060e14 ;
-  qudt:hasUnit unit:HZ ;
   qudt:value 2.417989454e14 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?evhz#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron volt-hertz relationship" ;
 .
 constant:Value_ElectronVoltInverseMeterRelationship
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:PER-M ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000020e5 ;
-  qudt:hasUnit unit:PER-M ;
   qudt:value 8.06554465e5 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?evminv#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron volt-inverse meter relationship" ;
 .
 constant:Value_ElectronVoltJouleRelationship
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:J ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000040e-19 ;
-  qudt:hasUnit unit:J ;
   qudt:value 1.602176487e-19 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?evj#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron volt-joule relationship" ;
 .
 constant:Value_ElectronVoltKelvinRelationship
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:K ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000020e4 ;
-  qudt:hasUnit unit:K ;
   qudt:value 1.1604505e4 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?evk#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron volt-kelvin relationship" ;
 .
 constant:Value_ElectronVoltKilogramRelationship
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:KiloGM ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000044e-36 ;
-  qudt:hasUnit unit:KiloGM ;
   qudt:value 1.782661758e-36 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?evkg#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron volt-kilogram relationship" ;
 .
 constant:Value_ElementaryCharge
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:C ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000040e-19 ;
-  qudt:hasUnit unit:C ;
   qudt:value 1.602176487e-19 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?e#mid"^^xsd:anyURI ;
   rdfs:label "Value for elementary charge" ;
 .
 constant:Value_ElementaryChargeOverH
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:A-PER-J ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000060e14 ;
-  qudt:hasUnit unit:A-PER-J ;
   qudt:value 2.417989454e14 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?esh#mid"^^xsd:anyURI ;
   rdfs:label "Value for elementary charge over h" ;
 .
 constant:Value_FaradayConstant
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:C-PER-MOL ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0024"^^xsd:double ;
-  qudt:hasUnit unit:C-PER-MOL ;
   qudt:value "96485.3399"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?f#mid"^^xsd:anyURI ;
   rdfs:label "Value for Faraday constant" ;
@@ -4075,630 +4075,630 @@ constant:Value_FaradayConstantForConventionalElectricCurrent
 .
 constant:Value_FermiCouplingConstant
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:PER-GigaEV2 ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00001e-5 ;
-  qudt:hasUnit unit:PER-GigaEV2 ;
   qudt:value 1.16637e-5 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?gf#mid"^^xsd:anyURI ;
   rdfs:label "Value for Fermi coupling constant" ;
 .
 constant:Value_FineStructureConstant
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000000050e-3 ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value 7.2973525376e-3 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?alph#mid"^^xsd:anyURI ;
   rdfs:label "Value for fine-structure constant" ;
 .
 constant:Value_FirstRadiationConstant
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:W-M2 ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000019e-16 ;
-  qudt:hasUnit unit:W-M2 ;
   qudt:value 3.74177118e-16 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?c11strc#mid"^^xsd:anyURI ;
   rdfs:label "Value for first radiation constant" ;
 .
 constant:Value_FirstRadiationConstantForSpectralRadiance
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:W-M2-PER-SR ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000059e-16 ;
-  qudt:hasUnit unit:W-M2-PER-SR ;
   qudt:value 1.191042759e-16 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?c1l#mid"^^xsd:anyURI ;
   rdfs:label "Value for first radiation constant for spectral radiance" ;
 .
 constant:Value_GravitationalConstant
   a qudt:ConstantValue ;
-  qudt:informativeReference "https://en.wikipedia.org/wiki/Gravitational_constant"^^xsd:anyURI ;
   qudt:hasUnit unit:N-M2-PER-KiloGM2 ;
+  qudt:informativeReference "https://en.wikipedia.org/wiki/Gravitational_constant"^^xsd:anyURI ;
   qudt:value 6.674e-11 ;
   rdfs:label "Value for gravitational constant" ;
 .
 constant:Value_HartreeAtomicMassUnitRelationship
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:U ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000000042e-8 ;
-  qudt:hasUnit unit:U ;
   qudt:value 2.9212622986e-8 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?hru#mid"^^xsd:anyURI ;
   rdfs:label "Value for hartree-atomic mass unit relationship" ;
 .
 constant:Value_HartreeElectronVoltRelationship
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:EV ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00000068"^^xsd:double ;
-  qudt:hasUnit unit:EV ;
   qudt:value "27.21138386"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?hrev#mid"^^xsd:anyURI ;
   rdfs:label "Value for hartree-electron volt relationship" ;
 .
 constant:Value_HartreeEnergy
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:J ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000022e-18 ;
-  qudt:hasUnit unit:J ;
   qudt:value 4.35974394e-18 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?hr#mid"^^xsd:anyURI ;
   rdfs:label "Value for Hartree energy" ;
 .
 constant:Value_HartreeEnergyInEV
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:EV ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00000068"^^xsd:double ;
-  qudt:hasUnit unit:EV ;
   qudt:value "27.21138386"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?threv#mid"^^xsd:anyURI ;
   rdfs:label "Value for Hartree energy in eV" ;
 .
 constant:Value_HartreeHertzRelationship
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:HZ ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000000044e15 ;
-  qudt:hasUnit unit:HZ ;
   qudt:value 6.579683920722e15 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?hrhz#mid"^^xsd:anyURI ;
   rdfs:label "Value for hartree-hertz relationship" ;
 .
 constant:Value_HartreeInverseMeterRelationship
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:PER-M ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000000015e7 ;
-  qudt:hasUnit unit:PER-M ;
   qudt:value 2.194746313705e7 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?hrminv#mid"^^xsd:anyURI ;
   rdfs:label "Value for hartree-inverse meter relationship" ;
 .
 constant:Value_HartreeJouleRelationship
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:J ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000022e-18 ;
-  qudt:hasUnit unit:J ;
   qudt:value 4.35974394e-18 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?hrj#mid"^^xsd:anyURI ;
   rdfs:label "Value for hartree-joule relationship" ;
 .
 constant:Value_HartreeKelvinRelationship
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:K ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000055e5 ;
-  qudt:hasUnit unit:K ;
   qudt:value 3.1577465e5 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?hrk#mid"^^xsd:anyURI ;
   rdfs:label "Value for hartree-kelvin relationship" ;
 .
 constant:Value_HartreeKilogramRelationship
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:KiloGM ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000024e-35 ;
-  qudt:hasUnit unit:KiloGM ;
   qudt:value 4.85086934e-35 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?hrkg#mid"^^xsd:anyURI ;
   rdfs:label "Value for hartree-kilogram relationship" ;
 .
 constant:Value_HelionElectronMassRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000052"^^xsd:double ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value "5495.8852765"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mhsme#mid"^^xsd:anyURI ;
   rdfs:label "Value for helion-electron mass ratio" ;
 .
 constant:Value_HelionMass
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:KiloGM ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000025e-27 ;
-  qudt:hasUnit unit:KiloGM ;
   qudt:value 5.00641192e-27 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mh#mid"^^xsd:anyURI ;
   rdfs:label "Value for helion mass" ;
 .
 constant:Value_HelionMassEnergyEquivalent
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:J ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000022e-10 ;
-  qudt:hasUnit unit:J ;
   qudt:value 4.49953864e-10 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mhc2#mid"^^xsd:anyURI ;
   rdfs:label "Value for helion mass energy equivalent" ;
 .
 constant:Value_HelionMassEnergyEquivalentInMeV
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:MegaEV ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.000070"^^xsd:double ;
-  qudt:hasUnit unit:MegaEV ;
   qudt:value "2808.391383"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mhc2mev#mid"^^xsd:anyURI ;
   rdfs:label "Value for helion mass energy equivalent in MeV" ;
 .
 constant:Value_HelionMassInAtomicMassUnit
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:U ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000000026"^^xsd:double ;
-  qudt:hasUnit unit:U ;
   qudt:value "3.0149322473"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mhu#mid"^^xsd:anyURI ;
   rdfs:label "Helion Mass (amu)" ;
 .
 constant:Value_HelionMolarMass
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:KiloGM-PER-MOL ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000000026e-3 ;
-  qudt:hasUnit unit:KiloGM-PER-MOL ;
   qudt:value 3.0149322473e-3 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mmh#mid"^^xsd:anyURI ;
   rdfs:label "Value for helion molar mass" ;
 .
 constant:Value_HelionProtonMassRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000000026"^^xsd:double ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value "2.9931526713"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mhsmp#mid"^^xsd:anyURI ;
   rdfs:label "Value for helion-proton mass ratio" ;
 .
 constant:Value_HertzAtomicMassUnitRelationship
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:U ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000000064e-24 ;
-  qudt:hasUnit unit:U ;
   qudt:value 4.4398216294e-24 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?hzu#mid"^^xsd:anyURI ;
   rdfs:label "Value for hertz-atomic mass unit relationship" ;
 .
 constant:Value_HertzElectronVoltRelationship
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:EV ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000010e-15 ;
-  qudt:hasUnit unit:EV ;
   qudt:value 4.13566733e-15 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?hzev#mid"^^xsd:anyURI ;
   rdfs:label "Value for hertz-electron volt relationship" ;
 .
 constant:Value_HertzHartreeRelationship
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:E_h ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000000010e-1 ;
-  qudt:hasUnit unit:E_h ;
   qudt:value 1.519829846006e-16 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?hzhr#mid"^^xsd:anyURI ;
   rdfs:label "Value for hertz-hartree relationship" ;
 .
 constant:Value_HertzInverseMeterRelationship
   a qudt:ConstantValue ;
-  qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:hasUnit unit:PER-M ;
+  qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:value 3.335640951e-9 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?hzminv#mid"^^xsd:anyURI ;
   rdfs:label "Value for hertz-inverse meter relationship" ;
 .
 constant:Value_HertzJouleRelationship
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:J ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000033e-34 ;
-  qudt:hasUnit unit:J ;
   qudt:value 6.62606896e-34 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?hzj#mid"^^xsd:anyURI ;
   rdfs:label "Value for hertz-joule relationship" ;
 .
 constant:Value_HertzKelvinRelationship
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:K ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000084e-11 ;
-  qudt:hasUnit unit:K ;
   qudt:value 4.7992374e-11 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?hzk#mid"^^xsd:anyURI ;
   rdfs:label "Value for hertz-kelvin relationship" ;
 .
 constant:Value_HertzKilogramRelationship
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:KiloGM ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000037e-51 ;
-  qudt:hasUnit unit:KiloGM ;
   qudt:value 7.37249600e-51 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?hzkg#mid"^^xsd:anyURI ;
   rdfs:label "Value for hertz-kilogram relationship" ;
 .
 constant:Value_InverseFineStructureConstant
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.000000094"^^xsd:double ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value "137.035999679"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?alphinv#mid"^^xsd:anyURI ;
   rdfs:label "Value for inverse fine-structure constant" ;
 .
 constant:Value_InverseMeterAtomicMassUnitRelationship
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:U ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000000019e-15 ;
-  qudt:hasUnit unit:U ;
   qudt:value 1.3310250394e-15 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?minvu#mid"^^xsd:anyURI ;
   rdfs:label "Value for inverse meter-atomic mass unit relationship" ;
 .
 constant:Value_InverseMeterElectronVoltRelationship
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:EV ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000031e-6 ;
-  qudt:hasUnit unit:EV ;
   qudt:value 1.239841875e-6 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?minvev#mid"^^xsd:anyURI ;
   rdfs:label "Value for inverse meter-electron volt relationship" ;
 .
 constant:Value_InverseMeterHartreeRelationship
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:E_h ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000000030e-8 ;
-  qudt:hasUnit unit:E_h ;
   qudt:value 4.556335252760e-8 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?minvhr#mid"^^xsd:anyURI ;
   rdfs:label "Value for inverse meter-hartree relationship" ;
 .
 constant:Value_InverseMeterHertzRelationship
   a qudt:ConstantValue ;
-  qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:hasUnit unit:HZ ;
+  qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:value "299792458"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?minvhz#mid"^^xsd:anyURI ;
   rdfs:label "Value for inverse meter-hertz relationship" ;
 .
 constant:Value_InverseMeterJouleRelationship
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:J ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000099e-25 ;
-  qudt:hasUnit unit:J ;
   qudt:value 1.986445501e-25 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?minvj#mid"^^xsd:anyURI ;
   rdfs:label "Value for inverse meter-joule relationship" ;
 .
 constant:Value_InverseMeterKelvinRelationship
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:K ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000025e-2 ;
-  qudt:hasUnit unit:K ;
   qudt:value 1.4387752e-2 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?minvk#mid"^^xsd:anyURI ;
   rdfs:label "Value for inverse meter-kelvin relationship" ;
 .
 constant:Value_InverseMeterKilogramRelationship
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:KiloGM ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000011e-42 ;
-  qudt:hasUnit unit:KiloGM ;
   qudt:value 2.21021870e-42 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?minvkg#mid"^^xsd:anyURI ;
   rdfs:label "Value for inverse meter-kilogram relationship" ;
 .
 constant:Value_InverseOfConductanceQuantum
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:OHM ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000088"^^xsd:double ;
-  qudt:hasUnit unit:OHM ;
   qudt:value "12906.4037787"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?invconqu#mid"^^xsd:anyURI ;
   rdfs:label "Value for inverse of conductance quantum" ;
 .
 constant:Value_JosephsonConstant
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:HZ-PER-V ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.012e9 ;
-  qudt:hasUnit unit:HZ-PER-V ;
   qudt:value 483597.891e9 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?kjos#mid"^^xsd:anyURI ;
   rdfs:label "Value for Josephson constant" ;
 .
 constant:Value_JouleAtomicMassUnitRelationship
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:U ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000033e9 ;
-  qudt:hasUnit unit:U ;
   qudt:value 6.70053641e9 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?ju#mid"^^xsd:anyURI ;
   rdfs:label "Value for joule-atomic mass unit relationship" ;
 .
 constant:Value_JouleElectronVoltRelationship
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:EV ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000016e18 ;
-  qudt:hasUnit unit:EV ;
   qudt:value 6.24150965e18 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?jev#mid"^^xsd:anyURI ;
   rdfs:label "Value for joule-electron volt relationship" ;
 .
 constant:Value_JouleHartreeRelationship
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:E_h ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000011e17 ;
-  qudt:hasUnit unit:E_h ;
   qudt:value 2.29371269e17 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?jhr#mid"^^xsd:anyURI ;
   rdfs:label "Value for joule-hartree relationship" ;
 .
 constant:Value_JouleHertzRelationship
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:HZ ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000075e33 ;
-  qudt:hasUnit unit:HZ ;
   qudt:value 1.509190450e33 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?jhz#mid"^^xsd:anyURI ;
   rdfs:label "Value for joule-hertz relationship" ;
 .
 constant:Value_JouleInverseMeterRelationship
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:PER-M ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000025e24 ;
-  qudt:hasUnit unit:PER-M ;
   qudt:value 5.03411747e24 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?jminv#mid"^^xsd:anyURI ;
   rdfs:label "Value for joule-inverse meter relationship" ;
 .
 constant:Value_JouleKelvinRelationship
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:K ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000013e22 ;
-  qudt:hasUnit unit:K ;
   qudt:value 7.242963e22 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?jk#mid"^^xsd:anyURI ;
   rdfs:label "Value for joule-kelvin relationship" ;
 .
 constant:Value_JouleKilogramRelationship
   a qudt:ConstantValue ;
-  qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:hasUnit unit:KiloGM ;
+  qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:value 1.112650056e-17 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?jkg#mid"^^xsd:anyURI ;
   rdfs:label "Value for joule-kilogram relationship" ;
 .
 constant:Value_KelvinAtomicMassUnitRelationship
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:U ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000016e-14 ;
-  qudt:hasUnit unit:U ;
   qudt:value 9.251098e-14 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?ku#mid"^^xsd:anyURI ;
   rdfs:label "Value for kelvin-atomic mass unit relationship" ;
 .
 constant:Value_KelvinElectronVoltRelationship
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:EV ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000015e-5 ;
-  qudt:hasUnit unit:EV ;
   qudt:value 8.617343e-5 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?kev#mid"^^xsd:anyURI ;
   rdfs:label "Value for kelvin-electron volt relationship" ;
 .
 constant:Value_KelvinHartreeRelationship
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:E_h ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000055e-6 ;
-  qudt:hasUnit unit:E_h ;
   qudt:value 3.1668153e-6 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?khr#mid"^^xsd:anyURI ;
   rdfs:label "Value for kelvin-hartree relationship" ;
 .
 constant:Value_KelvinHertzRelationship
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:HZ ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000036e10 ;
-  qudt:hasUnit unit:HZ ;
   qudt:value 2.0836644e10 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?khz#mid"^^xsd:anyURI ;
   rdfs:label "Value for kelvin-hertz relationship" ;
 .
 constant:Value_KelvinInverseMeterRelationship
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:PER-M ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00012"^^xsd:double ;
-  qudt:hasUnit unit:PER-M ;
   qudt:value "69.50356"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?kminv#mid"^^xsd:anyURI ;
   rdfs:label "Value for kelvin-inverse meter relationship" ;
 .
 constant:Value_KelvinJouleRelationship
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:J ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000024e-23 ;
-  qudt:hasUnit unit:J ;
   qudt:value 1.3806504e-23 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?kj#mid"^^xsd:anyURI ;
   rdfs:label "Value for kelvin-joule relationship" ;
 .
 constant:Value_KelvinKilogramRelationship
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:KiloGM ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000027e-40 ;
-  qudt:hasUnit unit:KiloGM ;
   qudt:value 1.5361807e-40 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?kkg#mid"^^xsd:anyURI ;
   rdfs:label "Value for kelvin-kilogram relationship" ;
 .
 constant:Value_KilogramAtomicMassUnitRelationship
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:U ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000030e26 ;
-  qudt:hasUnit unit:U ;
   qudt:value 6.02214179e26 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?kgu#mid"^^xsd:anyURI ;
   rdfs:label "Value for kilogram-atomic mass unit relationship" ;
 .
 constant:Value_KilogramElectronVoltRelationship
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:EV ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000014e35 ;
-  qudt:hasUnit unit:EV ;
   qudt:value 5.60958912e35 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?kgev#mid"^^xsd:anyURI ;
   rdfs:label "Value for kilogram-electron volt relationship" ;
 .
 constant:Value_KilogramHartreeRelationship
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:E_h ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000010e34 ;
-  qudt:hasUnit unit:E_h ;
   qudt:value 2.06148616e34 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?kghr#mid"^^xsd:anyURI ;
   rdfs:label "Value for kilogram-hartree relationship" ;
 .
 constant:Value_KilogramHertzRelationship
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:HZ ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000068e50 ;
-  qudt:hasUnit unit:HZ ;
   qudt:value 1.356392733e50 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?kghz#mid"^^xsd:anyURI ;
   rdfs:label "Value for kilogram-hertz relationship" ;
 .
 constant:Value_KilogramInverseMeterRelationship
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:PER-M ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000023e41 ;
-  qudt:hasUnit unit:PER-M ;
   qudt:value 4.52443915e41 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?kgminv#mid"^^xsd:anyURI ;
   rdfs:label "Value for kilogram-inverse meter relationship" ;
 .
 constant:Value_KilogramJouleRelationship
   a qudt:ConstantValue ;
-  qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:hasUnit unit:J ;
+  qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:value 8.987551787e16 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?kgj#mid"^^xsd:anyURI ;
   rdfs:label "Value for kilogram-joule relationship" ;
 .
 constant:Value_KilogramKelvinRelationship
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:K ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000011e39 ;
-  qudt:hasUnit unit:K ;
   qudt:value 6.509651e39 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?kgk#mid"^^xsd:anyURI ;
   rdfs:label "Value for kilogram-kelvin relationship" ;
 .
 constant:Value_LatticeParameterOfSilicon
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:M ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000014e-12 ;
-  qudt:hasUnit unit:M ;
   qudt:value 543.102064e-12 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?asil#mid"^^xsd:anyURI ;
   rdfs:label "Value for lattice parameter of silicon" ;
 .
 constant:Value_LatticeSpacingOfSilicon
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:M ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000050e-12 ;
-  qudt:hasUnit unit:M ;
   qudt:value 192.0155762e-12 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?d220sil#mid"^^xsd:anyURI ;
   rdfs:label "Value for lattice spacing of silicon" ;
 .
 constant:Value_LoschmidtConstant
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:PER-M3 ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000047e25 ;
-  qudt:hasUnit unit:PER-M3 ;
   qudt:value 2.6867774e25 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?n0#mid"^^xsd:anyURI ;
   rdfs:label "Value for Loschmidt constant 273.15 K 101.325 kPa" ;
 .
 constant:Value_MagneticConstant
   a qudt:ConstantValue ;
-  qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:hasUnit unit:FARAD-PER-M ;
+  qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:value 12.566370614e-7 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mu0#mid"^^xsd:anyURI ;
   rdfs:label "Value for magnetic constant" ;
 .
 constant:Value_MagneticFluxQuantum
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:WB ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000052e-15 ;
-  qudt:hasUnit unit:WB ;
   qudt:value 2.067833667e-15 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?flxquhs2e#mid"^^xsd:anyURI ;
   rdfs:label "Value for magnetic flux quantum" ;
 .
 constant:Value_MoXUnit
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:M ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000053e-13 ;
-  qudt:hasUnit unit:M ;
   qudt:value 1.00209955e-13 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?xumokalph1#mid"^^xsd:anyURI ;
   rdfs:label "Value for Mo x unit" ;
 .
 constant:Value_MolarGasConstant
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:J-PER-MOL-K ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.000015"^^xsd:double ;
-  qudt:hasUnit unit:J-PER-MOL-K ;
   qudt:value "8.31446261815324"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?r#mid"^^xsd:anyURI ;
   rdfs:label "Value for molar gas constant" ;
 .
 constant:Value_MolarMassConstant
   a qudt:ConstantValue ;
-  qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:hasUnit unit:KiloGM-PER-MOL ;
+  qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:value 1e-3 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mu#mid"^^xsd:anyURI ;
   rdfs:label "Value for molar mass constant" ;
 .
 constant:Value_MolarMassOfCarbon12
   a qudt:ConstantValue ;
-  qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:hasUnit unit:KiloGM-PER-MOL ;
+  qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:value 12e-3 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mm12c#mid"^^xsd:anyURI ;
   rdfs:label "Value for molar mass of carbon-12" ;
 .
 constant:Value_MolarPlanckConstant
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:J-SEC-PER-MOL ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000000057e-10 ;
-  qudt:hasUnit unit:J-SEC-PER-MOL ;
   qudt:value 3.9903126821e-10 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?nah#mid"^^xsd:anyURI ;
   rdfs:label "Value for molar Planck constant" ;
 .
 constant:Value_MolarPlanckConstantTimesC
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:J-M-PER-MOL ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00000000017"^^xsd:double ;
-  qudt:hasUnit unit:J-M-PER-MOL ;
   qudt:value "0.11962656472"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?nahc#mid"^^xsd:anyURI ;
   rdfs:label "Value for molar Planck constant times c" ;
 .
 constant:Value_MolarVolumeOfIdealGas
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:M3-PER-MOL ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000039e-3 ;
-  qudt:hasUnit unit:M3-PER-MOL ;
   qudt:value 22.710981e-3 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mvol#mid"^^xsd:anyURI ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mvolstd#mid"^^xsd:anyURI ;
@@ -4706,1299 +4706,1299 @@ constant:Value_MolarVolumeOfIdealGas
 .
 constant:Value_MolarVolumeOfSilicon
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:M3-PER-MOL ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000011e-6 ;
-  qudt:hasUnit unit:M3-PER-MOL ;
   qudt:value 12.0588349e-6 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mvolsil#mid"^^xsd:anyURI ;
   rdfs:label "Value for molar volume of silicon" ;
 .
 constant:Value_MuonComptonWavelength
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:M ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000030e-15 ;
-  qudt:hasUnit unit:M ;
   qudt:value 11.73444104e-15 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mcomwl#mid"^^xsd:anyURI ;
   rdfs:label "Value for muon Compton wavelength" ;
 .
 constant:Value_MuonComptonWavelengthOver2Pi
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:M ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000047e-15 ;
-  qudt:hasUnit unit:M ;
   qudt:value 1.867594295e-15 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mcomwlbar#mid"^^xsd:anyURI ;
   rdfs:label "Value for muon Compton wavelength over 2 pi" ;
 .
 constant:Value_MuonElectronMassRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000052"^^xsd:double ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value "206.7682823"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mmusme#mid"^^xsd:anyURI ;
   rdfs:label "Value for muon-electron mass ratio" ;
 .
 constant:Value_MuonGFactor
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000000012"^^xsd:double ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value "-2.0023318414"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?gmum#mid"^^xsd:anyURI ;
   rdfs:label "Value for muon g factor" ;
 .
 constant:Value_MuonMagneticMoment
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:J-PER-T ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000016e-26 ;
-  qudt:hasUnit unit:J-PER-T ;
   qudt:value -4.49044786e-26 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mumum#mid"^^xsd:anyURI ;
   rdfs:label "Value for muon magnetic moment" ;
 .
 constant:Value_MuonMagneticMomentAnomaly
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000060e-3 ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value 1.16592069e-3 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?amu#mid"^^xsd:anyURI ;
   rdfs:label "Value for muon magnetic moment anomaly" ;
 .
 constant:Value_MuonMagneticMomentToBohrMagnetonRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000012e-3 ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value -4.84197049e-3 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mumumsmub#mid"^^xsd:anyURI ;
   rdfs:label "Value for muon magnetic moment to Bohr magneton ratio" ;
 .
 constant:Value_MuonMagneticMomentToNuclearMagnetonRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00000023"^^xsd:double ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value "-8.89059705"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mumumsmun#mid"^^xsd:anyURI ;
   rdfs:label "Value for muon magnetic moment to nuclear magneton ratio" ;
 .
 constant:Value_MuonMass
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:KiloGM ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000011e-28 ;
-  qudt:hasUnit unit:KiloGM ;
   qudt:value 1.88353130e-28 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mmu#mid"^^xsd:anyURI ;
   rdfs:label "Value for muon mass" ;
 .
 constant:Value_MuonMassEnergyEquivalent
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:J ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000095e-11 ;
-  qudt:hasUnit unit:J ;
   qudt:value 1.692833510e-11 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mmuc2#mid"^^xsd:anyURI ;
   rdfs:label "Value for muon mass energy equivalent" ;
 .
 constant:Value_MuonMassEnergyEquivalentInMeV
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:MegaEV ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000038"^^xsd:double ;
-  qudt:hasUnit unit:MegaEV ;
   qudt:value "105.6583668"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mmuc2mev#mid"^^xsd:anyURI ;
   rdfs:label "Value for muon mass energy equivalent in MeV" ;
 .
 constant:Value_MuonMassInAtomicMassUnit
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:U ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000000029"^^xsd:double ;
-  qudt:hasUnit unit:U ;
   qudt:value "0.1134289256"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mmuu#mid"^^xsd:anyURI ;
   rdfs:label "Muon Mass (amu)" ;
 .
 constant:Value_MuonMolarMass
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:KiloGM-PER-MOL ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000000029e-3 ;
-  qudt:hasUnit unit:KiloGM-PER-MOL ;
   qudt:value 0.1134289256e-3 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mmmu#mid"^^xsd:anyURI ;
   rdfs:label "Value for muon molar mass" ;
 .
 constant:Value_MuonNeutronMassRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000000029"^^xsd:double ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value "0.1124545167"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mmusmn#mid"^^xsd:anyURI ;
   rdfs:label "Value for muon-neutron mass ratio" ;
 .
 constant:Value_MuonProtonMagneticMomentRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.000000085"^^xsd:double ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value "-3.183345137"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mumumsmup#mid"^^xsd:anyURI ;
   rdfs:label "Value for muon-proton magnetic moment ratio" ;
 .
 constant:Value_MuonProtonMassRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000000029"^^xsd:double ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value "0.1126095261"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mmusmp#mid"^^xsd:anyURI ;
   rdfs:label "Value for muon-proton mass ratio" ;
 .
 constant:Value_MuonTauMassRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00097e-2 ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value 5.94592e-2 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mmusmtau#mid"^^xsd:anyURI ;
   rdfs:label "Value for muon-tau mass ratio" ;
 .
 constant:Value_NaturalUnitOfAction
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:J-SEC ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000053e-34 ;
-  qudt:hasUnit unit:J-SEC ;
   qudt:value 1.054571628e-34 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?thbar#mid"^^xsd:anyURI ;
   rdfs:label "Value for natural unit of action" ;
 .
 constant:Value_NaturalUnitOfActionInEVS
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:EV-SEC ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000016e-16 ;
-  qudt:hasUnit unit:EV-SEC ;
   qudt:value 6.58211899e-16 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?thbarev#mid"^^xsd:anyURI ;
   rdfs:label "Value for natural unit of action in eV s" ;
 .
 constant:Value_NaturalUnitOfEnergy
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:J ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000041e-14 ;
-  qudt:hasUnit unit:J ;
   qudt:value 8.18710438e-14 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?tmec2#mid"^^xsd:anyURI ;
   rdfs:label "Value for natural unit of energy" ;
 .
 constant:Value_NaturalUnitOfEnergyInMeV
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:MegaEV ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.000000013"^^xsd:double ;
-  qudt:hasUnit unit:MegaEV ;
   qudt:value "0.510998910"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?tmec2mev#mid"^^xsd:anyURI ;
   rdfs:label "Value for natural unit of energy in MeV" ;
 .
 constant:Value_NaturalUnitOfLength
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:M ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000053e-15 ;
-  qudt:hasUnit unit:M ;
   qudt:value 386.15926459e-15 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?tecomwlbar#mid"^^xsd:anyURI ;
   rdfs:label "Value for natural unit of length" ;
 .
 constant:Value_NaturalUnitOfMass
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:KiloGM ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000045e-31 ;
-  qudt:hasUnit unit:KiloGM ;
   qudt:value 9.10938215e-31 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?tme#mid"^^xsd:anyURI ;
   rdfs:label "Value for natural unit of mass" ;
 .
 constant:Value_NaturalUnitOfMomentum
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:KiloGM-M-PER-SEC ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000014e-22 ;
-  qudt:hasUnit unit:KiloGM-M-PER-SEC ;
   qudt:value 2.73092406e-22 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mec#mid"^^xsd:anyURI ;
   rdfs:label "Value for natural unit of momentum" ;
 .
 constant:Value_NaturalUnitOfMomentumInMeVPerC
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:MegaEV-PER-SpeedOfLight ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.000000013"^^xsd:double ;
-  qudt:hasUnit unit:MegaEV-PER-SpeedOfLight ;
   qudt:value "0.510998910"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mecmevsc#mid"^^xsd:anyURI ;
   rdfs:label "Value for natural unit of momentum in MeV c^-1" ;
 .
 constant:Value_NaturalUnitOfTime
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:SEC ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000000018e-21 ;
-  qudt:hasUnit unit:SEC ;
   qudt:value 1.2880886570e-21 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?nut#mid"^^xsd:anyURI ;
   rdfs:label "Value for natural unit of time" ;
 .
 constant:Value_NaturalUnitOfVelocity
   a qudt:ConstantValue ;
-  qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:hasUnit unit:M-PER-SEC ;
+  qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:value "299792458"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?tc#mid"^^xsd:anyURI ;
   rdfs:label "Value for natural unit of velocity" ;
 .
 constant:Value_NeutronComptonWavelength
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:M ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000000020e-15 ;
-  qudt:hasUnit unit:M ;
   qudt:value 1.3195908951e-15 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?ncomwl#mid"^^xsd:anyURI ;
   rdfs:label "Value for neutron Compton wavelength" ;
 .
 constant:Value_NeutronComptonWavelengthOver2Pi
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:M ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000000031e-15 ;
-  qudt:hasUnit unit:M ;
   qudt:value 0.21001941382e-15 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?ncomwlbar#mid"^^xsd:anyURI ;
   rdfs:label "Value for neutron Compton wavelength over 2 pi" ;
 .
 constant:Value_NeutronElectronMagneticMomentRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000025e-3 ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value 1.04066882e-3 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?munsmue#mid"^^xsd:anyURI ;
   rdfs:label "Value for neutron-electron magnetic moment ratio" ;
 .
 constant:Value_NeutronElectronMassRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000011"^^xsd:double ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value "1838.6836605"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mnsme#mid"^^xsd:anyURI ;
   rdfs:label "Value for neutron-electron mass ratio" ;
 .
 constant:Value_NeutronGFactor
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00000090"^^xsd:double ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value "-3.82608545"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?gnn#mid"^^xsd:anyURI ;
   rdfs:label "Value for neutron g factor" ;
 .
 constant:Value_NeutronGyromagneticRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:PER-T-SEC ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000043e8 ;
-  qudt:hasUnit unit:PER-T-SEC ;
   qudt:value 1.83247185e8 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?gamman#mid"^^xsd:anyURI ;
   rdfs:label "Value for neutron gyromagnetic ratio" ;
 .
 constant:Value_NeutronGyromagneticRatioOver2Pi
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:MegaHZ-PER-T ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000069"^^xsd:double ;
-  qudt:hasUnit unit:MegaHZ-PER-T ;
   qudt:value "29.1646954"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?gammanbar#mid"^^xsd:anyURI ;
   rdfs:label "Value for neutron gyromagnetic ratio over 2 pi" ;
 .
 constant:Value_NeutronMagneticMoment
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:J-PER-T ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000023e-26 ;
-  qudt:hasUnit unit:J-PER-T ;
   qudt:value -0.96623641e-26 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?munn#mid"^^xsd:anyURI ;
   rdfs:label "Value for neutron magnetic moment" ;
 .
 constant:Value_NeutronMagneticMomentToBohrMagnetonRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000025e-3 ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value -1.04187563e-3 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?munsmub#mid"^^xsd:anyURI ;
   rdfs:label "Value for neutron magnetic moment to Bohr magneton ratio" ;
 .
 constant:Value_NeutronMagneticMomentToNuclearMagnetonRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00000045"^^xsd:double ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value "-1.91304273"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?munsmun#mid"^^xsd:anyURI ;
   rdfs:label "Value for neutron magnetic moment to nuclear magneton ratio" ;
 .
 constant:Value_NeutronMass
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:KiloGM ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000084e-27 ;
-  qudt:hasUnit unit:KiloGM ;
   qudt:value 1.674927211e-27 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mn#mid"^^xsd:anyURI ;
   rdfs:label "Value for neutron mass" ;
 .
 constant:Value_NeutronMassEnergyEquivalent
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:J ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000075e-10 ;
-  qudt:hasUnit unit:J ;
   qudt:value 1.505349505e-10 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mnc2#mid"^^xsd:anyURI ;
   rdfs:label "Value for neutron mass energy equivalent" ;
 .
 constant:Value_NeutronMassEnergyEquivalentInMeV
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:MegaEV ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.000023"^^xsd:double ;
-  qudt:hasUnit unit:MegaEV ;
   qudt:value "939.565346"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mnc2mev#mid"^^xsd:anyURI ;
   rdfs:label "Value for neutron mass energy equivalent in MeV" ;
 .
 constant:Value_NeutronMassInAtomicMassUnit
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:U ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00000000043"^^xsd:double ;
-  qudt:hasUnit unit:U ;
   qudt:value "1.00866491597"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mnu#mid"^^xsd:anyURI ;
   rdfs:label "Neutron Mass (amu)" ;
 .
 constant:Value_NeutronMolarMass
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:KiloGM-PER-MOL ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000000043e-3 ;
-  qudt:hasUnit unit:KiloGM-PER-MOL ;
   qudt:value 1.00866491597e-3 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mmn#mid"^^xsd:anyURI ;
   rdfs:label "Value for neutron molar mass" ;
 .
 constant:Value_NeutronMuonMassRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00000023"^^xsd:double ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value "8.89248409"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mnsmmu#mid"^^xsd:anyURI ;
   rdfs:label "Value for neutron-muon mass ratio" ;
 .
 constant:Value_NeutronProtonMagneticMomentRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00000016"^^xsd:double ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value "-0.68497934"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?munsmup#mid"^^xsd:anyURI ;
   rdfs:label "Value for neutron-proton magnetic moment ratio" ;
 .
 constant:Value_NeutronProtonMassRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00000000046"^^xsd:double ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value "1.00137841918"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mnsmp#mid"^^xsd:anyURI ;
   rdfs:label "Value for neutron-proton mass ratio" ;
 .
 constant:Value_NeutronTauMassRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.000086"^^xsd:double ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value "0.528740"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mnsmtau#mid"^^xsd:anyURI ;
   rdfs:label "Value for neutron-tau mass ratio" ;
 .
 constant:Value_NeutronToShieldedProtonMagneticMomentRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00000016"^^xsd:double ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value "-0.68499694"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?munsmupp#mid"^^xsd:anyURI ;
   rdfs:label "Value for neutron to shielded proton magnetic moment ratio" ;
 .
 constant:Value_NewtonianConstantOfGravitation
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:M3-PER-KiloGM-SEC2 ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:relativeStandardUncertainty 2.2e-5 ;
   qudt:standardUncertainty 0.00015e-11 ;
-  qudt:hasUnit unit:M3-PER-KiloGM-SEC2 ;
   qudt:value 6.67430e-11 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?bg#mid"^^xsd:anyURI ;
   rdfs:label "Value for Newtonian constant of gravitation" ;
 .
 constant:Value_NewtonianConstantOfGravitationOverHbarC
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:PER-PlanckMass2 ;
   qudt:relativeStandardUncertainty 2.2e-5 ;
   qudt:standardUncertainty 0.00015e-39 ;
-  qudt:hasUnit unit:PER-PlanckMass2 ;
   qudt:value 6.70883e-39 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?bgspu#mid"^^xsd:anyURI ;
   rdfs:label "Newtonian constant of gravitation over hbar c" ;
 .
 constant:Value_NuclearMagneton
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:J-PER-T ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000013e-27 ;
-  qudt:hasUnit unit:J-PER-T ;
   qudt:value 5.05078324e-27 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mun#mid"^^xsd:anyURI ;
   rdfs:label "Value for nuclear magneton" ;
 .
 constant:Value_NuclearMagnetonInEVPerT
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:EV-PER-T ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000000045e-8 ;
-  qudt:hasUnit unit:EV-PER-T ;
   qudt:value 3.1524512326e-8 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?munev#mid"^^xsd:anyURI ;
   rdfs:label "Value for nuclear magneton in eV per T" ;
 .
 constant:Value_NuclearMagnetonInInverseMetersPerTesla
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:PER-T-M ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000064e-2 ;
-  qudt:hasUnit unit:PER-T-M ;
   qudt:value 2.542623616e-2 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?munshcminv#mid"^^xsd:anyURI ;
   rdfs:label "Value for nuclear magneton in inverse meters per tesla" ;
 .
 constant:Value_NuclearMagnetonInKPerT
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:K-PER-T ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000064e-4 ;
-  qudt:hasUnit unit:K-PER-T ;
   qudt:value 3.6582637e-4 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?munskk#mid"^^xsd:anyURI ;
   rdfs:label "Value for nuclear magneton in K per T" ;
 .
 constant:Value_NuclearMagnetonInMHzPerT
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:MegaHZ-PER-T ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00000019"^^xsd:double ;
-  qudt:hasUnit unit:MegaHZ-PER-T ;
   qudt:value "7.62259384"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?munshhz#mid"^^xsd:anyURI ;
   rdfs:label "Value for nuclear magneton in MHz per T" ;
 .
 constant:Value_PermittivityOfVacuum
   a qudt:ConstantValue ;
-  qudt:relativeStandardUncertainty 1.5e-10 ;
   qudt:hasUnit unit:FARAD-PER-M ;
+  qudt:relativeStandardUncertainty 1.5e-10 ;
   qudt:value 6.8541878128e-12 ;
   rdfs:label "Value for permittivity of vacuum" ;
 .
 constant:Value_PlanckConstant
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:J-SEC ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000033e-34 ;
-  qudt:hasUnit unit:J-SEC ;
   qudt:value 6.62606896e-34 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?h#mid"^^xsd:anyURI ;
   rdfs:label "Value for Planck constant" ;
 .
 constant:Value_PlanckConstantInEVS
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:EV-SEC ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000010e-15 ;
-  qudt:hasUnit unit:EV-SEC ;
   qudt:value 4.13566733e-15 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?hev#mid"^^xsd:anyURI ;
   rdfs:label "Value for Planck constant in eV s" ;
 .
 constant:Value_PlanckConstantOver2Pi
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:J-SEC ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000053e-34 ;
-  qudt:hasUnit unit:J-SEC ;
   qudt:value 1.054571628e-34 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?hbar#mid"^^xsd:anyURI ;
   rdfs:label "Value for Planck constant over 2 pi" ;
 .
 constant:Value_PlanckConstantOver2PiInEVS
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:EV-SEC ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000016e-16 ;
-  qudt:hasUnit unit:EV-SEC ;
   qudt:value 6.58211899e-16 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?hbarev#mid"^^xsd:anyURI ;
   rdfs:label "Value for Planck constant over 2 pi in eV s" ;
 .
 constant:Value_PlanckConstantOver2PiTimesCInMeVFm
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:MegaEV-FemtoM ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000049"^^xsd:double ;
-  qudt:hasUnit unit:MegaEV-FemtoM ;
   qudt:value "197.3269631"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?hbcmevf#mid"^^xsd:anyURI ;
   rdfs:label "Value for Planck constant over 2 pi times c in MeV fm" ;
 .
 constant:Value_PlanckLength
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:M ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000081e-35 ;
-  qudt:hasUnit unit:M ;
   qudt:value 1.616252e-35 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?plkl#mid"^^xsd:anyURI ;
   rdfs:label "Value for Planck length" ;
 .
 constant:Value_PlanckMass
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:KiloGM ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00011e-8 ;
-  qudt:hasUnit unit:KiloGM ;
   qudt:value 2.17644e-8 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?plkm#mid"^^xsd:anyURI ;
   rdfs:label "Value for Planck mass" ;
 .
 constant:Value_PlanckMassEnergyEquivalentInGeV
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:GigaEV ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000061e19 ;
-  qudt:hasUnit unit:GigaEV ;
   qudt:value 1.220892e19 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?plkmc2gev#mid"^^xsd:anyURI ;
   rdfs:label "Value for Planck mass energy equivalent in GeV" ;
 .
 constant:Value_PlanckTemperature
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:K ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000071e32 ;
-  qudt:hasUnit unit:K ;
   qudt:value 1.416785e32 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?plktmp#mid"^^xsd:anyURI ;
   rdfs:label "Value for Planck temperature" ;
 .
 constant:Value_PlanckTime
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:SEC ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00027e-44 ;
-  qudt:hasUnit unit:SEC ;
   qudt:value 5.39124e-44 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?plkt#mid"^^xsd:anyURI ;
   rdfs:label "Value for Planck time" ;
 .
 constant:Value_ProtonChargeToMassQuotient
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:C-PER-KiloGM ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000024e7 ;
-  qudt:hasUnit unit:C-PER-KiloGM ;
   qudt:value 9.57883392e7 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?esmp#mid"^^xsd:anyURI ;
   rdfs:label "Value for proton charge to mass quotient" ;
 .
 constant:Value_ProtonComptonWavelength
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:M ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000000019e-15 ;
-  qudt:hasUnit unit:M ;
   qudt:value 1.3214098446e-15 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?pcomwl#mid"^^xsd:anyURI ;
   rdfs:label "Value for proton Compton wavelength" ;
 .
 constant:Value_ProtonComptonWavelengthOver2Pi
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:M ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000000030e-15 ;
-  qudt:hasUnit unit:M ;
   qudt:value 0.21030890861e-15 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?pcomwlbar#mid"^^xsd:anyURI ;
   rdfs:label "Value for proton Compton wavelength over 2 pi" ;
 .
 constant:Value_ProtonElectronMassRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00000080"^^xsd:double ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value "1836.15267247"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mpsme#mid"^^xsd:anyURI ;
   rdfs:label "Value for proton-electron mass ratio" ;
 .
 constant:Value_ProtonGFactor
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.000000046"^^xsd:double ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value "5.585694713"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?gp#mid"^^xsd:anyURI ;
   rdfs:label "Value for proton g factor" ;
 .
 constant:Value_ProtonGyromagneticRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:PER-T-SEC ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000070e8 ;
-  qudt:hasUnit unit:PER-T-SEC ;
   qudt:value 2.675222099e8 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?gammap#mid"^^xsd:anyURI ;
   rdfs:label "Value for proton gyromagnetic ratio" ;
 .
 constant:Value_ProtonGyromagneticRatioOver2Pi
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:MegaHZ-PER-T ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000011"^^xsd:double ;
-  qudt:hasUnit unit:MegaHZ-PER-T ;
   qudt:value "42.5774821"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?gammapbar#mid"^^xsd:anyURI ;
   rdfs:label "Value for proton gyromagnetic ratio over 2 pi" ;
 .
 constant:Value_ProtonMagneticMoment
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:J-PER-T ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000037e-26 ;
-  qudt:hasUnit unit:J-PER-T ;
   qudt:value 1.410606662e-26 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mup#mid"^^xsd:anyURI ;
   rdfs:label "Value for proton magnetic moment" ;
 .
 constant:Value_ProtonMagneticMomentToBohrMagnetonRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000012e-3 ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value 1.521032209e-3 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mupsmub#mid"^^xsd:anyURI ;
   rdfs:label "Value for proton magnetic moment to Bohr magneton ratio" ;
 .
 constant:Value_ProtonMagneticMomentToNuclearMagnetonRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.000000023"^^xsd:double ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value "2.792847356"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mupsmun#mid"^^xsd:anyURI ;
   rdfs:label "Value for proton magnetic moment to nuclear magneton ratio" ;
 .
 constant:Value_ProtonMagneticShieldingCorrection
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.014e-6 ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value 25.694e-6 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?sigmapp#mid"^^xsd:anyURI ;
   rdfs:label "Value for proton magnetic shielding correction" ;
 .
 constant:Value_ProtonMass
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:KiloGM ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000083e-27 ;
-  qudt:hasUnit unit:KiloGM ;
   qudt:value 1.672621637e-27 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mp#mid"^^xsd:anyURI ;
   rdfs:label "Value for proton mass" ;
 .
 constant:Value_ProtonMassEnergyEquivalent
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:J ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000075e-10 ;
-  qudt:hasUnit unit:J ;
   qudt:value 1.503277359e-10 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mpc2#mid"^^xsd:anyURI ;
   rdfs:label "Value for proton mass energy equivalent" ;
 .
 constant:Value_ProtonMassEnergyEquivalentInMeV
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:MegaEV ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.000023"^^xsd:double ;
-  qudt:hasUnit unit:MegaEV ;
   qudt:value "938.272013"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mpc2mev#mid"^^xsd:anyURI ;
   rdfs:label "Value for proton mass energy equivalent in MeV" ;
 .
 constant:Value_ProtonMassInAtomicMassUnit
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:U ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00000000010"^^xsd:double ;
-  qudt:hasUnit unit:U ;
   qudt:value "1.00727646677"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mpu#mid"^^xsd:anyURI ;
   rdfs:label "Proton Mass (amu)" ;
 .
 constant:Value_ProtonMolarMass
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:KiloGM-PER-MOL ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000000010e-3 ;
-  qudt:hasUnit unit:KiloGM-PER-MOL ;
   qudt:value 1.00727646677e-3 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mmp#mid"^^xsd:anyURI ;
   rdfs:label "Value for proton molar mass" ;
 .
 constant:Value_ProtonMuonMassRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00000023"^^xsd:double ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value "8.88024339"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mpsmmu#mid"^^xsd:anyURI ;
   rdfs:label "Value for proton-muon mass ratio" ;
 .
 constant:Value_ProtonNeutronMagneticMomentRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00000034"^^xsd:double ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value "-1.45989806"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mupsmunn#mid"^^xsd:anyURI ;
   rdfs:label "Value for proton-neutron magnetic moment ratio" ;
 .
 constant:Value_ProtonNeutronMassRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00000000046"^^xsd:double ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value "0.99862347824"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mpsmn#mid"^^xsd:anyURI ;
   rdfs:label "Value for proton-neutron mass ratio" ;
 .
 constant:Value_ProtonRmsChargeRadius
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:M ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0069e-15 ;
-  qudt:hasUnit unit:M ;
   qudt:value 0.8768e-15 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?rp#mid"^^xsd:anyURI ;
   rdfs:label "Value for proton rms charge radius" ;
 .
 constant:Value_ProtonTauMassRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.000086"^^xsd:double ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value "0.528012"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mpsmtau#mid"^^xsd:anyURI ;
   rdfs:label "Value for proton-tau mass ratio" ;
 .
 constant:Value_QuantumOfCirculation
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:M2-PER-SEC ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000000050e-4 ;
-  qudt:hasUnit unit:M2-PER-SEC ;
   qudt:value 3.6369475199e-4 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?qucirchs2me#mid"^^xsd:anyURI ;
   rdfs:label "Value for quantum of circulation" ;
 .
 constant:Value_QuantumOfCirculationTimes2
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:M2-PER-SEC ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000010e-4 ;
-  qudt:hasUnit unit:M2-PER-SEC ;
   qudt:value 7.273895040e-4 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?hsme#mid"^^xsd:anyURI ;
   rdfs:label "Value for quantum of circulation times 2" ;
 .
 constant:Value_RydbergConstant
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:PER-M ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.000073"^^xsd:double ;
-  qudt:hasUnit unit:PER-M ;
   qudt:value "10973731.568527"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?ryd#mid"^^xsd:anyURI ;
   rdfs:label "Value for Rydberg constant" ;
 .
 constant:Value_RydbergConstantTimesCInHz
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:HZ ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000000022e15 ;
-  qudt:hasUnit unit:HZ ;
   qudt:value 3.289841960361e15 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?rydchz#mid"^^xsd:anyURI ;
   rdfs:label "Value for Rydberg constant times c in Hz" ;
 .
 constant:Value_RydbergConstantTimesHcInEV
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:EV ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00000034"^^xsd:double ;
-  qudt:hasUnit unit:EV ;
   qudt:value "13.60569193"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?rydhcev#mid"^^xsd:anyURI ;
   rdfs:label "Value for Rydberg constant times hc in eV" ;
 .
 constant:Value_RydbergConstantTimesHcInJ
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:J ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000011e-18 ;
-  qudt:hasUnit unit:J ;
   qudt:value 2.17987197e-18 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?rydhcj#mid"^^xsd:anyURI ;
   rdfs:label "Value for Rydberg constant times hc in J" ;
 .
 constant:Value_SackurTetrodeConstant1K100KPa
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000044"^^xsd:double ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value "-1.1517047"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?s0sr#mid"^^xsd:anyURI ;
   rdfs:label "Value for Sackur-Tetrode constant 1 K 100 kPa" ;
 .
 <http://qudt.org/vocab/constant/Value_SackurTetrodeConstant1K101.325K>
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000044"^^xsd:double ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value "-1.1648677"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?s0srstd#mid"^^xsd:anyURI ;
   rdfs:label "Value for Sackur-Tetrode constant 1 K 101.325 kPa" ;
 .
 constant:Value_SecondRadiationConstant
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:M-K ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000025e-2 ;
-  qudt:hasUnit unit:M-K ;
   qudt:value 1.4387752e-2 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?c22ndrc#mid"^^xsd:anyURI ;
   rdfs:label "Value for second radiation constant" ;
 .
 constant:Value_ShieldedHelionGyromagneticRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:PER-T-SEC ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000056e8 ;
-  qudt:hasUnit unit:PER-T-SEC ;
   qudt:value 2.037894730e8 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?gammahp#mid"^^xsd:anyURI ;
   rdfs:label "Value for shielded helion gyromagnetic ratio" ;
 .
 constant:Value_ShieldedHelionGyromagneticRatioOver2Pi
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:MegaHZ-PER-T ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00000090"^^xsd:double ;
-  qudt:hasUnit unit:MegaHZ-PER-T ;
   qudt:value "32.43410198"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?gammahpbar#mid"^^xsd:anyURI ;
   rdfs:label "Value for shielded helion gyromagnetic ratio over 2 pi" ;
 .
 constant:Value_ShieldedHelionMagneticMoment
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:J-PER-T ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000030e-26 ;
-  qudt:hasUnit unit:J-PER-T ;
   qudt:value -1.074552982e-26 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?muhp#mid"^^xsd:anyURI ;
   rdfs:label "Value for shielded helion magnetic moment" ;
 .
 constant:Value_ShieldedHelionMagneticMomentToBohrMagnetonRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000014e-3 ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value -1.158671471e-3 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?muhpsmub#mid"^^xsd:anyURI ;
   rdfs:label "Value for shielded helion magnetic moment to Bohr magneton ratio" ;
 .
 constant:Value_ShieldedHelionMagneticMomentToNuclearMagnetonRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.000000025"^^xsd:double ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value "-2.127497718"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?muhpsmun#mid"^^xsd:anyURI ;
   rdfs:label "Value for shielded helion magnetic moment to nuclear magneton ratio" ;
 .
 constant:Value_ShieldedHelionToProtonMagneticMomentRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.000000011"^^xsd:double ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value "-0.761766558"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?muhpsmup#mid"^^xsd:anyURI ;
   rdfs:label "Value for shielded helion to proton magnetic moment ratio" ;
 .
 constant:Value_ShieldedHelionToShieldedProtonMagneticMomentRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000000033"^^xsd:double ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value "-0.7617861313"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?muhpsmupp#mid"^^xsd:anyURI ;
   rdfs:label "Value for shielded helion to shielded proton magnetic moment ratio" ;
 .
 constant:Value_ShieldedProtonGyromagneticRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:PER-T-SEC ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000073e8 ;
-  qudt:hasUnit unit:PER-T-SEC ;
   qudt:value 2.675153362e8 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?gammapp#mid"^^xsd:anyURI ;
   rdfs:label "Value for shielded proton gyromagnetic ratio" ;
 .
 constant:Value_ShieldedProtonGyromagneticRatioOver2Pi
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:MegaHZ-PER-T ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000012"^^xsd:double ;
-  qudt:hasUnit unit:MegaHZ-PER-T ;
   qudt:value "42.5763881"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?gammappbar#mid"^^xsd:anyURI ;
   rdfs:label "Value for shielded proton gyromagnetic ratio over 2 pi" ;
 .
 constant:Value_ShieldedProtonMagneticMoment
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:J-PER-T ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000038e-26 ;
-  qudt:hasUnit unit:J-PER-T ;
   qudt:value 1.410570419e-26 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mupp#mid"^^xsd:anyURI ;
   rdfs:label "Value for shielded proton magnetic moment" ;
 .
 constant:Value_ShieldedProtonMagneticMomentToBohrMagnetonRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000017e-3 ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value 1.520993128e-3 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?muppsmub#mid"^^xsd:anyURI ;
   rdfs:label "Value for shielded proton magnetic moment to Bohr magneton ratio" ;
 .
 constant:Value_ShieldedProtonMagneticMomentToNuclearMagnetonRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.000000030"^^xsd:double ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value "2.792775598"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?muppsmun#mid"^^xsd:anyURI ;
   rdfs:label "Value for shielded proton magnetic moment to nuclear magneton ratio" ;
 .
 constant:Value_SpeedOfLight
   a qudt:ConstantValue ;
-  qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:hasUnit unit:M-PER-SEC ;
+  qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:value "299792458"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?c#mid"^^xsd:anyURI ;
   rdfs:label "Value for velocity of light" ;
 .
 constant:Value_SpeedOfLight_Vacuum
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:M-PER-SEC ;
   qudt:informativeReference "http://physics.nist.gov/cgi-bin/cuu/Value?c#mid"^^xsd:anyURI ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000000"^^xsd:double ;
-  qudt:hasUnit unit:M-PER-SEC ;
   qudt:value 2.99792458e8 ;
   rdfs:label "Value for speed of light in a vacuum" ;
 .
 constant:Value_SpeedOfLight_Vacuum_Imperial
   a qudt:ConstantValue ;
-  qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:hasUnit unit:MI-PER-HR ;
+  qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:value 6.70616629e08 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?c#mid"^^xsd:anyURI ;
   rdfs:label "Value for speed of light in vacuum (Imperial units)" ;
 .
 constant:Value_StandardAccelerationOfGravity
   a qudt:ConstantValue ;
-  qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:hasUnit unit:M-PER-SEC2 ;
+  qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:value "9.80665"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?gn#mid"^^xsd:anyURI ;
   rdfs:label "Value for standard acceleration of gravity" ;
 .
 constant:Value_StandardAtmosphere
   a qudt:ConstantValue ;
-  qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:hasUnit unit:PA ;
+  qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:value "101325"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?stdatm#mid"^^xsd:anyURI ;
   rdfs:label "Value for standard atmosphere" ;
 .
 constant:Value_StefanBoltzmannConstant
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:W-PER-M2-K4 ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000040e-8 ;
-  qudt:hasUnit unit:W-PER-M2-K4 ;
   qudt:value 5.670400e-8 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?sigma#mid"^^xsd:anyURI ;
   rdfs:label "Value for Stefan-Boltzmann Constant" ;
 .
 constant:Value_TauComptonWavelength
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:M ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00011e-15 ;
-  qudt:hasUnit unit:M ;
   qudt:value 0.69772e-15 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?tcomwl#mid"^^xsd:anyURI ;
   rdfs:label "Value for tau Compton wavelength" ;
 .
 constant:Value_TauComptonWavelengthOver2Pi
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:M ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000018e-15 ;
-  qudt:hasUnit unit:M ;
   qudt:value 0.111046e-15 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?tcomwlbar#mid"^^xsd:anyURI ;
   rdfs:label "Value for tau Compton wavelength over 2 pi" ;
 .
 constant:Value_TauElectronMassRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.57"^^xsd:double ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value "3477.48"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mtausme#mid"^^xsd:anyURI ;
   rdfs:label "Value for tau-electron mass ratio" ;
 .
 constant:Value_TauMass
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:KiloGM ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00052e-27 ;
-  qudt:hasUnit unit:KiloGM ;
   qudt:value 3.16777e-27 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mtau#mid"^^xsd:anyURI ;
   rdfs:label "Value for tau mass" ;
 .
 constant:Value_TauMassEnergyEquivalent
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:J ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00046e-10 ;
-  qudt:hasUnit unit:J ;
   qudt:value 2.84705e-10 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mtauc2#mid"^^xsd:anyURI ;
   rdfs:label "Value for tau mass energy equivalent" ;
 .
 constant:Value_TauMassEnergyEquivalentInMeV
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:MegaEV ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.29"^^xsd:double ;
-  qudt:hasUnit unit:MegaEV ;
   qudt:value "1776.99"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mtauc2mev#mid"^^xsd:anyURI ;
   rdfs:label "Value for tau mass energy equivalent in MeV" ;
 .
 constant:Value_TauMassInAtomicMassUnit
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:U ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00031"^^xsd:double ;
-  qudt:hasUnit unit:U ;
   qudt:value "1.90768"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mtauu#mid"^^xsd:anyURI ;
   rdfs:label "Tau Mass (amu)" ;
 .
 constant:Value_TauMolarMass
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:KiloGM-PER-MOL ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00031e-3 ;
-  qudt:hasUnit unit:KiloGM-PER-MOL ;
   qudt:value 1.90768e-3 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mmtau#mid"^^xsd:anyURI ;
   rdfs:label "Value for tau molar mass" ;
 .
 constant:Value_TauMuonMassRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0027"^^xsd:double ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value "16.8183"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mtausmmu#mid"^^xsd:anyURI ;
   rdfs:label "Value for tau-muon mass ratio" ;
 .
 constant:Value_TauNeutronMassRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00031"^^xsd:double ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value "1.89129"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mtausmn#mid"^^xsd:anyURI ;
   rdfs:label "Value for tau-neutron mass ratio" ;
 .
 constant:Value_TauProtonMassRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00031"^^xsd:double ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value "1.89390"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mtausmp#mid"^^xsd:anyURI ;
   rdfs:label "Value for tau-proton mass ratio" ;
 .
 constant:Value_ThomsonCrossSection
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:M2 ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000000027e-28 ;
-  qudt:hasUnit unit:M2 ;
   qudt:value 0.6652458558e-28 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?sigmae#mid"^^xsd:anyURI ;
   rdfs:label "Value for Thomson cross section" ;
 .
 constant:Value_TritonElectronMagneticMomentRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000021e-3 ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value -1.620514423e-3 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mutsmuem#mid"^^xsd:anyURI ;
   rdfs:label "Value for triton-electron magnetic moment ratio" ;
 .
 constant:Value_TritonElectronMassRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000051"^^xsd:double ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value "5496.9215269"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mtsme#mid"^^xsd:anyURI ;
   rdfs:label "Value for triton-electron mass ratio" ;
 .
 constant:Value_TritonGFactor
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.000000076"^^xsd:double ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value "5.957924896"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?gtn#mid"^^xsd:anyURI ;
   rdfs:label "Value for triton g factor" ;
 .
 constant:Value_TritonMagneticMoment
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:J-PER-T ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000042e-26 ;
-  qudt:hasUnit unit:J-PER-T ;
   qudt:value 1.504609361e-26 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mut#mid"^^xsd:anyURI ;
   rdfs:label "Value for triton magnetic moment" ;
 .
 constant:Value_TritonMagneticMomentToBohrMagnetonRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000021e-3 ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value 1.622393657e-3 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mutsmub#mid"^^xsd:anyURI ;
   rdfs:label "Value for triton magnetic moment to Bohr magneton ratio" ;
 .
 constant:Value_TritonMagneticMomentToNuclearMagnetonRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.000000038"^^xsd:double ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value "2.978962448"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mutsmun#mid"^^xsd:anyURI ;
   rdfs:label "Value for triton magnetic moment to nuclear magneton ratio" ;
 .
 constant:Value_TritonMass
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:KiloGM ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000025e-27 ;
-  qudt:hasUnit unit:KiloGM ;
   qudt:value 5.00735588e-27 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mt#mid"^^xsd:anyURI ;
   rdfs:label "Value for triton mass" ;
 .
 constant:Value_TritonMassEnergyEquivalent
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:J ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.00000022e-10 ;
-  qudt:hasUnit unit:J ;
   qudt:value 4.50038703e-10 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mtc2#mid"^^xsd:anyURI ;
   rdfs:label "Value for triton mass energy equivalent" ;
 .
 constant:Value_TritonMassEnergyEquivalentInMeV
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:MegaEV ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.000070"^^xsd:double ;
-  qudt:hasUnit unit:MegaEV ;
   qudt:value "2808.920906"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mtc2mev#mid"^^xsd:anyURI ;
   rdfs:label "Value for triton mass energy equivalent in MeV" ;
 .
 constant:Value_TritonMassInAtomicMassUnit
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:U ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000000025"^^xsd:double ;
-  qudt:hasUnit unit:U ;
   qudt:value "3.0155007134"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mtu#mid"^^xsd:anyURI ;
   rdfs:label "Triton Mass (amu)" ;
 .
 constant:Value_TritonMolarMass
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:KiloGM-PER-MOL ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000000025e-3 ;
-  qudt:hasUnit unit:KiloGM-PER-MOL ;
   qudt:value 3.0155007134e-3 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mmt#mid"^^xsd:anyURI ;
   rdfs:label "Value for triton molar mass" ;
 .
 constant:Value_TritonNeutronMagneticMomentRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00000037"^^xsd:double ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value "-1.55718553"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mutsmunn#mid"^^xsd:anyURI ;
   rdfs:label "Value for triton-neutron magnetic moment ratio" ;
 .
 constant:Value_TritonProtonMagneticMomentRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.000000010"^^xsd:double ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value "1.066639908"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mutsmup#mid"^^xsd:anyURI ;
   rdfs:label "Value for triton-proton magnetic moment ratio" ;
 .
 constant:Value_TritonProtonMassRatio
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.0000000025"^^xsd:double ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value "2.9937170309"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?mtsmp#mid"^^xsd:anyURI ;
   rdfs:label "Value for triton-proton mass ratio" ;
 .
 constant:Value_UnifiedAtomicMassUnit
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:KiloGM ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000000083e-27 ;
-  qudt:hasUnit unit:KiloGM ;
   qudt:value 1.660538782e-27 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?tukg#mid"^^xsd:anyURI ;
   rdfs:label "Value for unified atomic mass unit" ;
 .
 constant:Value_VonKlitzingConstant
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:OHM ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.000018"^^xsd:double ;
-  qudt:hasUnit unit:OHM ;
   qudt:value "25812.807557"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?rk#mid"^^xsd:anyURI ;
   rdfs:label "Value for von Klitzing constant" ;
 .
 constant:Value_WeakMixingAngle
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty "0.00056"^^xsd:double ;
-  qudt:hasUnit unit:UNITLESS ;
   qudt:value "0.22255"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?sin2th#mid"^^xsd:anyURI ;
   rdfs:label "Value for weak mixing angle" ;
 .
 constant:Value_WienFrequencyDisplacementLawConstant
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:HZ-PER-K ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.000010e10 ;
-  qudt:hasUnit unit:HZ-PER-K ;
   qudt:value 5.878933e10 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?bpwien#mid"^^xsd:anyURI ;
   rdfs:label "Value for Wien frequency displacement law constant" ;
 .
 constant:Value_WienWavelengthDisplacementLawConstant
   a qudt:ConstantValue ;
+  qudt:hasUnit unit:M-K ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
   qudt:standardUncertainty 0.0000051e-3 ;
-  qudt:hasUnit unit:M-K ;
   qudt:value 2.8977685e-3 ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?bwien#mid"^^xsd:anyURI ;
   rdfs:label "Value for Wien wavelength displacement law constant" ;


### PR DESCRIPTION
Added the qudt:hasUnit relation wherever qudt:unit is used, and added a SHACL validation rule (sh:Info level) to point out uses of qudt:unit in data files.
Also, updated the Constants graph to qudt:hasUnit
