### PR TITLE
Fix value and standard uncertainty for Value_ElectronGFactor

### DIFF
--- a/vocab/constants/VOCAB_QUDT-CONSTANTS-v2.1.ttl
+++ b/vocab/constants/VOCAB_QUDT-CONSTANTS-v2.1.ttl
@@ -3795,8 +3795,8 @@ constant:Value_ElectronGFactor
   a qudt:ConstantValue ;
   qudt:hasUnit unit:UNITLESS ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
-  qudt:standardUncertainty "0.0000000000015"^^xsd:double ;
-  qudt:value "-2.002.1.3143622"^^xsd:double ;
+  qudt:standardUncertainty "0.00000000000035"^^xsd:double ;
+  qudt:value "-2.00231930436256"^^xsd:double ;
   vaem:website "http://physics.nist.gov/cgi-bin/cuu/Value?gem#mid"^^xsd:anyURI ;
   rdfs:label "Value for electron g factor" ;
 .


### PR DESCRIPTION
This fixes #770 by replacing the invalid value as well as the standard uncertainty with correctly formatted values from the provided NIST reference.