### PR TITLE
Add new units from existing quantity kinds and extend various ucum symbols

### DIFF
--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -17832,7 +17832,7 @@ unit:MicroGM-PER-L
   rdfs:label "Microgram Per Liter"@en-us ;
   rdfs:label "Microgram Per Litre"@en ;
 .
-unit:MicroGM-PER-deciL
+unit:MicroGM-PER-DeciL
   a qudt:Unit ;
   qudt:applicableSystem sou:CGS ;
   qudt:applicableSystem sou:CGS-EMU ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -9941,6 +9941,22 @@ The magnitude of one <strong>IU/L</strong> depends on the material, so there is 
   rdfs:label "International Unit per Litre"@en ;
   rdfs:seeAlso unit:IU ;
 .
+unit:IU-PER-MilliL
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"International Unit per Milliliter\" is a unit for  'Serum Or Plasma Level' expressed as \\(IU/mL\\)."^^qudt:LatexString ;
+  qudt:expression "\\(IU/mL\\)"^^qudt:LatexString ;
+  qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T0D0 ;
+  qudt:hasQuantityKind quantitykind:SerumOrPlasmaLevel ;
+  qudt:symbol "IU/mL" ;
+  qudt:ucumCode "[IU].mL-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[IU]/mL"^^qudt:UCUMcs ;
+  qudt:ucumCode "[iU].mL-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[iU]/mL"^^qudt:UCUMcs ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "International Unit per milliliter"@en-us ;
+  rdfs:label "International Unit per milliliter"@en ;
+.
 unit:IU-PER-MilliGM
   a qudt:Unit ;
   dcterms:description "International Units per milligramme."^^rdf:HTML ;
@@ -10875,6 +10891,24 @@ unit:KAT-PER-L
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Katal Per Liter"@en-us ;
   rdfs:label "Katal Per Litre"@en ;
+.
+unit:KAT-PER-MicroL
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "A unit of catalytic activity used especially in the chemistry of enzymes. A catalyst is a substance that starts or speeds a chemical reaction. Enzymes are proteins that act as catalysts within the bodies of living plants and animals. A catalyst has an activity of one katal if it enables a reaction to proceed at the rate of one mole per second. "^^rdf:HTML ;
+  qudt:applicableSystem sou:SI ;
+  qudt:conversionMultiplier 0.000000001 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Katal"^^xsd:anyURI ;
+  qudt:definedUnitOfSystem sou:SI ;
+  qudt:derivedCoherentUnitOfSystem sou:SI ;
+  qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T-1D0 ;
+  qudt:hasQuantityKind quantitykind:CatalyticActivityConcentration ;
+  qudt:plainTextDescription "A unit of catalytic activity used especially in the chemistry of enzymes. A catalyst is a substance that starts or speeds a chemical reaction. Enzymes are proteins that act as catalysts within the bodies of living plants and animals. A catalyst has an activity of one katal if it enables a reaction to proceed at the rate of one mole per second. " ;
+  qudt:symbol "kat/μL" ;
+  qudt:ucumCode "kat/uL"^^qudt:UCUMcs ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Katal Per Microliter"@en-us ;
+  rdfs:label "Katal Per Microlitre"@en ;
 .
 unit:KIP_F
   a qudt:Unit ;
@@ -12941,6 +12975,7 @@ unit:KiloMOL-PER-HR
   qudt:plainTextDescription "1 000-fold of the SI base unit mole divided by the unit for time hour" ;
   qudt:symbol "kmol/hr" ;
   qudt:ucumCode "kmol.h-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "kmol/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K58" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kilomole Per Hour"@en ;
@@ -17797,6 +17832,40 @@ unit:MicroGM-PER-L
   rdfs:label "Microgram Per Liter"@en-us ;
   rdfs:label "Microgram Per Litre"@en ;
 .
