### PR TITLE
More minor tweaks

### DIFF
--- a/schema/shacl/SCHEMA_QUDT_NoOWL-v2.1.ttl
+++ b/schema/shacl/SCHEMA_QUDT_NoOWL-v2.1.ttl
@@ -355,6 +355,7 @@ qudt:Concept
   rdfs:comment "The root class for all QUDT concepts."^^rdf:HTML ;
   rdfs:isDefinedBy <http://qudt.org/2.1/schema/shacl/qudt> ;
   rdfs:label "QUDT Concept" ;
+  rdfs:subClassOf rdfs:Resource ;
   sh:property qudt:Concept-abbreviation ;
   sh:property qudt:Concept-code ;
   sh:property qudt:Concept-deprecated ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -12032,8 +12032,8 @@ unit:KiloGM_F-M
   qudt:ucumCode "kgf.m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B38" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
-  rdfs:label "Kilogram?force Meter"@en-us ;
-  rdfs:label "Kilogram?force Metre"@en ;
+  rdfs:label "Kilogram-Force Meter"@en-us ;
+  rdfs:label "Kilogram-Force Metre"@en ;
 .
 unit:KiloGM_F-M-PER-CentiM2
   a qudt:Unit ;
@@ -12046,8 +12046,8 @@ unit:KiloGM_F-M-PER-CentiM2
   qudt:ucumCode "kgf.m.cm-2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E44" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
-  rdfs:label "Kilogram?force Meter Per Square Centimeter"@en-us ;
-  rdfs:label "Kilogram?force Metre Per Square Centimetre"@en ;
+  rdfs:label "Kilogram-Force Meter Per Square Centimeter"@en-us ;
+  rdfs:label "Kilogram-Force Metre Per Square Centimetre"@en ;
 .
 unit:KiloGM_F-M-PER-SEC
   a qudt:Unit ;
@@ -12059,8 +12059,8 @@ unit:KiloGM_F-M-PER-SEC
   qudt:ucumCode "kgf.m.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B39" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
-  rdfs:label "Kilogram?force Meter Per Second"@en-us ;
-  rdfs:label "Kilogram?force Metre Per Second"@en ;
+  rdfs:label "Kilogram-Force Meter Per Second"@en-us ;
+  rdfs:label "Kilogram-Force Metre Per Second"@en ;
 .
 unit:KiloGM_F-PER-CentiM2
   a qudt:Unit ;
@@ -26810,7 +26810,7 @@ unit:TONNE-PER-HA-YR
   qudt:hasDimensionVector qkdv:A0E0L-2I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:MassPerAreaTime ;
   qudt:plainTextDescription "A measure of density equivalent to 1000kg per hectare per year or one Megagram per hectare per year, typically used to express a volume of biomass or crop yield." ;
-  qudt:symbol "t/ha/year" ;
+  qudt:symbol "t/(ha⋅year)" ;
   qudt:ucumCode "t.har-1.year-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "tonne per hectare per year"@en ;


### PR DESCRIPTION
This includes the following:
- Add `rdfs:Resource` as an explicit superclass of `qudt:Concept` in the SHACL schema as all other classes defined there have an explicit superclass and some tools complain about one not existing
- Standardize a symbol for one unit
- Replace `Kilogram?force` with `Kilogram-Force` in the labels for a few units