### PR TITLE
Add ESG units

### DIFF
--- a/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
+++ b/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
@@ -11172,13 +11172,12 @@ quantitykind:MassPerElectricCharge
 .
 quantitykind:MassPerEnergy
   a qudt:QuantityKind ;
-  qudt:hasDimensionVector qkdv:A0E-1L-2I0M1H0T2D0 ;
+  qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T2D0 ;
   qudt:plainTextDescription "Mass per Energy is a physical quantity that can be used to relate the energy of a system to its mass." ;
-  dcterms:description "Mass per Energy (\(m/E\)) is a physical quantity that bridges mass and energy. The SI unit is \(kg/J\) or equivalently \(s^2/m^2\)."^^qudt:LatexString ;
+  dcterms:description "Mass per Energy (\\(m/E\\)) is a physical quantity that bridges mass and energy. The SI unit is \\(kg/J\\) or equivalently \\(s^2/m^2\\)."^^qudt:LatexString ;
   # qudt:applicableUnit unit:KiloGM-PER-J ; # unit doesn't exist
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
   rdfs:label "Mass per Energy"@en ;
-  skos:broader quantitykind:Mass ;
   .
 quantitykind:MassPerLength
   a qudt:QuantityKind ;

--- a/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
+++ b/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
@@ -11170,6 +11170,16 @@ quantitykind:MassPerElectricCharge
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
   rdfs:label "Mass per Electric Charge"@en ;
 .
+quantitykind:MassPerEnergy
+  a qudt:QuantityKind ;
+  qudt:hasDimensionVector qkdv:A0E-1L-2I0M1H0T2D0 ;
+  qudt:plainTextDescription "Mass per Energy is a physical quantity that can be used to relate the energy of a system to its mass." ;
+  dcterms:description "Mass per Energy (\(m/E\)) is a physical quantity that bridges mass and energy. The SI unit is \(kg/J\) or equivalently \(s^2/m^2\)."^^qudt:LatexString ;
+  # qudt:applicableUnit unit:KiloGM-PER-J ; # unit doesn't exist
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Mass per Energy"@en ;
+  skos:broader quantitykind:Mass ;
+  .
 quantitykind:MassPerLength
   a qudt:QuantityKind ;
   dcterms:description "Linear density, linear mass density or linear mass is a measure of mass per unit of length, and it is a characteristic of strings or other one-dimensional objects. The SI unit of linear density is the kilogram per metre (\\(kg/m\\))."^^qudt:LatexString ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -10972,9 +10972,9 @@ unit:KiloGM-PER-J
   qudt:applicableSystem sou:SI ;
   qudt:conversionMultiplier 0.001 ;
   qudt:definedUnitOfSystem sou:SI ;
-  qudt:hasDimensionVector qkdv:A0E0L-2I0M1H0T2D0 ;
+  qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T2D0 ;
   qudt:plainTextDescription "SI base unit kilogram divided by the SI derived unit joule" ;
-  qudt:hasQuantityKind quantitykind:MassPerEnergy;
+  qudt:hasQuantityKind quantitykind:MassPerEnergy ;
   qudt:symbol "kg/J" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kilogram per Joule"@en ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -10195,6 +10195,24 @@ unit:KiloBTU_IT
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kilo British Thermal Unit (International Definition)"@en ;
 .
+unit:KiloBTU_IT-PER-FT2
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "\\(\\textbf{kBTU per Square Foot}\\) is an Imperial unit for  'Energy Per Area' expressed as \\(kBtu/ft^2\\)."^^qudt:LatexString ;
+  qudt:applicableSystem sou:IMPERIAL ;
+  qudt:applicableSystem sou:USCS ;
+  qudt:conversionMultiplier 11356.5267 ;
+  qudt:definedUnitOfSystem sou:IMPERIAL ;
+  qudt:definedUnitOfSystem sou:USCS ;
+  qudt:expression "\\(kBtu/ft^{2}\\)"^^qudt:LatexString ;
+  qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-2D0 ;
+  qudt:hasQuantityKind quantitykind:EnergyPerArea ;
+  qudt:symbol "kBtu{IT}/ft²" ;
+  qudt:ucumCode "k[Btu_IT].[ft_i]-2"^^qudt:UCUMcs ;
+  qudt:ucumCode "k[Btu_IT]/[ft_i]2"^^qudt:UCUMcs ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "kBTU per Square Foot"@en ;
+.
 unit:KiloBTU_IT-PER-HR
   a qudt:DerivedUnit ;
   a qudt:Unit ;