+unit:MicroGM-PER-deciL
+  a qudt:Unit ;
+  qudt:applicableSystem sou:CGS ;
+  qudt:applicableSystem sou:CGS-EMU ;
+  qudt:applicableSystem sou:CGS-GAUSS ;
+  qudt:applicableSystem sou:SI ;
+  qudt:conversionMultiplier 0.0001 ;
+  qudt:hasDimensionVector qkdv:A0E0L-3I0M1H0T0D0 ;
+  qudt:hasQuantityKind quantitykind:MassDensity ;
+  qudt:plainTextDescription "0.0000000001-fold of the SI base unit kilogram divided by the unit decilitre" ;
+  qudt:symbol "μg/dL" ;
+  qudt:ucumCode "ug.dL-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "ug/dL"^^qudt:UCUMcs ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Microgram Per Deciliter"@en-us ;
+  rdfs:label "Microgram Per Decilitre"@en ;
+.
+unit:MicroGM-PER-MilliL
+  a qudt:Unit ;
+  qudt:applicableSystem sou:CGS ;
+  qudt:applicableSystem sou:CGS-EMU ;
+  qudt:applicableSystem sou:CGS-GAUSS ;
+  qudt:applicableSystem sou:SI ;
+  qudt:conversionMultiplier 0.001 ;
+  qudt:hasDimensionVector qkdv:A0E0L-3I0M1H0T0D0 ;
+  qudt:hasQuantityKind quantitykind:MassDensity ;
+  qudt:plainTextDescription "0.000000000001-fold of the SI base unit kilogram divided by the unit microlitre" ;
+  qudt:symbol "μg/mL" ;
+  qudt:ucumCode "ug.mL-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "ug/mL"^^qudt:UCUMcs ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Microgram Per Milliliter"@en-us ;
+  rdfs:label "Microgram Per MilliLitre"@en ;
+.
 unit:MicroGM-PER-L-HR
   a qudt:Unit ;
   dcterms:description "A rate of change of mass of a measurand equivalent to 10^-9 kilogram (the SI unit of mass) per litre volume of matrix over a period of 1 hour."@en ;
@@ -18014,6 +18083,7 @@ unit:MicroKAT-PER-L
   qudt:hasQuantityKind quantitykind:CatalyticActivityConcentration ;
   qudt:plainTextDescription "A unit of catalytic activity used especially in the chemistry of enzymes. A catalyst is a substance that starts or speeds a chemical reaction. Enzymes are proteins that act as catalysts within the bodies of living plants and animals. A catalyst has an activity of one katal if it enables a reaction to proceed at the rate of one mole per second. " ;
   qudt:symbol "ukat/L" ;
+  qudt:ucumCode "ukat/L"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Microkatal Per Liter"@en-us ;
   rdfs:label "Microkatal Per Litre"@en ;
@@ -18091,6 +18161,7 @@ unit:MicroM-PER-K
   qudt:plainTextDescription "0.000001-fold of the SI base unit metre divided by the SI base unit kelvin" ;
   qudt:symbol "μm/K" ;
   qudt:ucumCode "um.K-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "um/K"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F50" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Micrometer Per Kelvin"@en-us ;
@@ -18119,6 +18190,7 @@ unit:MicroM-PER-MilliL
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T0D0 ;
   qudt:symbol "µm/mL" ;
   qudt:ucumCode "um2.mL-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "um2/mL"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Square microns per millilitre"@en ;
 .
@@ -19264,6 +19336,44 @@ unit:MilliGM-PER-DeciL
   rdfs:label "milligrams per decilitre"@en ;
   rdfs:label "milligrams per decilitre"@en-us ;
 .
