### PR TITLE
Add new energy density and power units

### DIFF
--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -8792,6 +8792,24 @@ unit:GigaJ
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Gigajoule"@en ;
 .
+unit:GigaJ-PER-HR
+  a qudt:Unit ;
+  dcterms:description "SI derived unit Gigajoule divided by the 3600 times the SI base unit second"^^rdf:HTML ;
+  qudt:applicableSystem sou:CGS ;
+  qudt:applicableSystem sou:CGS-EMU ;
+  qudt:applicableSystem sou:CGS-GAUSS ;
+  qudt:applicableSystem sou:SI ;
+  qudt:conversionMultiplier 3600000000.0 ;
+  qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
+  qudt:hasQuantityKind quantitykind:Power ;
+  qudt:plainTextDescription "SI derived unit gigajoule divided by the 3600 times the SI base unit second" ;
+  qudt:symbol "GJ/hr" ;
+  qudt:ucumCode "GJ.h-1"^^qudt:UCUMcs ;
+  qudt:uneceCommonCode "P16" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Gigajoule Per Hour"@en ;
+.
+
 unit:GigaJ-PER-M2
   a qudt:DerivedUnit ;
   a qudt:Unit ;
@@ -16832,6 +16850,24 @@ unit:MegaJ
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Megajoule"@en ;
 .
+unit:MegaJ-PER-HR
+  a qudt:Unit ;
+  dcterms:description "SI derived unit MegaJoule divided by the 3600 times the SI base unit second"^^rdf:HTML ;
+  qudt:applicableSystem sou:CGS ;
+  qudt:applicableSystem sou:CGS-EMU ;
+  qudt:applicableSystem sou:CGS-GAUSS ;
+  qudt:applicableSystem sou:SI ;
+  qudt:conversionMultiplier 3600000.0 ;
+  qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
+  qudt:hasQuantityKind quantitykind:Power ;
+  qudt:plainTextDescription "SI derived unit Megajoule divided by the 3600 times the SI base unit second" ;
+  qudt:symbol "MJ/hr" ;
+  qudt:ucumCode "MJ.h-1"^^qudt:UCUMcs ;
+  qudt:uneceCommonCode "P16" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Megajoule Per Hour"@en ;
+.
+
 unit:MegaJ-PER-K
   a qudt:DerivedUnit ;
   a qudt:Unit ;
@@ -28901,6 +28937,22 @@ unit:W-HR
   qudt:uneceCommonCode "WHR" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Watthour"@en ;
+.
+unit:W-HR-PER-M2
+  a qudt:Unit ;
+  dcterms:description "A unit of energy per unit area, equivalent to 3,600 joules per square metre."^^rdf:HTML ;
+  qudt:applicableSystem sou:CGS ;
+  qudt:applicableSystem sou:CGS-EMU ;
+  qudt:applicableSystem sou:CGS-GAUSS ;
+  qudt:applicableSystem sou:SI ;
+  qudt:conversionMultiplier "3600"^^xsd:double ;
+  qudt:conversionOffset "0"^^xsd:double ;
+  qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-2D0 ;  # This vector represents energy per area correctly
+  qudt:hasQuantityKind quantitykind:EnergyPerArea ;
+  qudt:plainTextDescription "A unit of energy per unit area, equivalent to 3,600 joules per square metre." ;
+  qudt:symbol "W⋅h/m²" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Watt hour per square metre"@en ;
 .
 unit:W-HR-PER-M3
   a qudt:Unit ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -8799,7 +8799,7 @@ unit:GigaJ-PER-HR
   qudt:applicableSystem sou:CGS-EMU ;
   qudt:applicableSystem sou:CGS-GAUSS ;
   qudt:applicableSystem sou:SI ;
-  qudt:conversionMultiplier 3600000000.0 ;
+  qudt:conversionMultiplier 3600000000000.0 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:plainTextDescription "SI derived unit gigajoule divided by the 3600 times the SI base unit second" ;
@@ -16857,7 +16857,7 @@ unit:MegaJ-PER-HR
   qudt:applicableSystem sou:CGS-EMU ;
   qudt:applicableSystem sou:CGS-GAUSS ;
   qudt:applicableSystem sou:SI ;
-  qudt:conversionMultiplier 3600000.0 ;
+  qudt:conversionMultiplier 3600000000.0 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:plainTextDescription "SI derived unit Megajoule divided by the 3600 times the SI base unit second" ;


### PR DESCRIPTION
### Addition of New Energy and Power Units

I've introduced three new units to expand our support for energy and power measurements recently observed:
- `unit:MegaJ-PER-HR`: Represents energy flow at the scale of mega joules per hour.
- `unit:GigaJ-PER-HR`: Represents energy flow at the scale of giga joules per hour.
- `unit:W-HR-PER-M2`: This unit quantifies energy density in terms of watt-hours per square meter.

Thank you!