@@ -10891,6 +10909,20 @@ unit:KiloGM-PER-DeciM3
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kilogram Per Cubic Decimetre"@en , "Kilogram Per Cubic Decimeter"@en-us ;
 .
+unit:KiloGM-PER-FT2
+  a qudt:Unit ;
+  qudt:applicableSystem sou:IMPERIAL;
+  qudt:applicableSystem sou:USCS;
+  qudt:applicableSystem sou:SI ;
+  qudt:conversionMultiplier 10.763910416709722 ;
+  qudt:hasDimensionVector qkdv:A0E0L-2I0M1H0T0D0 ;
+  qudt:hasQuantityKind quantitykind:MassPerArea ;
+  qudt:plainTextDescription "SI base unit kilogram divided by the square of the imperial foot" ;
+  qudt:symbol "kg/ft²" ;
+  qudt:ucumCode "kg.ft-2"^^qudt:UCUMcs ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Kilogram Per Square Foot"@en ;
+.
 unit:KiloGM-PER-HA
   a qudt:DerivedUnit ;
   a qudt:Unit ;
@@ -11182,6 +11214,23 @@ unit:KiloGM-PER-M3-SEC
   qudt:ucumCode "kg.m-3.s-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kilograms per cubic metre per second"@en ;
+.
+unit:KiloGM-PER-MegaBTU_IT
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "\\(\\textbf{Kilogram per Mega BTU}\\) is an Imperial unit for 'Mass Per Energy' expressed as \\(kg/MBtu\\)."^^qudt:LatexString ;
+  qudt:applicableSystem sou:IMPERIAL ;
+  qudt:applicableSystem sou:USCS ;
+  qudt:conversionMultiplier 1.0 ;
+  qudt:definedUnitOfSystem sou:IMPERIAL ;
+  qudt:definedUnitOfSystem sou:USCS ;
+  qudt:expression "\\(kg/MBtu\\)"^^qudt:LatexString ;
+  qudt:hasDimensionVector qkdv:A0E-1L0I0M1H0T0D0 ;
+  qudt:hasQuantityKind quantitykind:MassPerEnergy ;
+  qudt:symbol "kg/MBtu{IT}" ;
+  qudt:ucumCode "k[g].[MBtu_IT]-1"^^qudt:UCUMcs ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Kilogram per Mega BTU"@en ;
 .
 unit:KiloGM-PER-MIN
   a qudt:Unit ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -10963,6 +10963,22 @@ unit:KiloGM-PER-HR
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kilogram per Hour"@en ;
 .
+unit:KiloGM-PER-J
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  qudt:applicableSystem sou:CGS ;
+  qudt:applicableSystem sou:CGS-EMU ;
+  qudt:applicableSystem sou:CGS-GAUSS ;
+  qudt:applicableSystem sou:SI ;
+  qudt:conversionMultiplier 0.001 ;
+  qudt:definedUnitOfSystem sou:SI ;
+  qudt:hasDimensionVector qkdv:A0E0L-2I0M1H0T2D0 ;
+  qudt:plainTextDescription "SI base unit kilogram divided by the SI derived unit joule" ;
+  qudt:hasQuantityKind quantitykind:MassPerEnergy;
+  qudt:symbol "kg/J" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Kilogram per Joule"@en ;
+.
 unit:KiloGM-PER-KiloGM
   a qudt:Unit ;
   qudt:applicableSystem sou:CGS ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -10198,7 +10198,8 @@ unit:KiloBTU_IT
 unit:KiloBTU_IT-PER-FT2
   a qudt:DerivedUnit ;
   a qudt:Unit ;
-  dcterms:description "\\(\\textbf{kBTU per Square Foot}\\) is an Imperial unit for  'Energy Per Area' expressed as \\(kBtu/ft^2\\)."^^qudt:LatexString ;
+  dcterms:description "\\(\\textbf{kBTU per Square Foot}\\) is an Imperial unit for 'Energy Per Area' expressed as \\(kBtu/ft^2\\)."^^qudt:LatexString ;
+  qudt:plainTextDescription "kBTU per Square Foot is an Imperieal unit for 'Energy Per Area." ;
   qudt:applicableSystem sou:IMPERIAL ;
   qudt:applicableSystem sou:USCS ;
   qudt:conversionMultiplier 11356.5267 ;