+unit:NanoGM-PER-DeciL
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "A derived unit for amount-of-substance concentration measured in ng/dL."^^rdf:HTML ;
+  qudt:applicableSystem sou:CGS ;
+  qudt:applicableSystem sou:CGS-EMU ;
+  qudt:applicableSystem sou:CGS-GAUSS ;
+  qudt:applicableSystem sou:SI ;
+  qudt:conversionMultiplier 0.00000001 ;
+  qudt:expression "\\(ng/dL\\)"^^qudt:LatexString ;
+  qudt:hasDimensionVector qkdv:A0E0L-3I0M1H0T0D0 ;
+  qudt:hasQuantityKind quantitykind:Density ;
+  qudt:symbol "ng/dL" ;
+  qudt:ucumCode "ng.dL-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "ng/dL"^^qudt:UCUMcs ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "nanograms per decilitre"@en ;
+  rdfs:label "nanograms per decilitre"@en-us ;
+.
+unit:GM-PER-DeciL
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "A derived unit for amount-of-substance concentration measured in g/dL."^^rdf:HTML ;
+  qudt:applicableSystem sou:CGS ;
+  qudt:applicableSystem sou:CGS-EMU ;
+  qudt:applicableSystem sou:CGS-GAUSS ;
+  qudt:applicableSystem sou:SI ;
+  qudt:conversionMultiplier 10 ;
+  qudt:expression "\\(g/dL\\)"^^qudt:LatexString ;
+  qudt:hasDimensionVector qkdv:A0E0L-3I0M1H0T0D0 ;
+  qudt:hasQuantityKind quantitykind:Density ;
+  qudt:symbol "g/dL" ;
+  qudt:ucumCode "g.dL-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "g/dL"^^qudt:UCUMcs ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "grams per decilitre"@en ;
+  rdfs:label "grams per decilitre"@en-us ;
+.
 unit:MilliGM-PER-GM
   a qudt:Unit ;
   dcterms:description "0.000001-fold of the SI base unit kilogram divided by the 0.001-fold of the SI base unit kilogram"^^rdf:HTML ;
@@ -19693,6 +19803,7 @@ unit:MilliKAT-PER-L
   qudt:hasQuantityKind quantitykind:CatalyticActivityConcentration ;
   qudt:plainTextDescription "A unit of catalytic activity used especially in the chemistry of enzymes. A catalyst is a substance that starts or speeds a chemical reaction. Enzymes are proteins that act as catalysts within the bodies of living plants and animals. A catalyst has an activity of one katal if it enables a reaction to proceed at the rate of one mole per second. " ;
   qudt:symbol "mkat/L" ;
+  qudt:ucumCode "mkat/L"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Millikatal Per Liter"@en-us ;
   rdfs:label "Millikatal Per Litre"@en ;
@@ -21752,8 +21863,20 @@ unit:NUM-PER-L
   qudt:hasQuantityKind quantitykind:NumberDensity ;
   qudt:symbol "/L" ;
   qudt:ucumCode "{#}.L-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "/L"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Number per litre"@en ;
+.
+unit:NUM-PER-MilliM3
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1000000000.0 ;
+  qudt:hasDimensionVector qkdv:A0E0L-3I0M0H0T0D0 ;
+  qudt:hasQuantityKind quantitykind:NumberDensity ;
+  qudt:symbol "/mm³" ;
+  qudt:ucumCode "{#}.mm-3"^^qudt:UCUMcs ;
+  qudt:ucumCode "/mm3"^^qudt:UCUMcs ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Number per cubic millimeter"@en ;
 .
 unit:NUM-PER-M
   a qudt:Unit ;
@@ -21762,6 +21885,7 @@ unit:NUM-PER-M
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T0D0 ;
   qudt:symbol "/m" ;
   qudt:ucumCode "{#}.m-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "/m"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Number per metre"@en ;
 .
@@ -21772,6 +21896,7 @@ unit:NUM-PER-M2
   qudt:hasQuantityKind quantitykind:ParticleFluence ;
   qudt:symbol "/m²" ;
   qudt:ucumCode "{#}.m-2"^^qudt:UCUMcs ;
+  qudt:ucumCode "/m2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Number per square metre"@en ;
 .
@@ -21792,6 +21917,7 @@ unit:NUM-PER-M3
   qudt:hasQuantityKind quantitykind:NumberDensity ;
   qudt:symbol "/m³" ;
   qudt:ucumCode "{#}.m-3"^^qudt:UCUMcs ;
+  qudt:ucumCode "/m3"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Number per cubic metre"@en ;
 .
@@ -21802,8 +21928,31 @@ unit:NUM-PER-MicroL
   qudt:hasQuantityKind quantitykind:NumberDensity ;
   qudt:symbol "/µL" ;
   qudt:ucumCode "{#}.uL-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "/uL"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Number per microlitre"@en ;
