### PR TITLE
Reflectivity and Reflectance

### DIFF
--- a/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
+++ b/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
@@ -17605,16 +17605,17 @@ quantitykind:RecombinationCoefficient
 .
 quantitykind:Reflectance
   a qudt:QuantityKind ;
-  dcterms:description "Reflectance and reflectivity generally refer to the fraction of incident power that is reflected at an interface, while the term \"reflection coefficient\" is used for the fraction of electric field reflected. Reflectance is always a real number between zero and 1.0."^^rdf:HTML ;
+  dcterms:description "Reflectance generally refers to the fraction of incident power that is reflected at an interface, while the term \"reflection coefficient\" is used for the fraction of electric field reflected. Reflectance is always a real number between zero and 1.0."^^rdf:HTML ;
   qudt:applicableUnit unit:UNITLESS ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Reflectivity"^^xsd:anyURI ;
   qudt:latexDefinition "\\(\\rho = \\frac{\\Phi_t}{\\Phi_m}\\), where \\(\\Phi_t\\) is the reflected radiant flux, the reflected luminous flux, or the reflected sound power and \\(\\Phi_m\\) is the incident radiant flux, incident luminous flux, or incident sound power, respectively."^^qudt:LatexString ;
   qudt:latexSymbol "\\(\\rho\\)"^^qudt:LatexString ;
-  qudt:plainTextDescription "Reflectance and reflectivity generally refer to the fraction of incident power that is reflected at an interface, while the term \"reflection coefficient\" is used for the fraction of electric field reflected. Reflectance is always a real number between zero and 1.0." ;
+  qudt:plainTextDescription "Reflectance generally refers to the fraction of incident power that is reflected at an interface, while the term \"reflection coefficient\" is used for the fraction of electric field reflected. Reflectance is always a real number between zero and 1.0." ;
   qudt:systemDerivedQuantityKind qudt:SOQ_SI ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
   rdfs:label "Reflectance"@en ;
+  skos:broader quantitykind:DimensionlessRatio ;
 .
 quantitykind:ReflectanceFactor
   a qudt:QuantityKind ;
@@ -17628,6 +17629,22 @@ quantitykind:ReflectanceFactor
   qudt:systemDerivedQuantityKind qudt:SOQ_SI ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
   rdfs:label "Reflectance Factor"@en ;
