### PR TITLE
Some more Unit and Quantity Kind tweaks

### DIFF
--- a/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
+++ b/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
@@ -3045,6 +3045,18 @@ quantitykind:Conductivity
   rdfs:seeAlso quantitykind:ElectricCurrentDensity ;
   rdfs:seeAlso quantitykind:ElectricFieldStrength ;
 .
+quantitykind:Constringence
+  a qudt:QuantityKind ;
+  dcterms:description "In optics and lens design, constringence of a transparent material, also known as the Abbe number or the V-number, is an approximate measure of the material's dispersion (change of refractive index versus wavelength), with high values of V indicating low dispersion." ;
+  qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
+  qudt:informativeReference "https://en.wikipedia.org/wiki/Abbe_number"^^xsd:anyURI ;
+  qudt:symbol "V" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Constringence"@en ;
+  skos:altLabel "Abbe Number"@en ;
+  skos:altLabel "V-number"@en ;
+  skos:broader quantitykind:DimensionlessRatio ;
+.
 quantitykind:ConvectiveHeatTransfer
   a qudt:QuantityKind ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -5093,6 +5093,7 @@ unit:DecaPA
   qudt:conversionMultiplier 10.0 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerArea ;
+  qudt:hasQuantityKind quantitykind:ModulusOfElasticity ;
   qudt:hasQuantityKind quantitykind:VaporPressure ;
   qudt:iec61360Code "0112/2///62720#UAB375" ;
   qudt:plainTextDescription "10-fold of the derived SI unit pascal" ;
@@ -5187,7 +5188,10 @@ unit:DeciB_M
   qudt:applicableSystem sou:PLANCK ;
   qudt:applicableSystem sou:SI ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
-  qudt:hasQuantityKind quantitykind:DimensionlessRatio ;
+  qudt:hasQuantityKind quantitykind:SoundExposureLevel ;
+  qudt:hasQuantityKind quantitykind:SoundPowerLevel ;
+  qudt:hasQuantityKind quantitykind:SoundPressureLevel ;
+  qudt:hasQuantityKind quantitykind:SoundReductionIndex ;
   qudt:symbol "dBmW" ;
   qudt:udunitsCode "Bm" ;
   qudt:uneceCommonCode "DBM" ;
@@ -8349,6 +8353,7 @@ unit:GigaPA
   qudt:conversionMultiplier 1000000000.0 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerArea ;
+  qudt:hasQuantityKind quantitykind:ModulusOfElasticity ;
   qudt:hasQuantityKind quantitykind:VaporPressure ;
   qudt:iec61360Code "0112/2///62720#UAA153" ;
   qudt:plainTextDescription "1 000 000 000-fold of the SI derived unit pascal" ;
@@ -8935,6 +8940,7 @@ unit:HectoPA
   qudt:exactMatch unit:MilliBAR ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerArea ;
+  qudt:hasQuantityKind quantitykind:ModulusOfElasticity ;
   qudt:hasQuantityKind quantitykind:VaporPressure ;
   qudt:iec61360Code "0112/2///62720#UAA527" ;
   qudt:symbol "hPa" ;
@@ -10102,6 +10108,7 @@ unit:KIP_F-PER-IN2
   qudt:expression "\\(kip/in^{2}\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerArea ;
+  qudt:hasQuantityKind quantitykind:ModulusOfElasticity ;
   qudt:hasQuantityKind quantitykind:VaporPressure ;
   qudt:iec61360Code "0112/2///62720#UAB242" ;
   qudt:symbol "kip/in²" ;
@@ -11804,6 +11811,7 @@ unit:KiloLB_F-PER-IN2
   qudt:conversionMultiplier 6894757.89 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerArea ;
+  qudt:hasQuantityKind quantitykind:ModulusOfElasticity ;
   qudt:hasQuantityKind quantitykind:VaporPressure ;
   qudt:iec61360Code "0112/2///62720#UAB138" ;
   qudt:plainTextDescription "1 000-fold of the unit for pressure psi as a compounded unit pound-force according to the Anglo-American system of units divided by the power of the unit Inch according to the Anglo-American and Imperial system of units by exponent 2" ;
@@ -12096,6 +12104,7 @@ unit:KiloPA
   qudt:dbpediaMatch "http://dbpedia.org/resource/Pascal_%28unit%29"^^xsd:anyURI ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerArea ;
