### PR TITLE
owl parsing error removal

### DIFF
--- a/schema/SCHEMA_QUDT-v2.1.ttl
+++ b/schema/SCHEMA_QUDT-v2.1.ttl
@@ -507,6 +507,7 @@ qudt:Datatype
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
+      owl:maxCardinality 1 ;
       owl:onProperty qudt:mySQLName ;
     ] ;
 .
@@ -1147,11 +1148,6 @@ qudt:QuantityKind
       owl:minCardinality "0"^^xsd:nonNegativeInteger ;
       owl:onProperty qudt:applicableUnit ;
     ] ;
-  rdfs:subClassOf [
-      a owl:Restriction ;
-      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
-      owl:onProperty qudt:expression ;
-    ] ;
 .
 qudt:QuantityKindDimensionVector
   a owl:Class ;
@@ -1315,11 +1311,6 @@ qudt:Rule
       a owl:Restriction ;
       owl:allValuesFrom qudt:RuleType ;
       owl:onProperty qudt:ruleType ;
-    ] ;
-  rdfs:subClassOf [
-      a owl:Restriction ;
-      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
-      owl:onProperty qudt:example ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
@@ -1772,11 +1763,6 @@ qudt:Unit
       a owl:Restriction ;
       owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onProperty qudt:qkdvNumerator ;
-    ] ;
-  rdfs:subClassOf [
-      a owl:Restriction ;
-      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
-      owl:onProperty qudt:expression ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;

--- a/schema/SCHEMA_QUDT-v2.1.ttl
+++ b/schema/SCHEMA_QUDT-v2.1.ttl
@@ -1069,31 +1069,6 @@ qudt:QuantityKind
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-      owl:onProperty qudt:baseCGSUnitDimensions ;
-    ] ;
-  rdfs:subClassOf [
-      a owl:Restriction ;
-      owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-      owl:onProperty qudt:baseISOUnitDimensions ;
-    ] ;
-  rdfs:subClassOf [
-      a owl:Restriction ;
-      owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-      owl:onProperty qudt:baseImperialUnitDimensions ;
-    ] ;
-  rdfs:subClassOf [
-      a owl:Restriction ;
-      owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-      owl:onProperty qudt:baseSIUnitDimensions ;
-    ] ;
-  rdfs:subClassOf [
-      a owl:Restriction ;
-      owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-      owl:onProperty qudt:baseUSCustomaryUnitDimensions ;
-    ] ;
-  rdfs:subClassOf [
-      a owl:Restriction ;
-      owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onProperty qudt:dimensionVectorForSI ;
     ] ;
   rdfs:subClassOf [
@@ -1986,7 +1961,7 @@ qudt:bits
   rdfs:range xsd:integer ;
 .
 qudt:bounded
-  a rdf:Property ;
+  a owl:DatatypeProperty ;
   rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
   rdfs:label "bounded" ;
 .
@@ -2248,7 +2223,7 @@ qudt:elementKind
   rdfs:label "element kind" ;
 .
 qudt:elementType
-  a rdf:Property ;
+  a owl:ObjectProperty ;
   rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
   rdfs:label "element type" ;
 .
@@ -3028,7 +3003,7 @@ qudt:url
   rdfs:range xsd:anyURI ;
 .
 qudt:value
-  a rdf:Property ;
+  a owl:DatatypeProperty ;
   dcterms:description "A property to relate an observable thing with a value of any kind"^^rdf:HTML ;
   rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
   rdfs:label "value" ;

--- a/schema/SCHEMA_QUDT-v2.1.ttl
+++ b/schema/SCHEMA_QUDT-v2.1.ttl
@@ -1828,11 +1828,6 @@ qudt:Verifiable
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:minCardinality "0"^^xsd:nonNegativeInteger ;
-      owl:onProperty qudt:informativeReference ;
-    ] ;
-  rdfs:subClassOf [
-      a owl:Restriction ;
-      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
       owl:onProperty qudt:isoNormativeReference ;
     ] ;
   rdfs:subClassOf [
@@ -1870,7 +1865,7 @@ qudt:acronym
   rdfs:range xsd:string ;
 .
 qudt:allowedPattern
-  a rdf:Property ;
+  a owl:DatatypeProperty ;
   rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
   rdfs:label "allowed pattern" ;
 .
@@ -1967,7 +1962,7 @@ qudt:baseUnitOfSystem
   owl:inverseOf qudt:hasBaseUnit ;
 .
 qudt:basis
-  a rdf:Property ;
+  a owl:ObjectProperty ;
   rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
   rdfs:label "basis" ;
 .
@@ -2017,7 +2012,7 @@ qudt:cName
   rdfs:range xsd:string ;
 .
 qudt:cardinality
-  a rdf:Property ;
+  a owl:ObjectProperty ;
   rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
   rdfs:label "cardinality" ;
 .
@@ -2774,7 +2769,7 @@ qudt:order
   rdfs:range xsd:nonNegativeInteger ;
 .
 qudt:orderedType
-  a rdf:Property ;
+  a owl:ObjectProperty ;
   rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
   rdfs:label "ordered type" ;
 .


### PR DESCRIPTION
removed undecleared properties;
removed min 0 cardinality constraints that have annotation properties
changed several properties from rdf:property to owl:data/object property

The resulting file has only 2 errors remaining from the linkedmodel