### PR TITLE
Implementation electrochemistry units:

### DIFF
--- a/vocab/dimensionvectors/VOCAB_QUDT-DIMENSION-VECTORS-v2.1.ttl
+++ b/vocab/dimensionvectors/VOCAB_QUDT-DIMENSION-VECTORS-v2.1.ttl
@@ -24,6 +24,36 @@
   owl:imports <http://qudt.org/2.1/schema/facade/qudt> ;
   owl:versionIRI <http://qudt.org/2.1/vocab/dimensionvector> ;
 .
+qkdv:A0E1L0I0M-1H0T1D0
+  rdf:type qudt:ISO-DimensionVector ;
+  qudt:dimensionExponentForAmountOfSubstance 0;
+  qudt:dimensionExponentForElectricCurrent 1;
+  qudt:dimensionExponentForLength 0;
+  qudt:dimensionExponentForLuminousIntensity 0;
+  qudt:dimensionExponentForMass -1 ;
+  qudt:dimensionExponentForThermodynamicTemperature 0;
+  qudt:dimensionExponentForTime 1 ;
+  qudt:dimensionlessExponent 0;
+  qudt:hasReferenceQuantityKind quantitykind:SpecificElectricCharge ;
+  qudt:isDimensionInSystem qudt:SOQ_ISQ ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/dimension> ;
+  qudt:latexDefinition "\\(I T M^{-1}\\)"^^qudt:LatexString ;
+.
+qkdv:A0E1L0I0M-1H0T0D0
+  rdf:type qudt:ISO-DimensionVector ;
+  qudt:dimensionExponentForAmountOfSubstance 0;
+  qudt:dimensionExponentForElectricCurrent 1;
+  qudt:dimensionExponentForLength 0;
+  qudt:dimensionExponentForLuminousIntensity 0;
+  qudt:dimensionExponentForMass -1 ;
+  qudt:dimensionExponentForThermodynamicTemperature 0;
+  qudt:dimensionExponentForTime 0 ;
+  qudt:dimensionlessExponent 0;
+  qudt:hasReferenceQuantityKind quantitykind:SpecificElectricCurrent ;
+  qudt:isDimensionInSystem qudt:SOQ_ISQ ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/dimension> ;
+  qudt:latexDefinition "\\(I M^{-1}\\)"^^qudt:LatexString ;
+.
 qkdv:A-1E0L-3I0M0H0T0D0
   a qudt:QuantityKindDimensionVector_CGS ;
   a qudt:QuantityKindDimensionVector_ISO ;

--- a/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
+++ b/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
@@ -30,7 +30,7 @@
 .
 quantitykind:SpecificElectricCharge
   rdf:type qudt:QuantityKind ;
-  qudt:hasDimensionVector <http://qudt.org/vocab/dimension/A0E1L0I0M-1H0T1D0> ;
+  qudt:hasDimensionVector qkdv:A0E1L0I0M-1H0T1D0 ;
   qudt:plainTextDescription "Electric charge (often capacity in the context of electrochemical cells) relativ to the mass (often only active components). capacity " ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
   rdfs:label "Specific Electric Charge" ;
@@ -4683,10 +4683,10 @@ quantitykind:ElectricCurrent
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
   rdfs:label "Electric Current"@en ;
 .
-quantitiykind:SpecificElectricCurrent
+quantitykind:SpecificElectricCurrent
   rdf:type qudt:QuantityKind ;
   dcterms:description "\"Specific Electric Current\" is a measure to specify the applied current relative to a corresponding mass. This measure is often used for standardization within electrochemistry."^^qudt:LatexString ;
-  qudt:hasDimensionVector <http://qudt.org/vocab/dimension/A0E1L0I0M-1H0T0D0> ;
+  qudt:hasDimensionVector qkdv:A0E1L0I0M-1H0T0D0 ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
   rdfs:label "Specific Electrical Current" ;
 .

--- a/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
+++ b/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
@@ -28,6 +28,13 @@
   owl:imports <http://qudt.org/2.1/vocab/dimensionvector> ;
   owl:versionIRI <http://qudt.org/2.1/vocab/quantitykind> ;
 .
+quantitykind:SpecificElectricCharge
+  rdf:type qudt:QuantityKind ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimension/A0E1L0I0M-1H0T1D0> ;
+  qudt:plainTextDescription "Electric charge (often capacity in the context of electrochemical cells) relativ to the mass (often only active components). capacity " ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Specific Electric Charge" ;
+.
 quantitykind:AbsoluteActivity
   a qudt:QuantityKind ;
   dcterms:description "The \"Absolute Activity\" is the exponential of the ratio of the chemical potential to \\(RT\\) where \\(R\\) is the gas constant and \\(T\\) the thermodynamic temperature."^^qudt:LatexString ;
@@ -4675,6 +4682,13 @@ quantitykind:ElectricCurrent
   qudt:symbol "I" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
   rdfs:label "Electric Current"@en ;
+.
+quantitiykind:SpecificElectricCurrent
+  rdf:type qudt:QuantityKind ;
+  dcterms:description "\"Specific Electric Current\" is a measure to specify the applied current relative to a corresponding mass. This measure is often used for standardization within electrochemistry."^^qudt:LatexString ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimension/A0E1L0I0M-1H0T0D0> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Specific Electrical Current" ;
 .
 quantitykind:ElectricCurrentDensity
   a qudt:QuantityKind ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -83,6 +83,32 @@ unit:A-HR
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Ampere Hour"@en ;
 .
+unit:MilliA-HR-PER-GM
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "\\(\\textbf{Milliampere hour per gram}\\) is a practical unit of electric charge relative to the mass of the (active) parts. 1mAh/g describes the capability of a material to store charge equivalent to 1h charge with 1mA per gram. The unit is often used in electrochemistry to describe the properties of active components like electrodes."^^qudt:LatexString
+  rdf:type qudt:Unit;
+  rdfs:label "Milliampere Hour per Gram @en ;
+  qudt:symbol "mA⋅h/g" ;
+  qudt:conversionMultiplier 3600.0;
+  qudt:conversionOffset 0.0 ;
+  qudt:hasDimensionVector qkdv:A0E1L0I0M-1H0T1D0 ;
+  qudt:hasQuantityKind quantitykind:SpecificElectricCharge ; 
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+.
+unit:A-PER-GM
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "\\(\\textbf{Ampere per gram}\\) is a practical unit to describe an (applied) current relative to the involved amount of material. This unit is often found in electrochemistry to standardize test conditions and compare various scales of investigated materials."^^qudt:LatexString
+  rdf:type qudt:Unit;
+  rdfs:label "Ampere per Gram @en ;
+  qudt:symbol "A⋅/g" ;
+  qudt:conversionMultiplier 1000;
+  qudt:conversionOffset 0.0 ;
+  qudt:hasDimensionVector qkdv:A0E1L0I0M-1H0T0D0 ;
+  qudt:hasQuantityKind quantitykind:SpecificElectricCurrent ; 
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+.
 unit:A-M2
   a qudt:DerivedUnit ;
   a qudt:Unit ;


### PR DESCRIPTION
Implementation of the units:
- mAh/g
- A/g 
which are commonly used in electrochemistry for standardization of test conditions. 
For implementation quantity kinds
- specific electric current
- specific electric charge 
and corresponding dimensions vectors were added.