### PR TITLE
fixed errors for physical constant and constant value

### DIFF
--- a/schema/SCHEMA_QUDT-v2.1.ttl
+++ b/schema/SCHEMA_QUDT-v2.1.ttl
@@ -351,11 +351,8 @@ qudt:ConstantValue
   rdfs:subClassOf qudt:QuantityValue ;
   rdfs:subClassOf [
       a owl:Restriction ;
+      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
       owl:onProperty qudt:exactConstant ;
-    ] ;
-  rdfs:subClassOf [
-      a owl:Restriction ;
-      owl:onProperty qudt:informativeReference ;
     ] ;
 .
 qudt:CountingUnit
@@ -915,6 +912,7 @@ qudt:PhysicalConstant
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
+      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
       owl:onProperty qudt:dbpediaMatch ;
     ] ;
   rdfs:subClassOf [
@@ -934,10 +932,7 @@ qudt:PhysicalConstant
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
-      owl:onProperty qudt:informativeReference ;
-    ] ;
-  rdfs:subClassOf [
-      a owl:Restriction ;
+      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
       owl:onProperty qudt:isoNormativeReference ;
     ] ;
   rdfs:subClassOf [
@@ -957,14 +952,17 @@ qudt:PhysicalConstant
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
+      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
       owl:onProperty qudt:normativeReference ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
+      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
       owl:onProperty qudt:symbol ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
+      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
       owl:onProperty qudt:ucumCode ;
     ] ;
 .


### PR DESCRIPTION
fixed properties with undeclared constraint type to owl:minCardinality "0"^^xsd:nonNegativeInteger ;
removed informative reference from constraints as it is an annotation property