+.
+unit:NUM-PER-NanoL
+  a qudt:Unit ;
+  qudt:conversionMultiplier  1000000000000.0 ;
+  qudt:hasDimensionVector qkdv:A0E0L-3I0M0H0T0D0 ;
+  qudt:hasQuantityKind quantitykind:NumberDensity ;
+  qudt:symbol "/nL" ;
+  qudt:ucumCode "{#}.nL-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "/nL"^^qudt:UCUMcs ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Number per nanoliter"@en ;
+.
+unit:NUM-PER-PicoL
+  a qudt:Unit ;
+  qudt:conversionMultiplier  1000000000000000.0 ;
+  qudt:hasDimensionVector qkdv:A0E0L-3I0M0H0T0D0 ;
+  qudt:hasQuantityKind quantitykind:NumberDensity ;
+  qudt:symbol "/pL" ;
+  qudt:ucumCode "{#}.pL-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "/pL"^^qudt:UCUMcs ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Number per picoliter"@en ;
 .
 unit:NUM-PER-MilliGM
   a qudt:Unit ;
@@ -21812,6 +21961,7 @@ unit:NUM-PER-MilliGM
   qudt:hasDimensionVector qkdv:A0E0L0I0M-1H0T0D0 ;
   qudt:symbol "/mg" ;
   qudt:ucumCode "{#}.mg-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "/mg"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Number per milligram"@en ;
 .
@@ -21822,6 +21972,7 @@ unit:NUM-PER-NanoL
   qudt:hasQuantityKind quantitykind:NumberDensity ;
   qudt:symbol "/nL" ;
   qudt:ucumCode "{#}.nL-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "/nL"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Number per nanolitre"@en ;
 .
@@ -22066,6 +22217,7 @@ unit:NanoGM-PER-MicroL
   qudt:hasQuantityKind quantitykind:MassDensity ;
   qudt:symbol "ng/µL" ;
   qudt:ucumCode "ng.uL-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "ng/uL"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Nanograms per microlitre"@en ;
 .
@@ -22133,6 +22285,7 @@ unit:NanoKAT-PER-L
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:CatalyticActivityConcentration ;
   qudt:symbol "nkat/L" ;
+  qudt:ucumCode "nkat/L"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Nanokatal Per Liter"@en-us ;
   rdfs:label "Nanokatal Per Litre"@en ;
@@ -22285,6 +22438,7 @@ unit:NanoMOL-PER-KiloGM
   qudt:hasQuantityKind quantitykind:AmountOfSubstancePerUnitMass ;
   qudt:symbol "nmol/kg" ;
   qudt:ucumCode "nmol.kg-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "nmol/kg"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Nanomoles per kilogram"@en ;
 .
@@ -22351,6 +22505,7 @@ unit:NanoMOL-PER-MicroMOL
   qudt:qkdvNumerator qkdv:A1E0L0I0M0H0T0D0 ;
   qudt:symbol "nmol/µmol" ;
   qudt:ucumCode "nmol.umol-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "nmol/umol"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Nanomoles per micromole"@en ;
 .
@@ -23878,6 +24033,7 @@ unit:PER-L
   qudt:plainTextDescription "reciprocal value of the unit litre" ;
   qudt:symbol "/L" ;
   qudt:ucumCode "L-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "/L"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K63" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Reciprocal Liter"@en-us ;
@@ -24131,6 +24287,7 @@ unit:PER-MOL
   qudt:hasQuantityKind quantitykind:InverseAmountOfSubstance ;
   qudt:symbol "/mol" ;
   qudt:ucumCode "mol-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "/mol"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C95" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Reciprocal Mole"@en ;
@@ -24212,6 +24369,7 @@ unit:PER-MilliM3
   qudt:plainTextDescription "reciprocal value of the 0.000000001-fold of the power of the SI base unit metre with the exponent 3" ;
   qudt:symbol "/mm³" ;
   qudt:ucumCode "mm-3"^^qudt:UCUMcs ;
+  qudt:ucumCode "/mm3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L20" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Reciprocal Cubic Millimeter"@en-us ;
@@ -25725,6 +25883,7 @@ unit:PicoKAT-PER-L
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:CatalyticActivityConcentration ;
   qudt:symbol "pkat/L" ;
