### PR TITLE
Add Stress Intensity Factor Quantity Kind and related items

### DIFF
--- a/vocab/dimensionvectors/VOCAB_QUDT-DIMENSION-VECTORS-v2.1.ttl
+++ b/vocab/dimensionvectors/VOCAB_QUDT-DIMENSION-VECTORS-v2.1.ttl
@@ -588,6 +588,25 @@ qkdv:A0E-2L4I0M2H-2T-6D0
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/dimensionvector> ;
   rdfs:label "A0E0L-0.5I0M0.5TE0TM-2D0" ;
 .
+qkdv:A0E0L-0_5I0M1H0T-2D0
+  a qudt:QuantityKindDimensionVector ;
+  a qudt:QuantityKindDimensionVector_CGS ;
+  a qudt:QuantityKindDimensionVector_ISO ;
+  a qudt:QuantityKindDimensionVector_Imperial ;
+  a qudt:QuantityKindDimensionVector_SI ;
+  qudt:dimensionExponentForAmountOfSubstance 0 ;
+  qudt:dimensionExponentForElectricCurrent 0 ;
+  qudt:dimensionExponentForLength -0.5 ;
+  qudt:dimensionExponentForLuminousIntensity 0 ;
+  qudt:dimensionExponentForMass 1 ;
+  qudt:dimensionExponentForThermodynamicTemperature 0 ;
+  qudt:dimensionExponentForTime -2 ;
+  qudt:dimensionlessExponent 0 ;
+  qudt:hasReferenceQuantityKind quantitykind:StressIntensityFactor ;
+  qudt:latexDefinition "\\(L^-0.5 M T^-2\\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/dimensionvector> ;
+  rdfs:label "A0E0L-0_5I0M1H0T-2D0" ;
+.
 <http://qudt.org/vocab/dimensionvector/A0E0L-1.5I0M0.5TE0TM-1D0>
   a qudt:QuantityKindDimensionVector_CGS ;
   qudt:dimensionExponentForAmountOfSubstance 0 ;

--- a/vocab/dimensionvectors/VOCAB_QUDT-DIMENSION-VECTORS-v2.1.ttl
+++ b/vocab/dimensionvectors/VOCAB_QUDT-DIMENSION-VECTORS-v2.1.ttl
@@ -588,7 +588,7 @@ qkdv:A0E-2L4I0M2H-2T-6D0
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/dimensionvector> ;
   rdfs:label "A0E0L-0.5I0M0.5TE0TM-2D0" ;
 .
-qkdv:A0E0L-0_5I0M1H0T-2D0
+qkdv:A0E0L-0pt5I0M1H0T-2D0
   a qudt:QuantityKindDimensionVector ;
   a qudt:QuantityKindDimensionVector_CGS ;
   a qudt:QuantityKindDimensionVector_ISO ;
@@ -605,7 +605,7 @@ qkdv:A0E0L-0_5I0M1H0T-2D0
   qudt:hasReferenceQuantityKind quantitykind:StressIntensityFactor ;
   qudt:latexDefinition "\\(L^-0.5 M T^-2\\)"^^qudt:LatexString ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/dimensionvector> ;
-  rdfs:label "A0E0L-0_5I0M1H0T-2D0" ;
+  rdfs:label "A0E0L-0pt5I0M1H0T-2D0" ;
 .
 <http://qudt.org/vocab/dimensionvector/A0E0L-1.5I0M0.5TE0TM-1D0>
   a qudt:QuantityKindDimensionVector_CGS ;

--- a/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
+++ b/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
@@ -18023,6 +18023,16 @@ quantitykind:Stress
   rdfs:label "Stress"@en ;
   skos:broader quantitykind:ForcePerArea ;
 .
