### PR TITLE
Several unit and quantity kind tweaks

### DIFF
--- a/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
+++ b/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
@@ -3019,6 +3019,14 @@ quantitykind:ChemicalAffinity
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
   rdfs:label "Chemical Affinity"@en ;
 .
+quantitykind:ChemicalConsumptionPerMass
+  a qudt:QuantityKind ;
+  qudt:hasDimensionVector qkdv:A0E0L3I0M-1H0T0D0 ;
+  qudt:plainTextDescription "In the context of a chemical durability test, this is measure of how much of a solution (often a corrosive or reactive one) is consumed or used up per unit mass of a material being tested. In other words, this the volume of solution needed to cause a certain level of chemical reaction or damage to a given mass of the material." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Chemical Consumption per Mass"@en ;
+  skos:broader quantitykind:SpecificVolume ;
+.
 quantitykind:ChemicalPotential
   a qudt:QuantityKind ;
   dcterms:description "\"Chemical Potential\", also known as partial molar free energy, is a form of potential energy that can be absorbed or released during a chemical reaction."^^rdf:HTML ;

--- a/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
+++ b/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
@@ -21889,7 +21889,6 @@ quantitykind:TouchThresholds
 quantitykind:Transmittance
   a qudt:QuantityKind ;
   dcterms:description "Transmittance is the fraction of incident light (electromagnetic radiation) at a specified wavelength that passes through a sample."^^rdf:HTML ;
-  qudt:applicableUnit unit:UNITLESS ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Transmittance"^^xsd:anyURI ;
   qudt:latexDefinition "\\(\\tau = \\frac{\\Phi_t}{\\Phi_m}\\), where \\(\\Phi_t\\) is the transmitted radiant flux or the transmitted luminous flux, and \\(\\Phi_m\\) is the radiant flux or luminous flux of the incident radiation."^^qudt:LatexString ;
@@ -21899,6 +21898,7 @@ quantitykind:Transmittance
   vaem:todo "belongs to SOQ-ISO" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
   rdfs:label "Transmittance"@en ;
+  skos:broader quantitykind:DimensionlessRatio ;
 .
 quantitykind:TransmittanceDensity
   a qudt:QuantityKind ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -22086,6 +22086,24 @@ unit:NanoM
   rdfs:label "Nanometer"@en-us ;
   rdfs:label "Nanometre"@en ;
 .
+unit:NanoM-PER-CentiM-MegaPA
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  qudt:applicableSystem sou:CGS ;
+  qudt:applicableSystem sou:CGS-EMU ;
+  qudt:applicableSystem sou:CGS-GAUSS ;
+  qudt:applicableSystem sou:SI ;
+  qudt:conversionMultiplier 0.0000000000001 ;
+  qudt:hasDimensionVector qkdv:A0E0L1I0M-1H0T2D0 ;
+  qudt:hasQuantityKind quantitykind:StressOpticCoefficient ;
+  qudt:qkdvDenominator qkdv:A0E0L0I0M1H0T-2D0 ;
+  qudt:qkdvNumerator qkdv:A0E0L1I0M0H0T0D0 ;
+  qudt:siUnitsExpression "nm/cm/MPa" ;
+  qudt:symbol "nm/(cm⋅MPa)" ;
+  qudt:ucumCode "nm.cm-1.MPa-1"^^qudt:UCUMcs ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Nanometer Per Centimeter Megapascal"@en ;
+.
 unit:NanoM-PER-CentiM-PSI
   a qudt:DerivedUnit ;
   a qudt:Unit ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -28592,7 +28592,6 @@ unit:UNITLESS
   qudt:hasQuantityKind quantitykind:ThermalDiffusionRatio ;
   qudt:hasQuantityKind quantitykind:ThermalUtilizationFactor ;
   qudt:hasQuantityKind quantitykind:TotalIonization ;
-  qudt:hasQuantityKind quantitykind:Transmittance ;
   qudt:hasQuantityKind quantitykind:TransmittanceDensity ;
   qudt:hasQuantityKind quantitykind:Turns ;
   qudt:symbol "一" ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -19716,8 +19716,8 @@ unit:MilliL-PER-GM
   qudt:ucumCode "mL.g-1"^^qudt:UCUMcs ;
   qudt:ucumCode "mL/g"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
-  rdfs:label "Cubic Milliliter per Gram"@en-us ;
-  rdfs:label "Cubic Millilitre per Gram"@en ;
+  rdfs:label "Milliliter per Gram"@en-us ;
+  rdfs:label "Millilitre per Gram"@en ;
 .
 unit:MilliL-PER-HR
   a qudt:Unit ;


### PR DESCRIPTION
I apologize in advance if this would have been better as several tiny PRs- if so, let me know and I'll do that next time.

This includes several changes:
- Fix incorrect labels on `unit:MilliL-PER-GM`
- Add `unit:NanoM-PER-CentiM-MegaPA` as a unit for `quantitykind:StressOpticCoefficient`
- Add `quantitykind:ChemicalConsumptionPerMass` as narrower than Specific Volume
- Implicitly add more applicable units for `quantitykind:Transmittance` by making it narrower than `quantitykind:DimensionlessRatio` and removing `unit:UNITLESS qudt:hasQuantityKind quantitykind:Transmittance`; that way, the applicable units for `quantitykind:Transmittance` will be inherited from `quantitykind:DimensionlessRatio`.