### PR TITLE
Standardize qudt:symbol for a few units

### DIFF
--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -11168,7 +11168,7 @@ unit:Kilo-FT3
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:LiquidVolume ;
   qudt:hasQuantityKind quantitykind:Volume ;
-  qudt:symbol "kft³" ;
+  qudt:symbol "k(ft³)" ;
   qudt:ucumCode "[k.cft_i]"^^qudt:UCUMcs ;
   qudt:ucumCode "k[ft_i]3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "FC" ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -11168,7 +11168,7 @@ unit:Kilo-FT3
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:LiquidVolume ;
   qudt:hasQuantityKind quantitykind:Volume ;
-  qudt:symbol "k.ft³" ;
+  qudt:symbol "kft³" ;
   qudt:ucumCode "[k.cft_i]"^^qudt:UCUMcs ;
   qudt:ucumCode "k[ft_i]3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "FC" ;
@@ -18304,7 +18304,7 @@ unit:MicroKAT-PER-L
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:CatalyticActivityConcentration ;
   qudt:plainTextDescription "A unit of catalytic activity used especially in the chemistry of enzymes. A catalyst is a substance that starts or speeds a chemical reaction. Enzymes are proteins that act as catalysts within the bodies of living plants and animals. A catalyst has an activity of one katal if it enables a reaction to proceed at the rate of one mole per second. " ;
-  qudt:symbol "ukat/L" ;
+  qudt:symbol "µkat/L" ;
   qudt:ucumCode "ukat/L"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Microkatal Per Liter"@en-us ;
@@ -28457,7 +28457,7 @@ unit:TON_FG
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Ton_of_refrigeration?oldid=494342824"^^xsd:anyURI ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/tonOfRefrigeration> ;
-  qudt:symbol "t/fg" ;
+  qudt:symbol "TOR" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Ton of Refrigeration"@en ;
 .
@@ -28471,6 +28471,7 @@ unit:TON_FG-HR
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ThermalEnergy ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Ton_of_refrigeration?oldid=494342824"^^xsd:anyURI ;
+  qudt:symbol "TOR⋅hr" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Ton of Refrigeration Hour"@en ;
 .


### PR DESCRIPTION
Just standardizes a few unit symbols to match the rest of the symbols.

Note that I used `TOR` for Ton of Refrigeration because it seems to be commonly used but doesn't conflict with the symbol for Register Ton.