### PR TITLE
Make several existing units applicable for Shear Modulus

### DIFF
--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -5425,6 +5425,7 @@ unit:DecaPA
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerArea ;
   qudt:hasQuantityKind quantitykind:ModulusOfElasticity ;
+  qudt:hasQuantityKind quantitykind:ShearModulus ;
   qudt:hasQuantityKind quantitykind:VaporPressure ;
   qudt:iec61360Code "0112/2///62720#UAB375" ;
   qudt:plainTextDescription "10-fold of the derived SI unit pascal" ;
@@ -8864,6 +8865,7 @@ unit:GigaPA
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerArea ;
   qudt:hasQuantityKind quantitykind:ModulusOfElasticity ;
+  qudt:hasQuantityKind quantitykind:ShearModulus ;
   qudt:hasQuantityKind quantitykind:VaporPressure ;
   qudt:iec61360Code "0112/2///62720#UAA153" ;
   qudt:plainTextDescription "1 000 000 000-fold of the SI derived unit pascal" ;
@@ -9519,6 +9521,7 @@ unit:HectoPA
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerArea ;
   qudt:hasQuantityKind quantitykind:ModulusOfElasticity ;
+  qudt:hasQuantityKind quantitykind:ShearModulus ;
   qudt:hasQuantityKind quantitykind:VaporPressure ;
   qudt:iec61360Code "0112/2///62720#UAA527" ;
   qudt:symbol "hPa" ;
@@ -10899,6 +10902,7 @@ unit:KIP_F-PER-IN2
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerArea ;
   qudt:hasQuantityKind quantitykind:ModulusOfElasticity ;
+  qudt:hasQuantityKind quantitykind:ShearModulus ;
   qudt:hasQuantityKind quantitykind:VaporPressure ;
   qudt:iec61360Code "0112/2///62720#UAB242" ;
   qudt:symbol "kip/in²" ;
@@ -12808,6 +12812,7 @@ unit:KiloLB_F-PER-IN2
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerArea ;
   qudt:hasQuantityKind quantitykind:ModulusOfElasticity ;
+  qudt:hasQuantityKind quantitykind:ShearModulus ;
   qudt:hasQuantityKind quantitykind:VaporPressure ;
   qudt:iec61360Code "0112/2///62720#UAB138" ;
   qudt:plainTextDescription "1 000-fold of the unit for pressure psi as a compounded unit pound-force according to the Anglo-American system of units divided by the power of the unit Inch according to the Anglo-American and Imperial system of units by exponent 2" ;
@@ -13109,6 +13114,7 @@ unit:KiloPA
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerArea ;
   qudt:hasQuantityKind quantitykind:ModulusOfElasticity ;
+  qudt:hasQuantityKind quantitykind:ShearModulus ;
   qudt:hasQuantityKind quantitykind:VaporPressure ;
   qudt:iec61360Code "0112/2///62720#UAA575" ;
   qudt:symbol "kPa" ;
@@ -14281,6 +14287,7 @@ unit:LB_F-PER-IN2
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerArea ;
   qudt:hasQuantityKind quantitykind:ModulusOfElasticity ;
+  qudt:hasQuantityKind quantitykind:ShearModulus ;
   qudt:hasQuantityKind quantitykind:VaporPressure ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Pounds_per_square_inch?oldid=485678341"^^xsd:anyURI ;
   qudt:symbol "psia" ;
@@ -17139,6 +17146,7 @@ unit:MegaPA
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerArea ;
   qudt:hasQuantityKind quantitykind:ModulusOfElasticity ;
+  qudt:hasQuantityKind quantitykind:ShearModulus ;
   qudt:hasQuantityKind quantitykind:VaporPressure ;
   qudt:iec61360Code "0112/2///62720#UAA215" ;
   qudt:plainTextDescription "1,000,000-fold of the derived unit pascal" ;
@@ -17245,6 +17253,7 @@ unit:MegaPSI
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerArea ;
   qudt:hasQuantityKind quantitykind:ModulusOfElasticity ;
+  qudt:hasQuantityKind quantitykind:ShearModulus ;
   qudt:hasQuantityKind quantitykind:VaporPressure ;
   qudt:plainTextDescription "Megapounds of force per square inch is a unit for pressure in the Anglo-American system of units." ;
   qudt:symbol "Mpsi" ;
@@ -18465,6 +18474,7 @@ unit:MicroPA
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerArea ;
   qudt:hasQuantityKind quantitykind:ModulusOfElasticity ;
+  qudt:hasQuantityKind quantitykind:ShearModulus ;
   qudt:hasQuantityKind quantitykind:VaporPressure ;
   qudt:iec61360Code "0112/2///62720#UAA073" ;
   qudt:plainTextDescription "0.000001-fold of the SI derived unit pascal" ;
@@ -20491,6 +20501,7 @@ unit:MilliPA
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerArea ;
   qudt:hasQuantityKind quantitykind:ModulusOfElasticity ;
+  qudt:hasQuantityKind quantitykind:ShearModulus ;
   qudt:hasQuantityKind quantitykind:VaporPressure ;
   qudt:iec61360Code "0112/2///62720#UAA796" ;
   qudt:plainTextDescription "0.001-fold of the SI derived unit pascal" ;
@@ -25303,6 +25314,7 @@ unit:PSI
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerArea ;
   qudt:hasQuantityKind quantitykind:ModulusOfElasticity ;
+  qudt:hasQuantityKind quantitykind:ShearModulus ;
   qudt:hasQuantityKind quantitykind:VaporPressure ;
   qudt:plainTextDescription "Pounds of force per square inch, the unit for pressure as a compounded unit pound-force according to the Anglo-American system of units divided by the power of the unit Inch according to the Anglo-American and Imperial system of units by exponent 2" ;
   qudt:symbol "psi" ;


### PR DESCRIPTION
Make 12 additional already existing units applicable for `quantitykind:ShearModulus`.