### PR TITLE
ESG Units Enhancement

### DIFF
--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -8592,6 +8592,31 @@ unit:GigaJ
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Gigajoule"@en ;
 .
+unit:GigaJ-PER-M2
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "Gigajoule Per Square Meter (\\(J/m^2\\)) is a unit in the category of Energy density. It is also known as Gigajoules per square meter, Gigajoule per square metre, Gigajoule/square meter, Gigajoule/square metre."^^qudt:LatexString ;
+  qudt:applicableSystem sou:CGS ;
+  qudt:applicableSystem sou:CGS-EMU ;
+  qudt:applicableSystem sou:CGS-GAUSS ;
+  qudt:applicableSystem sou:SI ;
+  qudt:conversionMultiplier 1000000000.0 ;
+  qudt:definedUnitOfSystem sou:SI ;
+  qudt:derivedCoherentUnitOfSystem sou:SI ;
+  qudt:expression "\\(GJ/m^2\\)"^^qudt:LatexString ;
+  qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-2D0 ;
+  qudt:hasQuantityKind quantitykind:EnergyFluence ;
+  qudt:hasQuantityKind quantitykind:EnergyPerArea ;
+  qudt:hasQuantityKind quantitykind:RadiantFluence ;
+  qudt:iec61360Code "0112/2///62720#UAA179" ;
+  qudt:symbol "GJ/m²" ;
+  qudt:ucumCode "GJ.m-2"^^qudt:UCUMcs ;
+  qudt:ucumCode "GJ/m2"^^qudt:UCUMcs ;
+  qudt:uneceCommonCode "B13" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Gigajoule per Square Meter"@en-us ;
+  rdfs:label "Gigajoule per Square Metre"@en ;
+.
 unit:GigaOHM
   a qudt:Unit ;
   qudt:applicableSystem sou:CGS-EMU ;
@@ -11575,6 +11600,22 @@ unit:KiloGM-PER-FT2
   qudt:ucumCode "kg.ft-2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kilogram Per Square Foot"@en ;
+.
+unit:KiloGM-PER-GigaJ
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  qudt:applicableSystem sou:CGS ;
+  qudt:applicableSystem sou:CGS-EMU ;
+  qudt:applicableSystem sou:CGS-GAUSS ;
+  qudt:applicableSystem sou:SI ;
+  qudt:conversionMultiplier .000000001 ;
+  qudt:definedUnitOfSystem sou:SI ;
+  qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T2D0 ;
+  qudt:plainTextDescription "SI base unit kilogram divided by the SI base unit gigajoule" ;
+  qudt:hasQuantityKind quantitykind:MassPerEnergy ;
+  qudt:symbol "kg/GJ" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Kilogram per Gigajoule"@en ;
 .
 unit:KiloGM-PER-HA
   a qudt:DerivedUnit ;


### PR DESCRIPTION
- GJ/m² is a unit used by EnergyStar to determine the energy a property consumes divided by the property's square meters
- kg/GJ is unit is used for calculating the GHG Emissions Factor, particularly for Direct Fuels, District Steam, District Hot Water, and District Chilled Water in metric systems