+.
+quantitykind:Reflectivity
+  a qudt:QuantityKind ;
+  dcterms:description """<p>For homogeneous and semi-infinite materials, reflectivity is the same as reflectance. Reflectivity is the square of the magnitude of the Fresnel reflection coefficient, which is the ratio of the reflected to incident electric field;&nbsp;as such the reflection coefficient can be expressed as a complex number as determined by the Fresnel equations for a single layer, whereas the reflectance is always a positive real number.</p>
+
+<p>For layered and finite media, according to the CIE,&nbsp;<em>reflectivity</em> is distinguished from <em>reflectance</em> by the fact that reflectivity is a value that applies to <em>thick</em> reflecting objects.<span style=\"font-size:10.8333px\"> </span>When reflection occurs from thin layers of material, internal reflection effects can cause the reflectance to vary with surface thickness. Reflectivity is the limit value of reflectance as the sample becomes thick; it is the intrinsic reflectance of the surface, hence irrespective of other parameters such as the reflectance of the rear surface. Another way to interpret this is that the reflectance is the fraction of electromagnetic power reflected from a specific sample, while reflectivity is a property of the material itself, which would be measured on a perfect machine if the material filled half of all space.</p>"""^^rdf:HTML ;
+  qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Reflectivity"^^xsd:anyURI ;
+  qudt:latexSymbol "\\(\\rho\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription """For homogeneous and semi-infinite materials, reflectivity is the same as reflectance. Reflectivity is the square of the magnitude of the Fresnel reflection coefficient, which is the ratio of the reflected to incident electric field; as such the reflection coefficient can be expressed as a complex number as determined by the Fresnel equations for a single layer, whereas the reflectance is always a positive real number.
+
+For layered and finite media, according to the CIE, reflectivity is distinguished from reflectance by the fact that reflectivity is a value that applies to thick reflecting objects. When reflection occurs from thin layers of material, internal reflection effects can cause the reflectance to vary with surface thickness. Reflectivity is the limit value of reflectance as the sample becomes thick; it is the intrinsic reflectance of the surface, hence irrespective of other parameters such as the reflectance of the rear surface. Another way to interpret this is that the reflectance is the fraction of electromagnetic power reflected from a specific sample, while reflectivity is a property of the material itself, which would be measured on a perfect machine if the material filled half of all space.""" ;
+  qudt:systemDerivedQuantityKind qudt:SOQ_SI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Reflectance"@en ;
+  skos:broader quantitykind:Reflectance ;
 .
 quantitykind:RefractiveIndex
   a qudt:QuantityKind ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -6669,6 +6669,7 @@ unit:FRACTION
   qudt:conversionOffset "0"^^xsd:double ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:DimensionlessRatio ;
+  qudt:hasQuantityKind quantitykind:Reflectance ;
   qudt:plainTextDescription "Fraction is a unit for 'Dimensionless Ratio' expressed as the value of the ratio itself." ;
   qudt:symbol "÷" ;
   qudt:ucumCode "{fraction}"^^qudt:UCUMcs ;
@@ -24815,6 +24816,7 @@ unit:PERCENT
   qudt:hasQuantityKind quantitykind:LengthPercentage ;
   qudt:hasQuantityKind quantitykind:PressurePercentage ;
   qudt:hasQuantityKind quantitykind:Prevalence ;
+  qudt:hasQuantityKind quantitykind:Reflectance ;
   qudt:hasQuantityKind quantitykind:RelativeHumidity ;
   qudt:hasQuantityKind quantitykind:RelativeLuminousFlux ;
   qudt:hasQuantityKind quantitykind:RelativePartialPressure ;
@@ -28907,6 +28909,7 @@ unit:UNITLESS
   qudt:hasQuantityKind quantitykind:RadianceFactor ;
   qudt:hasQuantityKind quantitykind:RatioOfSpecificHeatCapacities ;
   qudt:hasQuantityKind quantitykind:Reactivity ;
+  qudt:hasQuantityKind quantitykind:Reflectance ;
   qudt:hasQuantityKind quantitykind:ReflectanceFactor ;
   qudt:hasQuantityKind quantitykind:RefractiveIndex ;
   qudt:hasQuantityKind quantitykind:RelativeMassConcentrationOfVapour ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -28907,8 +28907,6 @@ unit:UNITLESS
   qudt:hasQuantityKind quantitykind:RadianceFactor ;
   qudt:hasQuantityKind quantitykind:RatioOfSpecificHeatCapacities ;
   qudt:hasQuantityKind quantitykind:Reactivity ;
-  qudt:hasQuantityKind quantitykind:Refectance ;
-  qudt:hasQuantityKind quantitykind:Reflectance ;
   qudt:hasQuantityKind quantitykind:ReflectanceFactor ;
   qudt:hasQuantityKind quantitykind:RefractiveIndex ;
   qudt:hasQuantityKind quantitykind:RelativeMassConcentrationOfVapour ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -24810,6 +24810,7 @@ unit:PERCENT
   qudt:applicableSystem sou:IMPERIAL ;
   qudt:applicableSystem sou:PLANCK ;
   qudt:applicableSystem sou:SI ;
+  qudt:conversionMultiplier 0.01 ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Percentage"^^xsd:anyURI ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:DimensionlessRatio ;


### PR DESCRIPTION
This includes the following changes:
- Add `Reflectivity` as a narrower Quantity Kind than `Reflectance`.
- Add 3 units for `Reflectance` (and therefore `Reflectivity`).
- Remove a lingering reference to `quantitykind:Refectance`.
- Add a conversion multiplier of 0.01 to `unit:PERCENT`.