### PR TITLE
Fix label on Reflectivity

### DIFF
--- a/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
+++ b/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
@@ -17643,7 +17643,7 @@ quantitykind:Reflectivity
 For layered and finite media, according to the CIE, reflectivity is distinguished from reflectance by the fact that reflectivity is a value that applies to thick reflecting objects. When reflection occurs from thin layers of material, internal reflection effects can cause the reflectance to vary with surface thickness. Reflectivity is the limit value of reflectance as the sample becomes thick; it is the intrinsic reflectance of the surface, hence irrespective of other parameters such as the reflectance of the rear surface. Another way to interpret this is that the reflectance is the fraction of electromagnetic power reflected from a specific sample, while reflectivity is a property of the material itself, which would be measured on a perfect machine if the material filled half of all space.""" ;
   qudt:systemDerivedQuantityKind qudt:SOQ_SI ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Reflectance"@en ;
+  rdfs:label "Reflectivity"@en ;
   skos:broader quantitykind:Reflectance ;
 .
 quantitykind:RefractiveIndex


### PR DESCRIPTION
I realized shortly after #777 was merged (of course) that I accidentally used the wrong label for Reflectivity.