@@ -11219,6 +11220,7 @@ unit:KiloGM-PER-MegaBTU_IT
   a qudt:DerivedUnit ;
   a qudt:Unit ;
   dcterms:description "\\(\\textbf{Kilogram per Mega BTU}\\) is an Imperial unit for 'Mass Per Energy' expressed as \\(kg/MBtu\\)."^^qudt:LatexString ;
+  qudt:plainTextDescription "Kilogram per Mega BTU is an Imperial Unit for 'Mass Per Energy." ;
   qudt:applicableSystem sou:IMPERIAL ;
   qudt:applicableSystem sou:USCS ;
   qudt:conversionMultiplier 1.0 ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -11223,7 +11223,7 @@ unit:KiloGM-PER-MegaBTU_IT
   qudt:plainTextDescription "Kilogram per Mega BTU is an Imperial Unit for 'Mass Per Energy." ;
   qudt:applicableSystem sou:IMPERIAL ;
   qudt:applicableSystem sou:USCS ;
-  qudt:conversionMultiplier 1.0 ;
+  qudt:conversionMultiplier 0.000000000947817 ;
   qudt:definedUnitOfSystem sou:IMPERIAL ;
   qudt:definedUnitOfSystem sou:USCS ;
   qudt:expression "\\(kg/MBtu\\)"^^qudt:LatexString ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -10970,10 +10970,10 @@ unit:KiloGM-PER-J
   qudt:applicableSystem sou:CGS-EMU ;
   qudt:applicableSystem sou:CGS-GAUSS ;
   qudt:applicableSystem sou:SI ;
-  qudt:conversionMultiplier 0.001 ;
+  qudt:conversionMultiplier 1.0 ;
   qudt:definedUnitOfSystem sou:SI ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T2D0 ;
-  qudt:plainTextDescription "SI base unit kilogram divided by the SI derived unit joule" ;
+  qudt:plainTextDescription "SI base unit kilogram divided by the SI base unit joule" ;
   qudt:hasQuantityKind quantitykind:MassPerEnergy ;
   qudt:symbol "kg/J" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -10199,10 +10199,10 @@ unit:KiloBTU_IT-PER-FT2
   a qudt:DerivedUnit ;
   a qudt:Unit ;
   dcterms:description "\\(\\textbf{kBTU per Square Foot}\\) is an Imperial unit for 'Energy Per Area' expressed as \\(kBtu/ft^2\\)."^^qudt:LatexString ;
-  qudt:plainTextDescription "kBTU per Square Foot is an Imperieal unit for 'Energy Per Area." ;
+  qudt:plainTextDescription "kBTU per Square Foot is an Imperial unit for 'Energy Per Area." ;
   qudt:applicableSystem sou:IMPERIAL ;
   qudt:applicableSystem sou:USCS ;
-  qudt:conversionMultiplier 11356.5267 ;
+  qudt:conversionMultiplier 11356526.7 ;
   qudt:definedUnitOfSystem sou:IMPERIAL ;
   qudt:definedUnitOfSystem sou:USCS ;
   qudt:expression "\\(kBtu/ft^{2}\\)"^^qudt:LatexString ;
@@ -11227,7 +11227,7 @@ unit:KiloGM-PER-MegaBTU_IT
   qudt:definedUnitOfSystem sou:IMPERIAL ;
   qudt:definedUnitOfSystem sou:USCS ;
   qudt:expression "\\(kg/MBtu\\)"^^qudt:LatexString ;
-  qudt:hasDimensionVector qkdv:A0E-1L0I0M1H0T0D0 ;
+  qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T2D0 ;
   qudt:hasQuantityKind quantitykind:MassPerEnergy ;
   qudt:symbol "kg/MBtu{IT}" ;
   qudt:ucumCode "k[g].[MBtu_IT]-1"^^qudt:UCUMcs ;


### PR DESCRIPTION
Introducing units mainly utilized in CO2 emissions:
- KiloGM-PER-FT2
- KiloGM-PER-MegaBTU
- KiloBTU_IT-PER-FT2

These units are currently in use by the EPA, as documented in the following resource:
[Custom_Reporting_Metric_Inventory_en_US.xlsx](https://github.com/qudt/qudt-public-repo/files/11885685/Custom_Reporting_Metric_Inventory_en_US.xlsx)

In the process of defining these units, I am uncertain in a few areas, particularly concerning conversion multipliers and dimension vectors. Any expert insights and contributions in this regard would be highly appreciated.

For the unit `KiloGM-PER-MegaBTU_IT`, a temporary conversion multiplier of 1.0 was used. This serves as a placeholder, as I could not determine an accurate conversion multiplier.