+  qudt:ucumCode "pkat/L"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Picokatal Per Liter"@en-us ;
   rdfs:label "Picokatal Per Litre"@en ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -9944,7 +9944,11 @@ The magnitude of one <strong>IU/L</strong> depends on the material, so there is 
 unit:IU-PER-MilliL
   a qudt:DerivedUnit ;
   a qudt:Unit ;
-  dcterms:description "\"International Unit per Milliliter\" is a unit for  'Serum Or Plasma Level' expressed as \\(IU/mL\\)."^^qudt:LatexString ;
+  dcterms:description """
+<p><strong>International Unit per Milliliter</strong> is a unit for  'Serum Or Plasma Level' expressed as <strong>IU/mL</strong>.
+The magnitude of one <strong>IU/L</strong> depends on the material, so there is no single conversion multiplier.
+(See <a href=\"http://qudt.org/vocab/unit/IU)\"><strong>IU</strong></a> for more information).
+</p>"""^^rdf:HTML ;
   qudt:expression "\\(IU/mL\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:SerumOrPlasmaLevel ;
@@ -9959,9 +9963,11 @@ unit:IU-PER-MilliL
 .
 unit:IU-PER-MilliGM
   a qudt:Unit ;
-  dcterms:description "International Units per milligramme."^^rdf:HTML ;
-  qudt:conversionMultiplier "0.000001"^^xsd:double ;
-  qudt:conversionOffset "0"^^xsd:double ;
+  dcterms:description """
+<p>International Unit per milligramme.
+The magnitude of one <strong>IU/L</strong> depends on the material, so there is no single conversion multiplier.
+(See <a href=\"http://qudt.org/vocab/unit/IU)\"><strong>IU</strong></a> for more information).
+</p>"""^^rdf:HTML ;
   qudt:hasDimensionVector qkdv:A1E0L0I0M-1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:AmountOfSubstancePerUnitMass ;
   qudt:plainTextDescription "International Units per milligramme." ;
@@ -24038,6 +24044,24 @@ unit:PER-L
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Reciprocal Liter"@en-us ;
   rdfs:label "Reciprocal Litre"@en ;
+.
+ unit:PER-MilliL
+  a qudt:Unit ;
+  dcterms:description "reciprocal value of the unit Millilitre"^^rdf:HTML ;
+  qudt:applicableSystem sou:CGS ;
+  qudt:applicableSystem sou:CGS-EMU ;
+  qudt:applicableSystem sou:CGS-GAUSS ;
+  qudt:applicableSystem sou:SI ;
+  qudt:conversionMultiplier 1000000.0 ;
+  qudt:hasDimensionVector qkdv:A0E0L-3I0M0H0T0D0 ;
+  qudt:hasQuantityKind quantitykind:InverseVolume ;
+  qudt:plainTextDescription "reciprocal value of the unit millilitre" ;
+  qudt:symbol "/mL" ;
+  qudt:ucumCode "mL-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "/mL"^^qudt:UCUMcs ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Reciprocal Milliliter"@en-us ;
+  rdfs:label "Reciprocal Millilitre"@en ;
 .
 unit:PER-M
   a qudt:Unit ;


### PR DESCRIPTION
Added the following units, which were mostly copied from existing related units:
* unit:IU-PER-MilliL
* unit:KAT-PER-MicroL
* unit:MicroGM-PER-deciL
* unit:MicroGM-PER-MilliL
* unit:NanoGM-PER-DeciL
* unit:GM-PER-DeciL
* unit:NUM-PER-MilliM3
* unit:NUM-PER-NanoL
* unit:NUM-PER-PicoL

in addition, added some missing or alternative ucum symbols in other units.

One question I have is related to the units unit:IU-PER-MilliL (new) and unit:IU-PER-L (existing). in the existing one the description says `The magnitude of one <strong>IU/L</strong> depends on the material, so there is no single conversion multiplier. (See <a href=\"http://qudt.org/vocab/unit/IU)\"><strong>IU</strong></a> for more information)`. 
To me it seems that the international unit `IU` is generic and the `quantitykind:AmountOfSubstancePerUnitVolume` could be assigned to both of them (and thus, define the related multipliers) but I wanted to verify this assumption first.