+  qudt:hasQuantityKind quantitykind:ModulusOfElasticity ;
   qudt:hasQuantityKind quantitykind:VaporPressure ;
   qudt:iec61360Code "0112/2///62720#UAA575" ;
   qudt:symbol "kPa" ;
@@ -13233,6 +13242,7 @@ unit:LB_F-PER-IN2
   qudt:exactMatch unit:PSI ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerArea ;
+  qudt:hasQuantityKind quantitykind:ModulusOfElasticity ;
   qudt:hasQuantityKind quantitykind:VaporPressure ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Pounds_per_square_inch?oldid=485678341"^^xsd:anyURI ;
   qudt:symbol "psia" ;
@@ -15822,6 +15832,7 @@ unit:MegaPA
   qudt:conversionMultiplier 1000000.0 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerArea ;
+  qudt:hasQuantityKind quantitykind:ModulusOfElasticity ;
   qudt:hasQuantityKind quantitykind:VaporPressure ;
   qudt:iec61360Code "0112/2///62720#UAA215" ;
   qudt:plainTextDescription "1,000,000-fold of the derived unit pascal" ;
@@ -17071,6 +17082,7 @@ unit:MicroPA
   qudt:conversionMultiplier 0.000001 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerArea ;
+  qudt:hasQuantityKind quantitykind:ModulusOfElasticity ;
   qudt:hasQuantityKind quantitykind:VaporPressure ;
   qudt:iec61360Code "0112/2///62720#UAA073" ;
   qudt:plainTextDescription "0.000001-fold of the SI derived unit pascal" ;
@@ -18978,6 +18990,7 @@ unit:MilliPA
   qudt:conversionMultiplier 0.001 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerArea ;
+  qudt:hasQuantityKind quantitykind:ModulusOfElasticity ;
   qudt:hasQuantityKind quantitykind:VaporPressure ;
   qudt:iec61360Code "0112/2///62720#UAA796" ;
   qudt:plainTextDescription "0.001-fold of the SI derived unit pascal" ;
@@ -23327,6 +23340,7 @@ unit:PPM-PER-K
   qudt:expression "\\(PPM/K\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H-1T0D0 ;
   qudt:hasQuantityKind quantitykind:ExpansionRatio ;
+  qudt:hasQuantityKind quantitykind:ThermalExpansionCoefficient ;
   qudt:symbol "PPM/K" ;
   qudt:ucumCode "ppm.K-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -23390,6 +23404,7 @@ unit:PPTM-PER-K
   qudt:expression "\\(PPTM/K\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H-1T0D0 ;
   qudt:hasQuantityKind quantitykind:ExpansionRatio ;
+  qudt:hasQuantityKind quantitykind:ThermalExpansionCoefficient ;
   qudt:symbol "PPTM/K" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Parts Per Ten Million per Kelvin"@en ;
@@ -23441,6 +23456,7 @@ unit:PSI
   qudt:exactMatch unit:LB_F-PER-IN2 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerArea ;
+  qudt:hasQuantityKind quantitykind:ModulusOfElasticity ;
   qudt:hasQuantityKind quantitykind:VaporPressure ;
   qudt:plainTextDescription "Pounds of force per square inch, the unit for pressure as a compounded unit pound-force according to the Anglo-American system of units divided by the power of the unit Inch according to the Anglo-American and Imperial system of units by exponent 2" ;
   qudt:symbol "psi" ;
@@ -26484,6 +26500,7 @@ unit:UNITLESS
   qudt:hasQuantityKind quantitykind:BioconcentrationFactor ;
   qudt:hasQuantityKind quantitykind:CanonicalPartitionFunction ;
   qudt:hasQuantityKind quantitykind:Chromaticity ;
+  qudt:hasQuantityKind quantitykind:Constringence ;
   qudt:hasQuantityKind quantitykind:Count ;
   qudt:hasQuantityKind quantitykind:CouplingFactor ;
   qudt:hasQuantityKind quantitykind:Debye-WallerFactor ;


### PR DESCRIPTION
This includes the following:
- Add `quantitykind:Constringence` and specify `unit:UNITLESS` as a unit for it
- Change the quanity kinds specified for `unit:DeciB_M` to match those specified for `unit:DeciB`
- Specify 11 additional units for `quantitykind:ModulusOfElasticity`
- Specify 2 additional units for `quantitykind:ThermalExpansionCoefficient`