### PR TITLE
fix conversion offset for DEG_F

### DIFF
--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -4820,7 +4820,7 @@ unit:DEG_F
   qudt:applicableSystem sou:IMPERIAL ;
   qudt:applicableSystem sou:USCS ;
   qudt:conversionMultiplier 0.5555555555555556 ;
-  qudt:conversionOffset 459.669607 ;
+  qudt:conversionOffset 459.67 ;
   qudt:definedUnitOfSystem sou:IMPERIAL ;
   qudt:definedUnitOfSystem sou:USCS ;
   qudt:expression "\\(degF\\)"^^qudt:LatexString ;


### PR DESCRIPTION
The only reference to 459.669607 on google is from qudt. While 459.67 gets lots of hits, including in the definition on wikipedia.