### PR TITLE
fixed small typo in unit:M3-PER-HA qudt:symbol

### DIFF
--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -14206,7 +14206,7 @@ unit:M3-PER-HA
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:VolumePerArea ;
   qudt:iec61360Code "0112/2///62720#UAA757" ;
-  qudt:symbol "m^3/ha" ;
+  qudt:symbol "m³/ha" ;
   qudt:ucumCode "m3.har-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Cubic Meter per Hectare"@en-us ;


### PR DESCRIPTION
Found a small inconsistency in the unit:M3-PER-HA. It's the only one where the object associated with predicate qudt:symbol uses latex-style "^" for superscript instead of the actual superscript.