+quantitykind:StressIntensityFactor
+  a qudt:QuantityKind ;
+  qudt:hasDimensionVector qkdv:A0E0L-0_5I0M1H0T-2D0 ;
+  qudt:informativeReference "https://en.wikipedia.org/wiki/Stress_intensity_factor"^^xsd:anyURI ;
+  qudt:latexSymbol "\\(\\K\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "In fracture mechanics, the stress intensity factor (K) is used to predict the stress state (\"stress intensity\") near the tip of a crack or notch caused by a remote load or residual stresses. It is a theoretical construct usually applied to a homogeneous, linear elastic material and is useful for providing a failure criterion for brittle materials, and is a critical technique in the discipline of damage tolerance. The concept can also be applied to materials that exhibit small-scale yielding at a crack tip." ;
+  qudt:symbol "K" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Stress Intensity Factor"@en ;
+.
 quantitykind:StressOpticCoefficient
   a qudt:QuantityKind ;
   qudt:applicableUnit unit:NanoM-PER-CentiM-PSI ;

--- a/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
+++ b/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
@@ -18025,7 +18025,7 @@ quantitykind:Stress
 .
 quantitykind:StressIntensityFactor
   a qudt:QuantityKind ;
-  qudt:hasDimensionVector qkdv:A0E0L-0_5I0M1H0T-2D0 ;
+  qudt:hasDimensionVector qkdv:A0E0L-0pt5I0M1H0T-2D0 ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Stress_intensity_factor"^^xsd:anyURI ;
   qudt:latexSymbol "\\(\\K\\)"^^qudt:LatexString ;
   qudt:plainTextDescription "In fracture mechanics, the stress intensity factor (K) is used to predict the stress state (\"stress intensity\") near the tip of a crack or notch caused by a remote load or residual stresses. It is a theoretical construct usually applied to a homogeneous, linear elastic material and is useful for providing a failure criterion for brittle materials, and is a critical technique in the discipline of damage tolerance. The concept can also be applied to materials that exhibit small-scale yielding at a crack tip." ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -15494,6 +15494,24 @@ unit:MegaGM
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Megagram"@en ;
 .
+unit:MegaGM-PER-HA
+  a qudt:Unit ;
+  qudt:applicableSystem sou:CGS ;
+  qudt:applicableSystem sou:CGS-EMU ;
+  qudt:applicableSystem sou:CGS-GAUSS ;
+  qudt:applicableSystem sou:SI ;
+  qudt:conversionMultiplier 0.1 ;
+  qudt:exactMatch unit:TONNE-PER-HA ;
+  qudt:exactMatch unit:TON_Metric-PER-HA ;
+  qudt:hasDimensionVector qkdv:A0E0L-2I0M1H0T0D0 ;
+  qudt:hasQuantityKind quantitykind:MassPerArea ;
+  qudt:plainTextDescription "1 000-fold of the SI base unit kilogram divided by the 10,0000-fold of the power of the SI base unit metre with the exponent 2" ;
+  qudt:symbol "Mg/ha" ;
+  qudt:ucumCode "Mg.har-1"^^qudt:UCUMcs ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Megagram Per Hectare"@en ;
+  rdfs:label "Megagram Per Hectare"@en-us ;
+.
 unit:MegaGM-PER-M3
   a qudt:Unit ;
   qudt:applicableSystem sou:CGS ;
@@ -15511,24 +15529,6 @@ unit:MegaGM-PER-M3
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Megagram Per Cubic Meter"@en-us ;
   rdfs:label "Megagram Per Cubic Metre"@en ;
-.
-unit:MegaGM-PER-HA
-  a qudt:Unit ;
-  qudt:applicableSystem sou:CGS ;
-  qudt:applicableSystem sou:CGS-EMU ;
-  qudt:applicableSystem sou:CGS-GAUSS ;
-  qudt:applicableSystem sou:SI ;
-  qudt:conversionMultiplier 0.1 ;
-  qudt:hasDimensionVector qkdv:A0E0L-2I0M1H0T0D0 ;
-  qudt:hasQuantityKind quantitykind:MassPerArea ;
-  qudt:plainTextDescription "1 000-fold of the SI base unit kilogram divided by the 10,0000-fold of the power of the SI base unit metre with the exponent 2" ;
-  qudt:symbol "Mg/ha" ;
-  qudt:ucumCode "Mg.har-1"^^qudt:UCUMcs ;
-  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
-  rdfs:label "Megagram Per Hectare"@en-us ;
-  rdfs:label "Megagram Per Hectare"@en ;
-  qudt:exactMatch unit:TON_Metric-PER-HA ;
-  qudt:exactMatch unit:TONNE-PER-HA ;
 .
 unit:MegaHZ
   a qudt:DerivedUnit ;
@@ -15821,6 +15821,21 @@ unit:MegaPA-L-PER-SEC
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Megapascal Liter Per Second"@en-us ;
   rdfs:label "Megapascal Litre Per Second"@en ;
+.
+unit:MegaPA-M0_5
+  a qudt:Unit ;
+  qudt:applicableSystem sou:CGS ;
+  qudt:applicableSystem sou:CGS-EMU ;
+  qudt:applicableSystem sou:CGS-GAUSS ;
+  qudt:applicableSystem sou:SI ;
+  qudt:conversionMultiplier 1000000.0 ;
+  qudt:hasDimensionVector qkdv:A0E0L-0_5I0M1H0T-2D0 ;
+  qudt:hasQuantityKind quantitykind:StressIntensityFactor ;
+  qudt:plainTextDescription "1,000,000-fold of the derived unit Pascal Square Root Meter" ;
+  qudt:prefix prefix:Mega ;
+  qudt:symbol "MPa√m" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Megapascal Square Root Meter"@en ;
 .
 unit:MegaPA-M3-PER-SEC
   a qudt:Unit ;
@@ -21310,6 +21325,20 @@ unit:PA-M-PER-SEC2
   qudt:ucumCode "Pa.m.s-2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Pascal metres per square second"@en ;
+.
+unit:PA-M0_5
+  a qudt:Unit ;
+  qudt:applicableSystem sou:CGS ;
+  qudt:applicableSystem sou:CGS-EMU ;
+  qudt:applicableSystem sou:CGS-GAUSS ;
+  qudt:applicableSystem sou:SI ;
+  qudt:conversionMultiplier 1.0 ;
+  qudt:hasDimensionVector qkdv:A0E0L-0_5I0M1H0T-2D0 ;
+  qudt:hasQuantityKind quantitykind:StressIntensityFactor ;
+  qudt:plainTextDescription "A metric unit for stress intensity factor and fracture toughness." ;
+  qudt:symbol "Pa√m" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Pascal Square Root Meter"@en ;
 .
 unit:PA-M3-PER-SEC
   a qudt:Unit ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -15822,14 +15822,14 @@ unit:MegaPA-L-PER-SEC
   rdfs:label "Megapascal Liter Per Second"@en-us ;
   rdfs:label "Megapascal Litre Per Second"@en ;
 .
-unit:MegaPA-M0_5
+unit:MegaPA-M0pt5
   a qudt:Unit ;
   qudt:applicableSystem sou:CGS ;
   qudt:applicableSystem sou:CGS-EMU ;
   qudt:applicableSystem sou:CGS-GAUSS ;
   qudt:applicableSystem sou:SI ;
   qudt:conversionMultiplier 1000000.0 ;
-  qudt:hasDimensionVector qkdv:A0E0L-0_5I0M1H0T-2D0 ;
+  qudt:hasDimensionVector qkdv:A0E0L-0pt5I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:StressIntensityFactor ;
   qudt:plainTextDescription "1,000,000-fold of the derived unit Pascal Square Root Meter" ;
   qudt:prefix prefix:Mega ;
@@ -21326,14 +21326,14 @@ unit:PA-M-PER-SEC2
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Pascal metres per square second"@en ;
 .
-unit:PA-M0_5
+unit:PA-M0pt5
   a qudt:Unit ;
   qudt:applicableSystem sou:CGS ;
   qudt:applicableSystem sou:CGS-EMU ;
   qudt:applicableSystem sou:CGS-GAUSS ;
   qudt:applicableSystem sou:SI ;
   qudt:conversionMultiplier 1.0 ;
-  qudt:hasDimensionVector qkdv:A0E0L-0_5I0M1H0T-2D0 ;
+  qudt:hasDimensionVector qkdv:A0E0L-0pt5I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:StressIntensityFactor ;
   qudt:plainTextDescription "A metric unit for stress intensity factor and fracture toughness." ;
   qudt:symbol "Pa√m" ;


### PR DESCRIPTION
This adds a quantity kind for Stress Intensity Factor, the corresponding dimension vector, and two units for it.

This is a bit of a tricky one since the dimensionality has a fractional exponent- the common unit for stress intensity factor and fracture toughness is MPa√m. I don't think there's a standard for how to represent fractional exponents in unit or dimension vector URIs, so I used a decimal representation with the `.` replaced with `_` (e.g. MPa√m => `unit:MegaPA-M0_5`). If there is a different way this should be represented, please let me know and I'll make the appropriate changes.

Also, for some reason `unit:MegaGM-PER-HA` was not in the correct location in the file and was moved when the file was reserialized.