### PR TITLE
Unit and Quantity Kind Label Language Tags

### DIFF
--- a/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
+++ b/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
@@ -8623,7 +8623,7 @@ quantitykind:GrowingDegreeDay_Cereal
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H1T1D0 ;
   qudt:plainTextDescription "The sum of excess temperature over 5.5°C, where the temperature is the mean of the minimum and maximum atmospheric temperature in a day. This measure is appropriate for most cereal crops." ;
   rdfs:isDefinedBy <https://data.agrimetrics.co.uk/ontologies/qudt-extension> ;
-  rdfs:label "Growing Degree Days (Cereals)" ;
+  rdfs:label "Growing Degree Days (Cereals)"@en ;
   skos:broader quantitykind:TimeTemperature ;
 .
 quantitykind:GruneisenParameter
@@ -9456,7 +9456,7 @@ quantitykind:Incidence
   qudt:qkdvDenominator qkdv:A0E0L0I0M0H0T1D0 ;
   qudt:qkdvNumerator qkdv:A0E0L0I0M0H0T0D1 ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Incidence" ;
+  rdfs:label "Incidence"@en ;
   skos:broader quantitykind:Frequency ;
 .
 quantitykind:IncidenceProportion
@@ -16091,7 +16091,7 @@ quantitykind:PhotosyntheticPhotonFlux
   qudt:informativeReference "https://www.dormgrow.com/par/"^^xsd:anyURI ;
   qudt:plainTextDescription "Photosynthetic Photon Flux (PPF) is a measurement of the total number of photons emitted by a light source each second within the PAR wavelength range and is measured in μmol/s. Lighting manufacturers may specify their grow light products in terms of PPF. It can be considered as analogous to measuring the luminous flux (lumens) of visible light which would typically require the use of an integrating sphere or a goniometer system with spectroradiometer sensor." ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Photosynthetic Photon Flux" ;
+  rdfs:label "Photosynthetic Photon Flux"@en ;
   skos:altLabel "PPF" ;
   prov:wasDerivedFrom <https://www.gigahertz-optik.com/en-us/service-and-support/knowledge-base/measurement-of-par/#WasistPAR> ;
 .
@@ -16103,7 +16103,7 @@ quantitykind:PhotosyntheticPhotonFluxDensity
   qudt:informativeReference "https://www.gigahertz-optik.com/en-us/service-and-support/knowledge-base/measurement-of-par/"^^xsd:anyURI ;
   qudt:plainTextDescription "Photosynthetically Active Radiation are the wavelengths of light within the visible range of 400 to 700 nanometers (nm) that are critical for photosynthesis. PPFD measures the amount of PAR light (photons) that arrive at the plant’s surface each second. The PPFD is measured at various distances with a Full-spectrum Quantum Sensor, also known as a PAR meter. Natural sunlight has a PAR value of 900-1500μMol/m2/s when the sun is directly overhead. For a grow light to be effective, it should have PAR values of 500-1500 μMol/m2/s." ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Photosynthetic Photon Flux Density" ;
+  rdfs:label "Photosynthetic Photon Flux Density"@en ;
   skos:altLabel "PPFD" ;
   prov:wasDerivedFrom <https://www.dormgrow.com/par> ;
 .
@@ -16919,7 +16919,7 @@ quantitykind:Prevalence
   qudt:qkdvDenominator qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:qkdvNumerator qkdv:A0E0L0I0M0H0T0D1 ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Prevalence" ;
+  rdfs:label "Prevalence"@en ;
   skos:broader quantitykind:DimensionlessRatio ;
 .
 quantitykind:PrincipalQuantumNumber
@@ -18772,7 +18772,7 @@ quantitykind:ShannonDiversityIndex
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:plainTextDescription "Information entropy applied to a collection of indiviual organisms [of selected species] in a sample area. A measure of biodiversity." ;
   rdfs:isDefinedBy <https://data.agrimetrics.co.uk/ontologies/qudt-extension> ;
-  rdfs:label "Shannon Diversity Index" ;
+  rdfs:label "Shannon Diversity Index"@en ;
   skos:broader quantitykind:InformationEntropy ;
 .
 quantitykind:ShearModulus
@@ -18886,7 +18886,7 @@ quantitykind:ShearStress
   qudt:latexSymbol "\\(\\tau\\)"^^qudt:LatexString ;
   qudt:plainTextDescription "Shear stress occurs when the force  occurs in shear, or perpendicular to the normal." ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Shear Stress" ;
+  rdfs:label "Shear Stress"@en ;
   skos:broader quantitykind:Stress ;
 .
 quantitykind:Short-RangeOrderParameter
@@ -19642,7 +19642,7 @@ quantitykind:SpecificElectricCharge
   qudt:hasDimensionVector qkdv:A0E1L0I0M-1H0T1D0 ;
   qudt:plainTextDescription "Electric charge (often capacity in the context of electrochemical cells) relativ to the mass (often only active components). capacity " ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Specific Electric Charge" ;
+  rdfs:label "Specific Electric Charge"@en ;
 .
 quantitykind:SpecificElectricCurrent
   a qudt:QuantityKind ;
@@ -19650,7 +19650,7 @@ quantitykind:SpecificElectricCurrent
   qudt:applicableUnit unit:A-PER-GM ;
   qudt:hasDimensionVector qkdv:A0E1L0I0M-1H0T0D0 ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Specific Electrical Current" ;
+  rdfs:label "Specific Electrical Current"@en ;
 .
 quantitykind:SpecificEnergy
   a qudt:QuantityKind ;
@@ -22433,7 +22433,7 @@ quantitykind:Unknown
   qudt:applicableUnit unit:W-PER-M2-NanoM-SR ;
   qudt:hasDimensionVector qkdv:NotApplicable ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Unknown" ;
+  rdfs:label "Unknown"@en ;
 .
 quantitykind:UpperCriticalMagneticFluxDensity
   a qudt:QuantityKind ;

--- a/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
+++ b/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
@@ -185,7 +185,26 @@ quantitykind:Acceleration
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T-2D0 ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Acceleration"^^xsd:anyURI ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Beschleunigung"@de , "Pecutan"@ms , "Zrychlení"@cs , "acceleratio"@la , "acceleration"@en , "accelerazione"@it , "accelerație"@ro , "accélération"@fr , "aceleración"@es , "aceleração"@pt , "ivme"@tr , "pospešek"@sl , "przyspieszenie"@pl , "Όγκος"@el , "Ускоре́ние"@ru , "التسارع"@ar , "شتاب"@fa , "त्वरण"@hi , "加速度"@ja , "加速度"@zh ;
+  rdfs:label "Beschleunigung"@de ;
+  rdfs:label "Pecutan"@ms ;
+  rdfs:label "Zrychlení"@cs ;
+  rdfs:label "acceleratio"@la ;
+  rdfs:label "acceleration"@en ;
+  rdfs:label "accelerazione"@it ;
+  rdfs:label "accelerație"@ro ;
+  rdfs:label "accélération"@fr ;
+  rdfs:label "aceleración"@es ;
+  rdfs:label "aceleração"@pt ;
+  rdfs:label "ivme"@tr ;
+  rdfs:label "pospešek"@sl ;
+  rdfs:label "przyspieszenie"@pl ;
+  rdfs:label "Όγκος"@el ;
+  rdfs:label "Ускоре́ние"@ru ;
+  rdfs:label "التسارع"@ar ;
+  rdfs:label "شتاب"@fa ;
+  rdfs:label "त्वरण"@hi ;
+  rdfs:label "加速度"@ja ;
+  rdfs:label "加速度"@zh ;
 .
 quantitykind:AccelerationOfGravity
   a qudt:QuantityKind ;
@@ -698,8 +717,33 @@ quantitykind:AmountOfSubstance
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
   qudt:symbol "n" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "amount of substance"@en , "Stoffmenge"@de , "quantité de matière"@fr , "cantidad de sustancia"@es , "quantidade de substância"@pt , "quantità di sostanza"@it , "cantitate de substanță"@ro , "Количество вещество"@bg , "množina snovi"@sl , "Látkové množství"@cs , "liczność materii"@pl , "Количество вещества"@ru , "anyagmennyiség"@hu , "madde miktarı"@tr , "Ποσότητα Ουσίας"@el , "כמות חומר"@he , "كمية المادة"@ar , "مقدار ماده"@fa , "पदार्थ की मात्रा"@hi , "物质的量"@zh , "物質量"@ja , "Jumlah bahan"@ms , "quantitas substantiae"@la ;
-  skos:altLabel "chemical amount"@en , "quantità di materia"@it , "quantità chimica"@it , "jumlah kimia"@ms ;
+  rdfs:label "Jumlah bahan"@ms ;
+  rdfs:label "Látkové množství"@cs ;
+  rdfs:label "Stoffmenge"@de ;
+  rdfs:label "amount of substance"@en ;
+  rdfs:label "anyagmennyiség"@hu ;
+  rdfs:label "cantidad de sustancia"@es ;
+  rdfs:label "cantitate de substanță"@ro ;
+  rdfs:label "liczność materii"@pl ;
+  rdfs:label "madde miktarı"@tr ;
+  rdfs:label "množina snovi"@sl ;
+  rdfs:label "quantidade de substância"@pt ;
+  rdfs:label "quantitas substantiae"@la ;
+  rdfs:label "quantità di sostanza"@it ;
+  rdfs:label "quantité de matière"@fr ;
+  rdfs:label "Ποσότητα Ουσίας"@el ;
+  rdfs:label "Количество вещества"@ru ;
+  rdfs:label "Количество вещество"@bg ;
+  rdfs:label "כמות חומר"@he ;
+  rdfs:label "كمية المادة"@ar ;
+  rdfs:label "مقدار ماده"@fa ;
+  rdfs:label "पदार्थ की मात्रा"@hi ;
+  rdfs:label "物質量"@ja ;
+  rdfs:label "物质的量"@zh ;
+  skos:altLabel "chemical amount"@en ;
+  skos:altLabel "jumlah kimia"@ms ;
+  skos:altLabel "quantità chimica"@it ;
+  skos:altLabel "quantità di materia"@it ;
 .
 quantitykind:AmountOfSubstanceConcentration
   a qudt:QuantityKind ;
@@ -900,7 +944,23 @@ quantitykind:AngularAcceleration
   qudt:qkdvDenominator qkdv:A0E0L1I0M0H0T2D0 ;
   qudt:qkdvNumerator qkdv:A0E0L1I0M0H0T0D0 ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Accelerație unghiulară"@ro , "Açısal ivme"@tr , "Pecutan bersudut"@ms , "Przyspieszenie kątowe"@pl , "Winkelbeschleunigung"@de , "accelerazione angolare"@it , "accélération angulaire"@fr , "aceleración angular"@es , "aceleração angular"@pt , "angular acceleration"@en , "Úhlové zrychlení"@cs , "Угловое ускорение"@ru , "تسارع زاوي"@ar , "شتاب زاویه‌ای"@fa , "कोणीय त्वरण"@hi , "角加速度"@ja , "角加速度"@zh ;
+  rdfs:label "Accelerație unghiulară"@ro ;
+  rdfs:label "Açısal ivme"@tr ;
+  rdfs:label "Pecutan bersudut"@ms ;
+  rdfs:label "Przyspieszenie kątowe"@pl ;
+  rdfs:label "Winkelbeschleunigung"@de ;
+  rdfs:label "accelerazione angolare"@it ;
+  rdfs:label "accélération angulaire"@fr ;
+  rdfs:label "aceleración angular"@es ;
+  rdfs:label "aceleração angular"@pt ;
+  rdfs:label "angular acceleration"@en ;
+  rdfs:label "Úhlové zrychlení"@cs ;
+  rdfs:label "Угловое ускорение"@ru ;
+  rdfs:label "تسارع زاوي"@ar ;
+  rdfs:label "شتاب زاویه‌ای"@fa ;
+  rdfs:label "कोणीय त्वरण"@hi ;
+  rdfs:label "角加速度"@ja ;
+  rdfs:label "角加速度"@zh ;
   skos:broader quantitykind:InverseSquareTime ;
 .
 quantitykind:AngularCrossSection
@@ -959,8 +1019,23 @@ quantitykind:AngularFrequency
   qudt:latexSymbol "\\(\\omega\\)"^^qudt:LatexString ;
   vaem:todo "belongs to SOQ-ISO" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "angular frequency"@en , "Kreisfrequenz"@de , "Pulsación"@fr , "pulsación"@es , "frequência angular"@pt , "frequenza angolare"@it , "pulsacja"@pl , "تردد زاوى"@ar , "角频率"@zh , "角振動数"@ja ;
-  skos:altLabel "pulsatance"@en , "Pulsatanzpulsation"@de , "pulsação"@pt , "pulsazione"@it , "نابض"@ar , "角速度"@zh , "角周波数"@ja ;
+  rdfs:label "Kreisfrequenz"@de ;
+  rdfs:label "Pulsación"@fr ;
+  rdfs:label "angular frequency"@en ;
+  rdfs:label "frequenza angolare"@it ;
+  rdfs:label "frequência angular"@pt ;
+  rdfs:label "pulsación"@es ;
+  rdfs:label "pulsacja"@pl ;
+  rdfs:label "تردد زاوى"@ar ;
+  rdfs:label "角振動数"@ja ;
+  rdfs:label "角频率"@zh ;
+  skos:altLabel "Pulsatanzpulsation"@de ;
+  skos:altLabel "pulsatance"@en ;
+  skos:altLabel "pulsazione"@it ;
+  skos:altLabel "pulsação"@pt ;
+  skos:altLabel "نابض"@ar ;
+  skos:altLabel "角周波数"@ja ;
+  skos:altLabel "角速度"@zh ;
   skos:broader quantitykind:AngularVelocity ;
 .
 quantitykind:AngularImpulse
@@ -979,7 +1054,16 @@ quantitykind:AngularImpulse
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31889"^^xsd:anyURI ;
   qudt:symbol "H" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "angular impulse"@en , "Drehstoß"@de , "impulsion angulaire"@fr , "impulso angular"@es , "impulsão angular"@pt , "impulso angolare"@it , "popęd kątowy"@pl , "نبضة دفعية زاوية"@ar , "角冲量;冲量矩"@zh , "角力積"@ja ;
+  rdfs:label "Drehstoß"@de ;
+  rdfs:label "angular impulse"@en ;
+  rdfs:label "impulsion angulaire"@fr ;
+  rdfs:label "impulso angolare"@it ;
+  rdfs:label "impulso angular"@es ;
+  rdfs:label "impulsão angular"@pt ;
+  rdfs:label "popęd kątowy"@pl ;
+  rdfs:label "نبضة دفعية زاوية"@ar ;
+  rdfs:label "角冲量;冲量矩"@zh ;
+  rdfs:label "角力積"@ja ;
   skos:altLabel "Drehmomentstoß"@de ;
 .
 quantitykind:AngularMomentum
@@ -1045,8 +1129,26 @@ quantitykind:AngularVelocity
   qudt:qkdvDenominator qkdv:A0E0L1I0M0H0T1D0 ;
   qudt:qkdvNumerator qkdv:A0E0L1I0M0H0T0D0 ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "angular velocity"@en , "Winkelgeschwindigkeit"@de , "vitesse angulaire"@fr , "velocidad angular"@es , "velocidade angular"@pt , "velocità angolare"@it , "Viteză unghiulară"@ro , "kotna hitrost"@sl , "Úhlová rychlost"@cs , "Prędkość kątowa"@pl , "Угловая скорость"@ru , "Açısal hız"@tr , "سرعة زاوية"@ar , "سرعت زاویه‌ای"@fa , "कोणीय वेग"@hi , "角速度"@zh , "角速度"@ja , "Halaju bersudut"@ms ;
-  skos:altLabel "angular speed"@en , "kelajuan bersudut"@ms ;
+  rdfs:label "Açısal hız"@tr ;
+  rdfs:label "Halaju bersudut"@ms ;
+  rdfs:label "Prędkość kątowa"@pl ;
+  rdfs:label "Viteză unghiulară"@ro ;
+  rdfs:label "Winkelgeschwindigkeit"@de ;
+  rdfs:label "angular velocity"@en ;
+  rdfs:label "kotna hitrost"@sl ;
+  rdfs:label "velocidad angular"@es ;
+  rdfs:label "velocidade angular"@pt ;
+  rdfs:label "velocità angolare"@it ;
+  rdfs:label "vitesse angulaire"@fr ;
+  rdfs:label "Úhlová rychlost"@cs ;
+  rdfs:label "Угловая скорость"@ru ;
+  rdfs:label "سرعة زاوية"@ar ;
+  rdfs:label "سرعت زاویه‌ای"@fa ;
+  rdfs:label "कोणीय वेग"@hi ;
+  rdfs:label "角速度"@ja ;
+  rdfs:label "角速度"@zh ;
+  skos:altLabel "angular speed"@en ;
+  skos:altLabel "kelajuan bersudut"@ms ;
 .
 quantitykind:AngularWavenumber
   a qudt:QuantityKind ;
@@ -1064,8 +1166,22 @@ Alternatively:
   qudt:symbol "k" ;
   vaem:todo "belongs to SOQ-ISO" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "angular wavenumber"@en , "Kreisrepetenz"@de , "nombre d'onde angulaire"@fr , "número de onda angular"@es , "número de onda angular"@pt , "numero d'onda angolare"@it , "liczba falowa kątowa"@pl , "عدد موجى زاوى"@ar , "角波数"@zh , "角波数"@ja ;
-  skos:altLabel "angular repetency"@en , "Kreiswellenzahl"@de , "répétence angulaire"@fr , "repetência angular"@pt , "repetencja kątowa"@pl , "تكرار زاوى"@ar ;
+  rdfs:label "Kreisrepetenz"@de ;
+  rdfs:label "angular wavenumber"@en ;
+  rdfs:label "liczba falowa kątowa"@pl ;
+  rdfs:label "nombre d'onde angulaire"@fr ;
+  rdfs:label "numero d'onda angolare"@it ;
+  rdfs:label "número de onda angular"@es ;
+  rdfs:label "número de onda angular"@pt ;
+  rdfs:label "عدد موجى زاوى"@ar ;
+  rdfs:label "角波数"@ja ;
+  rdfs:label "角波数"@zh ;
+  skos:altLabel "Kreiswellenzahl"@de ;
+  skos:altLabel "angular repetency"@en ;
+  skos:altLabel "repetencja kątowa"@pl ;
+  skos:altLabel "repetência angular"@pt ;
+  skos:altLabel "répétence angulaire"@fr ;
+  skos:altLabel "تكرار زاوى"@ar ;
   skos:broader quantitykind:InverseLength ;
 .
 quantitykind:ApogeeRadius
@@ -1126,10 +1242,19 @@ quantitykind:ApparentPower
   qudt:latexDefinition "\\(\\left | \\underline{S} \\right | =  UI\\), where \\(U\\) is rms value of voltage and \\(I\\) is rms value of electric current."^^qudt:LatexString ;
   qudt:latexSymbol "\\(\\left | \\underline{S} \\right |\\)"^^qudt:LatexString ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "apparent power"@en , "Scheinleistung"@de , "puissance apparente"@fr , "potencia aparente"@es , "potência aparente"@pt , "potenza apparente"@it , "moc pozorna"@pl , "القدرة الظاهرية"@ar , "视在功率"@zh , "皮相電力"@ja ;
-  skos:altLabel "表观功率"@zh ;
+  rdfs:label "Scheinleistung"@de ;
+  rdfs:label "apparent power"@en ;
+  rdfs:label "moc pozorna"@pl ;
+  rdfs:label "potencia aparente"@es ;
+  rdfs:label "potenza apparente"@it ;
+  rdfs:label "potência aparente"@pt ;
+  rdfs:label "puissance apparente"@fr ;
+  rdfs:label "القدرة الظاهرية"@ar ;
+  rdfs:label "皮相電力"@ja ;
+  rdfs:label "视在功率"@zh ;
   rdfs:seeAlso quantitykind:ElectricCurrent ;
   rdfs:seeAlso quantitykind:Voltage ;
+  skos:altLabel "表观功率"@zh ;
   skos:broader quantitykind:ComplexPower ;
 .
 quantitykind:Area
@@ -1158,7 +1283,27 @@ quantitykind:Area
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T0D0 ;
   qudt:plainTextDescription "Area is a quantity expressing the two-dimensional size of a defined part of a surface, typically a region bounded by a closed curve." ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "area"@en , "Fläche"@de , "aire"@fr , "área"@es , "área"@pt , "area"@it , "arie"@ro , "Площ"@bg , "površina"@sl , "plocha"@cs , "pole powierzchni"@pl , "Площадь"@ru , "alan"@tr , "Ταχύτητα"@el , "שטח"@he , "مساحة"@ar , "مساحت"@fa , "क्षेत्रफल"@hi , "面积"@zh , "面積"@ja , "Keluasan"@ms ;
+  rdfs:label "Fläche"@de ;
+  rdfs:label "Keluasan"@ms ;
+  rdfs:label "aire"@fr ;
+  rdfs:label "alan"@tr ;
+  rdfs:label "area"@en ;
+  rdfs:label "area"@it ;
+  rdfs:label "arie"@ro ;
+  rdfs:label "plocha"@cs ;
+  rdfs:label "pole powierzchni"@pl ;
+  rdfs:label "površina"@sl ;
+  rdfs:label "área"@es ;
+  rdfs:label "área"@pt ;
+  rdfs:label "Ταχύτητα"@el ;
+  rdfs:label "Площ"@bg ;
+  rdfs:label "Площадь"@ru ;
+  rdfs:label "שטח"@he ;
+  rdfs:label "مساحة"@ar ;
+  rdfs:label "مساحت"@fa ;
+  rdfs:label "क्षेत्रफल"@hi ;
+  rdfs:label "面积"@zh ;
+  rdfs:label "面積"@ja ;
   skos:altLabel "superficie"@fr ;
 .
 quantitykind:AreaAngle
@@ -1989,7 +2134,22 @@ quantitykind:Breadth
   qudt:plainTextDescription "\"Breadth\" is the extent or measure of how broad or wide something is." ;
   qudt:symbol "b" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Breite"@de , "ancho"@es , "breadth"@en , "genişliği"@tr , "largeur"@fr , "larghezza"@it , "largura"@pt , "lebar"@ms , "szerokość"@pl , "širina"@sl , "šířka"@cs , "ширина"@ru , "العرض"@ar , "عرض"@fa , "寬度"@zh , "幅"@ja ;
+  rdfs:label "Breite"@de ;
+  rdfs:label "ancho"@es ;
+  rdfs:label "breadth"@en ;
+  rdfs:label "genişliği"@tr ;
+  rdfs:label "largeur"@fr ;
+  rdfs:label "larghezza"@it ;
+  rdfs:label "largura"@pt ;
+  rdfs:label "lebar"@ms ;
+  rdfs:label "szerokość"@pl ;
+  rdfs:label "širina"@sl ;
+  rdfs:label "šířka"@cs ;
+  rdfs:label "ширина"@ru ;
+  rdfs:label "العرض"@ar ;
+  rdfs:label "عرض"@fa ;
+  rdfs:label "寬度"@zh ;
+  rdfs:label "幅"@ja ;
   skos:broader quantitykind:Length ;
 .
 quantitykind:BucklingFactor
@@ -2621,7 +2781,16 @@ quantitykind:CartesianCoordinates
   qudt:plainTextDescription "\"Cartesian Coordinates\" specify each point uniquely in a plane by a pair of numerical coordinates, which are the signed distances from the point to two fixed perpendicular directed lines, measured in the same unit of length. " ;
   qudt:symbol "x, y, z" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Cartesian coordinates"@en , "kartesische Koordinaten"@de , "coordonnées cartésiennes"@fr , "coordenadas cartesianas"@pt , "coordinate cartesiane"@it , "Kartézská soustava souřadnic"@cs , "kartezyen koordinatları"@tr , "مختصات دکارتی"@fa , "直角坐标系"@zh , "Koordiant Kartesius"@ms ;
+  rdfs:label "Cartesian coordinates"@en ;
+  rdfs:label "Kartézská soustava souřadnic"@cs ;
+  rdfs:label "Koordiant Kartesius"@ms ;
+  rdfs:label "coordenadas cartesianas"@pt ;
+  rdfs:label "coordinate cartesiane"@it ;
+  rdfs:label "coordonnées cartésiennes"@fr ;
+  rdfs:label "kartesische Koordinaten"@de ;
+  rdfs:label "kartezyen koordinatları"@tr ;
+  rdfs:label "مختصات دکارتی"@fa ;
+  rdfs:label "直角坐标系"@zh ;
   skos:altLabel "Kartézské souřadnice"@cs ;
   skos:broader quantitykind:Length ;
 .
@@ -2679,7 +2848,27 @@ quantitykind:CartesianVolume
   qudt:plainTextDescription "\"Volume\" is the quantity of three-dimensional space enclosed by some closed boundary, for example, the space that a substance (solid, liquid, gas, or plasma) or shape occupies or contains." ;
   qudt:symbol "V" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Isipadu"@ms , "Objem"@cs , "Volumen"@de , "hacim"@tr , "objętość"@pl , "prostornina"@sl , "volum"@ro , "volume"@en , "volume"@fr , "volume"@it , "volume"@pt , "volumen"@es , "Επιτάχυνση"@el , "Обем"@bg , "Объём"@ru , "נפח"@he , "حجم"@ar , "حجم"@fa , "आयतन"@hi , "体积"@zh , "体積"@ja ;
+  rdfs:label "Isipadu"@ms ;
+  rdfs:label "Objem"@cs ;
+  rdfs:label "Volumen"@de ;
+  rdfs:label "hacim"@tr ;
+  rdfs:label "objętość"@pl ;
+  rdfs:label "prostornina"@sl ;
+  rdfs:label "volum"@ro ;
+  rdfs:label "volume"@en ;
+  rdfs:label "volume"@fr ;
+  rdfs:label "volume"@it ;
+  rdfs:label "volume"@pt ;
+  rdfs:label "volumen"@es ;
+  rdfs:label "Επιτάχυνση"@el ;
+  rdfs:label "Обем"@bg ;
+  rdfs:label "Объём"@ru ;
+  rdfs:label "נפח"@he ;
+  rdfs:label "حجم"@ar ;
+  rdfs:label "حجم"@fa ;
+  rdfs:label "आयतन"@hi ;
+  rdfs:label "体积"@zh ;
+  rdfs:label "体積"@ja ;
   skos:broader quantitykind:Volume ;
 .
 quantitykind:CatalyticActivity
@@ -2719,7 +2908,25 @@ quantitykind:CelsiusTemperature
 \\(t = T - T_0\\), where \\(T\\) is Thermodynamic Temperature and \\(T_0 = 273.15 K\\)."""^^qudt:LatexString ;
   qudt:plainTextDescription "\"Celsius Temperature\", the thermodynamic temperature T_0, is exactly 0.01 kelvin below the thermodynamic temperature of the triple point of water." ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Celsius sıcaklık"@tr , "Celsius temperature"@en , "Celsius-Temperatur"@de , "Suhu Celsius"@ms , "temperatura Celsius"@es , "temperatura Celsius"@it , "temperatura celsius"@pt , "temperatura"@pl , "temperatura"@sl , "temperatură Celsius"@ro , "température Celsius"@fr , "teplota"@cs , "Температура Цельсия"@ru , "צלזיוס"@he , "درجة الحرارة المئوية أو السيلسيوس"@ar , "دمای سلسیوس/سانتیگراد"@fa , "सेल्सियस तापमान"@hi , "温度"@ja , "温度"@zh ;
+  rdfs:label "Celsius sıcaklık"@tr ;
+  rdfs:label "Celsius temperature"@en ;
+  rdfs:label "Celsius-Temperatur"@de ;
+  rdfs:label "Suhu Celsius"@ms ;
+  rdfs:label "temperatura Celsius"@es ;
+  rdfs:label "temperatura Celsius"@it ;
+  rdfs:label "temperatura celsius"@pt ;
+  rdfs:label "temperatura"@pl ;
+  rdfs:label "temperatura"@sl ;
+  rdfs:label "temperatură Celsius"@ro ;
+  rdfs:label "température Celsius"@fr ;
+  rdfs:label "teplota"@cs ;
+  rdfs:label "Температура Цельсия"@ru ;
+  rdfs:label "צלזיוס"@he ;
+  rdfs:label "درجة الحرارة المئوية أو السيلسيوس"@ar ;
+  rdfs:label "دمای سلسیوس/سانتیگراد"@fa ;
+  rdfs:label "सेल्सियस तापमान"@hi ;
+  rdfs:label "温度"@ja ;
+  rdfs:label "温度"@zh ;
   skos:broader quantitykind:ThermodynamicTemperature ;
   prov:wasDerivedFrom quantitykind:ThermodynamicTemperature ;
 .
@@ -2933,7 +3140,22 @@ quantitykind:ChemicalPotential
   qudt:latexSymbol "\\(\\mu_B\\)"^^qudt:LatexString ;
   qudt:plainTextDescription "\"Chemical Potential\", also known as partial molar free energy, is a form of potential energy that can be absorbed or released during a chemical reaction." ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Chemický potenciál"@cs , "Keupayaan kimia"@ms , "Potencjał chemiczny"@pl , "Potențial chimic"@ro , "chemical potential"@en , "chemisches Potential des Stoffs B"@de , "kimyasal potansiyel"@tr , "potencial químico"@es , "potencial químico"@pt , "potential chimique"@fr , "potenziale chimico"@it , "Химический потенциал"@ru , "جهد كيميائي"@ar , "پتانسیل شیمیایی"@fa , "化学ポテンシャル"@ja , "化学势"@zh ;
+  rdfs:label "Chemický potenciál"@cs ;
+  rdfs:label "Keupayaan kimia"@ms ;
+  rdfs:label "Potencjał chemiczny"@pl ;
+  rdfs:label "Potențial chimic"@ro ;
+  rdfs:label "chemical potential"@en ;
+  rdfs:label "chemisches Potential des Stoffs B"@de ;
+  rdfs:label "kimyasal potansiyel"@tr ;
+  rdfs:label "potencial químico"@es ;
+  rdfs:label "potencial químico"@pt ;
+  rdfs:label "potential chimique"@fr ;
+  rdfs:label "potenziale chimico"@it ;
+  rdfs:label "Химический потенциал"@ru ;
+  rdfs:label "جهد كيميائي"@ar ;
+  rdfs:label "پتانسیل شیمیایی"@fa ;
+  rdfs:label "化学ポテンシャル"@ja ;
+  rdfs:label "化学势"@zh ;
   skos:broader quantitykind:MolarEnergy ;
 .
 quantitykind:Chromaticity
@@ -3269,7 +3491,8 @@ quantitykind:Constringence
   qudt:symbol "V" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
   rdfs:label "Constringence"@en ;
-  skos:altLabel "Abbe Number"@en , "V-number"@en ;
+  skos:altLabel "Abbe Number"@en ;
+  skos:altLabel "V-number"@en ;
   skos:broader quantitykind:DimensionlessRatio ;
 .
 quantitykind:ConvectiveHeatTransfer
@@ -3317,7 +3540,16 @@ quantitykind:CouplingFactor
   qudt:plainTextDescription "\"Coupling Factor\" is the ratio of an electromagnetic quantity, usually voltage or current, appearing at a specified location of a given circuit to the corresponding quantity at a specified location in the circuit from which energy is transferred by coupling." ;
   qudt:symbol "k" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Constantă de cuplaj"@ro , "constante de acoplamiento"@es , "constante de couplage"@fr , "coupling factor"@en , "fattore di accoppiamento"@it , "stała sprzężenia"@pl , "Çiftlenim sabiti"@tr , "Константа взаимодействия"@ru , "結合定数"@ja , "耦合常數"@zh ;
+  rdfs:label "Constantă de cuplaj"@ro ;
+  rdfs:label "constante de acoplamiento"@es ;
+  rdfs:label "constante de couplage"@fr ;
+  rdfs:label "coupling factor"@en ;
+  rdfs:label "fattore di accoppiamento"@it ;
+  rdfs:label "stała sprzężenia"@pl ;
+  rdfs:label "Çiftlenim sabiti"@tr ;
+  rdfs:label "Константа взаимодействия"@ru ;
+  rdfs:label "結合定数"@ja ;
+  rdfs:label "耦合常數"@zh ;
 .
 quantitykind:CrossSection
   a qudt:QuantityKind ;
@@ -3394,7 +3626,23 @@ quantitykind:CubicExpansionCoefficient
   qudt:qkdvDenominator qkdv:A0E0L3I0M0H1T0D0 ;
   qudt:qkdvNumerator qkdv:A0E0L3I0M0H0T0D0 ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Hullámszám"@hu , "Volumenausdehnungskoeffizient"@de , "coefficient de dilatation volumique"@fr , "coefficiente di dilatazione volumica"@it , "coeficiente de dilatación cúbica"@es , "coeficiente de dilatação volúmica"@pt , "cubic expansion coefficient"@en , "kübik genleşme katsayısı"@tr , "współczynnik rozszerzalności objętościowej"@pl , "Κυματαριθμός"@el , "Вълново число"@bg , "Температурный коэффициент"@ru , "מספר גל"@he , "ضریب انبساط گرمایی"@fa , "معامل التمدد الحجمى"@ar , "体膨胀系数"@zh , "線膨張係数"@ja ;
+  rdfs:label "Hullámszám"@hu ;
+  rdfs:label "Volumenausdehnungskoeffizient"@de ;
+  rdfs:label "coefficient de dilatation volumique"@fr ;
+  rdfs:label "coefficiente di dilatazione volumica"@it ;
+  rdfs:label "coeficiente de dilatación cúbica"@es ;
+  rdfs:label "coeficiente de dilatação volúmica"@pt ;
+  rdfs:label "cubic expansion coefficient"@en ;
+  rdfs:label "kübik genleşme katsayısı"@tr ;
+  rdfs:label "współczynnik rozszerzalności objętościowej"@pl ;
+  rdfs:label "Κυματαριθμός"@el ;
+  rdfs:label "Вълново число"@bg ;
+  rdfs:label "Температурный коэффициент"@ru ;
+  rdfs:label "מספר גל"@he ;
+  rdfs:label "ضریب انبساط گرمایی"@fa ;
+  rdfs:label "معامل التمدد الحجمى"@ar ;
+  rdfs:label "体膨胀系数"@zh ;
+  rdfs:label "線膨張係数"@ja ;
   skos:broader quantitykind:ExpansionRatio ;
 .
 quantitykind:CurieTemperature
@@ -3406,7 +3654,23 @@ quantitykind:CurieTemperature
   qudt:plainTextDescription "\"Curie Temperature\" is the critical thermodynamic temperature of a ferromagnet." ;
   qudt:symbol "T_C" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Curie sıcaklığı"@tr , "Curie temperature"@en , "Curie-Temperatur"@de , "Curieova teplota"@cs , "Punct Curie"@ro , "Suhu Curie"@ms , "punto di Curie"@it , "temperatura Curie"@pl , "temperatura de Curie"@es , "temperatura de Curie"@pt , "température de Curie"@fr , "Точка Кюри"@ru , "درجة حرارة كوري"@ar , "نقطه کوری"@fa , "क्यूरी ताप"@hi , "キュリー温度"@ja , "居里点"@zh ;
+  rdfs:label "Curie sıcaklığı"@tr ;
+  rdfs:label "Curie temperature"@en ;
+  rdfs:label "Curie-Temperatur"@de ;
+  rdfs:label "Curieova teplota"@cs ;
+  rdfs:label "Punct Curie"@ro ;
+  rdfs:label "Suhu Curie"@ms ;
+  rdfs:label "punto di Curie"@it ;
+  rdfs:label "temperatura Curie"@pl ;
+  rdfs:label "temperatura de Curie"@es ;
+  rdfs:label "temperatura de Curie"@pt ;
+  rdfs:label "température de Curie"@fr ;
+  rdfs:label "Точка Кюри"@ru ;
+  rdfs:label "درجة حرارة كوري"@ar ;
+  rdfs:label "نقطه کوری"@fa ;
+  rdfs:label "क्यूरी ताप"@hi ;
+  rdfs:label "キュリー温度"@ja ;
+  rdfs:label "居里点"@zh ;
   skos:closeMatch quantitykind:NeelTemperature ;
   skos:closeMatch quantitykind:SuperconductionTransitionTemperature ;
 .
@@ -3951,7 +4215,21 @@ quantitykind:Diameter
   qudt:plainTextDescription "In classical geometry, the \"Diameter\" of a circle is any straight line segment that passes through the center of the circle and whose endpoints lie on the circle. " ;
   qudt:symbol "d" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Durchmesser"@de , "diameter"@en , "diametro"@it , "diamètre"@fr , "diámetro"@es , "diâmetro"@pt , "premer"@sl , "průměr"@cs , "çap"@tr , "średnica"@pl , "диаметр"@ru , "قطر"@ar , "قطر"@fa , "直径"@ja , "直径"@zh ;
+  rdfs:label "Durchmesser"@de ;
+  rdfs:label "diameter"@en ;
+  rdfs:label "diametro"@it ;
+  rdfs:label "diamètre"@fr ;
+  rdfs:label "diámetro"@es ;
+  rdfs:label "diâmetro"@pt ;
+  rdfs:label "premer"@sl ;
+  rdfs:label "průměr"@cs ;
+  rdfs:label "çap"@tr ;
+  rdfs:label "średnica"@pl ;
+  rdfs:label "диаметр"@ru ;
+  rdfs:label "قطر"@ar ;
+  rdfs:label "قطر"@fa ;
+  rdfs:label "直径"@ja ;
+  rdfs:label "直径"@zh ;
   skos:broader quantitykind:Length ;
 .
 quantitykind:DiastolicBloodPressure
@@ -4057,7 +4335,13 @@ quantitykind:DiffusionCoefficient
   qudt:plainTextDescription "The \"Diffusion Coefficient\" is a proportionality constant between the molar flux due to molecular diffusion and the gradient in the concentration of the species (or the driving force for diffusion). Diffusivity is encountered in Fick's law and numerous other equations of physical chemistry." ;
   qudt:symbol "D" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Diffusionskoeffizient"@de , "coefficient de diffusion"@fr , "coefficiente di diffusione"@it , "coeficiente de difusión"@es , "coeficiente de difusão"@pt , "diffusion coefficient"@en , "difuzijski koeficient"@sl ;
+  rdfs:label "Diffusionskoeffizient"@de ;
+  rdfs:label "coefficient de diffusion"@fr ;
+  rdfs:label "coefficiente di diffusione"@it ;
+  rdfs:label "coeficiente de difusión"@es ;
+  rdfs:label "coeficiente de difusão"@pt ;
+  rdfs:label "diffusion coefficient"@en ;
+  rdfs:label "difuzijski koeficient"@sl ;
 .
 quantitykind:DiffusionCoefficientForFluenceRate
   a qudt:QuantityKind ;
@@ -4381,7 +4665,17 @@ quantitykind:Distance
   qudt:plainTextDescription "\"Distance\" is a numerical description of how far apart objects are. " ;
   qudt:symbol "d" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Entfernung"@de , "Jarak"@ms , "Vzdálenost"@cs , "distance"@en , "distance"@fr , "distancia"@es , "distanza"@it , "distância"@pt , "uzaklık"@tr , "مسافت"@fa , "距离"@zh ;
+  rdfs:label "Entfernung"@de ;
+  rdfs:label "Jarak"@ms ;
+  rdfs:label "Vzdálenost"@cs ;
+  rdfs:label "distance"@en ;
+  rdfs:label "distance"@fr ;
+  rdfs:label "distancia"@es ;
+  rdfs:label "distanza"@it ;
+  rdfs:label "distância"@pt ;
+  rdfs:label "uzaklık"@tr ;
+  rdfs:label "مسافت"@fa ;
+  rdfs:label "距离"@zh ;
   skos:broader quantitykind:Length ;
 .
 quantitykind:DistanceTraveledDuringBurn
@@ -4684,7 +4978,24 @@ quantitykind:DynamicViscosity
   qudt:latexSymbol "\\(\\mu\\)"^^qudt:LatexString ;
   qudt:plainTextDescription "A measure of the molecular frictional resistance of a fluid as calculated using Newton's law." ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "dynamic viscosity"@en , "dynamische Viskosität"@de , "viscosité dynamique"@fr , "viscosidad dinámica"@es , "viscosidade dinâmica"@pt , "viscosità dinamica"@it , "Viscozitate dinamică"@ro , "dinamična viskoznost"@sl , "viskozita"@cs , "lepkość dynamiczna"@pl , "динамическую вязкость"@ru , "dinamik akmazlık"@tr , "لزوجة"@ar , "گرانروی دینامیکی/ویسکوزیته دینامیکی"@fa , "श्यानता"@hi , "动力粘度"@zh , "粘度"@ja , "Kelikatan dinamik"@ms ;
+  rdfs:label "Kelikatan dinamik"@ms ;
+  rdfs:label "Viscozitate dinamică"@ro ;
+  rdfs:label "dinamik akmazlık"@tr ;
+  rdfs:label "dinamična viskoznost"@sl ;
+  rdfs:label "dynamic viscosity"@en ;
+  rdfs:label "dynamische Viskosität"@de ;
+  rdfs:label "lepkość dynamiczna"@pl ;
+  rdfs:label "viscosidad dinámica"@es ;
+  rdfs:label "viscosidade dinâmica"@pt ;
+  rdfs:label "viscosità dinamica"@it ;
+  rdfs:label "viscosité dynamique"@fr ;
+  rdfs:label "viskozita"@cs ;
+  rdfs:label "динамическую вязкость"@ru ;
+  rdfs:label "لزوجة"@ar ;
+  rdfs:label "گرانروی دینامیکی/ویسکوزیته دینامیکی"@fa ;
+  rdfs:label "श्यानता"@hi ;
+  rdfs:label "动力粘度"@zh ;
+  rdfs:label "粘度"@ja ;
   skos:altLabel "viscosità di taglio"@it ;
   skos:broader quantitykind:Viscosity ;
 .
@@ -4839,7 +5150,17 @@ quantitykind:Efficiency
   qudt:latexSymbol "\\(\\eta\\)"^^qudt:LatexString ;
   qudt:plainTextDescription "Efficiency is the ratio of output power to input power." ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "efficiency"@en , "Wirkungsgrad"@de , "rendement"@fr , "rendimiento"@es , "eficiência"@pt , "efficienza"@it , "sprawność"@pl , "коэффициент полезного действия"@ru , "كفاءة"@ar , "效率"@zh , "効率"@ja ;
+  rdfs:label "Wirkungsgrad"@de ;
+  rdfs:label "efficiency"@en ;
+  rdfs:label "efficienza"@it ;
+  rdfs:label "eficiência"@pt ;
+  rdfs:label "rendement"@fr ;
+  rdfs:label "rendimiento"@es ;
+  rdfs:label "sprawność"@pl ;
+  rdfs:label "коэффициент полезного действия"@ru ;
+  rdfs:label "كفاءة"@ar ;
+  rdfs:label "効率"@ja ;
+  rdfs:label "效率"@zh ;
   skos:altLabel "rendimento"@it ;
   skos:broader quantitykind:DimensionlessRatio ;
 .
@@ -4896,9 +5217,31 @@ quantitykind:ElectricCharge
   qudt:latexDefinition "\\(dQ = Idt\\), where \\(I\\) is electric current."^^qudt:LatexString ;
   qudt:symbol "Q" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "electric charge"@en , "elektrische Ladung"@de , "Charge électrique"@fr , "carga eléctrica"@es , "carga elétrica"@pt , "carica elettrica"@it , "sarcină electrică"@ro , "Електрически заряд"@bg , "električni naboj"@sl , "Elektrický náboj"@cs , "ładunek elektryczny"@pl , "Электрический заряд"@ru , "elektromos töltés"@hu , "elektrik yükü"@tr , "Ηλεκτρικό φορτίο"@el , "מטען חשמלי"@he , "الشحنة الكهربائية"@ar , "بار الکتریکی"@fa , "विद्युत आवेग या विद्युत बहाव"@hi , "电荷"@zh , "電荷"@ja , "Cas elektrik"@ms , "onus electricum"@la ;
-  skos:altLabel "cantitate de electricitate"@ro ;
+  rdfs:label "Cas elektrik"@ms ;
+  rdfs:label "Charge électrique"@fr ;
+  rdfs:label "Elektrický náboj"@cs ;
+  rdfs:label "carga eléctrica"@es ;
+  rdfs:label "carga elétrica"@pt ;
+  rdfs:label "carica elettrica"@it ;
+  rdfs:label "electric charge"@en ;
+  rdfs:label "elektrik yükü"@tr ;
+  rdfs:label "elektrische Ladung"@de ;
+  rdfs:label "električni naboj"@sl ;
+  rdfs:label "elektromos töltés"@hu ;
+  rdfs:label "onus electricum"@la ;
+  rdfs:label "sarcină electrică"@ro ;
+  rdfs:label "ładunek elektryczny"@pl ;
+  rdfs:label "Ηλεκτρικό φορτίο"@el ;
+  rdfs:label "Електрически заряд"@bg ;
+  rdfs:label "Электрический заряд"@ru ;
+  rdfs:label "מטען חשמלי"@he ;
+  rdfs:label "الشحنة الكهربائية"@ar ;
+  rdfs:label "بار الکتریکی"@fa ;
+  rdfs:label "विद्युत आवेग या विद्युत बहाव"@hi ;
+  rdfs:label "电荷"@zh ;
+  rdfs:label "電荷"@ja ;
   rdfs:seeAlso quantitykind:ElectricCurrent ;
+  skos:altLabel "cantitate de electricitate"@ro ;
 .
 quantitykind:ElectricChargeDensity
   a qudt:QuantityKind ;
@@ -5028,7 +5371,17 @@ quantitykind:ElectricConductivity
   qudt:hasDimensionVector qkdv:A0E2L-3I0M-1H0T3D0 ;
   qudt:latexSymbol "\\(\\sigma\\)"^^qudt:LatexString ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Kekonduksian elektrik"@ms , "conducibilità elettrica"@it , "conductividad eléctrica"@es , "conductivité électrique"@fr , "condutividade elétrica"@pt , "electric conductivity"@en , "elektrik iletkenliği"@tr , "elektrische Leitfähigkeit"@de , "električna prevodnost"@sl , "رسانايى الکتريکى/هدایت الکتریکی"@fa , "电导率"@zh ;
+  rdfs:label "Kekonduksian elektrik"@ms ;
+  rdfs:label "conducibilità elettrica"@it ;
+  rdfs:label "conductividad eléctrica"@es ;
+  rdfs:label "conductivité électrique"@fr ;
+  rdfs:label "condutividade elétrica"@pt ;
+  rdfs:label "electric conductivity"@en ;
+  rdfs:label "elektrik iletkenliği"@tr ;
+  rdfs:label "elektrische Leitfähigkeit"@de ;
+  rdfs:label "električna prevodnost"@sl ;
+  rdfs:label "رسانايى الکتريکى/هدایت الکتریکی"@fa ;
+  rdfs:label "电导率"@zh ;
 .
 quantitykind:ElectricCurrent
   a qudt:QuantityKind ;
@@ -5050,7 +5403,29 @@ quantitykind:ElectricCurrent
   qudt:plainTextDescription "\"Electric Current\" is the flow (movement) of electric charge. The amount of electric current through some surface, for example, a section through a copper conductor, is defined as the amount of electric charge flowing through that surface over time. Current is a scalar-valued quantity. Electric current is one of the base quantities in the International System of Quantities, ISQ, on which the International System of Units, SI, is based. " ;
   qudt:symbol "I" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Arus elektrik"@ms , "Elektrický proud"@cs , "corrente elettrica"@it , "corrente elétrica"@pt , "corriente eléctrica"@es , "curent electric"@ro , "electric current"@en , "elektrik akımı"@tr , "elektrische Stromstärke"@de , "električni tok"@sl , "elektromos áramerősség"@hu , "fluxio electrica"@la , "intensité de courant électrique"@fr , "prąd elektryczny"@pl , "Ένταση ηλεκτρικού ρεύματος"@el , "Електрически ток"@bg , "Сила электрического тока"@ru , "זרם חשמלי"@he , "تيار كهربائي"@ar , "جریان الکتریکی"@fa , "विद्युत धारा"@hi , "电流"@zh , "電流"@ja ;
+  rdfs:label "Arus elektrik"@ms ;
+  rdfs:label "Elektrický proud"@cs ;
+  rdfs:label "corrente elettrica"@it ;
+  rdfs:label "corrente elétrica"@pt ;
+  rdfs:label "corriente eléctrica"@es ;
+  rdfs:label "curent electric"@ro ;
+  rdfs:label "electric current"@en ;
+  rdfs:label "elektrik akımı"@tr ;
+  rdfs:label "elektrische Stromstärke"@de ;
+  rdfs:label "električni tok"@sl ;
+  rdfs:label "elektromos áramerősség"@hu ;
+  rdfs:label "fluxio electrica"@la ;
+  rdfs:label "intensité de courant électrique"@fr ;
+  rdfs:label "prąd elektryczny"@pl ;
+  rdfs:label "Ένταση ηλεκτρικού ρεύματος"@el ;
+  rdfs:label "Електрически ток"@bg ;
+  rdfs:label "Сила электрического тока"@ru ;
+  rdfs:label "זרם חשמלי"@he ;
+  rdfs:label "تيار كهربائي"@ar ;
+  rdfs:label "جریان الکتریکی"@fa ;
+  rdfs:label "विद्युत धारा"@hi ;
+  rdfs:label "电流"@zh ;
+  rdfs:label "電流"@ja ;
 .
 quantitykind:ElectricCurrentDensity
   a qudt:QuantityKind ;
@@ -5070,8 +5445,26 @@ quantitykind:ElectricCurrentDensity
   qudt:latexDefinition "\\(J = \\rho v\\), where \\(\\rho\\) is electric current density and \\(v\\) is volume."^^qudt:LatexString ;
   qudt:symbol "J" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "electric current density"@en , "elektrische Stromdichte"@de , "densité de courant"@fr , "densidad de corriente"@es , "densidade de corrente elétrica"@pt , "densità di corrente elettrica"@it , "Densitate de curent"@ro , "gostota električnega toka"@sl , "Hustota elektrického proudu"@cs , "Gęstość prądu elektrycznego"@pl , "плотность тока"@ru , "Akım yoğunluğu"@tr , "كثافة التيار"@ar , "چگالی جریان الکتریکی"@fa , "धारा घनत्व"@hi , "电流密度"@zh , "電流密度"@ja , "Ketumpatan arus elektrik"@ms ;
-  skos:altLabel "areic electric current"@en , "keluasan arus elektrik"@ms ;
+  rdfs:label "Akım yoğunluğu"@tr ;
+  rdfs:label "Densitate de curent"@ro ;
+  rdfs:label "Gęstość prądu elektrycznego"@pl ;
+  rdfs:label "Hustota elektrického proudu"@cs ;
+  rdfs:label "Ketumpatan arus elektrik"@ms ;
+  rdfs:label "densidad de corriente"@es ;
+  rdfs:label "densidade de corrente elétrica"@pt ;
+  rdfs:label "densità di corrente elettrica"@it ;
+  rdfs:label "densité de courant"@fr ;
+  rdfs:label "electric current density"@en ;
+  rdfs:label "elektrische Stromdichte"@de ;
+  rdfs:label "gostota električnega toka"@sl ;
+  rdfs:label "плотность тока"@ru ;
+  rdfs:label "كثافة التيار"@ar ;
+  rdfs:label "چگالی جریان الکتریکی"@fa ;
+  rdfs:label "धारा घनत्व"@hi ;
+  rdfs:label "电流密度"@zh ;
+  rdfs:label "電流密度"@ja ;
+  skos:altLabel "areic electric current"@en ;
+  skos:altLabel "keluasan arus elektrik"@ms ;
 .
 quantitykind:ElectricCurrentPerAngle
   a qudt:QuantityKind ;
@@ -5131,7 +5524,23 @@ quantitykind:ElectricDipoleMoment
   qudt:plainTextDescription "\"Electric Dipole Moment\" is a measure of the separation of positive and negative electrical charges in a system of (discrete or continuous) charges. It is a vector-valued quantity. If the system of charges is neutral, that is if the sum of all charges is zero, then the dipole moment of the system is independent of the choice of a reference frame; however in a non-neutral system, such as the dipole moment of a single proton, a dependence on the choice of reference point arises. In such cases it is conventional to choose the reference point to be the center of mass of the system or the center of charge, not some arbitrary origin. This convention ensures that the dipole moment is an intrinsic property of the system. The electric dipole moment of a substance within a domain is the vector sum of electric dipole moments of all electric dipoles included in the domain." ;
   qudt:symbol "p" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Dipólový moment"@cs , "Momen dwikutub elektrik"@ms , "electric dipole moment"@en , "elektrik dipol momenti"@tr , "elektrisches Dipolmoment"@de , "elektryczny moment dipolowy"@pl , "moment dipolaire"@fr , "moment electric dipolar"@ro , "momento de dipolo eléctrico"@es , "momento di dipolo elettrico"@it , "momento do dipolo elétrico"@pt , "Электрический дипольный момент"@ru , "عزم ثنائي قطب"@ar , "گشتاور دوقطبی الکتریکی"@fa , "विद्युत द्विध्रुव आघूर्ण"@hi , "电偶极矩"@zh , "電気双極子"@ja ;
+  rdfs:label "Dipólový moment"@cs ;
+  rdfs:label "Momen dwikutub elektrik"@ms ;
+  rdfs:label "electric dipole moment"@en ;
+  rdfs:label "elektrik dipol momenti"@tr ;
+  rdfs:label "elektrisches Dipolmoment"@de ;
+  rdfs:label "elektryczny moment dipolowy"@pl ;
+  rdfs:label "moment dipolaire"@fr ;
+  rdfs:label "moment electric dipolar"@ro ;
+  rdfs:label "momento de dipolo eléctrico"@es ;
+  rdfs:label "momento di dipolo elettrico"@it ;
+  rdfs:label "momento do dipolo elétrico"@pt ;
+  rdfs:label "Электрический дипольный момент"@ru ;
+  rdfs:label "عزم ثنائي قطب"@ar ;
+  rdfs:label "گشتاور دوقطبی الکتریکی"@fa ;
+  rdfs:label "विद्युत द्विध्रुव आघूर्ण"@hi ;
+  rdfs:label "电偶极矩"@zh ;
+  rdfs:label "電気双極子"@ja ;
 .
 quantitykind:ElectricDipoleMoment_CubicPerEnergy_Squared
   a qudt:QuantityKind ;
@@ -5219,7 +5628,28 @@ quantitykind:ElectricFieldStrength
   qudt:latexSymbol "\\(\\mathbf{E} \\)"^^qudt:LatexString ;
   qudt:symbol "E" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Elektromos mező"@hu , "Kekuatan medan elektrik"@ms , "câmp electric"@ro , "electric field strength"@en , "elektrické pole"@cs , "elektriksel alan kuvveti"@tr , "elektrische Feldstärke"@de , "intensidad de campo eléctrico"@es , "intensidade de campo elétrico"@pt , "intensità di campo elettrico"@it , "intensité de champ électrique"@fr , "jakost električnega polja"@sl , "natężenie pola elektrycznego"@pl , "Ηλεκτρικό πεδίο"@el , "Електрично поле"@bg , "Напряженность электрического поля"@ru , "שדה חשמלי"@he , "شدت میدان الکتریکی"@fa , "عدد الموجة"@ar , "विद्युत्-क्षेत्र"@hi , "電場"@zh , "電界強度"@ja ;
+  rdfs:label "Elektromos mező"@hu ;
+  rdfs:label "Kekuatan medan elektrik"@ms ;
+  rdfs:label "câmp electric"@ro ;
+  rdfs:label "electric field strength"@en ;
+  rdfs:label "elektrické pole"@cs ;
+  rdfs:label "elektriksel alan kuvveti"@tr ;
+  rdfs:label "elektrische Feldstärke"@de ;
+  rdfs:label "intensidad de campo eléctrico"@es ;
+  rdfs:label "intensidade de campo elétrico"@pt ;
+  rdfs:label "intensità di campo elettrico"@it ;
+  rdfs:label "intensité de champ électrique"@fr ;
+  rdfs:label "jakost električnega polja"@sl ;
+  rdfs:label "natężenie pola elektrycznego"@pl ;
+  rdfs:label "Ηλεκτρικό πεδίο"@el ;
+  rdfs:label "Електрично поле"@bg ;
+  rdfs:label "Напряженность электрического поля"@ru ;
+  rdfs:label "שדה חשמלי"@he ;
+  rdfs:label "شدت میدان الکتریکی"@fa ;
+  rdfs:label "عدد الموجة"@ar ;
+  rdfs:label "विद्युत्-क्षेत्र"@hi ;
+  rdfs:label "電場"@zh ;
+  rdfs:label "電界強度"@ja ;
 .
 quantitykind:ElectricFlux
   a qudt:QuantityKind ;
@@ -5256,8 +5686,29 @@ quantitykind:ElectricFluxDensity
   qudt:latexDefinition "\\(\\mathbf{D}  = \\epsilon_0 E + P\\), where \\(\\epsilon_0\\) is the electric constant, \\(\\mathbf{E} \\) is electric field strength, and \\(P\\) is electric polarization."^^qudt:LatexString ;
   qudt:latexSymbol "\\(\\mathbf{D}\\)"^^qudt:LatexString ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "electric flux density"@en , "elektrische Flussdichte"@de , "Induction électrique"@fr , "Densidad de flujo eléctrico"@es , "campo de deslocamento elétrico"@pt , "spostamento elettrico"@it , "Inducție electrică"@ro , "Elektrická indukce"@cs , "Indukcja elektryczna"@pl , "Электрическая индукция"@ru , "elektrik akı yoğunluğu"@tr , "إزاحة كهربائية"@ar , "چگالی شار الکتریکی"@fa , "電位移"@zh , "電束密度"@ja , "Ketumpatan fluks elektrik"@ms ;
-  skos:altLabel "displacement"@en , "elektrische Induktion"@de , "elektrische Verschiebung"@de , "densité de flux électrique"@fr , "induzione elettrica"@it , "yer değiştirme"@tr , "anjakan"@ms ;
+  rdfs:label "Densidad de flujo eléctrico"@es ;
+  rdfs:label "Elektrická indukce"@cs ;
+  rdfs:label "Induction électrique"@fr ;
+  rdfs:label "Inducție electrică"@ro ;
+  rdfs:label "Indukcja elektryczna"@pl ;
+  rdfs:label "Ketumpatan fluks elektrik"@ms ;
+  rdfs:label "campo de deslocamento elétrico"@pt ;
+  rdfs:label "electric flux density"@en ;
+  rdfs:label "elektrik akı yoğunluğu"@tr ;
+  rdfs:label "elektrische Flussdichte"@de ;
+  rdfs:label "spostamento elettrico"@it ;
+  rdfs:label "Электрическая индукция"@ru ;
+  rdfs:label "إزاحة كهربائية"@ar ;
+  rdfs:label "چگالی شار الکتریکی"@fa ;
+  rdfs:label "電位移"@zh ;
+  rdfs:label "電束密度"@ja ;
+  skos:altLabel "anjakan"@ms ;
+  skos:altLabel "densité de flux électrique"@fr ;
+  skos:altLabel "displacement"@en ;
+  skos:altLabel "elektrische Induktion"@de ;
+  skos:altLabel "elektrische Verschiebung"@de ;
+  skos:altLabel "induzione elettrica"@it ;
+  skos:altLabel "yer değiştirme"@tr ;
   skos:broader quantitykind:ElectricChargePerArea ;
 .
 quantitykind:ElectricPolarizability
@@ -5271,7 +5722,21 @@ quantitykind:ElectricPolarizability
   qudt:latexSymbol "\\(\\alpha\\)"^^qudt:LatexString ;
   qudt:plainTextDescription "\"Electric Polarizability\" is the relative tendency of a charge distribution, like the electron cloud of an atom or molecule, to be distorted from its normal shape by an external electric field, which is applied typically by inserting the molecule in a charged parallel-plate capacitor, but may also be caused by the presence of a nearby ion or dipole." ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Kepengkutuban elektrik"@ms , "Kutuplanabilirlik"@tr , "Polarisabilité"@fr , "Polarizabilidad"@es , "Polarizovatelnost"@cs , "Polaryzowalność"@pl , "electric polarizability"@en , "elektrische Polarisierbarkeit"@de , "polarizabilidade"@pt , "polarizzabilità elettrica"@it , "Поляризуемость"@ru , "قابلية استقطاب"@ar , "قطبیت پذیری الکتریکی"@fa , "分極率"@ja , "極化性"@zh ;
+  rdfs:label "Kepengkutuban elektrik"@ms ;
+  rdfs:label "Kutuplanabilirlik"@tr ;
+  rdfs:label "Polarisabilité"@fr ;
+  rdfs:label "Polarizabilidad"@es ;
+  rdfs:label "Polarizovatelnost"@cs ;
+  rdfs:label "Polaryzowalność"@pl ;
+  rdfs:label "electric polarizability"@en ;
+  rdfs:label "elektrische Polarisierbarkeit"@de ;
+  rdfs:label "polarizabilidade"@pt ;
+  rdfs:label "polarizzabilità elettrica"@it ;
+  rdfs:label "Поляризуемость"@ru ;
+  rdfs:label "قابلية استقطاب"@ar ;
+  rdfs:label "قطبیت پذیری الکتریکی"@fa ;
+  rdfs:label "分極率"@ja ;
+  rdfs:label "極化性"@zh ;
 .
 quantitykind:ElectricPolarization
   a qudt:QuantityKind ;
@@ -5285,7 +5750,16 @@ quantitykind:ElectricPolarization
   qudt:plainTextDescription "\"Electric Polarization\" is the relative shift of positive and negative electric charge in opposite directions within an insulator, or dielectric, induced by an external electric field. Polarization occurs when an electric field distorts the negative cloud of electrons around positive atomic nuclei in a direction opposite the field. This slight separation of charge makes one side of the atom somewhat positive and the opposite side somewhat negative. In some materials whose molecules are permanently polarized by chemical forces, such as water molecules, some of the polarization is caused by molecules rotating into the same alignment under the influence of the electric field. One of the measures of polarization is electric dipole moment, which equals the distance between the slightly shifted centres of positive and negative charge multiplied by the amount of one of the charges. Polarization P in its quantitative meaning is the amount of dipole moment p per unit volume V of a polarized material, P = p/V." ;
   qudt:symbol "P" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "electric polarization"@en , "elektrische Polarisation"@de , "polarisation électrique"@fr , "polarización eléctrica"@es , "polarização eléctrica"@pt , "polarizzazione elettrica"@it , "polaryzacja elektryczna"@pl , "электрическая поляризация"@ru , "إستقطاب كهربائي"@ar , "電気分極"@ja ;
+  rdfs:label "electric polarization"@en ;
+  rdfs:label "elektrische Polarisation"@de ;
+  rdfs:label "polarisation électrique"@fr ;
+  rdfs:label "polarización eléctrica"@es ;
+  rdfs:label "polarização eléctrica"@pt ;
+  rdfs:label "polarizzazione elettrica"@it ;
+  rdfs:label "polaryzacja elektryczna"@pl ;
+  rdfs:label "электрическая поляризация"@ru ;
+  rdfs:label "إستقطاب كهربائي"@ar ;
+  rdfs:label "電気分極"@ja ;
   rdfs:seeAlso quantitykind:ElectricChargeDensity ;
   rdfs:seeAlso quantitykind:ElectricDipoleMoment ;
 .
@@ -5310,7 +5784,28 @@ quantitykind:ElectricPotential
   qudt:latexSymbol "\\(\\phi\\)"^^qudt:LatexString ;
   qudt:symbol "V" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Keupayaan elektrik"@ms , "electric potential"@en , "elektrický potenciál"@cs , "elektrik potansiyeli"@tr , "elektrisches Potenzial"@de , "električni potencial"@sl , "elektromos feszültség , elektromos potenciálkülönbség"@hu , "potencial eléctrico"@es , "potencial elétrico"@pt , "potencjał elektryczny"@pl , "potentiel électrique"@fr , "potenziale elettrico"@it , "potențial electric"@ro , "tensio electrica"@la , "Електрически потенциал"@bg , "электростатический потенциал"@ru , "מתח חשמלי (הפרש פוטנציאלים)"@he , "كمون كهربائي"@ar , "پتانسیل الکتریکی"@fa , "विद्युत विभव"@hi , "電位"@ja , "電勢"@zh ;
+  rdfs:label "Keupayaan elektrik"@ms ;
+  rdfs:label "electric potential"@en ;
+  rdfs:label "elektrický potenciál"@cs ;
+  rdfs:label "elektrik potansiyeli"@tr ;
+  rdfs:label "elektrisches Potenzial"@de ;
+  rdfs:label "električni potencial"@sl ;
+  rdfs:label "elektromos feszültség , elektromos potenciálkülönbség"@hu ;
+  rdfs:label "potencial eléctrico"@es ;
+  rdfs:label "potencial elétrico"@pt ;
+  rdfs:label "potencjał elektryczny"@pl ;
+  rdfs:label "potentiel électrique"@fr ;
+  rdfs:label "potenziale elettrico"@it ;
+  rdfs:label "potențial electric"@ro ;
+  rdfs:label "tensio electrica"@la ;
+  rdfs:label "Електрически потенциал"@bg ;
+  rdfs:label "электростатический потенциал"@ru ;
+  rdfs:label "מתח חשמלי (הפרש פוטנציאלים)"@he ;
+  rdfs:label "كمون كهربائي"@ar ;
+  rdfs:label "پتانسیل الکتریکی"@fa ;
+  rdfs:label "विद्युत विभव"@hi ;
+  rdfs:label "電位"@ja ;
+  rdfs:label "電勢"@zh ;
   skos:altLabel "vis electromotrix"@la ;
   skos:broader quantitykind:EnergyPerElectricCharge ;
 .
@@ -5334,8 +5829,28 @@ quantitykind:ElectricPotentialDifference
   qudt:plainTextDescription "\"Electric Potential Difference\" is a scalar valued quantity associated with an electric field." ;
   qudt:symbol "V_{ab}" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "electric potential difference"@en , "elektrische Spannung"@de , "tension électrique"@fr , "tensión eléctrica"@es , "tensão elétrica (diferença de potencial)"@pt , "differenza di potenziale elettrico"@it , "diferență de potențial electric"@ro , "električna napetost"@sl , "elektrické napětí"@cs , "napięcie elektryczne"@pl , "электрическое напряжение"@ru , "gerilim"@tr , "جهد كهربائي"@ar , "ولتاژ/ اختلاف پتانسیل"@fa , "विभवांतर"@hi , "電壓"@zh , "電圧"@ja , "Voltan Perbezaan keupayaan elektrik"@ms ;
-  skos:altLabel "tension"@en , "tensione elettrica"@it , "tensiune"@ro , "ketegangan"@ms ;
+  rdfs:label "Voltan Perbezaan keupayaan elektrik"@ms ;
+  rdfs:label "diferență de potențial electric"@ro ;
+  rdfs:label "differenza di potenziale elettrico"@it ;
+  rdfs:label "electric potential difference"@en ;
+  rdfs:label "elektrické napětí"@cs ;
+  rdfs:label "elektrische Spannung"@de ;
+  rdfs:label "električna napetost"@sl ;
+  rdfs:label "gerilim"@tr ;
+  rdfs:label "napięcie elektryczne"@pl ;
+  rdfs:label "tension électrique"@fr ;
+  rdfs:label "tensión eléctrica"@es ;
+  rdfs:label "tensão elétrica (diferença de potencial)"@pt ;
+  rdfs:label "электрическое напряжение"@ru ;
+  rdfs:label "جهد كهربائي"@ar ;
+  rdfs:label "ولتاژ/ اختلاف پتانسیل"@fa ;
+  rdfs:label "विभवांतर"@hi ;
+  rdfs:label "電圧"@ja ;
+  rdfs:label "電壓"@zh ;
+  skos:altLabel "ketegangan"@ms ;
+  skos:altLabel "tension"@en ;
+  skos:altLabel "tensione elettrica"@it ;
+  skos:altLabel "tensiune"@ro ;
   skos:broader quantitykind:EnergyPerElectricCharge ;
 .
 quantitykind:ElectricPower
@@ -5392,7 +5907,16 @@ quantitykind:ElectricPower
   qudt:latexDefinition "\\(p = ui\\), where \\(u\\) is instantaneous voltage and \\(i\\) is instantaneous electric current."^^qudt:LatexString ;
   qudt:symbol "P_E" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Wirkleistung"@de , "electric power"@en , "moc czynna"@pl , "potencia activa"@es , "potenza attiva"@it , "potência activa"@pt , "puissance active"@fr , "القدرة الفعالة"@ar , "有功功率"@zh , "有効電力"@ja ;
+  rdfs:label "Wirkleistung"@de ;
+  rdfs:label "electric power"@en ;
+  rdfs:label "moc czynna"@pl ;
+  rdfs:label "potencia activa"@es ;
+  rdfs:label "potenza attiva"@it ;
+  rdfs:label "potência activa"@pt ;
+  rdfs:label "puissance active"@fr ;
+  rdfs:label "القدرة الفعالة"@ar ;
+  rdfs:label "有功功率"@zh ;
+  rdfs:label "有効電力"@ja ;
   skos:broader quantitykind:Power ;
 .
 quantitykind:ElectricPropulsionPropellantMass
@@ -5459,7 +5983,19 @@ quantitykind:ElectricQuadrupoleMoment
   qudt:plainTextDescription "The Electric Quadrupole Moment is a quantity which describes the effective shape of the ellipsoid of nuclear charge distribution. A non-zero quadrupole moment Q indicates that the charge distribution is not spherically symmetric. By convention, the value of Q is taken to be positive if the ellipsoid is prolate and negative if it is oblate. In general, the electric quadrupole moment is tensor-valued." ;
   qudt:symbol "Q" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Momen kuadrupol elektrik"@ms , "electric quadrupole moment"@en , "elektrik kuadrupol momenti"@tr , "elektrisches Quadrupolmoment"@de , "elektryczny moment kwadrupolowy"@pl , "moment quadrupolaire électrique"@fr , "momento de cuadrupolo eléctrico"@es , "momento de quadrupolo elétrico"@pt , "momento di quadrupolo elettrico"@it , "Электрический квадрупольный момент"@ru , "گشتاور چهار قطبی الکتریکی"@fa , "四極子"@ja , "电四极矩"@zh ;
+  rdfs:label "Momen kuadrupol elektrik"@ms ;
+  rdfs:label "electric quadrupole moment"@en ;
+  rdfs:label "elektrik kuadrupol momenti"@tr ;
+  rdfs:label "elektrisches Quadrupolmoment"@de ;
+  rdfs:label "elektryczny moment kwadrupolowy"@pl ;
+  rdfs:label "moment quadrupolaire électrique"@fr ;
+  rdfs:label "momento de cuadrupolo eléctrico"@es ;
+  rdfs:label "momento de quadrupolo elétrico"@pt ;
+  rdfs:label "momento di quadrupolo elettrico"@it ;
+  rdfs:label "Электрический квадрупольный момент"@ru ;
+  rdfs:label "گشتاور چهار قطبی الکتریکی"@fa ;
+  rdfs:label "四極子"@ja ;
+  rdfs:label "电四极矩"@zh ;
 .
 quantitykind:ElectricSusceptibility
   a qudt:QuantityKind ;
@@ -5473,10 +6009,20 @@ quantitykind:ElectricSusceptibility
   qudt:latexSymbol "\\(\\chi\\)"^^qudt:LatexString ;
   qudt:plainTextDescription "\"Electric Susceptibility\" is the ratio of electric polarization to electric field strength, normalized to the electric constant. The definition applies to an isotropic medium. For an anisotropic medium, electric susceptibility is a second order tensor." ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "electric susceptibility"@en , "elektrische Suszeptibilität"@de , "susceptibilité électrique"@fr , "susceptibilidad eléctrica"@es , "susceptibilidade eléctrica"@pt , "suscettività elettrica"@it , "podatność elektryczna"@pl , "электрическая восприимчивость"@ru , "المتأثرية الكهربائية، سرعة التأثر الكهربائية"@ar , "電気感受率"@ja ;
-  skos:altLabel "susceptywność elektryczna"@pl , "диэлектрическая восприимчивость"@ru ;
+  rdfs:label "electric susceptibility"@en ;
+  rdfs:label "elektrische Suszeptibilität"@de ;
+  rdfs:label "podatność elektryczna"@pl ;
+  rdfs:label "susceptibilidad eléctrica"@es ;
+  rdfs:label "susceptibilidade eléctrica"@pt ;
+  rdfs:label "susceptibilité électrique"@fr ;
+  rdfs:label "suscettività elettrica"@it ;
+  rdfs:label "электрическая восприимчивость"@ru ;
+  rdfs:label "المتأثرية الكهربائية، سرعة التأثر الكهربائية"@ar ;
+  rdfs:label "電気感受率"@ja ;
   rdfs:seeAlso quantitykind:ElectricFieldStrength ;
   rdfs:seeAlso quantitykind:ElectricPolarization ;
+  skos:altLabel "susceptywność elektryczna"@pl ;
+  skos:altLabel "диэлектрическая восприимчивость"@ru ;
 .
 quantitykind:ElectricalPowerToMassRatio
   a qudt:QuantityKind ;
@@ -5576,7 +6122,24 @@ quantitykind:ElectromotiveForce
   qudt:hasDimensionVector qkdv:A0E-1L2I0M1H0T-3D0 ;
   qudt:symbol "E" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Daya gerak elektrik"@ms , "Elektromotor kuvvet"@tr , "Elektromotorické napětí"@cs , "electromotive force"@en , "elektromotorische Kraft"@de , "elektromotorna sila"@sl , "force électromotrice"@fr , "forza elettromotrice"@it , "força eletromotriz"@pt , "forță electromotoare"@ro , "fuerza electromotriz"@es , "siła elektromotoryczna"@pl , "электродвижущая сила"@ru , "قوة محركة كهربائية"@ar , "نیروی محرک الکتریکی"@fa , "विद्युतवाहक बल"@hi , "起電力"@ja , "電動勢"@zh ;
+  rdfs:label "Daya gerak elektrik"@ms ;
+  rdfs:label "Elektromotor kuvvet"@tr ;
+  rdfs:label "Elektromotorické napětí"@cs ;
+  rdfs:label "electromotive force"@en ;
+  rdfs:label "elektromotorische Kraft"@de ;
+  rdfs:label "elektromotorna sila"@sl ;
+  rdfs:label "force électromotrice"@fr ;
+  rdfs:label "forza elettromotrice"@it ;
+  rdfs:label "força eletromotriz"@pt ;
+  rdfs:label "forță electromotoare"@ro ;
+  rdfs:label "fuerza electromotriz"@es ;
+  rdfs:label "siła elektromotoryczna"@pl ;
+  rdfs:label "электродвижущая сила"@ru ;
+  rdfs:label "قوة محركة كهربائية"@ar ;
+  rdfs:label "نیروی محرک الکتریکی"@fa ;
+  rdfs:label "विद्युतवाहक बल"@hi ;
+  rdfs:label "起電力"@ja ;
+  rdfs:label "電動勢"@zh ;
   skos:broader quantitykind:EnergyPerElectricCharge ;
 .
 quantitykind:ElectronAffinity
@@ -5895,7 +6458,29 @@ quantitykind:Energy
   qudt:plainTextDescription "Energy is the quantity characterizing the ability of a system to do work." ;
   qudt:symbol "E" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Energie"@cs , "Energie"@de , "Tenaga"@ms , "energia , munka , hő"@hu , "energia"@es , "energia"@it , "energia"@la , "energia"@pl , "energia"@pt , "energie"@ro , "energija"@sl , "energy"@en , "enerji"@tr , "énergie"@fr , "Έργο - Ενέργεια"@el , "Енергия"@bg , "Энергия"@ru , "אנרגיה ועבודה"@he , "الطاقة"@ar , "انرژی"@fa , "ऊर्जा"@hi , "エネルギー"@ja , "能量"@zh ;
+  rdfs:label "Energie"@cs ;
+  rdfs:label "Energie"@de ;
+  rdfs:label "Tenaga"@ms ;
+  rdfs:label "energia , munka , hő"@hu ;
+  rdfs:label "energia"@es ;
+  rdfs:label "energia"@it ;
+  rdfs:label "energia"@la ;
+  rdfs:label "energia"@pl ;
+  rdfs:label "energia"@pt ;
+  rdfs:label "energie"@ro ;
+  rdfs:label "energija"@sl ;
+  rdfs:label "energy"@en ;
+  rdfs:label "enerji"@tr ;
+  rdfs:label "énergie"@fr ;
+  rdfs:label "Έργο - Ενέργεια"@el ;
+  rdfs:label "Енергия"@bg ;
+  rdfs:label "Энергия"@ru ;
+  rdfs:label "אנרגיה ועבודה"@he ;
+  rdfs:label "الطاقة"@ar ;
+  rdfs:label "انرژی"@fa ;
+  rdfs:label "ऊर्जा"@hi ;
+  rdfs:label "エネルギー"@ja ;
+  rdfs:label "能量"@zh ;
   rdfs:seeAlso quantitykind:Enthalpy ;
   rdfs:seeAlso quantitykind:Entropy ;
   rdfs:seeAlso quantitykind:GibbsEnergy ;
@@ -6100,8 +6685,29 @@ quantitykind:EnergyInternal
   qudt:informativeReference "http://en.wikipedia.org/wiki/Internal_energy"^^xsd:anyURI ;
   qudt:symbol "U" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "internal energy"@en , "innere Energie"@de , "énergie interne"@fr , "energía interna"@es , "energia interna"@pt , "energia interna"@it , "energie internă"@ro , "Notranja energija"@sl , "vnitřní energie"@cs , "energia wewnętrzna"@pl , "внутренняя энергия"@ru , "İç enerji"@tr , "طاقة داخلية"@ar , "انرژی درونی"@fa , "आन्तरिक ऊर्जा"@hi , "内能"@zh , "内部エネルギー"@ja , "Tenaga dalaman"@ms ;
-  skos:altLabel "thermodynamic energy"@en , "thermodynamische Energie"@de , "énergie thermodynamique"@fr , "energia termodinamica"@it , "tenaga termodinamik"@ms ;
+  rdfs:label "Notranja energija"@sl ;
+  rdfs:label "Tenaga dalaman"@ms ;
+  rdfs:label "energia interna"@it ;
+  rdfs:label "energia interna"@pt ;
+  rdfs:label "energia wewnętrzna"@pl ;
+  rdfs:label "energie internă"@ro ;
+  rdfs:label "energía interna"@es ;
+  rdfs:label "innere Energie"@de ;
+  rdfs:label "internal energy"@en ;
+  rdfs:label "vnitřní energie"@cs ;
+  rdfs:label "énergie interne"@fr ;
+  rdfs:label "İç enerji"@tr ;
+  rdfs:label "внутренняя энергия"@ru ;
+  rdfs:label "انرژی درونی"@fa ;
+  rdfs:label "طاقة داخلية"@ar ;
+  rdfs:label "आन्तरिक ऊर्जा"@hi ;
+  rdfs:label "内能"@zh ;
+  rdfs:label "内部エネルギー"@ja ;
+  skos:altLabel "energia termodinamica"@it ;
+  skos:altLabel "tenaga termodinamik"@ms ;
+  skos:altLabel "thermodynamic energy"@en ;
+  skos:altLabel "thermodynamische Energie"@de ;
+  skos:altLabel "énergie thermodynamique"@fr ;
   skos:broader quantitykind:Energy ;
 .
 quantitykind:EnergyKinetic
@@ -6157,7 +6763,23 @@ quantitykind:EnergyKinetic
   qudt:informativeReference "http://en.wikipedia.org/wiki/Kinetic_energy"^^xsd:anyURI ;
   qudt:plainTextDescription "The kinetic energy of an object is the energy which it possesses due to its motion. It is defined as the work needed to accelerate a body of a given mass from rest to its stated velocity." ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Energie cinetică"@ro , "Kinetik enerji"@tr , "Tenaga kinetik"@ms , "energia cinetica"@it , "energia cinética"@pt , "energia kinetyczna"@pl , "energía cinética"@es , "kinetic energy"@en , "kinetická energie"@cs , "kinetische Energie"@de , "énergie cinétique"@fr , "кинетическая энергия"@ru , "انرژی جنبشی"@fa , "طاقة حركية"@ar , "गतिज ऊर्जा"@hi , "动能"@zh , "運動エネルギー"@ja ;
+  rdfs:label "Energie cinetică"@ro ;
+  rdfs:label "Kinetik enerji"@tr ;
+  rdfs:label "Tenaga kinetik"@ms ;
+  rdfs:label "energia cinetica"@it ;
+  rdfs:label "energia cinética"@pt ;
+  rdfs:label "energia kinetyczna"@pl ;
+  rdfs:label "energía cinética"@es ;
+  rdfs:label "kinetic energy"@en ;
+  rdfs:label "kinetická energie"@cs ;
+  rdfs:label "kinetische Energie"@de ;
+  rdfs:label "énergie cinétique"@fr ;
+  rdfs:label "кинетическая энергия"@ru ;
+  rdfs:label "انرژی جنبشی"@fa ;
+  rdfs:label "طاقة حركية"@ar ;
+  rdfs:label "गतिज ऊर्जा"@hi ;
+  rdfs:label "动能"@zh ;
+  rdfs:label "運動エネルギー"@ja ;
   skos:broader quantitykind:Energy ;
 .
 quantitykind:EnergyLevel
@@ -6364,7 +6986,24 @@ quantitykind:Enthalpy
   qudt:normativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI ;
   qudt:symbol "H" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Entalpi"@ms , "Entalpi"@tr , "Entalpie"@ro , "Enthalpie"@de , "entalpia"@it , "entalpia"@pl , "entalpia"@pt , "entalpie"@cs , "entalpija"@sl , "entalpía"@es , "enthalpie"@fr , "enthalpy"@en , "энтальпия"@ru , "آنتالپی"@fa , "محتوى حراري"@ar , "पूर्ण ऊष्मा"@hi , "エンタルピー"@ja , "焓"@zh ;
+  rdfs:label "Entalpi"@ms ;
+  rdfs:label "Entalpi"@tr ;
+  rdfs:label "Entalpie"@ro ;
+  rdfs:label "Enthalpie"@de ;
+  rdfs:label "entalpia"@it ;
+  rdfs:label "entalpia"@pl ;
+  rdfs:label "entalpia"@pt ;
+  rdfs:label "entalpie"@cs ;
+  rdfs:label "entalpija"@sl ;
+  rdfs:label "entalpía"@es ;
+  rdfs:label "enthalpie"@fr ;
+  rdfs:label "enthalpy"@en ;
+  rdfs:label "энтальпия"@ru ;
+  rdfs:label "آنتالپی"@fa ;
+  rdfs:label "محتوى حراري"@ar ;
+  rdfs:label "पूर्ण ऊष्मा"@hi ;
+  rdfs:label "エンタルピー"@ja ;
+  rdfs:label "焓"@zh ;
   rdfs:seeAlso quantitykind:InternalEnergy ;
   skos:broader quantitykind:Energy ;
 .
@@ -6377,7 +7016,24 @@ quantitykind:Entropy
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI ;
   qudt:symbol "S" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Entropi"@ms , "Entropie"@de , "entropi"@tr , "entropia"@it , "entropia"@pl , "entropia"@pt , "entropie"@cs , "entropie"@fr , "entropie"@ro , "entropija"@sl , "entropy"@en , "entropía"@es , "Энтропия"@ru , "آنتروپی"@fa , "إنتروبيا"@ar , "एन्ट्रॉपी"@hi , "エントロピー"@ja , "熵"@zh ;
+  rdfs:label "Entropi"@ms ;
+  rdfs:label "Entropie"@de ;
+  rdfs:label "entropi"@tr ;
+  rdfs:label "entropia"@it ;
+  rdfs:label "entropia"@pl ;
+  rdfs:label "entropia"@pt ;
+  rdfs:label "entropie"@cs ;
+  rdfs:label "entropie"@fr ;
+  rdfs:label "entropie"@ro ;
+  rdfs:label "entropija"@sl ;
+  rdfs:label "entropy"@en ;
+  rdfs:label "entropía"@es ;
+  rdfs:label "Энтропия"@ru ;
+  rdfs:label "آنتروپی"@fa ;
+  rdfs:label "إنتروبيا"@ar ;
+  rdfs:label "एन्ट्रॉपी"@hi ;
+  rdfs:label "エントロピー"@ja ;
+  rdfs:label "熵"@zh ;
 .
 quantitykind:EquilibriumConstant
   a qudt:QuantityKind ;
@@ -7217,7 +7873,29 @@ quantitykind:Force
   qudt:latexDefinition "\\(F = \\frac{dp}{dt}\\), where \\(F\\) is the resultant force acting on a body, \\(p\\) is momentum of a body, and \\(t\\) is time."^^qudt:LatexString ;
   qudt:symbol "F" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "force"@en , "Kraft"@de , "force"@fr , "fuerza"@es , "força"@pt , "forza"@it , "forță"@ro , "сила"@bg , "sila"@sl , "Síla"@cs , "siła"@pl , "Сила"@ru , "erő"@hu , "kuvvet"@tr , "Δύναμη"@el , "כוח"@he , "وحدة القوة في نظام متر كيلوغرام ثانية"@ar , "نیرو"@fa , "बल"@hi , "力"@zh , "力"@ja , "Daya"@ms , "vis"@la ;
+  rdfs:label "Daya"@ms ;
+  rdfs:label "Kraft"@de ;
+  rdfs:label "Síla"@cs ;
+  rdfs:label "erő"@hu ;
+  rdfs:label "force"@en ;
+  rdfs:label "force"@fr ;
+  rdfs:label "forza"@it ;
+  rdfs:label "força"@pt ;
+  rdfs:label "forță"@ro ;
+  rdfs:label "fuerza"@es ;
+  rdfs:label "kuvvet"@tr ;
+  rdfs:label "sila"@sl ;
+  rdfs:label "siła"@pl ;
+  rdfs:label "vis"@la ;
+  rdfs:label "Δύναμη"@el ;
+  rdfs:label "Сила"@ru ;
+  rdfs:label "сила"@bg ;
+  rdfs:label "כוח"@he ;
+  rdfs:label "نیرو"@fa ;
+  rdfs:label "وحدة القوة في نظام متر كيلوغرام ثانية"@ar ;
+  rdfs:label "बल"@hi ;
+  rdfs:label "力"@ja ;
+  rdfs:label "力"@zh ;
   skos:altLabel "भार"@hi ;
 .
 quantitykind:ForceMagnitude
@@ -7394,7 +8072,29 @@ Alternatively,
 \\(\\nu = 1/T\\)"""^^qudt:LatexString ;
   qudt:latexSymbol "\\(\\nu, f\\)"^^qudt:LatexString ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Frekuensi"@ms , "Frekvence"@cs , "Frequenz"@de , "częstotliwość"@pl , "frecuencia"@es , "frecvență"@ro , "frekans"@tr , "frekvenca"@sl , "frekvencia"@hu , "frequency"@en , "frequentia"@la , "frequenza"@it , "frequência"@pt , "fréquence"@fr , "Συχνότητα"@el , "Частота"@ru , "Честота"@bg , "תדירות"@he , "التردد لدى نظام الوحدات الدولي"@ar , "بسامد"@fa , "आवृत्ति"@hi , "周波数"@ja , "频率"@zh ;
+  rdfs:label "Frekuensi"@ms ;
+  rdfs:label "Frekvence"@cs ;
+  rdfs:label "Frequenz"@de ;
+  rdfs:label "częstotliwość"@pl ;
+  rdfs:label "frecuencia"@es ;
+  rdfs:label "frecvență"@ro ;
+  rdfs:label "frekans"@tr ;
+  rdfs:label "frekvenca"@sl ;
+  rdfs:label "frekvencia"@hu ;
+  rdfs:label "frequency"@en ;
+  rdfs:label "frequentia"@la ;
+  rdfs:label "frequenza"@it ;
+  rdfs:label "frequência"@pt ;
+  rdfs:label "fréquence"@fr ;
+  rdfs:label "Συχνότητα"@el ;
+  rdfs:label "Частота"@ru ;
+  rdfs:label "Честота"@bg ;
+  rdfs:label "תדירות"@he ;
+  rdfs:label "التردد لدى نظام الوحدات الدولي"@ar ;
+  rdfs:label "بسامد"@fa ;
+  rdfs:label "आवृत्ति"@hi ;
+  rdfs:label "周波数"@ja ;
+  rdfs:label "频率"@zh ;
   skos:broader quantitykind:InverseTime ;
 .
 quantitykind:Friction
@@ -7457,7 +8157,21 @@ quantitykind:Fugacity
   qudt:latexSymbol "\\(\\tilde{p}_B\\)"^^qudt:LatexString ;
   qudt:plainTextDescription "\"Fugacity\" of a real gas is an effective pressure which replaces the true mechanical pressure in accurate chemical equilibrium calculations. It is equal to the pressure of an ideal gas which has the same chemical potential as the real gas." ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Fugasiti"@ms , "Fugazität"@de , "Lotność"@pl , "fugacidad"@es , "fugacidade"@pt , "fugacita"@cs , "fugacitate"@ro , "fugacity"@en , "fugacità"@it , "fugacité"@fr , "fügasite"@tr , "انفلاتية"@ar , "بی‌دوامی"@fa , "フガシティー"@ja , "逸度"@zh ;
+  rdfs:label "Fugasiti"@ms ;
+  rdfs:label "Fugazität"@de ;
+  rdfs:label "Lotność"@pl ;
+  rdfs:label "fugacidad"@es ;
+  rdfs:label "fugacidade"@pt ;
+  rdfs:label "fugacita"@cs ;
+  rdfs:label "fugacitate"@ro ;
+  rdfs:label "fugacity"@en ;
+  rdfs:label "fugacità"@it ;
+  rdfs:label "fugacité"@fr ;
+  rdfs:label "fügasite"@tr ;
+  rdfs:label "انفلاتية"@ar ;
+  rdfs:label "بی‌دوامی"@fa ;
+  rdfs:label "フガシティー"@ja ;
+  rdfs:label "逸度"@zh ;
 .
 quantitykind:FundamentalLatticeVector
   a qudt:QuantityKind ;
@@ -7796,12 +8510,31 @@ quantitykind:GibbsEnergy
   qudt:plainTextDescription "\"Gibbs Energy} is one of the potentials are used to measure energy changes in systems as they evolve from an initial state to a final state. The potential used depends on the constraints of the system, such as constant temperature or pressure. \\textit{Internal Energy} is the internal energy of the system, \\textit{Enthalpy} is the internal energy of the system plus the energy related to pressure-volume work, and Helmholtz and Gibbs free energy are the energies available in a system to do useful work when the temperature and volume or the pressure and temperature are fixed, respectively. The name \\textit{Gibbs Free Energy\" is also used." ;
   qudt:symbol "G" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Gibbs energy"@en , "freie Enthalpie"@de , "enthalpie libre"@fr , "Energía de Gibbs"@es , "energia livre de Gibbs"@pt , "energia libera di Gibbs"@it , "Entalpie liberă"@ro , "Prosta entalpija"@sl , "Gibbsova volná energie"@cs , "entalpia swobodna"@pl , "энергия Гиббса"@ru , "Gibbs Serbest Enerjisi"@tr , "طاقة غيبس الحرة"@ar , "انرژی آزاد گیبس"@fa , "吉布斯自由能"@zh , "ギブズエネルギー"@ja , "Tenaga Gibbs"@ms ;
-  skos:altLabel "Gibbs function"@en , "Gibbs-Energie"@de , "Gibbs-Funktion"@de , "fungsi Gibbs"@ms ;
+  rdfs:label "Energía de Gibbs"@es ;
+  rdfs:label "Entalpie liberă"@ro ;
+  rdfs:label "Gibbs Serbest Enerjisi"@tr ;
+  rdfs:label "Gibbs energy"@en ;
+  rdfs:label "Gibbsova volná energie"@cs ;
+  rdfs:label "Prosta entalpija"@sl ;
+  rdfs:label "Tenaga Gibbs"@ms ;
+  rdfs:label "energia libera di Gibbs"@it ;
+  rdfs:label "energia livre de Gibbs"@pt ;
+  rdfs:label "entalpia swobodna"@pl ;
+  rdfs:label "enthalpie libre"@fr ;
+  rdfs:label "freie Enthalpie"@de ;
+  rdfs:label "энергия Гиббса"@ru ;
+  rdfs:label "انرژی آزاد گیبس"@fa ;
+  rdfs:label "طاقة غيبس الحرة"@ar ;
+  rdfs:label "ギブズエネルギー"@ja ;
+  rdfs:label "吉布斯自由能"@zh ;
   rdfs:seeAlso quantitykind:Energy ;
   rdfs:seeAlso quantitykind:Enthalpy ;
   rdfs:seeAlso quantitykind:HelmholtzEnergy ;
   rdfs:seeAlso quantitykind:InternalEnergy ;
+  skos:altLabel "Gibbs function"@en ;
+  skos:altLabel "Gibbs-Energie"@de ;
+  skos:altLabel "Gibbs-Funktion"@de ;
+  skos:altLabel "fungsi Gibbs"@ms ;
   skos:broader quantitykind:Energy ;
 .
 quantitykind:GrandCanonicalPartitionFunction
@@ -7936,7 +8669,17 @@ quantitykind:Half-Life
   qudt:plainTextDescription "The \"Half-Life\" is the average duration required for the decay of one half of the atoms or nuclei." ;
   qudt:symbol "T_{1/2}" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "half-life"@en , "Halbwertszeit"@de , "temps de demi-vie"@fr , "semiperiodo"@es , "meia-vida"@pt , "tempo di dimezzamento"@it , "Poločas rozpadu"@cs , "yarılanma süresi"@tr , "نیمه عمر"@fa , "半衰期"@zh , "Separuh hayat"@ms ;
+  rdfs:label "Halbwertszeit"@de ;
+  rdfs:label "Poločas rozpadu"@cs ;
+  rdfs:label "Separuh hayat"@ms ;
+  rdfs:label "half-life"@en ;
+  rdfs:label "meia-vida"@pt ;
+  rdfs:label "semiperiodo"@es ;
+  rdfs:label "tempo di dimezzamento"@it ;
+  rdfs:label "temps de demi-vie"@fr ;
+  rdfs:label "yarılanma süresi"@tr ;
+  rdfs:label "نیمه عمر"@fa ;
+  rdfs:label "半衰期"@zh ;
   skos:altLabel "semivita"@it ;
 .
 quantitykind:Half-ValueThickness
@@ -8115,8 +8858,30 @@ quantitykind:Heat
   qudt:plainTextDescription "\"Heat\" is the energy transferred by a thermal process.  Heat can be measured in terms of the dynamical units of energy, as the erg, joule, etc., or in terms of the amount of energy required to produce a definite thermal change in some substance, as, for example, the energy required per degree to raise the temperature of a unit mass of water at some temperature ( calorie, Btu)." ;
   qudt:symbol "Q" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "heat"@en , "Wärme"@de , "quantité de chaleur"@fr , "calor"@es , "quantidade de calor"@pt , "calore"@it , "cantitate de căldură"@ro , "toplota"@sl , "jednotka tepla"@cs , "ciepło"@pl , "Теплота"@ru , "ısı miktarı"@tr , "حرارة"@ar , "کمیت گرما"@fa , "ऊष्मा"@hi , "热量"@zh , "熱量"@ja , "kuantiti haba Haba"@ms , "labor"@la ;
-  skos:altLabel "amount of heat"@en , "Wärmemenge"@de , "chaleur"@fr , "quantità di calore"@it , "jumlah haba"@ms ;
+  rdfs:label "Wärme"@de ;
+  rdfs:label "calor"@es ;
+  rdfs:label "calore"@it ;
+  rdfs:label "cantitate de căldură"@ro ;
+  rdfs:label "ciepło"@pl ;
+  rdfs:label "heat"@en ;
+  rdfs:label "jednotka tepla"@cs ;
+  rdfs:label "kuantiti haba Haba"@ms ;
+  rdfs:label "labor"@la ;
+  rdfs:label "quantidade de calor"@pt ;
+  rdfs:label "quantité de chaleur"@fr ;
+  rdfs:label "toplota"@sl ;
+  rdfs:label "ısı miktarı"@tr ;
+  rdfs:label "Теплота"@ru ;
+  rdfs:label "حرارة"@ar ;
+  rdfs:label "کمیت گرما"@fa ;
+  rdfs:label "ऊष्मा"@hi ;
+  rdfs:label "热量"@zh ;
+  rdfs:label "熱量"@ja ;
+  skos:altLabel "Wärmemenge"@de ;
+  skos:altLabel "amount of heat"@en ;
+  skos:altLabel "chaleur"@fr ;
+  skos:altLabel "jumlah haba"@ms ;
+  skos:altLabel "quantità di calore"@it ;
   skos:broader quantitykind:ThermalEnergy ;
 .
 quantitykind:HeatCapacity
@@ -8132,7 +8897,24 @@ quantitykind:HeatCapacity
   qudt:latexDefinition "\\(C = dQ/dT\\), where \\(Q\\) is amount of heat and \\(T\\) is thermodynamic temperature."^^qudt:LatexString ;
   qudt:symbol "C_P" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Wärmekapazität"@de , "capacidad calorífica"@es , "capacidade térmica"@pt , "capacitate termică"@ro , "capacità termica"@it , "capacité thermique"@fr , "heat capacity"@en , "isı kapasitesi"@tr , "muatan haba"@ms , "pojemność cieplna"@pl , "tepelná kapacita"@cs , "toplotna kapaciteta"@sl , "теплоёмкость"@ru , "سعة حرارية"@ar , "ظرفیت گرمایی"@fa , "ऊष्मा धारिता"@hi , "热容"@zh , "熱容量"@ja ;
+  rdfs:label "Wärmekapazität"@de ;
+  rdfs:label "capacidad calorífica"@es ;
+  rdfs:label "capacidade térmica"@pt ;
+  rdfs:label "capacitate termică"@ro ;
+  rdfs:label "capacità termica"@it ;
+  rdfs:label "capacité thermique"@fr ;
+  rdfs:label "heat capacity"@en ;
+  rdfs:label "isı kapasitesi"@tr ;
+  rdfs:label "muatan haba"@ms ;
+  rdfs:label "pojemność cieplna"@pl ;
+  rdfs:label "tepelná kapacita"@cs ;
+  rdfs:label "toplotna kapaciteta"@sl ;
+  rdfs:label "теплоёмкость"@ru ;
+  rdfs:label "سعة حرارية"@ar ;
+  rdfs:label "ظرفیت گرمایی"@fa ;
+  rdfs:label "ऊष्मा धारिता"@hi ;
+  rdfs:label "热容"@zh ;
+  rdfs:label "熱容量"@ja ;
   skos:broader quantitykind:EnergyPerTemperature ;
 .
 quantitykind:HeatCapacityRatio
@@ -8259,7 +9041,8 @@ quantitykind:HeatingValue
   qudt:plainTextDescription "The heating value (or energy value or calorific value) of a substance, usually a fuel or food (see food energy), is the amount of heat released during the combustion of a specified amount of it. " ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
   rdfs:label "Calorific Value"@en ;
-  skos:altLabel "Energy Value"@en , "Heating Value"@en ;
+  skos:altLabel "Energy Value"@en ;
+  skos:altLabel "Heating Value"@en ;
   skos:broader quantitykind:SpecificEnergy ;
 .
 quantitykind:Height
@@ -8309,7 +9092,19 @@ quantitykind:Height
   qudt:plainTextDescription "\"Height\" is the measurement of vertical distance, but has two meanings in common use. It can either indicate how \"tall\" something is, or how \"high up\" it is." ;
   qudt:symbol "h" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Höhe"@de , "Ketinggian"@ms , "Výška"@cs , "altezza"@it , "altura"@es , "altura"@pt , "hauteur"@fr , "height"@en , "yükseklik"@tr , "Înălțime"@ro , "высота"@ru , "ارتفاع"@fa , "高度"@zh ;
+  rdfs:label "Höhe"@de ;
+  rdfs:label "Ketinggian"@ms ;
+  rdfs:label "Výška"@cs ;
+  rdfs:label "altezza"@it ;
+  rdfs:label "altura"@es ;
+  rdfs:label "altura"@pt ;
+  rdfs:label "hauteur"@fr ;
+  rdfs:label "height"@en ;
+  rdfs:label "yükseklik"@tr ;
+  rdfs:label "Înălțime"@ro ;
+  rdfs:label "высота"@ru ;
+  rdfs:label "ارتفاع"@fa ;
+  rdfs:label "高度"@zh ;
   skos:broader quantitykind:Length ;
 .
 quantitykind:HelmholtzEnergy
@@ -8366,12 +9161,31 @@ quantitykind:HelmholtzEnergy
   qudt:latexDefinition "\\(H = U - T \\cdot S\\), where \\(U\\) is internal energy, \\(T\\) is thermodynamic temperature and \\(S\\) is entropy."^^qudt:LatexString ;
   qudt:symbol "A" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Helmholtz energy"@en , "freie Energie"@de , "énergie libre"@fr , "Energía de Helmholtz"@es , "energia livre de Helmholtz"@pt , "energia libera di Helmholz"@it , "Prosta energija"@sl , "Helmholtzova volná energie"@cs , "energia swobodna"@pl , "свободная энергия Гельмгольца"@ru , "Helmholtz enerjisi"@tr , "طاقة هلمهولتز الحرة"@ar , "انرژی آزاد هلمولتز"@fa , "亥姆霍兹自由能"@zh , "ヘルムホルツの自由エネルギー"@ja , "Tenaga Helmholtz"@ms ;
-  skos:altLabel "Helmholtz function"@en , "Helmholtz-Energie"@de , "Helmholtz-Funktion"@de , " Helmholtz fonksiyonu"@tr , "fungsi Helmholtz"@ms ;
+  rdfs:label "Energía de Helmholtz"@es ;
+  rdfs:label "Helmholtz energy"@en ;
+  rdfs:label "Helmholtz enerjisi"@tr ;
+  rdfs:label "Helmholtzova volná energie"@cs ;
+  rdfs:label "Prosta energija"@sl ;
+  rdfs:label "Tenaga Helmholtz"@ms ;
+  rdfs:label "energia libera di Helmholz"@it ;
+  rdfs:label "energia livre de Helmholtz"@pt ;
+  rdfs:label "energia swobodna"@pl ;
+  rdfs:label "freie Energie"@de ;
+  rdfs:label "énergie libre"@fr ;
+  rdfs:label "свободная энергия Гельмгольца"@ru ;
+  rdfs:label "انرژی آزاد هلمولتز"@fa ;
+  rdfs:label "طاقة هلمهولتز الحرة"@ar ;
+  rdfs:label "ヘルムホルツの自由エネルギー"@ja ;
+  rdfs:label "亥姆霍兹自由能"@zh ;
   rdfs:seeAlso quantitykind:Energy ;
   rdfs:seeAlso quantitykind:Enthalpy ;
   rdfs:seeAlso quantitykind:GibbsEnergy ;
   rdfs:seeAlso quantitykind:InternalEnergy ;
+  skos:altLabel " Helmholtz fonksiyonu"@tr ;
+  skos:altLabel "Helmholtz function"@en ;
+  skos:altLabel "Helmholtz-Energie"@de ;
+  skos:altLabel "Helmholtz-Funktion"@de ;
+  skos:altLabel "fungsi Helmholtz"@ms ;
   skos:broader quantitykind:Energy ;
 .
 quantitykind:HenrysLawVolatilityConstant
@@ -8590,7 +9404,27 @@ quantitykind:Illuminance
   qudt:latexDefinition "\\(E_v = \\frac{d\\Phi}{dA}\\), where \\(d\\Phi\\) is the luminous flux incident on an element of the surface with area \\(dA\\)."^^qudt:LatexString ;
   qudt:plainTextDescription "Illuminance is the total luminous flux incident on a surface, per unit area. It is a measure of the intensity of the incident light, wavelength-weighted by the luminosity function to correlate with human brightness perception." ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "illuminance"@en , "Beleuchtungsstärke"@de , "éclairement lumineux"@fr , "luminosidad"@es , "iluminamento"@pt , "illuminamento"@it , "iluminare"@ro , "Осветеност"@bg , "osvetljenost"@sl , "Intenzita osvětlení"@cs , "natężenie oświetlenia"@pl , "Освещённость"@ru , "megvilágítás"@hu , "aydınlanma şiddeti"@tr , "הארה (שטף ליחידת שטח)"@he , "شدة الضوء"@ar , "شدت روشنایی"@fa , "प्रदीपन"@hi , "照度"@zh , "照度"@ja , "Pencahayaan"@ms ;
+  rdfs:label "Beleuchtungsstärke"@de ;
+  rdfs:label "Intenzita osvětlení"@cs ;
+  rdfs:label "Pencahayaan"@ms ;
+  rdfs:label "aydınlanma şiddeti"@tr ;
+  rdfs:label "illuminamento"@it ;
+  rdfs:label "illuminance"@en ;
+  rdfs:label "iluminamento"@pt ;
+  rdfs:label "iluminare"@ro ;
+  rdfs:label "luminosidad"@es ;
+  rdfs:label "megvilágítás"@hu ;
+  rdfs:label "natężenie oświetlenia"@pl ;
+  rdfs:label "osvetljenost"@sl ;
+  rdfs:label "éclairement lumineux"@fr ;
+  rdfs:label "Осветеност"@bg ;
+  rdfs:label "Освещённость"@ru ;
+  rdfs:label "הארה (שטף ליחידת שטח)"@he ;
+  rdfs:label "شدة الضوء"@ar ;
+  rdfs:label "شدت روشنایی"@fa ;
+  rdfs:label "प्रदीपन"@hi ;
+  rdfs:label "照度"@ja ;
+  rdfs:label "照度"@zh ;
   skos:altLabel "éclairement"@fr ;
   skos:broader quantitykind:LuminousFluxPerArea ;
 .
@@ -8672,9 +9506,31 @@ quantitykind:Inductance
   qudt:plainTextDescription "\"Inductance\" is an electromagentic quantity that characterizes a circuit's resistance to any change of electric current; a change in the electric current through induces an opposing electromotive force (EMF). Quantitatively, inductance is proportional to the magnetic flux per unit of electric current." ;
   qudt:symbol "L" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "inductance"@en , "Induktivität"@de , "Inductance électrique"@fr , "inductancia"@es , "indutância"@pt , "induttanza"@it , "inductanță"@ro , "Индуктивност"@bg , "induktivnost"@sl , "Indukčnost"@cs , "indukcyjność"@pl , "Индуктивность"@ru , "induktivitás"@hu , "İndüktans"@tr , "השראות"@he , "المحاثة (التحريض)"@ar , "القاوری"@fa , "प्रेरकत्व"@hi , "电感"@zh , "インダクタンス・誘導係数"@ja , "Indukstans"@ms , "inductantia"@la ;
-  skos:altLabel "inductivity"@en , "Induktiviti"@ms ;
+  rdfs:label "Inductance électrique"@fr ;
+  rdfs:label "Indukstans"@ms ;
+  rdfs:label "Induktivität"@de ;
+  rdfs:label "Indukčnost"@cs ;
+  rdfs:label "inductance"@en ;
+  rdfs:label "inductancia"@es ;
+  rdfs:label "inductantia"@la ;
+  rdfs:label "inductanță"@ro ;
+  rdfs:label "indukcyjność"@pl ;
+  rdfs:label "induktivitás"@hu ;
+  rdfs:label "induktivnost"@sl ;
+  rdfs:label "induttanza"@it ;
+  rdfs:label "indutância"@pt ;
+  rdfs:label "İndüktans"@tr ;
+  rdfs:label "Индуктивност"@bg ;
+  rdfs:label "Индуктивность"@ru ;
+  rdfs:label "השראות"@he ;
+  rdfs:label "القاوری"@fa ;
+  rdfs:label "المحاثة (التحريض)"@ar ;
+  rdfs:label "प्रेरकत्व"@hi ;
+  rdfs:label "インダクタンス・誘導係数"@ja ;
+  rdfs:label "电感"@zh ;
   rdfs:seeAlso quantitykind:MutualInductance ;
+  skos:altLabel "Induktiviti"@ms ;
+  skos:altLabel "inductivity"@en ;
 .
 quantitykind:InfiniteMultiplicationFactor
   a qudt:QuantityKind ;
@@ -9390,7 +10246,20 @@ quantitykind:Irradiance
   qudt:plainTextDescription "Irradiance and Radiant Emittance are radiometry terms for the power per unit area of electromagnetic radiation at a surface. \"Irradiance\" is used when the electromagnetic radiation is incident on the surface. \"Radiant emmitance\" (or \"radiant exitance\") is used when the radiation is emerging from the surface." ;
   qudt:symbol "E" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "irradiance"@en , "Bestrahlungsstärke"@de , "éclairement énergétique"@fr , "irradiancia"@es , "irradiância"@pt , "irradianza"@it , "Intenzita záření"@cs , "Поверхностная плотность потока энергии"@ru , "yoğunluk"@tr , "الطاقة الهلامية"@ar , "پرتو افکنی/چگالی تابش"@fa , "辐照度"@zh , "熱流束"@ja , "Kepenyinaran"@ms ;
+  rdfs:label "Bestrahlungsstärke"@de ;
+  rdfs:label "Intenzita záření"@cs ;
+  rdfs:label "Kepenyinaran"@ms ;
+  rdfs:label "irradiance"@en ;
+  rdfs:label "irradiancia"@es ;
+  rdfs:label "irradianza"@it ;
+  rdfs:label "irradiância"@pt ;
+  rdfs:label "yoğunluk"@tr ;
+  rdfs:label "éclairement énergétique"@fr ;
+  rdfs:label "Поверхностная плотность потока энергии"@ru ;
+  rdfs:label "الطاقة الهلامية"@ar ;
+  rdfs:label "پرتو افکنی/چگالی تابش"@fa ;
+  rdfs:label "熱流束"@ja ;
+  rdfs:label "辐照度"@zh ;
   skos:altLabel "koyuluk"@tr ;
   skos:broader quantitykind:PowerPerArea ;
 .
@@ -9418,9 +10287,24 @@ quantitykind:IsentropicExponent
   qudt:latexDefinition "\\(\\varkappa = -\\frac{V}{p}\\left \\{  \\frac{\\partial p}{\\partial  V}\\right \\}_S\\), where \\(V\\) is volume, \\(p\\) is pressure, and \\(S\\) is entropy."^^qudt:LatexString ;
   qudt:latexSymbol "\\(\\varkappa\\)"^^qudt:LatexString ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "isentropic exponent"@en , "Isentropenexponent"@de , "exposant isoentropique"@fr , "Coeficiente de dilatación adiabática"@es , "Coeficiente de expansão adiabática"@pt , "Coefficiente di dilatazione adiabatica"@it , "Coeficient de transformare adiabatică"@ro , "adiabatni eksponent"@sl , "Poissonova konstanta"@cs , "Wykładnik adiabaty"@pl , "Показатель адиабаты"@ru , "ısı sığası oranı; adyabatik indeks"@tr , "نسبة السعة الحرارية"@ar , "绝热指数"@zh , "比熱比"@ja ;
-  skos:altLabel "indice adiabatique"@fr , "indice adiabatico"@it ;
+  rdfs:label "Coefficiente di dilatazione adiabatica"@it ;
+  rdfs:label "Coeficient de transformare adiabatică"@ro ;
+  rdfs:label "Coeficiente de dilatación adiabática"@es ;
+  rdfs:label "Coeficiente de expansão adiabática"@pt ;
+  rdfs:label "Isentropenexponent"@de ;
+  rdfs:label "Poissonova konstanta"@cs ;
+  rdfs:label "Wykładnik adiabaty"@pl ;
+  rdfs:label "adiabatni eksponent"@sl ;
+  rdfs:label "exposant isoentropique"@fr ;
+  rdfs:label "isentropic exponent"@en ;
+  rdfs:label "ısı sığası oranı; adyabatik indeks"@tr ;
+  rdfs:label "Показатель адиабаты"@ru ;
+  rdfs:label "نسبة السعة الحرارية"@ar ;
+  rdfs:label "比熱比"@ja ;
+  rdfs:label "绝热指数"@zh ;
   rdfs:seeAlso quantitykind:IsentropicCompressibility ;
+  skos:altLabel "indice adiabatico"@it ;
+  skos:altLabel "indice adiabatique"@fr ;
 .
 quantitykind:IsothermalCompressibility
   a qudt:QuantityKind ;
@@ -9436,7 +10320,21 @@ quantitykind:IsothermalCompressibility
   qudt:latexSymbol "\\(\\varkappa_T\\)"^^qudt:LatexString ;
   qudt:plainTextDescription "The isothermal compressibility defines the rate of change of system volume with pressure." ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Izotermna stisljivost"@sl , "Ketermampatan isotermik"@ms , "compresibilidad isotérmica"@es , "compressibilidade isotérmica"@pt , "compressibilité isotherme"@fr , "comprimibilità isotermica"@it , "isothermal compressibility"@en , "isotherme Kompressibilität"@de , "objemová stlačitelnost"@cs , "ściśliwość izotermiczna"@pl , "изотермический коэффициент сжимаемости"@ru , "ضریب تراکم‌پذیری همدما"@fa , "معامل الانضغاط عند ثبوت درجة الحرارة"@ar , "等温压缩率"@zh , "等温圧縮率"@ja ;
+  rdfs:label "Izotermna stisljivost"@sl ;
+  rdfs:label "Ketermampatan isotermik"@ms ;
+  rdfs:label "compresibilidad isotérmica"@es ;
+  rdfs:label "compressibilidade isotérmica"@pt ;
+  rdfs:label "compressibilité isotherme"@fr ;
+  rdfs:label "comprimibilità isotermica"@it ;
+  rdfs:label "isothermal compressibility"@en ;
+  rdfs:label "isotherme Kompressibilität"@de ;
+  rdfs:label "objemová stlačitelnost"@cs ;
+  rdfs:label "ściśliwość izotermiczna"@pl ;
+  rdfs:label "изотермический коэффициент сжимаемости"@ru ;
+  rdfs:label "ضریب تراکم‌پذیری همدما"@fa ;
+  rdfs:label "معامل الانضغاط عند ثبوت درجة الحرارة"@ar ;
+  rdfs:label "等温压缩率"@zh ;
+  rdfs:label "等温圧縮率"@ja ;
 .
 quantitykind:IsothermalMoistureCapacity
   a qudt:QuantityKind ;
@@ -9492,7 +10390,24 @@ quantitykind:KinematicViscosity
   qudt:latexDefinition "\\(\\nu = \\frac{\\eta}{\\rho}\\), where \\(\\eta\\) is dynamic viscosity and \\(\\rho\\) is mass density."^^qudt:LatexString ;
   qudt:latexSymbol "\\(\\nu\\)"^^qudt:LatexString ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Kelikatan kinematik"@ms , "Kinematik akmazlık"@tr , "Viscozitate cinematică"@ro , "kinematic viscosity"@en , "kinematische Viskosität"@de , "kinematična viskoznost"@sl , "lepkość kinematyczna"@pl , "viscosidad cinemática"@es , "viscosidade cinemática"@pt , "viscosità cinematica"@it , "viscosité cinématique"@fr , "viskozita"@cs , "кинематическую вязкость"@ru , "لزوجة"@ar , "گرانروی جنبشی/ویسکوزیته جنبشی"@fa , "श्यानता"@hi , "粘度"@ja , "运动粘度"@zh ;
+  rdfs:label "Kelikatan kinematik"@ms ;
+  rdfs:label "Kinematik akmazlık"@tr ;
+  rdfs:label "Viscozitate cinematică"@ro ;
+  rdfs:label "kinematic viscosity"@en ;
+  rdfs:label "kinematische Viskosität"@de ;
+  rdfs:label "kinematična viskoznost"@sl ;
+  rdfs:label "lepkość kinematyczna"@pl ;
+  rdfs:label "viscosidad cinemática"@es ;
+  rdfs:label "viscosidade cinemática"@pt ;
+  rdfs:label "viscosità cinematica"@it ;
+  rdfs:label "viscosité cinématique"@fr ;
+  rdfs:label "viskozita"@cs ;
+  rdfs:label "кинематическую вязкость"@ru ;
+  rdfs:label "لزوجة"@ar ;
+  rdfs:label "گرانروی جنبشی/ویسکوزیته جنبشی"@fa ;
+  rdfs:label "श्यानता"@hi ;
+  rdfs:label "粘度"@ja ;
+  rdfs:label "运动粘度"@zh ;
   rdfs:seeAlso quantitykind:DynamicViscosity ;
   rdfs:seeAlso quantitykind:MolecularViscosity ;
   skos:broader quantitykind:AreaPerTime ;
@@ -9776,7 +10691,29 @@ quantitykind:Length
   qudt:plainTextDescription "In geometric measurements, length most commonly refers to the est dimension of an object. In some contexts, the term \"length\" is reserved for a certain dimension of an object along which the length is measured." ;
   qudt:symbol "l" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Délka"@cs , "Länge"@de , "Panjang"@ms , "comprimento"@pt , "dolžina"@sl , "długość"@pl , "hossz"@hu , "length"@en , "longitud"@es , "longitudo"@la , "longueur"@fr , "lunghezza"@it , "lungime"@ro , "uzunluk"@tr , "Μήκος"@el , "Длина"@ru , "Дължина"@bg , "אורך"@he , "طول"@ar , "طول"@fa , "लम्बाई"@hi , "長さ"@ja , "长度"@zh ;
+  rdfs:label "Délka"@cs ;
+  rdfs:label "Länge"@de ;
+  rdfs:label "Panjang"@ms ;
+  rdfs:label "comprimento"@pt ;
+  rdfs:label "dolžina"@sl ;
+  rdfs:label "długość"@pl ;
+  rdfs:label "hossz"@hu ;
+  rdfs:label "length"@en ;
+  rdfs:label "longitud"@es ;
+  rdfs:label "longitudo"@la ;
+  rdfs:label "longueur"@fr ;
+  rdfs:label "lunghezza"@it ;
+  rdfs:label "lungime"@ro ;
+  rdfs:label "uzunluk"@tr ;
+  rdfs:label "Μήκος"@el ;
+  rdfs:label "Длина"@ru ;
+  rdfs:label "Дължина"@bg ;
+  rdfs:label "אורך"@he ;
+  rdfs:label "طول"@ar ;
+  rdfs:label "طول"@fa ;
+  rdfs:label "लम्बाई"@hi ;
+  rdfs:label "長さ"@ja ;
+  rdfs:label "长度"@zh ;
 .
 quantitykind:LengthByForce
   a qudt:QuantityKind ;
@@ -10086,7 +11023,16 @@ quantitykind:LinearExpansionCoefficient
   qudt:qkdvDenominator qkdv:A0E0L1I0M0H1T0D0 ;
   qudt:qkdvNumerator qkdv:A0E0L1I0M0H0T0D0 ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "coefficient de dilatation linéique"@fr , "coefficiente di dilatazione lineare"@it , "coeficiente de dilatação térmica linear"@pt , "coeficiente de expansión térmica lineal"@es , "linear expansion coefficient"@en , "linearer Ausdehnungskoeffizient"@de , "współczynnik liniowej rozszerzalności cieplnej"@pl , "معدل التمدد الحراري الخطي"@ar , "線熱膨張係数"@ja , "线性热膨胀系数"@zh ;
+  rdfs:label "coefficient de dilatation linéique"@fr ;
+  rdfs:label "coefficiente di dilatazione lineare"@it ;
+  rdfs:label "coeficiente de dilatação térmica linear"@pt ;
+  rdfs:label "coeficiente de expansión térmica lineal"@es ;
+  rdfs:label "linear expansion coefficient"@en ;
+  rdfs:label "linearer Ausdehnungskoeffizient"@de ;
+  rdfs:label "współczynnik liniowej rozszerzalności cieplnej"@pl ;
+  rdfs:label "معدل التمدد الحراري الخطي"@ar ;
+  rdfs:label "線熱膨張係数"@ja ;
+  rdfs:label "线性热膨胀系数"@zh ;
   skos:broader quantitykind:ExpansionRatio ;
 .
 quantitykind:LinearForce
@@ -10107,7 +11053,8 @@ quantitykind:LinearForce
   qudt:informativeReference "https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC1/HTML/schema/ifcmeasureresource/lexical/ifclinearforcemeasure.htm"^^xsd:anyURI ;
   qudt:plainTextDescription "Another name for Force Per Length, used by the Industry Foundation Classes (IFC) standard." ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Linear Force"@en , "Streckenlast"@de ;
+  rdfs:label "Linear Force"@en ;
+  rdfs:label "Streckenlast"@de ;
   skos:broader quantitykind:ForcePerLength ;
 .
 quantitykind:LinearIonization
@@ -10163,7 +11110,8 @@ quantitykind:LinearStiffness
   qudt:informativeReference "https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC1/HTML/schema/ifcmeasureresource/lexical/ifclinearstiffnessmeasure.htm"^^xsd:anyURI ;
   qudt:plainTextDescription "Stiffness is the extent to which an object resists deformation in response to an applied force. Linear Stiffness is the term used in the Industry Foundation Classes (IFC) standard." ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Linear Force"@en , "Streckenlast"@de ;
+  rdfs:label "Linear Force"@en ;
+  rdfs:label "Streckenlast"@de ;
   skos:broader quantitykind:ForcePerLength ;
 .
 quantitykind:LinearStrain
@@ -10319,7 +11267,17 @@ quantitykind:LogarithmicFrequencyInterval
   qudt:latexDefinition "\\(G = \\log_{2}(f2/f1)\\), where \\(f1\\) and \\(f2 \\geq f1\\) are frequencies of two tones."^^qudt:LatexString ;
   vaem:todo "belongs to SOQ-ISO" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Frequenzmaßintervall"@de , "Interval měření frekvence ?"@cs , "Selang kekerapan logaritma"@ms , "intervalle de fréquence logarithmique"@fr , "intervallo logaritmico di frequenza"@it , "intervalo logarítmico de frequência"@pt , "logarithmic frequency interval"@en , "logaritmik frekans aralığı"@tr , "частотный интервал"@ru , "فاصله فرکانس لگاریتمی"@fa , "对数频率间隔"@zh ;
+  rdfs:label "Frequenzmaßintervall"@de ;
+  rdfs:label "Interval měření frekvence ?"@cs ;
+  rdfs:label "Selang kekerapan logaritma"@ms ;
+  rdfs:label "intervalle de fréquence logarithmique"@fr ;
+  rdfs:label "intervallo logaritmico di frequenza"@it ;
+  rdfs:label "intervalo logarítmico de frequência"@pt ;
+  rdfs:label "logarithmic frequency interval"@en ;
+  rdfs:label "logaritmik frekans aralığı"@tr ;
+  rdfs:label "частотный интервал"@ru ;
+  rdfs:label "فاصله فرکانس لگاریتمی"@fa ;
+  rdfs:label "对数频率间隔"@zh ;
 .
 quantitykind:LondonPenetrationDepth
   a qudt:QuantityKind ;
@@ -10534,7 +11492,28 @@ quantitykind:LuminousFlux
   qudt:plainTextDescription "Luminous Flux or Luminous Power is the measure of the perceived power of light. It differs from radiant flux, the measure of the total power of light emitted, in that luminous flux is adjusted to reflect the varying sensitivity of the human eye to different wavelengths of light." ;
   qudt:symbol "F" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Fluks berluminositi"@ms , "Lichtstrom"@de , "Světelný tok"@cs , "fluctús lucis"@la , "flujo luminoso"@es , "flusso luminoso"@it , "flux lumineux"@fr , "flux luminos"@ro , "fluxo luminoso"@pt , "fényáram"@hu , "işık akısı"@tr , "luminous flux"@en , "strumień świetlny"@pl , "svetlobni tok"@sl , "Светлинен поток"@bg , "Световой поток"@ru , "שטף הארה"@he , "التدفق الضوئي"@ar , "شار نوری"@fa , "प्रकाशीय बहाव"@hi , "光束"@ja , "光通量"@zh ;
+  rdfs:label "Fluks berluminositi"@ms ;
+  rdfs:label "Lichtstrom"@de ;
+  rdfs:label "Světelný tok"@cs ;
+  rdfs:label "fluctús lucis"@la ;
+  rdfs:label "flujo luminoso"@es ;
+  rdfs:label "flusso luminoso"@it ;
+  rdfs:label "flux lumineux"@fr ;
+  rdfs:label "flux luminos"@ro ;
+  rdfs:label "fluxo luminoso"@pt ;
+  rdfs:label "fényáram"@hu ;
+  rdfs:label "işık akısı"@tr ;
+  rdfs:label "luminous flux"@en ;
+  rdfs:label "strumień świetlny"@pl ;
+  rdfs:label "svetlobni tok"@sl ;
+  rdfs:label "Светлинен поток"@bg ;
+  rdfs:label "Световой поток"@ru ;
+  rdfs:label "שטף הארה"@he ;
+  rdfs:label "التدفق الضوئي"@ar ;
+  rdfs:label "شار نوری"@fa ;
+  rdfs:label "प्रकाशीय बहाव"@hi ;
+  rdfs:label "光束"@ja ;
+  rdfs:label "光通量"@zh ;
 .
 quantitykind:LuminousFluxPerArea
   a qudt:QuantityKind ;
@@ -10580,7 +11559,29 @@ quantitykind:LuminousIntensity
   qudt:plainTextDescription "Luminous Intensity is a measure of the wavelength-weighted power emitted by a light source in a particular direction per unit solid angle. The weighting is determined by the luminosity function, a standardized model of the sensitivity of the human eye to different wavelengths." ;
   qudt:symbol "J" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Keamatan berluminositi"@ms , "Lichtstärke"@de , "Svítivost"@cs , "fényerősség"@hu , "intensidad luminosa"@es , "intensidade luminosa"@pt , "intensitas luminosa"@la , "intensitate luminoasă"@ro , "intensità luminosa"@it , "intensité lumineuse"@fr , "luminous intensity"@en , "svetilnost"@sl , "ışık şiddeti"@tr , "światłość"@pl , "Ένταση Φωτεινότητας"@el , "Интензитет на светлината"@bg , "Сила света"@ru , "עוצמת הארה"@he , "شدة الإضاءة"@ar , "شدت نور"@fa , "प्रकाशीय तीव्रता"@hi , "光度"@ja , "发光强度"@zh ;
+  rdfs:label "Keamatan berluminositi"@ms ;
+  rdfs:label "Lichtstärke"@de ;
+  rdfs:label "Svítivost"@cs ;
+  rdfs:label "fényerősség"@hu ;
+  rdfs:label "intensidad luminosa"@es ;
+  rdfs:label "intensidade luminosa"@pt ;
+  rdfs:label "intensitas luminosa"@la ;
+  rdfs:label "intensitate luminoasă"@ro ;
+  rdfs:label "intensità luminosa"@it ;
+  rdfs:label "intensité lumineuse"@fr ;
+  rdfs:label "luminous intensity"@en ;
+  rdfs:label "svetilnost"@sl ;
+  rdfs:label "ışık şiddeti"@tr ;
+  rdfs:label "światłość"@pl ;
+  rdfs:label "Ένταση Φωτεινότητας"@el ;
+  rdfs:label "Интензитет на светлината"@bg ;
+  rdfs:label "Сила света"@ru ;
+  rdfs:label "עוצמת הארה"@he ;
+  rdfs:label "شدة الإضاءة"@ar ;
+  rdfs:label "شدت نور"@fa ;
+  rdfs:label "प्रकाशीय तीव्रता"@hi ;
+  rdfs:label "光度"@ja ;
+  rdfs:label "发光强度"@zh ;
 .
 quantitykind:LuminousIntensityDistribution
   a qudt:QuantityKind ;
@@ -10819,7 +11820,24 @@ quantitykind:MachNumber
   qudt:qkdvNumerator qkdv:A0E0L1I0M0H0T-1D0 ;
   qudt:symbol "Ma" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Mach number"@en , "Mach sayısı"@tr , "Mach-Zahl"@de , "Machovo číslo"@cs , "Machovo število"@sl , "Nombor Mach"@ms , "liczba Macha"@pl , "nombre de Mach"@fr , "numero di Mach"@it , "număr Mach"@ro , "número de Mach"@es , "número de Mach"@pt , "число Маха"@ru , "عدد ماخ"@ar , "عدد ماخ"@fa , "मैक संख्या"@hi , "マッハ数n"@ja , "马赫"@zh ;
+  rdfs:label "Mach number"@en ;
+  rdfs:label "Mach sayısı"@tr ;
+  rdfs:label "Mach-Zahl"@de ;
+  rdfs:label "Machovo číslo"@cs ;
+  rdfs:label "Machovo število"@sl ;
+  rdfs:label "Nombor Mach"@ms ;
+  rdfs:label "liczba Macha"@pl ;
+  rdfs:label "nombre de Mach"@fr ;
+  rdfs:label "numero di Mach"@it ;
+  rdfs:label "număr Mach"@ro ;
+  rdfs:label "número de Mach"@es ;
+  rdfs:label "número de Mach"@pt ;
+  rdfs:label "число Маха"@ru ;
+  rdfs:label "عدد ماخ"@ar ;
+  rdfs:label "عدد ماخ"@fa ;
+  rdfs:label "मैक संख्या"@hi ;
+  rdfs:label "マッハ数n"@ja ;
+  rdfs:label "马赫"@zh ;
   skos:broader quantitykind:DimensionlessRatio ;
   skos:closeMatch <http://dbpedia.org/resource/Mach_number> ;
 .
@@ -10894,7 +11912,18 @@ quantitykind:MadelungConstant
   qudt:latexSymbol "\\(\\alpha\\)"^^qudt:LatexString ;
   qudt:plainTextDescription "\"Madelung Constant\" is used in determining the electrostatic potential of a single ion in a crystal by approximating the ions by point charges. It is named after Erwin Madelung, a German physicist." ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Constante de Madelung"@es , "Constante de Madelung"@fr , "Costante di Madelung"@it , "Madelung constant"@en , "Madelung-Konstante"@de , "Stała Madelunga"@pl , "constante de Madelung"@pt , "постоянная Маделунга"@ru , "ثابت مادلونك"@ar , "ثابت مادلونگ"@fa , "マーデルングエネルギー"@ja , "馬德隆常數"@zh ;
+  rdfs:label "Constante de Madelung"@es ;
+  rdfs:label "Constante de Madelung"@fr ;
+  rdfs:label "Costante di Madelung"@it ;
+  rdfs:label "Madelung constant"@en ;
+  rdfs:label "Madelung-Konstante"@de ;
+  rdfs:label "Stała Madelunga"@pl ;
+  rdfs:label "constante de Madelung"@pt ;
+  rdfs:label "постоянная Маделунга"@ru ;
+  rdfs:label "ثابت مادلونك"@ar ;
+  rdfs:label "ثابت مادلونگ"@fa ;
+  rdfs:label "マーデルングエネルギー"@ja ;
+  rdfs:label "馬德隆常數"@zh ;
 .
 quantitykind:MagneticAreaMoment
   a qudt:QuantityKind ;
@@ -10962,7 +11991,23 @@ quantitykind:MagneticFieldStrength_H
   qudt:latexDefinition "\\(\\mathbf{H} = \\frac{\\mathbf{B} }{\\mu_0} - M\\), where \\(\\mathbf{B} \\) is magnetic flux density, \\(\\mu_0\\) is the magnetic constant and \\(M\\) is magnetization."^^qudt:LatexString ;
   qudt:latexSymbol "\\(\\mathbf{H} \\)"^^qudt:LatexString ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Câmp magnetic"@ro , "Kekuatan medan magnetik"@ms , "Magnetické pole"@cs , "Manyetik alan"@tr , "intensidad de campo magnético"@es , "intensidade de campo magnético"@pt , "intensità di campo magnetico"@it , "intensité de champ magnétique"@fr , "jakost magnetnega polja"@sl , "magnetic field strength"@en , "magnetische Feldstärke"@de , "pole magnetyczne"@pl , "Магнитное поле"@ru , "حقل مغناطيسي"@ar , "شدت میدان مغناطیسی"@fa , "磁場"@ja , "磁場"@zh ;
+  rdfs:label "Câmp magnetic"@ro ;
+  rdfs:label "Kekuatan medan magnetik"@ms ;
+  rdfs:label "Magnetické pole"@cs ;
+  rdfs:label "Manyetik alan"@tr ;
+  rdfs:label "intensidad de campo magnético"@es ;
+  rdfs:label "intensidade de campo magnético"@pt ;
+  rdfs:label "intensità di campo magnetico"@it ;
+  rdfs:label "intensité de champ magnétique"@fr ;
+  rdfs:label "jakost magnetnega polja"@sl ;
+  rdfs:label "magnetic field strength"@en ;
+  rdfs:label "magnetische Feldstärke"@de ;
+  rdfs:label "pole magnetyczne"@pl ;
+  rdfs:label "Магнитное поле"@ru ;
+  rdfs:label "حقل مغناطيسي"@ar ;
+  rdfs:label "شدت میدان مغناطیسی"@fa ;
+  rdfs:label "磁場"@ja ;
+  rdfs:label "磁場"@zh ;
   skos:broader quantitykind:ElectricCurrentPerUnitLength ;
 .
 quantitykind:MagneticFlux
@@ -10986,7 +12031,28 @@ quantitykind:MagneticFlux
   qudt:latexSymbol "\\(\\phi\\)"^^qudt:LatexString ;
   qudt:plainTextDescription "\"Magnetic Flux\" is the product of the average magnetic field times the perpendicular area that it penetrates." ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Fluks magnet"@ms , "Flux d'induction magnétique"@fr , "Magnetický tok"@cs , "flujo magnético"@es , "flusso magnetico"@it , "flux de inducție magnetică"@ro , "fluxo magnético"@pt , "fluxus magneticus"@la , "magnetic flux"@en , "magnetischer Flux"@de , "magnetni pretok"@sl , "manyetik akı"@tr , "mágneses fluxus"@hu , "strumień magnetyczny"@pl , "Магнитен поток"@bg , "Магнитный поток"@ru , "שטף מגנטי"@he , "التدفق المغناطيسي"@ar , "شار مغناطیسی"@fa , "चुम्बकीय बहाव"@hi , "磁束"@ja , "磁通量"@zh ;
+  rdfs:label "Fluks magnet"@ms ;
+  rdfs:label "Flux d'induction magnétique"@fr ;
+  rdfs:label "Magnetický tok"@cs ;
+  rdfs:label "flujo magnético"@es ;
+  rdfs:label "flusso magnetico"@it ;
+  rdfs:label "flux de inducție magnetică"@ro ;
+  rdfs:label "fluxo magnético"@pt ;
+  rdfs:label "fluxus magneticus"@la ;
+  rdfs:label "magnetic flux"@en ;
+  rdfs:label "magnetischer Flux"@de ;
+  rdfs:label "magnetni pretok"@sl ;
+  rdfs:label "manyetik akı"@tr ;
+  rdfs:label "mágneses fluxus"@hu ;
+  rdfs:label "strumień magnetyczny"@pl ;
+  rdfs:label "Магнитен поток"@bg ;
+  rdfs:label "Магнитный поток"@ru ;
+  rdfs:label "שטף מגנטי"@he ;
+  rdfs:label "التدفق المغناطيسي"@ar ;
+  rdfs:label "شار مغناطیسی"@fa ;
+  rdfs:label "चुम्बकीय बहाव"@hi ;
+  rdfs:label "磁束"@ja ;
+  rdfs:label "磁通量"@zh ;
 .
 quantitykind:MagneticFluxDensity
   a qudt:QuantityKind ;
@@ -11006,9 +12072,31 @@ quantitykind:MagneticFluxDensity
   qudt:latexDefinition "\\(\\mathbf{F}  = qv \\times B\\), where \\(F\\) is force and \\(v\\) is velocity of any test particle with electric charge \\(q\\)."^^qudt:LatexString ;
   qudt:symbol "B" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "magnetic flux density"@en , "magnetische Flussdichte"@de , "Densité de flux magnétique"@fr , "Densidad de flujo magnético"@es , "densidade de fluxo magnético"@pt , "densità di flusso magnetico"@it , "inducție magnetică"@ro , "Магнитна индукция"@bg , "gostota magnetnega pretoka"@sl , "Magnetická indukce"@cs , "indukcja magnetyczna"@pl , "Магнитная индукция"@ru , "mágneses indukció"@hu , "manyetik akı yoğunluğu"@tr , "צפיפות שטף מגנטי"@he , "المجال المغناطيسي"@ar , "چگالی شار مغناطیسی"@fa , "चुम्बकीय क्षेत्र"@hi , "磁通量密度"@zh , "磁束密度"@ja , "Ketumpatan fluks magnet"@ms , "densitas fluxus magnetici"@la ;
-  skos:altLabel "magnetische Induktion"@de , "inducción magnética"@es ;
+  rdfs:label "Densidad de flujo magnético"@es ;
+  rdfs:label "Densité de flux magnétique"@fr ;
+  rdfs:label "Ketumpatan fluks magnet"@ms ;
+  rdfs:label "Magnetická indukce"@cs ;
+  rdfs:label "densidade de fluxo magnético"@pt ;
+  rdfs:label "densitas fluxus magnetici"@la ;
+  rdfs:label "densità di flusso magnetico"@it ;
+  rdfs:label "gostota magnetnega pretoka"@sl ;
+  rdfs:label "inducție magnetică"@ro ;
+  rdfs:label "indukcja magnetyczna"@pl ;
+  rdfs:label "magnetic flux density"@en ;
+  rdfs:label "magnetische Flussdichte"@de ;
+  rdfs:label "manyetik akı yoğunluğu"@tr ;
+  rdfs:label "mágneses indukció"@hu ;
+  rdfs:label "Магнитна индукция"@bg ;
+  rdfs:label "Магнитная индукция"@ru ;
+  rdfs:label "צפיפות שטף מגנטי"@he ;
+  rdfs:label "المجال المغناطيسي"@ar ;
+  rdfs:label "چگالی شار مغناطیسی"@fa ;
+  rdfs:label "चुम्बकीय क्षेत्र"@hi ;
+  rdfs:label "磁束密度"@ja ;
+  rdfs:label "磁通量密度"@zh ;
   rdfs:seeAlso quantitykind:MagneticField ;
+  skos:altLabel "inducción magnética"@es ;
+  skos:altLabel "magnetische Induktion"@de ;
 .
 quantitykind:MagneticFluxPerUnitLength
   a qudt:QuantityKind ;
@@ -11036,8 +12124,25 @@ quantitykind:MagneticMoment
   qudt:plainTextDescription "\"Magnetic Moment\", for a magnetic dipole, is a vector quantity equal to the product of the current, the loop area, and the unit vector normal to the loop plane, the direction of which corresponds to the loop orientation. \"Magnetic Moment\" is also referred to as \"Magnetic Area Moment\", and is not to be confused with Magnetic Dipole Moment." ;
   qudt:symbol "m" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "magnetic moment"@en , "magnetisches Dipolmoment"@de , "moment magnétique"@fr , "momento de dipolo magnético"@es , "momento de dipolo magnético"@pt , "momento di dipolo magnetico"@it , "Magnetický dipól"@cs , "dipol magnetyczny"@pl , "Магнитный момент"@ru , "Manyetik moment"@tr , "عزم مغناطيسي"@ar , "دوقطبی مغناطیسی"@fa , "चुम्बकीय द्विध्रुव"@hi , "磁偶极"@zh , "磁気双極子"@ja , "Momen magnetik"@ms ;
-  skos:altLabel "giromagnetic moment"@en , "moment giromagnétique"@fr , "momen giromagnetik"@ms ;
+  rdfs:label "Magnetický dipól"@cs ;
+  rdfs:label "Manyetik moment"@tr ;
+  rdfs:label "Momen magnetik"@ms ;
+  rdfs:label "dipol magnetyczny"@pl ;
+  rdfs:label "magnetic moment"@en ;
+  rdfs:label "magnetisches Dipolmoment"@de ;
+  rdfs:label "moment magnétique"@fr ;
+  rdfs:label "momento de dipolo magnético"@es ;
+  rdfs:label "momento de dipolo magnético"@pt ;
+  rdfs:label "momento di dipolo magnetico"@it ;
+  rdfs:label "Магнитный момент"@ru ;
+  rdfs:label "دوقطبی مغناطیسی"@fa ;
+  rdfs:label "عزم مغناطيسي"@ar ;
+  rdfs:label "चुम्बकीय द्विध्रुव"@hi ;
+  rdfs:label "磁偶极"@zh ;
+  rdfs:label "磁気双極子"@ja ;
+  skos:altLabel "giromagnetic moment"@en ;
+  skos:altLabel "momen giromagnetik"@ms ;
+  skos:altLabel "moment giromagnétique"@fr ;
 .
 quantitykind:MagneticPolarization
   a qudt:QuantityKind ;
@@ -11124,7 +12229,20 @@ quantitykind:MagneticVectorPotential
   qudt:plainTextDescription "\"Magnetic Vector Potential\" is the vector potential of the magnetic flux density. The magnetic vector potential is not unique since any irrotational vector field quantity can be added to a given magnetic vector potential without changing its rotation. Under static conditions the magnetic vector potential is often chosen so that its divergence is zero." ;
   qudt:symbol "A" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Keupayaan vektor magnetik"@ms , "magnetic vector potential"@en , "magnetický potenciál"@cs , "magnetisches Potenzial"@de , "manyetik potansiyeli"@tr , "potencial magnético"@es , "potencial magnético"@pt , "potencjał magnetyczny"@pl , "potentiel magnétique"@fr , "potenziale vettore magnetico"@it , "potențial magnetic"@ro , "Магнитний потенциал"@ru , "پتانسیل برداری مغناطیسی"@fa , "磁向量势"@zh ;
+  rdfs:label "Keupayaan vektor magnetik"@ms ;
+  rdfs:label "magnetic vector potential"@en ;
+  rdfs:label "magnetický potenciál"@cs ;
+  rdfs:label "magnetisches Potenzial"@de ;
+  rdfs:label "manyetik potansiyeli"@tr ;
+  rdfs:label "potencial magnético"@es ;
+  rdfs:label "potencial magnético"@pt ;
+  rdfs:label "potencjał magnetyczny"@pl ;
+  rdfs:label "potentiel magnétique"@fr ;
+  rdfs:label "potenziale vettore magnetico"@it ;
+  rdfs:label "potențial magnetic"@ro ;
+  rdfs:label "Магнитний потенциал"@ru ;
+  rdfs:label "پتانسیل برداری مغناطیسی"@fa ;
+  rdfs:label "磁向量势"@zh ;
   rdfs:seeAlso quantitykind:MagneticFluxDensity ;
 .
 quantitykind:Magnetization
@@ -11144,7 +12262,16 @@ quantitykind:Magnetization
   qudt:symbol "H_i" ;
   qudt:symbol "M" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Magnetisierung"@de , "aimantation"@fr , "magnetización"@es , "magnetization"@en , "magnetização"@pt , "magnetizzazione"@it , "magnetyzacia"@pl , "намагниченность"@ru , "مغنطة"@ar , "磁化"@ja ;
+  rdfs:label "Magnetisierung"@de ;
+  rdfs:label "aimantation"@fr ;
+  rdfs:label "magnetización"@es ;
+  rdfs:label "magnetization"@en ;
+  rdfs:label "magnetização"@pt ;
+  rdfs:label "magnetizzazione"@it ;
+  rdfs:label "magnetyzacia"@pl ;
+  rdfs:label "намагниченность"@ru ;
+  rdfs:label "مغنطة"@ar ;
+  rdfs:label "磁化"@ja ;
   skos:broader quantitykind:LinearElectricCurrent ;
 .
 quantitykind:MagnetizationField
@@ -11230,7 +12357,29 @@ quantitykind:Mass
   qudt:informativeReference "http://en.wikipedia.org/wiki/Mass"^^xsd:anyURI ;
   qudt:symbol "m" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Hmotnost"@cs , "Jisim"@ms , "Masse"@de , "kütle"@tr , "masa"@es , "masa"@pl , "masa"@sl , "mass"@en , "massa"@it , "massa"@la , "massa"@pt , "masse"@fr , "masă"@ro , "tömeg"@hu , "Μάζα"@el , "Маса"@bg , "Масса"@ru , "מסה"@he , "جرم"@fa , "كتلة"@ar , "भार"@hi , "質量"@ja , "质量"@zh ;
+  rdfs:label "Hmotnost"@cs ;
+  rdfs:label "Jisim"@ms ;
+  rdfs:label "Masse"@de ;
+  rdfs:label "kütle"@tr ;
+  rdfs:label "masa"@es ;
+  rdfs:label "masa"@pl ;
+  rdfs:label "masa"@sl ;
+  rdfs:label "mass"@en ;
+  rdfs:label "massa"@it ;
+  rdfs:label "massa"@la ;
+  rdfs:label "massa"@pt ;
+  rdfs:label "masse"@fr ;
+  rdfs:label "masă"@ro ;
+  rdfs:label "tömeg"@hu ;
+  rdfs:label "Μάζα"@el ;
+  rdfs:label "Маса"@bg ;
+  rdfs:label "Масса"@ru ;
+  rdfs:label "מסה"@he ;
+  rdfs:label "جرم"@fa ;
+  rdfs:label "كتلة"@ar ;
+  rdfs:label "भार"@hi ;
+  rdfs:label "質量"@ja ;
+  rdfs:label "质量"@zh ;
 .
 quantitykind:MassAbsorptionCoefficient
   a qudt:QuantityKind ;
@@ -11445,8 +12594,29 @@ quantitykind:MassDensity
   qudt:latexSymbol "\\(\\rho\\)"^^qudt:LatexString ;
   qudt:plainTextDescription "The mass density or density of a material is its mass per unit volume." ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "mass density"@en , "Massendichte"@de , "densité"@fr , "densidad"@es , "densidade"@pt , "densità"@it , "densitate"@ro , "Gostôta"@sl , "hustota"@cs , "gęstość"@pl , "плотность"@ru , "yoğunluk"@tr , "الكثافة"@ar , "چگالی"@fa , "घनत्व"@hi , "密度"@zh , "密度"@ja , "Ketumpatan jisim"@ms ;
-  skos:altLabel "volumic mass"@en , "volumenbezogene Masse"@de , "massa volumica"@it , "भार घनत्व"@hi , " jisim isipadu"@ms ;
+  rdfs:label "Gostôta"@sl ;
+  rdfs:label "Ketumpatan jisim"@ms ;
+  rdfs:label "Massendichte"@de ;
+  rdfs:label "densidad"@es ;
+  rdfs:label "densidade"@pt ;
+  rdfs:label "densitate"@ro ;
+  rdfs:label "densità"@it ;
+  rdfs:label "densité"@fr ;
+  rdfs:label "gęstość"@pl ;
+  rdfs:label "hustota"@cs ;
+  rdfs:label "mass density"@en ;
+  rdfs:label "yoğunluk"@tr ;
+  rdfs:label "плотность"@ru ;
+  rdfs:label "الكثافة"@ar ;
+  rdfs:label "چگالی"@fa ;
+  rdfs:label "घनत्व"@hi ;
+  rdfs:label "密度"@ja ;
+  rdfs:label "密度"@zh ;
+  skos:altLabel " jisim isipadu"@ms ;
+  skos:altLabel "massa volumica"@it ;
+  skos:altLabel "volumenbezogene Masse"@de ;
+  skos:altLabel "volumic mass"@en ;
+  skos:altLabel "भार घनत्व"@hi ;
 .
 quantitykind:MassEnergyTransferCoefficient
   a qudt:QuantityKind ;
@@ -12668,7 +13838,16 @@ quantitykind:Mobility
   qudt:latexSymbol "\\(\\mu\\)"^^qudt:LatexString ;
   qudt:plainTextDescription "\"Mobility\" characterizes how quickly a particle can move through a metal or semiconductor, when pulled by an electric field. The average drift speed imparted to a charged particle in a medium by an electric field, divided by the electric field strength." ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "mobility"@en , "Beweglichkeit"@de , "mobilité"@fr , "movilidad"@es , "mobilidade"@pt , "mobilità"@it , "mobilność"@pl , "قابلية التحرك"@ar , "迁移率"@zh , "移動度"@ja ;
+  rdfs:label "Beweglichkeit"@de ;
+  rdfs:label "mobilidade"@pt ;
+  rdfs:label "mobility"@en ;
+  rdfs:label "mobilità"@it ;
+  rdfs:label "mobilité"@fr ;
+  rdfs:label "mobilność"@pl ;
+  rdfs:label "movilidad"@es ;
+  rdfs:label "قابلية التحرك"@ar ;
+  rdfs:label "移動度"@ja ;
+  rdfs:label "迁移率"@zh ;
   skos:altLabel "Mobilität"@de ;
 .
 quantitykind:MobilityRatio
@@ -13014,8 +14193,26 @@ quantitykind:MolarMass
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
   qudt:symbol "M" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "molar mass"@en , "Molmasse"@de , "masse molaire"@fr , "masa molar"@es , "massa molar"@pt , "massa molare"@it , "Masă molară"@ro , "molska masa"@sl , "Molární hmotnost"@cs , "Masa molowa"@pl , "Молярная масса"@ru , "molar kütle"@tr , "كتلة مولية"@ar , "جرم مولی"@fa , "मोलर द्रव्यमान"@hi , "摩尔质量"@zh , "モル質量"@ja , "Jisim molar"@ms ;
-  skos:altLabel "molare Masse"@de , "stoffmengenbezogene Masse"@de ;
+  rdfs:label "Jisim molar"@ms ;
+  rdfs:label "Masa molowa"@pl ;
+  rdfs:label "Masă molară"@ro ;
+  rdfs:label "Molmasse"@de ;
+  rdfs:label "Molární hmotnost"@cs ;
+  rdfs:label "masa molar"@es ;
+  rdfs:label "massa molar"@pt ;
+  rdfs:label "massa molare"@it ;
+  rdfs:label "masse molaire"@fr ;
+  rdfs:label "molar kütle"@tr ;
+  rdfs:label "molar mass"@en ;
+  rdfs:label "molska masa"@sl ;
+  rdfs:label "Молярная масса"@ru ;
+  rdfs:label "جرم مولی"@fa ;
+  rdfs:label "كتلة مولية"@ar ;
+  rdfs:label "मोलर द्रव्यमान"@hi ;
+  rdfs:label "モル質量"@ja ;
+  rdfs:label "摩尔质量"@zh ;
+  skos:altLabel "molare Masse"@de ;
+  skos:altLabel "stoffmengenbezogene Masse"@de ;
 .
 quantitykind:MolarOpticalRotatoryPower
   a qudt:QuantityKind ;
@@ -13058,8 +14255,25 @@ quantitykind:MolarVolume
   qudt:latexDefinition "\\(V_m = \\frac{V}{n}\\), where \\(V\\) is volume and \\(n\\) is amount of substance."^^qudt:LatexString ;
   qudt:symbol "V_m" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "molar volume"@en , "Molvolumen"@de , "volume molaire"@fr , "volumen molar"@es , "volume molar"@pt , "volume molare"@it , "volum molar"@ro , "molski volumen"@sl , "molární objem"@cs , "volume molar"@pl , "Молярный объём"@ru , "molar hacim"@tr , "حجم مولي"@ar , "حجم مولی"@fa , "摩尔体积"@zh , "モル体積"@ja , "Isipadu molar"@ms ;
-  skos:altLabel "molares Volumen"@de , "stoffmengenbezogenes Volumen"@de ;
+  rdfs:label "Isipadu molar"@ms ;
+  rdfs:label "Molvolumen"@de ;
+  rdfs:label "molar hacim"@tr ;
+  rdfs:label "molar volume"@en ;
+  rdfs:label "molski volumen"@sl ;
+  rdfs:label "molární objem"@cs ;
+  rdfs:label "volum molar"@ro ;
+  rdfs:label "volume molaire"@fr ;
+  rdfs:label "volume molar"@pl ;
+  rdfs:label "volume molar"@pt ;
+  rdfs:label "volume molare"@it ;
+  rdfs:label "volumen molar"@es ;
+  rdfs:label "Молярный объём"@ru ;
+  rdfs:label "حجم مولي"@ar ;
+  rdfs:label "حجم مولی"@fa ;
+  rdfs:label "モル体積"@ja ;
+  rdfs:label "摩尔体积"@zh ;
+  skos:altLabel "molares Volumen"@de ;
+  skos:altLabel "stoffmengenbezogenes Volumen"@de ;
 .
 quantitykind:MoleFraction
   a qudt:QuantityKind ;
@@ -13172,7 +14386,23 @@ quantitykind:MomentOfInertia
   qudt:plainTextDescription "The rotational inertia or resistance to change in direction or speed of rotation about a defined axis." ;
   qudt:symbol "I" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Eylemsizlik momenti"@tr , "Massenträgheitsmoment"@de , "Momen inersia"@ms , "Moment bezwładności"@pl , "Moment de inerție"@ro , "Moment setrvačnosti"@cs , "moment d'inertie"@fr , "moment of inertia"@en , "momento de inercia"@es , "momento de inércia"@pt , "momento di inerzia"@it , "Момент инерции"@ru , "عزم القصور الذاتي"@ar , "گشتاور لختی"@fa , "जड़त्वाघूर्ण"@hi , "慣性モーメント"@ja , "轉動慣量"@zh ;
+  rdfs:label "Eylemsizlik momenti"@tr ;
+  rdfs:label "Massenträgheitsmoment"@de ;
+  rdfs:label "Momen inersia"@ms ;
+  rdfs:label "Moment bezwładności"@pl ;
+  rdfs:label "Moment de inerție"@ro ;
+  rdfs:label "Moment setrvačnosti"@cs ;
+  rdfs:label "moment d'inertie"@fr ;
+  rdfs:label "moment of inertia"@en ;
+  rdfs:label "momento de inercia"@es ;
+  rdfs:label "momento de inércia"@pt ;
+  rdfs:label "momento di inerzia"@it ;
+  rdfs:label "Момент инерции"@ru ;
+  rdfs:label "عزم القصور الذاتي"@ar ;
+  rdfs:label "گشتاور لختی"@fa ;
+  rdfs:label "जड़त्वाघूर्ण"@hi ;
+  rdfs:label "慣性モーメント"@ja ;
+  rdfs:label "轉動慣量"@zh ;
   skos:altLabel "MOI" ;
 .
 quantitykind:Momentum
@@ -13190,7 +14420,23 @@ quantitykind:Momentum
   qudt:plainTextDescription "The momentum of a system of particles is given by the sum of the momentums of the individual particles which make up the system or by the product of the total mass of the system and the velocity of the center of gravity of the system. The momentum of a continuous medium is given by the integral of the velocity over the mass of the medium or by the product of the total mass of the medium and the velocity of the center of gravity of the medium." ;
   qudt:symbol "p" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Impuls"@de , "Momentum"@ms , "Momentum"@tr , "cantidad de movimiento"@es , "gibalna količina"@sl , "hybnost"@cs , "impuls"@ro , "momento linear"@pt , "momentum"@en , "pęd"@pl , "quantità di moto"@it , "quantité de mouvement"@fr , "импульс"@ru , "تکانه"@fa , "زخم الحركة"@ar , "动量"@zh , "運動量"@ja ;
+  rdfs:label "Impuls"@de ;
+  rdfs:label "Momentum"@ms ;
+  rdfs:label "Momentum"@tr ;
+  rdfs:label "cantidad de movimiento"@es ;
+  rdfs:label "gibalna količina"@sl ;
+  rdfs:label "hybnost"@cs ;
+  rdfs:label "impuls"@ro ;
+  rdfs:label "momento linear"@pt ;
+  rdfs:label "momentum"@en ;
+  rdfs:label "pęd"@pl ;
+  rdfs:label "quantità di moto"@it ;
+  rdfs:label "quantité de mouvement"@fr ;
+  rdfs:label "импульс"@ru ;
+  rdfs:label "تکانه"@fa ;
+  rdfs:label "زخم الحركة"@ar ;
+  rdfs:label "动量"@zh ;
+  rdfs:label "運動量"@ja ;
 .
 quantitykind:MomentumPerAngle
   a qudt:QuantityKind ;
@@ -13358,7 +14604,13 @@ quantitykind:NeutronDiffusionCoefficient
   qudt:plainTextDescription "The \"Diffusion Coefficient\" is " ;
   qudt:symbol "D" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Diffusionskoeffizient"@de , "coefficient de diffusion"@fr , "coefficiente di diffusione"@it , "coeficiente de difusión"@es , "coeficiente de difusão"@pt , "diffusion coefficient"@en , "difuzijski koeficient"@sl ;
+  rdfs:label "Diffusionskoeffizient"@de ;
+  rdfs:label "coefficient de diffusion"@fr ;
+  rdfs:label "coefficiente di diffusione"@it ;
+  rdfs:label "coeficiente de difusión"@es ;
+  rdfs:label "coeficiente de difusão"@pt ;
+  rdfs:label "diffusion coefficient"@en ;
+  rdfs:label "difuzijski koeficient"@sl ;
 .
 quantitykind:NeutronDiffusionLength
   a qudt:QuantityKind ;
@@ -13416,7 +14668,20 @@ quantitykind:NeutronNumber
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
   qudt:symbol "N" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Neutronenzahl"@de , "Neutronové číslo"@cs , "Nombor neutron"@ms , "Nombre de neutrons"@fr , "liczba neutronowa"@pl , "neutron number"@en , "numero neutronico"@it , "nötron snumarası"@tr , "número de neutrons"@pt , "número neutrónico"@es , "число нейтронов"@ru , "عدد النيوترونات"@ar , "عدد نوترون"@fa , "中子數"@zh ;
+  rdfs:label "Neutronenzahl"@de ;
+  rdfs:label "Neutronové číslo"@cs ;
+  rdfs:label "Nombor neutron"@ms ;
+  rdfs:label "Nombre de neutrons"@fr ;
+  rdfs:label "liczba neutronowa"@pl ;
+  rdfs:label "neutron number"@en ;
+  rdfs:label "numero neutronico"@it ;
+  rdfs:label "nötron snumarası"@tr ;
+  rdfs:label "número de neutrons"@pt ;
+  rdfs:label "número neutrónico"@es ;
+  rdfs:label "число нейтронов"@ru ;
+  rdfs:label "عدد النيوترونات"@ar ;
+  rdfs:label "عدد نوترون"@fa ;
+  rdfs:label "中子數"@zh ;
   skos:broader quantitykind:Count ;
 .
 quantitykind:NeutronYieldPerAbsorption
@@ -13845,8 +15110,25 @@ quantitykind:NucleonNumber
   qudt:plainTextDescription "Number of nucleons in an atomic nucleus.A = Z+N. Nuclides with the same value of A are called isobars." ;
   qudt:symbol "A" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "nucleon number"@en , "Nukleonenzahl"@de , "nombre de masse"@fr , "número másico"@es , "número de massa"@pt , "numero di massa"@it , "Nukleové číslo"@cs , "liczba masowa"@pl , "nükleon numarası"@tr , "عدد كتلي"@ar , "عدد جرمی"@fa , "质量数"@zh , "質量数"@ja , "Nombor nukleon"@ms ;
-  skos:altLabel "mass number"@en , "Massenzahl"@de , "numero di nucleoni"@it , "kütle numarası"@tr , "nombor jisim"@ms ;
+  rdfs:label "Nombor nukleon"@ms ;
+  rdfs:label "Nukleonenzahl"@de ;
+  rdfs:label "Nukleové číslo"@cs ;
+  rdfs:label "liczba masowa"@pl ;
+  rdfs:label "nombre de masse"@fr ;
+  rdfs:label "nucleon number"@en ;
+  rdfs:label "numero di massa"@it ;
+  rdfs:label "número de massa"@pt ;
+  rdfs:label "número másico"@es ;
+  rdfs:label "nükleon numarası"@tr ;
+  rdfs:label "عدد جرمی"@fa ;
+  rdfs:label "عدد كتلي"@ar ;
+  rdfs:label "質量数"@ja ;
+  rdfs:label "质量数"@zh ;
+  skos:altLabel "Massenzahl"@de ;
+  skos:altLabel "kütle numarası"@tr ;
+  skos:altLabel "mass number"@en ;
+  skos:altLabel "nombor jisim"@ms ;
+  skos:altLabel "numero di nucleoni"@it ;
   skos:broader quantitykind:Count ;
 .
 quantitykind:NumberDensity
@@ -14049,7 +15331,17 @@ quantitykind:OsmoticPressure
   qudt:plainTextDescription "The \"Osmotic Pressure\" is the pressure which needs to be applied to a solution to prevent the inward flow of water across a semipermeable membrane." ;
   qudt:symbol "Π" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Osmotický tlak"@cs , "Tekanan osmotik"@ms , "osmotic pressure"@en , "osmotischer Druck"@de , "ozmotik basıç"@tr , "presión osmótica"@es , "pression osmotique"@fr , "pressione osmotica"@it , "pressão osmótica"@pt , "فشار اسمزی"@fa , "渗透压"@zh ;
+  rdfs:label "Osmotický tlak"@cs ;
+  rdfs:label "Tekanan osmotik"@ms ;
+  rdfs:label "osmotic pressure"@en ;
+  rdfs:label "osmotischer Druck"@de ;
+  rdfs:label "ozmotik basıç"@tr ;
+  rdfs:label "presión osmótica"@es ;
+  rdfs:label "pression osmotique"@fr ;
+  rdfs:label "pressione osmotica"@it ;
+  rdfs:label "pressão osmótica"@pt ;
+  rdfs:label "فشار اسمزی"@fa ;
+  rdfs:label "渗透压"@zh ;
   skos:broader quantitykind:Pressure ;
 .
 quantitykind:OverRangeDistance
@@ -14688,8 +15980,17 @@ quantitykind:PhaseDifference
   qudt:latexDefinition "\\(\\varphi = \\varphi_u - \\varphi_i\\), where \\(\\varphi_u\\) is the initial phase of the voltage and \\(\\varphi_i\\) is the initial phase of the electric current."^^qudt:LatexString ;
   qudt:latexSymbol "\\(\\varphi\\)"^^qudt:LatexString ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "phase difference"@en , "Phasenverschiebungswinkel"@de , "différence de phase"@fr , "diferencia de fase"@es , "diferença de fase"@pt , "sfasamento angolare"@it , "przesunięcie fazowe"@pl , "اختلاف طور"@ar , "位相差"@ja ;
-  skos:altLabel "déphasage"@fr , "desfasagem"@pt ;
+  rdfs:label "Phasenverschiebungswinkel"@de ;
+  rdfs:label "diferencia de fase"@es ;
+  rdfs:label "diferença de fase"@pt ;
+  rdfs:label "différence de phase"@fr ;
+  rdfs:label "phase difference"@en ;
+  rdfs:label "przesunięcie fazowe"@pl ;
+  rdfs:label "sfasamento angolare"@it ;
+  rdfs:label "اختلاف طور"@ar ;
+  rdfs:label "位相差"@ja ;
+  skos:altLabel "desfasagem"@pt ;
+  skos:altLabel "déphasage"@fr ;
   skos:broader quantitykind:Angle ;
 .
 quantitykind:PhaseSpeedOfSound
@@ -14867,7 +16168,8 @@ quantitykind:PlanarForce
   qudt:plainTextDescription "Another name for Force Per Area, used by the Industry Foundation Classes (IFC) standard." ;
   qudt:symbol "p" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Flächenlast"@de , "Planar Force"@en ;
+  rdfs:label "Flächenlast"@de ;
+  rdfs:label "Planar Force"@en ;
   skos:broader quantitykind:ForcePerArea ;
 .
 quantitykind:PlanckFunction
@@ -14914,7 +16216,29 @@ quantitykind:PlaneAngle
   qudt:qkdvDenominator qkdv:A0E0L1I0M0H0T0D0 ;
   qudt:qkdvNumerator qkdv:A0E0L1I0M0H0T0D0 ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Rovinný úhel"@cs , "Sudut satah"@ms , "angle plan"@fr , "angolo piano"@it , "angulus planus"@la , "düzlemsel açı"@tr , "ebener Winkel"@de , "kąt płaski"@pl , "medida angular"@pt , "plane angle"@en , "ravninski kot"@sl , "szög"@hu , "unghi plan"@ro , "ángulo plano"@es , "Επίπεδη γωνία"@el , "Плоский угол"@ru , "Равнинен ъгъл"@bg , "זווית"@he , "الزاوية النصف قطرية"@ar , "زاویه مستوی"@fa , "क्षेत्र"@hi , "弧度"@ja , "角度"@zh ;
+  rdfs:label "Rovinný úhel"@cs ;
+  rdfs:label "Sudut satah"@ms ;
+  rdfs:label "angle plan"@fr ;
+  rdfs:label "angolo piano"@it ;
+  rdfs:label "angulus planus"@la ;
+  rdfs:label "düzlemsel açı"@tr ;
+  rdfs:label "ebener Winkel"@de ;
+  rdfs:label "kąt płaski"@pl ;
+  rdfs:label "medida angular"@pt ;
+  rdfs:label "plane angle"@en ;
+  rdfs:label "ravninski kot"@sl ;
+  rdfs:label "szög"@hu ;
+  rdfs:label "unghi plan"@ro ;
+  rdfs:label "ángulo plano"@es ;
+  rdfs:label "Επίπεδη γωνία"@el ;
+  rdfs:label "Плоский угол"@ru ;
+  rdfs:label "Равнинен ъгъл"@bg ;
+  rdfs:label "זווית"@he ;
+  rdfs:label "الزاوية النصف قطرية"@ar ;
+  rdfs:label "زاویه مستوی"@fa ;
+  rdfs:label "क्षेत्र"@hi ;
+  rdfs:label "弧度"@ja ;
+  rdfs:label "角度"@zh ;
   skos:broader quantitykind:Angle ;
 .
 quantitykind:PoissonRatio
@@ -15181,7 +16505,23 @@ quantitykind:PotentialEnergy
   qudt:symbol "PE" ;
   qudt:symbol "U" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Energia potencjalna"@pl , "Energie potențială"@ro , "Potansiyel enerji"@tr , "Tenaga keupayaan"@ms , "energia potencial"@pt , "energia potenziale"@it , "energía potencial"@es , "potenciální energie"@cs , "potential energy"@en , "potentielle Energie"@de , "énergie potentielle"@fr , "потенциальная энергия"@ru , "انرژی پتانسیل"@fa , "طاقة وضع"@ar , "स्थितिज ऊर्जा"@hi , "位置エネルギー"@ja , "势能"@zh ;
+  rdfs:label "Energia potencjalna"@pl ;
+  rdfs:label "Energie potențială"@ro ;
+  rdfs:label "Potansiyel enerji"@tr ;
+  rdfs:label "Tenaga keupayaan"@ms ;
+  rdfs:label "energia potencial"@pt ;
+  rdfs:label "energia potenziale"@it ;
+  rdfs:label "energía potencial"@es ;
+  rdfs:label "potenciální energie"@cs ;
+  rdfs:label "potential energy"@en ;
+  rdfs:label "potentielle Energie"@de ;
+  rdfs:label "énergie potentielle"@fr ;
+  rdfs:label "потенциальная энергия"@ru ;
+  rdfs:label "انرژی پتانسیل"@fa ;
+  rdfs:label "طاقة وضع"@ar ;
+  rdfs:label "स्थितिज ऊर्जा"@hi ;
+  rdfs:label "位置エネルギー"@ja ;
+  rdfs:label "势能"@zh ;
   skos:broader quantitykind:Energy ;
 .
 quantitykind:Power
@@ -15239,8 +16579,33 @@ quantitykind:Power
   qudt:symbol "P" ;
   qudt:symbol "p" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "power"@en , "Leistung"@de , "puissance"@fr , "potencia"@es , "potência"@pt , "potenza"@it , "putere"@ro , "Мощност"@bg , "moč"@sl , "Výkon"@cs , "moc"@pl , "Мощность"@ru , "teljesítmény , hőáramlás"@hu , "güç"@tr , "Ισχύς"@el , "הספק"@he , "القدرة"@ar , "توان، نرخ جریان گرما"@fa , "शक्ति"@hi , "功率、热流"@zh , "電力・仕事率"@ja , "Kuasa"@ms , "potentia"@la ;
-  skos:altLabel "flux energetic"@ro , "strumień promieniowania"@pl , "ısı akış oranı"@tr , "विकिरणी बहाव"@hi ;
+  rdfs:label "Kuasa"@ms ;
+  rdfs:label "Leistung"@de ;
+  rdfs:label "Výkon"@cs ;
+  rdfs:label "güç"@tr ;
+  rdfs:label "moc"@pl ;
+  rdfs:label "moč"@sl ;
+  rdfs:label "potencia"@es ;
+  rdfs:label "potentia"@la ;
+  rdfs:label "potenza"@it ;
+  rdfs:label "potência"@pt ;
+  rdfs:label "power"@en ;
+  rdfs:label "puissance"@fr ;
+  rdfs:label "putere"@ro ;
+  rdfs:label "teljesítmény , hőáramlás"@hu ;
+  rdfs:label "Ισχύς"@el ;
+  rdfs:label "Мощност"@bg ;
+  rdfs:label "Мощность"@ru ;
+  rdfs:label "הספק"@he ;
+  rdfs:label "القدرة"@ar ;
+  rdfs:label "توان، نرخ جریان گرما"@fa ;
+  rdfs:label "शक्ति"@hi ;
+  rdfs:label "功率、热流"@zh ;
+  rdfs:label "電力・仕事率"@ja ;
+  skos:altLabel "flux energetic"@ro ;
+  skos:altLabel "strumień promieniowania"@pl ;
+  skos:altLabel "ısı akış oranı"@tr ;
+  skos:altLabel "विकिरणी बहाव"@hi ;
 .
 quantitykind:PowerArea
   a qudt:QuantityKind ;
@@ -15269,7 +16634,23 @@ quantitykind:PowerFactor
   qudt:latexDefinition "\\(\\lambda = \\left | P \\right | / \\left | S \\right |\\), where \\(P\\) is active power and \\(S\\) is apparent power."^^qudt:LatexString ;
   qudt:latexSymbol "\\(\\lambda\\)"^^qudt:LatexString ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Leistungsfaktor"@de , "Współczynnik mocy"@pl , "facteur de puissance"@fr , "factor de potencia"@es , "factor de putere"@ro , "faktor kuasa"@ms , "fator de potência"@pt , "fattore di potenza"@it , "güç faktörü"@tr , "power factor"@en , "Účiník"@cs , "Коэффициент_мощности"@ru , "ضریب توان"@fa , "معامل القدرة"@ar , "शक्ति गुणांक"@hi , "力率"@ja , "功率因数"@zh ;
+  rdfs:label "Leistungsfaktor"@de ;
+  rdfs:label "Współczynnik mocy"@pl ;
+  rdfs:label "facteur de puissance"@fr ;
+  rdfs:label "factor de potencia"@es ;
+  rdfs:label "factor de putere"@ro ;
+  rdfs:label "faktor kuasa"@ms ;
+  rdfs:label "fator de potência"@pt ;
+  rdfs:label "fattore di potenza"@it ;
+  rdfs:label "güç faktörü"@tr ;
+  rdfs:label "power factor"@en ;
+  rdfs:label "Účiník"@cs ;
+  rdfs:label "Коэффициент_мощности"@ru ;
+  rdfs:label "ضریب توان"@fa ;
+  rdfs:label "معامل القدرة"@ar ;
+  rdfs:label "शक्ति गुणांक"@hi ;
+  rdfs:label "力率"@ja ;
+  rdfs:label "功率因数"@zh ;
   rdfs:seeAlso quantitykind:ActivePower ;
   rdfs:seeAlso quantitykind:ApparentPower ;
 .
@@ -15331,7 +16712,16 @@ quantitykind:PoyntingVector
   qudt:latexSymbol "\\(\\mathbf{S} \\)"^^qudt:LatexString ;
   qudt:plainTextDescription "\"Poynting Vector} is the vector product of the electric field strength \\mathbf{E} and the magnetic field strength \\mathbf{H\" of the electromagnetic field at a given point. The flux of the Poynting vector through a closed surface is equal to the electromagnetic power passing through this surface. For a periodic electromagnetic field, the time average of the Poynting vector is a vector of which, with certain reservations, the direction may be considered as being the direction of propagation of electromagnetic energy and the magnitude considered as being the average electromagnetic power flux density." ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Poynting vector"@en , "Poynting-Vektor"@de , "vecteur de Poynting"@fr , "vector de Poynting"@es , "vector de Poynting"@pt , "vettore di Poynting"@it , "wektor Poyntinga"@pl , "вектор Пойнтинга"@ru , "متجَه بوينتنج"@ar , "ポインティングベクトル"@ja ;
+  rdfs:label "Poynting vector"@en ;
+  rdfs:label "Poynting-Vektor"@de ;
+  rdfs:label "vecteur de Poynting"@fr ;
+  rdfs:label "vector de Poynting"@es ;
+  rdfs:label "vector de Poynting"@pt ;
+  rdfs:label "vettore di Poynting"@it ;
+  rdfs:label "wektor Poyntinga"@pl ;
+  rdfs:label "вектор Пойнтинга"@ru ;
+  rdfs:label "متجَه بوينتنج"@ar ;
+  rdfs:label "ポインティングベクトル"@ja ;
 .
 quantitykind:Pressure
   a qudt:QuantityKind ;
@@ -15395,8 +16785,37 @@ quantitykind:Pressure
   qudt:latexDefinition "\\(p = \\frac{dF}{dA}\\), where \\(dF\\) is the force component perpendicular to the surface element of area \\(dA\\)."^^qudt:LatexString ;
   qudt:plainTextDescription "Pressure is an effect which occurs when a force is applied on a surface. Pressure is the amount of force acting on a unit area. Pressure is distinct from stress, as the former is the ratio of the component of force normal to a surface to the surface area. Stress is a tensor that relates the vector force to the vector area." ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "pressure"@en , "Druck"@de , "pression"@fr , "presión"@es , "pressão"@pt , "pressione"@it , "presiune"@ro , "Налягане"@bg , "tlak"@sl , "Tlak"@cs , "ciśnienie"@pl , "Давление"@ru , "nyomás"@hu , "basınç"@tr , "Πίεση - τάση"@el , "לחץ"@he , "الضغط أو الإجهاد"@ar , "فشار، تنش"@fa , "दबाव"@hi , "压强、压力"@zh , "圧力"@ja , "Tekanan"@ms , "pressio"@la ;
-  skos:altLabel "tensão"@pt , "tensione meccanica"@it , "tensiune mecanică"@ro , "механично напрежение"@bg , "pritisk"@sl , "naprężenie"@pl , "दाब"@hi , "tegasan"@ms ;
+  rdfs:label "Druck"@de ;
+  rdfs:label "Tekanan"@ms ;
+  rdfs:label "Tlak"@cs ;
+  rdfs:label "basınç"@tr ;
+  rdfs:label "ciśnienie"@pl ;
+  rdfs:label "nyomás"@hu ;
+  rdfs:label "presiune"@ro ;
+  rdfs:label "presión"@es ;
+  rdfs:label "pressio"@la ;
+  rdfs:label "pression"@fr ;
+  rdfs:label "pressione"@it ;
+  rdfs:label "pressure"@en ;
+  rdfs:label "pressão"@pt ;
+  rdfs:label "tlak"@sl ;
+  rdfs:label "Πίεση - τάση"@el ;
+  rdfs:label "Давление"@ru ;
+  rdfs:label "Налягане"@bg ;
+  rdfs:label "לחץ"@he ;
+  rdfs:label "الضغط أو الإجهاد"@ar ;
+  rdfs:label "فشار، تنش"@fa ;
+  rdfs:label "दबाव"@hi ;
+  rdfs:label "压强、压力"@zh ;
+  rdfs:label "圧力"@ja ;
+  skos:altLabel "naprężenie"@pl ;
+  skos:altLabel "pritisk"@sl ;
+  skos:altLabel "tegasan"@ms ;
+  skos:altLabel "tensione meccanica"@it ;
+  skos:altLabel "tensiune mecanică"@ro ;
+  skos:altLabel "tensão"@pt ;
+  skos:altLabel "механично напрежение"@bg ;
+  skos:altLabel "दाब"@hi ;
   skos:broader quantitykind:ForcePerArea ;
 .
 quantitykind:PressureBurningRateConstant
@@ -15898,7 +17317,22 @@ quantitykind:RadiantEnergy
   qudt:symbol "Q_e" ;
   qudt:symbol "R" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Işınım erkesi"@tr , "Strahlungsenergie"@de , "Tenaga sinaran"@ms , "energia promienista"@pl , "energia radiante"@it , "energia radiante"@pt , "energie záření"@cs , "energía radiante"@es , "radiant energy"@en , "énergie rayonnante"@fr , "энергия излучения"@ru , "انرژی تابشی"@fa , "طاقة إشعاعية"@ar , "विकिरण ऊर्जा"@hi , "放射エネルギー"@ja , "辐射能"@zh ;
+  rdfs:label "Işınım erkesi"@tr ;
+  rdfs:label "Strahlungsenergie"@de ;
+  rdfs:label "Tenaga sinaran"@ms ;
+  rdfs:label "energia promienista"@pl ;
+  rdfs:label "energia radiante"@it ;
+  rdfs:label "energia radiante"@pt ;
+  rdfs:label "energie záření"@cs ;
+  rdfs:label "energía radiante"@es ;
+  rdfs:label "radiant energy"@en ;
+  rdfs:label "énergie rayonnante"@fr ;
+  rdfs:label "энергия излучения"@ru ;
+  rdfs:label "انرژی تابشی"@fa ;
+  rdfs:label "طاقة إشعاعية"@ar ;
+  rdfs:label "विकिरण ऊर्जा"@hi ;
+  rdfs:label "放射エネルギー"@ja ;
+  rdfs:label "辐射能"@zh ;
   skos:broader quantitykind:Energy ;
   skos:closeMatch quantitykind:LuminousEnergy ;
 .
@@ -16035,8 +17469,22 @@ quantitykind:RadiantFlux
   qudt:latexSymbol "\\(\\phi\\)"^^qudt:LatexString ;
   qudt:plainTextDescription "Radiant Flux, or radiant power, is the measure of the total power of electromagnetic radiation (including infrared, ultraviolet, and visible light). The power may be the total emitted from a source, or the total landing on a particular surface." ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "radiant flux"@en , "Strahlungsfluss"@de , "flux énergétique"@fr , "potencia radiante"@es , "potência radiante"@pt , "flusso radiante"@it , "moc promieniowania"@pl , "قدرة إشعاعية"@ar , "放射パワー"@ja ;
-  skos:altLabel "radiant power"@en , "Strahlungsleistung"@de , "puissance rayonnante"@fr , "flujo radiante"@es , "fluxo energético"@pt , "potenza radiante"@it , "moc promienista"@pl ;
+  rdfs:label "Strahlungsfluss"@de ;
+  rdfs:label "flusso radiante"@it ;
+  rdfs:label "flux énergétique"@fr ;
+  rdfs:label "moc promieniowania"@pl ;
+  rdfs:label "potencia radiante"@es ;
+  rdfs:label "potência radiante"@pt ;
+  rdfs:label "radiant flux"@en ;
+  rdfs:label "قدرة إشعاعية"@ar ;
+  rdfs:label "放射パワー"@ja ;
+  skos:altLabel "Strahlungsleistung"@de ;
+  skos:altLabel "flujo radiante"@es ;
+  skos:altLabel "fluxo energético"@pt ;
+  skos:altLabel "moc promienista"@pl ;
+  skos:altLabel "potenza radiante"@it ;
+  skos:altLabel "puissance rayonnante"@fr ;
+  skos:altLabel "radiant power"@en ;
   skos:broader quantitykind:Power ;
 .
 quantitykind:RadiantIntensity
@@ -16287,7 +17735,20 @@ quantitykind:ReactivePower
   qudt:latexDefinition "\\(Q = lm \\underline{S}\\), where \\(\\underline{S}\\) is complex power. Alternatively expressed as: \\(Q = S \\cdot \\sin  \\psi\\), where \\(\\psi\\) is the displacement angle."^^qudt:LatexString ;
   qudt:symbol "Q" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Blindleistung"@de , "Jalový výkon"@cs , "Kuasa reaktif"@ms , "moc bierna"@pl , "potencia reactiva"@es , "potenza reattiva"@it , "potência reativa"@pt , "puissance réactive"@fr , "reactive power"@en , "reaktif güç"@tr , "القدرة الكهربائية الردفعلية;الردية"@ar , "توان راکتیو"@fa , "无功功率"@zh , "無効電力"@ja ;
+  rdfs:label "Blindleistung"@de ;
+  rdfs:label "Jalový výkon"@cs ;
+  rdfs:label "Kuasa reaktif"@ms ;
+  rdfs:label "moc bierna"@pl ;
+  rdfs:label "potencia reactiva"@es ;
+  rdfs:label "potenza reattiva"@it ;
+  rdfs:label "potência reativa"@pt ;
+  rdfs:label "puissance réactive"@fr ;
+  rdfs:label "reactive power"@en ;
+  rdfs:label "reaktif güç"@tr ;
+  rdfs:label "القدرة الكهربائية الردفعلية;الردية"@ar ;
+  rdfs:label "توان راکتیو"@fa ;
+  rdfs:label "无功功率"@zh ;
+  rdfs:label "無効電力"@ja ;
   rdfs:seeAlso quantitykind:ComplexPower ;
   skos:broader quantitykind:ComplexPower ;
 .
@@ -16419,7 +17880,23 @@ quantitykind:RefractiveIndex
   qudt:plainTextDescription "\"refractive index\" or index of refraction n of a substance (optical medium) is a dimensionless number that describes how light, or any other radiation, propagates through that medium." ;
   qudt:symbol "n" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "refractive index"@en , "Brechzahl"@de , "indice de réfraction"@fr , "índice de refracción"@es , "índice refrativo"@pt , "indice di rifrazione"@it , "Indice de refracție"@ro , "Index lomu"@cs , "Współczynnik załamania"@pl , "Показатель преломления"@ru , "kırılma indeksi"@tr , "معامل الانكسار"@ar , "ضریب شکست"@fa , "अपवर्तनांक"@hi , "折射率"@zh , "屈折率"@ja , "Indeks biasan"@ms ;
+  rdfs:label "Brechzahl"@de ;
+  rdfs:label "Indeks biasan"@ms ;
+  rdfs:label "Index lomu"@cs ;
+  rdfs:label "Indice de refracție"@ro ;
+  rdfs:label "Współczynnik załamania"@pl ;
+  rdfs:label "indice de réfraction"@fr ;
+  rdfs:label "indice di rifrazione"@it ;
+  rdfs:label "kırılma indeksi"@tr ;
+  rdfs:label "refractive index"@en ;
+  rdfs:label "índice de refracción"@es ;
+  rdfs:label "índice refrativo"@pt ;
+  rdfs:label "Показатель преломления"@ru ;
+  rdfs:label "ضریب شکست"@fa ;
+  rdfs:label "معامل الانكسار"@ar ;
+  rdfs:label "अपवर्तनांक"@hi ;
+  rdfs:label "屈折率"@ja ;
+  rdfs:label "折射率"@zh ;
   skos:altLabel "Brechungsindex"@de ;
 .
 quantitykind:RelativeAtomicMass
@@ -16964,8 +18441,32 @@ quantitykind:RestMass
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
   qudt:symbol "m_X" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "rest mass"@en , "Ruhemasse"@de , "masse au repos"@fr , "masa invariante"@es , "massa de repouso"@pt , "massa a riposo"@it , "masa invariantă"@ro , "Mirovna masa"@sl , "Klidová hmotnost"@cs , "masa spoczynkowa"@pl , "инвариантная масса"@ru , "dinlenme kütlesi"@tr , "كتلة ساكنة"@ar , "جرم سکون"@fa , "निश्चर द्रव्यमान"@hi , "静止质量"@zh , "不変質量"@ja , "Jisim rehat"@ms ;
-  skos:altLabel "träge Masse"@de , "masse propre"@fr , "masse invariante"@fr , "lastna masa"@sl , "invariantna masa"@sl , "masa niezmiennicza"@pl , "масса покоя"@ru , "Proper Mass" ;
+  rdfs:label "Jisim rehat"@ms ;
+  rdfs:label "Klidová hmotnost"@cs ;
+  rdfs:label "Mirovna masa"@sl ;
+  rdfs:label "Ruhemasse"@de ;
+  rdfs:label "dinlenme kütlesi"@tr ;
+  rdfs:label "masa invariante"@es ;
+  rdfs:label "masa invariantă"@ro ;
+  rdfs:label "masa spoczynkowa"@pl ;
+  rdfs:label "massa a riposo"@it ;
+  rdfs:label "massa de repouso"@pt ;
+  rdfs:label "masse au repos"@fr ;
+  rdfs:label "rest mass"@en ;
+  rdfs:label "инвариантная масса"@ru ;
+  rdfs:label "جرم سکون"@fa ;
+  rdfs:label "كتلة ساكنة"@ar ;
+  rdfs:label "निश्चर द्रव्यमान"@hi ;
+  rdfs:label "不変質量"@ja ;
+  rdfs:label "静止质量"@zh ;
+  skos:altLabel "Proper Mass" ;
+  skos:altLabel "invariantna masa"@sl ;
+  skos:altLabel "lastna masa"@sl ;
+  skos:altLabel "masa niezmiennicza"@pl ;
+  skos:altLabel "masse invariante"@fr ;
+  skos:altLabel "masse propre"@fr ;
+  skos:altLabel "träge Masse"@de ;
+  skos:altLabel "масса покоя"@ru ;
   skos:broader quantitykind:Mass ;
 .
 quantitykind:ReverberationTime
@@ -17142,7 +18643,17 @@ quantitykind:SecondMomentOfArea
   qudt:plainTextDescription "The second moment of area is a property of a physical object that can be used to predict its resistance to bending and deflection. The deflection of an object under load depends not only on the load, but also on the geometry of the object's cross-section." ;
   qudt:symbol "J" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "second moment of area"@en , "Flächenträgheitsmoment"@de , "moment quadratique"@fr , "segundo momento de érea"@es , "Segundo momento de área"@pt , "secondo momento di area"@it , "Geometryczny moment bezwładności"@pl , "گشتاور دوم سطح"@fa , "क्षेत्रफल का द्वितीय आघूर्ण"@hi , "截面二次轴矩"@zh , "断面二次モーメント"@ja ;
+  rdfs:label "Flächenträgheitsmoment"@de ;
+  rdfs:label "Geometryczny moment bezwładności"@pl ;
+  rdfs:label "Segundo momento de área"@pt ;
+  rdfs:label "moment quadratique"@fr ;
+  rdfs:label "second moment of area"@en ;
+  rdfs:label "secondo momento di area"@it ;
+  rdfs:label "segundo momento de érea"@es ;
+  rdfs:label "گشتاور دوم سطح"@fa ;
+  rdfs:label "क्षेत्रफल का द्वितीय आघूर्ण"@hi ;
+  rdfs:label "截面二次轴矩"@zh ;
+  rdfs:label "断面二次モーメント"@ja ;
   skos:altLabel "momento de inércia de área"@pt ;
   skos:broader quantitykind:MomentOfInertia ;
 .
@@ -17551,7 +19062,29 @@ quantitykind:SolidAngle
   qudt:qkdvDenominator qkdv:A0E0L2I0M0H0T0D0 ;
   qudt:qkdvNumerator qkdv:A0E0L2I0M0H0T0D0 ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Prostorový úhel"@cs , "Raumwinkel"@de , "Sudut padu"@ms , "angle solide"@fr , "angolo solido"@it , "angulus solidus"@la , "katı cisimdeki açı"@tr , "kąt bryłowy"@pl , "prostorski kot"@sl , "solid angle"@en , "térszög"@hu , "unghi solid"@ro , "ángulo sólido"@es , "ângulo sólido"@pt , "Στερεά γωνία"@el , "Пространствен ъгъл"@bg , "Телесный угол"@ru , "זווית מרחבית"@he , "الزاوية الصلبة"@ar , "زاویه فضایی"@fa , "आयतन"@hi , "立体角"@ja , "立体角度"@zh ;
+  rdfs:label "Prostorový úhel"@cs ;
+  rdfs:label "Raumwinkel"@de ;
+  rdfs:label "Sudut padu"@ms ;
+  rdfs:label "angle solide"@fr ;
+  rdfs:label "angolo solido"@it ;
+  rdfs:label "angulus solidus"@la ;
+  rdfs:label "katı cisimdeki açı"@tr ;
+  rdfs:label "kąt bryłowy"@pl ;
+  rdfs:label "prostorski kot"@sl ;
+  rdfs:label "solid angle"@en ;
+  rdfs:label "térszög"@hu ;
+  rdfs:label "unghi solid"@ro ;
+  rdfs:label "ángulo sólido"@es ;
+  rdfs:label "ângulo sólido"@pt ;
+  rdfs:label "Στερεά γωνία"@el ;
+  rdfs:label "Пространствен ъгъл"@bg ;
+  rdfs:label "Телесный угол"@ru ;
+  rdfs:label "זווית מרחבית"@he ;
+  rdfs:label "الزاوية الصلبة"@ar ;
+  rdfs:label "زاویه فضایی"@fa ;
+  rdfs:label "आयतन"@hi ;
+  rdfs:label "立体角"@ja ;
+  rdfs:label "立体角度"@zh ;
   skos:broader quantitykind:AreaRatio ;
 .
 quantitykind:SolidStateDiffusionLength
@@ -17780,7 +19313,15 @@ quantitykind:SoundParticleVelocity
   qudt:symbol "v" ;
   vaem:todo "belongs to SOQ-ISO" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "sound particle velocity"@en , "Schallschnelle"@de , "vitesse  acoustique d‘une particule"@fr , "velocidad acústica de una partícula"@es , "velocidade acústica de uma partícula"@pt , "velocità di spostamento"@it , "prędkość akustyczna"@pl , "سرعة جسيم"@ar , "粒子速度"@ja ;
+  rdfs:label "Schallschnelle"@de ;
+  rdfs:label "prędkość akustyczna"@pl ;
+  rdfs:label "sound particle velocity"@en ;
+  rdfs:label "velocidad acústica de una partícula"@es ;
+  rdfs:label "velocidade acústica de uma partícula"@pt ;
+  rdfs:label "velocità di spostamento"@it ;
+  rdfs:label "vitesse  acoustique d‘une particule"@fr ;
+  rdfs:label "سرعة جسيم"@ar ;
+  rdfs:label "粒子速度"@ja ;
   skos:altLabel "prędkość cząstki"@pl ;
   skos:broader quantitykind:Velocity ;
 .
@@ -17836,7 +19377,16 @@ quantitykind:SoundPower
   qudt:symbol "P" ;
   vaem:todo "belongs to SOQ-ISO" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "sound power"@en , "Schallleistung"@de , "puissance acoustique"@fr , "potencie acústica"@es , "potência acústica"@pt , "potenza sonora"@it , "moc akustyczna"@pl , "звуковая мощность"@ru , "القدرة الصوتية"@ar , "音源の音響出力"@ja ;
+  rdfs:label "Schallleistung"@de ;
+  rdfs:label "moc akustyczna"@pl ;
+  rdfs:label "potencie acústica"@es ;
+  rdfs:label "potenza sonora"@it ;
+  rdfs:label "potência acústica"@pt ;
+  rdfs:label "puissance acoustique"@fr ;
+  rdfs:label "sound power"@en ;
+  rdfs:label "звуковая мощность"@ru ;
+  rdfs:label "القدرة الصوتية"@ar ;
+  rdfs:label "音源の音響出力"@ja ;
   skos:altLabel "potência sonora"@pt ;
   skos:broader quantitykind:Power ;
 .
@@ -17931,7 +19481,21 @@ quantitykind:SoundPressureLevel
   qudt:symbol "L" ;
   vaem:todo "belongs to SOQ-ISO" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Hladina akustického tlaku"@cs , "Schalldruckpegel"@de , "Tahap medan"@ms , "gerilim veya akım oranı"@tr , "livello di pressione sonora"@it , "miary wielkości ilorazowych"@pl , "niveau de pression acoustique"@fr , "nivel de presión sonora"@es , "nível de pressão acústica"@pt , "sound pressure level"@en , "уровень звукового давления"@ru , "سطح یک کمیت توان-ریشه"@fa , "كمية جذر الطاقة"@ar , "利得"@ja , "声压级"@zh ;
+  rdfs:label "Hladina akustického tlaku"@cs ;
+  rdfs:label "Schalldruckpegel"@de ;
+  rdfs:label "Tahap medan"@ms ;
+  rdfs:label "gerilim veya akım oranı"@tr ;
+  rdfs:label "livello di pressione sonora"@it ;
+  rdfs:label "miary wielkości ilorazowych"@pl ;
+  rdfs:label "niveau de pression acoustique"@fr ;
+  rdfs:label "nivel de presión sonora"@es ;
+  rdfs:label "nível de pressão acústica"@pt ;
+  rdfs:label "sound pressure level"@en ;
+  rdfs:label "уровень звукового давления"@ru ;
+  rdfs:label "سطح یک کمیت توان-ریشه"@fa ;
+  rdfs:label "كمية جذر الطاقة"@ar ;
+  rdfs:label "利得"@ja ;
+  rdfs:label "声压级"@zh ;
   skos:altLabel "Tahap tekanan bunyi"@ms ;
 .
 quantitykind:SoundReductionIndex
@@ -18594,7 +20158,24 @@ quantitykind:SpeedOfLight
   qudt:informativeReference "http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=113-01-34"^^xsd:anyURI ;
   qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Hitrost svetlobe"@sl , "Işık hızı"@tr , "Kelajuan cahaya"@ms , "Lichtgeschwindigkeit"@de , "Prędkość światła"@pl , "Rychlost světla"@cs , "Velocidade da luz"@pt , "Viteza luminii"@ro , "speed of light"@en , "velocidad de la luz"@es , "velocità della luce"@it , "vitesse de la lumière"@fr , "Скорость света"@ru , "سرعة الضوء"@ar , "سرعت نور"@fa , "प्रकाश का वेग"@hi , "光速"@ja , "光速"@zh ;
+  rdfs:label "Hitrost svetlobe"@sl ;
+  rdfs:label "Işık hızı"@tr ;
+  rdfs:label "Kelajuan cahaya"@ms ;
+  rdfs:label "Lichtgeschwindigkeit"@de ;
+  rdfs:label "Prędkość światła"@pl ;
+  rdfs:label "Rychlost světla"@cs ;
+  rdfs:label "Velocidade da luz"@pt ;
+  rdfs:label "Viteza luminii"@ro ;
+  rdfs:label "speed of light"@en ;
+  rdfs:label "velocidad de la luz"@es ;
+  rdfs:label "velocità della luce"@it ;
+  rdfs:label "vitesse de la lumière"@fr ;
+  rdfs:label "Скорость света"@ru ;
+  rdfs:label "سرعة الضوء"@ar ;
+  rdfs:label "سرعت نور"@fa ;
+  rdfs:label "प्रकाश का वेग"@hi ;
+  rdfs:label "光速"@ja ;
+  rdfs:label "光速"@zh ;
   rdfs:seeAlso constant:MagneticConstant ;
   rdfs:seeAlso constant:PermittivityOfVacuum ;
   rdfs:seeAlso constant:SpeedOfLight_Vacuum ;
@@ -18618,8 +20199,26 @@ quantitykind:SpeedOfSound
   qudt:symbol "c" ;
   vaem:todo "belongs to SOQ-ISO" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "speed of sound"@en , "Schallgeschwindigkeit"@de , "vitesse du son"@fr , "velocidad del sonido"@es , "velocidade do som"@pt , "velocità del suono"@it , "viteza sunetului"@ro , "Hitrost zvoka"@sl , "rychlost zvuku"@cs , "prędkość dźwięku"@pl , "скорость звука"@ru , "Ses hızı"@tr , "سرعة الصوت"@ar , "سرعت صوت"@fa , "ध्वनि का वेग"@hi , "音速"@zh , "音速"@ja , "Kelajuan bunyi"@ms ;
-  skos:altLabel "Schallausbreitungsgeschwindigkeit"@de , "célérité du son"@fr ;
+  rdfs:label "Hitrost zvoka"@sl ;
+  rdfs:label "Kelajuan bunyi"@ms ;
+  rdfs:label "Schallgeschwindigkeit"@de ;
+  rdfs:label "Ses hızı"@tr ;
+  rdfs:label "prędkość dźwięku"@pl ;
+  rdfs:label "rychlost zvuku"@cs ;
+  rdfs:label "speed of sound"@en ;
+  rdfs:label "velocidad del sonido"@es ;
+  rdfs:label "velocidade do som"@pt ;
+  rdfs:label "velocità del suono"@it ;
+  rdfs:label "vitesse du son"@fr ;
+  rdfs:label "viteza sunetului"@ro ;
+  rdfs:label "скорость звука"@ru ;
+  rdfs:label "سرعة الصوت"@ar ;
+  rdfs:label "سرعت صوت"@fa ;
+  rdfs:label "ध्वनि का वेग"@hi ;
+  rdfs:label "音速"@ja ;
+  rdfs:label "音速"@zh ;
+  skos:altLabel "Schallausbreitungsgeschwindigkeit"@de ;
+  skos:altLabel "célérité du son"@fr ;
   skos:broader quantitykind:Speed ;
 .
 quantitykind:SphericalIlluminance
@@ -18650,7 +20249,23 @@ quantitykind:Spin
   qudt:plainTextDescription "In quantum mechanics and particle physics \"Spin\" is an intrinsic form of angular momentum carried by elementary particles, composite particles (hadrons), and atomic nuclei." ;
   qudt:symbol "s" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Spin"@de , "Spin"@ms , "Spin"@ro , "Spin"@tr , "espín"@es , "spin"@cs , "spin"@en , "spin"@fr , "spin"@it , "spin"@pl , "spin"@pt , "spin"@sl , "Спин"@ru , "اسپین/چرخش"@fa , "لف مغزلي"@ar , "スピン角運動量"@ja , "自旋"@zh ;
+  rdfs:label "Spin"@de ;
+  rdfs:label "Spin"@ms ;
+  rdfs:label "Spin"@ro ;
+  rdfs:label "Spin"@tr ;
+  rdfs:label "espín"@es ;
+  rdfs:label "spin"@cs ;
+  rdfs:label "spin"@en ;
+  rdfs:label "spin"@fr ;
+  rdfs:label "spin"@it ;
+  rdfs:label "spin"@pl ;
+  rdfs:label "spin"@pt ;
+  rdfs:label "spin"@sl ;
+  rdfs:label "Спин"@ru ;
+  rdfs:label "اسپین/چرخش"@fa ;
+  rdfs:label "لف مغزلي"@ar ;
+  rdfs:label "スピン角運動量"@ja ;
+  rdfs:label "自旋"@zh ;
   skos:broader quantitykind:AngularMomentum ;
 .
 quantitykind:SpinQuantumNumber
@@ -19310,7 +20925,24 @@ quantitykind:SurfaceTension
   qudt:plainTextDescription "\"Surface Tension\" is a contractive tendency of the surface of a liquid that allows it to resist an external force." ;
   qudt:symbol "γ" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "surface tension"@en , "Oberflächenspannung"@de , "tension superficielle"@fr , "tensión superficial"@es , "tensão superficial"@pt , "tensione superficiale"@it , "Tensiune superficială"@ro , "površinska napetost"@sl , "povrchové napětí"@cs , "napięcie powierzchniowe"@pl , "поверхностное натяжение"@ru , "Yüzey gerilimi"@tr , "توتر سطحي"@ar , "کشش سطحی"@fa , "पृष्ठ तनाव"@hi , "表面张力"@zh , "表面張力"@ja , "Tegangan permukaan"@ms ;
+  rdfs:label "Oberflächenspannung"@de ;
+  rdfs:label "Tegangan permukaan"@ms ;
+  rdfs:label "Tensiune superficială"@ro ;
+  rdfs:label "Yüzey gerilimi"@tr ;
+  rdfs:label "napięcie powierzchniowe"@pl ;
+  rdfs:label "povrchové napětí"@cs ;
+  rdfs:label "površinska napetost"@sl ;
+  rdfs:label "surface tension"@en ;
+  rdfs:label "tension superficielle"@fr ;
+  rdfs:label "tensione superficiale"@it ;
+  rdfs:label "tensión superficial"@es ;
+  rdfs:label "tensão superficial"@pt ;
+  rdfs:label "поверхностное натяжение"@ru ;
+  rdfs:label "توتر سطحي"@ar ;
+  rdfs:label "کشش سطحی"@fa ;
+  rdfs:label "पृष्ठ तनाव"@hi ;
+  rdfs:label "表面张力"@zh ;
+  rdfs:label "表面張力"@ja ;
   skos:altLabel "tension de surface"@fr ;
   skos:broader quantitykind:EnergyPerArea ;
 .
@@ -19814,11 +21446,20 @@ quantitykind:ThermalResistance
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI ;
   qudt:symbol "R" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "thermal resistance"@en , "thermischer Widerstand"@de , "résistance thermique"@fr , "resistencia térmica"@es , "resistência térmica"@pt , "resistenza termica"@it , "opór cieplny"@cs , "مقاومة حرارية"@ar , "热阻"@zh , "熱抵抗"@ja ;
-  skos:altLabel "Wärmewiderstand"@de ;
+  rdfs:label "opór cieplny"@cs ;
+  rdfs:label "resistencia térmica"@es ;
+  rdfs:label "resistenza termica"@it ;
+  rdfs:label "resistência térmica"@pt ;
+  rdfs:label "résistance thermique"@fr ;
+  rdfs:label "thermal resistance"@en ;
+  rdfs:label "thermischer Widerstand"@de ;
+  rdfs:label "مقاومة حرارية"@ar ;
+  rdfs:label "热阻"@zh ;
+  rdfs:label "熱抵抗"@ja ;
   rdfs:seeAlso quantitykind:HeatFlowRate ;
   rdfs:seeAlso quantitykind:ThermalInsulance ;
   rdfs:seeAlso quantitykind:ThermodynamicTemperature ;
+  skos:altLabel "Wärmewiderstand"@de ;
 .
 quantitykind:ThermalResistivity
   a qudt:QuantityKind ;
@@ -19985,9 +21626,32 @@ Temperature is a physical property of matter that quantitatively expresses the c
 In thermodynamics, in a system of which the entropy is considered as an independent externally controlled variable, absolute, or thermodynamic temperature is defined as the derivative of the internal energy with respect to the entropy. This is a base quantity in the International System of Quantities, ISQ, on which the International System of Units, SI, is based.""" ;
   qudt:symbol "T" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "thermodynamic temperature"@en , "thermodynamische Temperatur"@de , "température thermodynamique"@fr , "temperatura"@es , "temperatura"@pt , "temperatura termodinamica"@it , "temperatură termodinamică"@ro , "Термодинамична температура"@bg , "temperatura"@sl , "Termodynamická teplota"@cs , "temperatura"@pl , "Термодинамическая температура"@ru , "abszolút hőmérséklet"@hu , "termodinamik sıcaklık"@tr , "Απόλυτη"@el , "טמפרטורה מוחלטת"@he , "درجة الحرارة المطلقة"@ar , "دمای ترمودینامیکی"@fa , "ऊष्मगतिकीय तापमान"@hi , "热力学温度"@zh , "熱力学温度"@ja , "Suhu termodinamik"@ms , "temperatura thermodynamica absoluta"@la ;
-  skos:altLabel "temperatura assoluta"@it , "Θερμοδυναμική Θερμοκρασία"@el ;
+  rdfs:label "Suhu termodinamik"@ms ;
+  rdfs:label "Termodynamická teplota"@cs ;
+  rdfs:label "abszolút hőmérséklet"@hu ;
+  rdfs:label "temperatura termodinamica"@it ;
+  rdfs:label "temperatura thermodynamica absoluta"@la ;
+  rdfs:label "temperatura"@es ;
+  rdfs:label "temperatura"@pl ;
+  rdfs:label "temperatura"@pt ;
+  rdfs:label "temperatura"@sl ;
+  rdfs:label "temperatură termodinamică"@ro ;
+  rdfs:label "température thermodynamique"@fr ;
+  rdfs:label "termodinamik sıcaklık"@tr ;
+  rdfs:label "thermodynamic temperature"@en ;
+  rdfs:label "thermodynamische Temperatur"@de ;
+  rdfs:label "Απόλυτη"@el ;
+  rdfs:label "Термодинамическая температура"@ru ;
+  rdfs:label "Термодинамична температура"@bg ;
+  rdfs:label "טמפרטורה מוחלטת"@he ;
+  rdfs:label "درجة الحرارة المطلقة"@ar ;
+  rdfs:label "دمای ترمودینامیکی"@fa ;
+  rdfs:label "ऊष्मगतिकीय तापमान"@hi ;
+  rdfs:label "热力学温度"@zh ;
+  rdfs:label "熱力学温度"@ja ;
   rdfs:seeAlso quantitykind:Temperature ;
+  skos:altLabel "temperatura assoluta"@it ;
+  skos:altLabel "Θερμοδυναμική Θερμοκρασία"@el ;
   skos:broader quantitykind:Temperature ;
 .
 quantitykind:Thickness
@@ -20175,7 +21839,29 @@ quantitykind:Time
   qudt:plainTextDescription "Time is a basic component of the measuring system used to sequence events, to compare the durations of events and the intervals between them, and to quantify the motions of objects." ;
   qudt:symbol "t" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Masa"@ms , "Zeit"@de , "czas"@pl , "idő"@hu , "tempo"@it , "tempo"@pt , "temps"@fr , "tempus"@la , "tiempo"@es , "time"@en , "timp"@ro , "zaman"@tr , "Čas"@cs , "čas"@sl , "Χρόνος"@el , "Време"@bg , "Время"@ru , "זמן"@he , "زمان"@fa , "زمن"@ar , "समय"@hi , "时间"@zh , "時間"@ja ;
+  rdfs:label "Masa"@ms ;
+  rdfs:label "Zeit"@de ;
+  rdfs:label "czas"@pl ;
+  rdfs:label "idő"@hu ;
+  rdfs:label "tempo"@it ;
+  rdfs:label "tempo"@pt ;
+  rdfs:label "temps"@fr ;
+  rdfs:label "tempus"@la ;
+  rdfs:label "tiempo"@es ;
+  rdfs:label "time"@en ;
+  rdfs:label "timp"@ro ;
+  rdfs:label "zaman"@tr ;
+  rdfs:label "Čas"@cs ;
+  rdfs:label "čas"@sl ;
+  rdfs:label "Χρόνος"@el ;
+  rdfs:label "Време"@bg ;
+  rdfs:label "Время"@ru ;
+  rdfs:label "זמן"@he ;
+  rdfs:label "زمان"@fa ;
+  rdfs:label "زمن"@ar ;
+  rdfs:label "समय"@hi ;
+  rdfs:label "时间"@zh ;
+  rdfs:label "時間"@ja ;
 .
 quantitykind:TimeAveragedSoundIntensity
   a qudt:QuantityKind ;
@@ -20297,8 +21983,21 @@ t stands for time."""^^qudt:LatexString ;
   qudt:latexDefinition "\\(\\tau = M \\cdot e_Q\\), where \\(M\\) is the momentof force and \\(e_Q\\) is a unit vector directed along a \\(Q-axis\\) with respect to which the torque is considered."^^qudt:LatexString ;
   qudt:latexSymbol "\\(\\tau\\)"^^qudt:LatexString ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "torque"@en , "Torsionmoment"@de , "couple"@fr , "par"@es , "momento de torção"@pt , "coppia"@it , "moment obrotowy"@pl , "عزم محورى"@ar , "转矩"@zh , "トルク"@ja ;
-  skos:altLabel "Drillmoment"@de , "moment de torsion"@fr , "momento de torsión"@es , "binârio"@pt , "momento torcente"@it ;
+  rdfs:label "Torsionmoment"@de ;
+  rdfs:label "coppia"@it ;
+  rdfs:label "couple"@fr ;
+  rdfs:label "moment obrotowy"@pl ;
+  rdfs:label "momento de torção"@pt ;
+  rdfs:label "par"@es ;
+  rdfs:label "torque"@en ;
+  rdfs:label "عزم محورى"@ar ;
+  rdfs:label "トルク"@ja ;
+  rdfs:label "转矩"@zh ;
+  skos:altLabel "Drillmoment"@de ;
+  skos:altLabel "binârio"@pt ;
+  skos:altLabel "moment de torsion"@fr ;
+  skos:altLabel "momento de torsión"@es ;
+  skos:altLabel "momento torcente"@it ;
 .
 quantitykind:TorquePerAngle
   a qudt:QuantityKind ;
@@ -20935,8 +22634,29 @@ quantitykind:Velocity
   qudt:plainTextDescription "In kinematics, velocity is the speed of an object and a specification of its direction of motion. Speed describes only how fast an object is moving, whereas velocity gives both how fast and in what direction the object is moving. " ;
   qudt:symbol "v" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "velocity"@en , "Geschwindigkeit"@de , "vitesse"@fr , "velocidad"@es , "velocidade"@pt , "velocità"@it , "viteză"@ro , "hitrost"@sl , "Rychlost"@cs , "prędkość"@pl , "Ско́рость"@ru , "hız"@tr , "Επιφάνεια"@el , "מהירות"@he , "السرعة"@ar , "سرعت/تندی"@fa , "गति"@hi , "速度"@zh , "速力"@ja , "Halaju"@ms , "velocitas"@la ;
-  skos:altLabel "rapidez"@es , "वेग"@hi ;
+  rdfs:label "Geschwindigkeit"@de ;
+  rdfs:label "Halaju"@ms ;
+  rdfs:label "Rychlost"@cs ;
+  rdfs:label "hitrost"@sl ;
+  rdfs:label "hız"@tr ;
+  rdfs:label "prędkość"@pl ;
+  rdfs:label "velocidad"@es ;
+  rdfs:label "velocidade"@pt ;
+  rdfs:label "velocitas"@la ;
+  rdfs:label "velocity"@en ;
+  rdfs:label "velocità"@it ;
+  rdfs:label "vitesse"@fr ;
+  rdfs:label "viteză"@ro ;
+  rdfs:label "Επιφάνεια"@el ;
+  rdfs:label "Ско́рость"@ru ;
+  rdfs:label "מהירות"@he ;
+  rdfs:label "السرعة"@ar ;
+  rdfs:label "سرعت/تندی"@fa ;
+  rdfs:label "गति"@hi ;
+  rdfs:label "速力"@ja ;
+  rdfs:label "速度"@zh ;
+  skos:altLabel "rapidez"@es ;
+  skos:altLabel "वेग"@hi ;
 .
 quantitykind:VentilationRatePerFloorArea
   a qudt:QuantityKind ;
@@ -21704,7 +23424,18 @@ quantitykind:Wavelength
   qudt:symbol "λ" ;
   vaem:todo "belongs to SOQ-ISO" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Jarak gelombang"@ms , "Vlnové délka"@cs , "Wellenlänge"@de , "comprimento de onda"@pt , "dalga boyu"@tr , "longitud de onda"@es , "longueur d'onde"@fr , "lunghezza d'onda"@it , "wavelength"@en , "длина волны"@ru , "طول موج"@fa , "波长"@zh ;
+  rdfs:label "Jarak gelombang"@ms ;
+  rdfs:label "Vlnové délka"@cs ;
+  rdfs:label "Wellenlänge"@de ;
+  rdfs:label "comprimento de onda"@pt ;
+  rdfs:label "dalga boyu"@tr ;
+  rdfs:label "longitud de onda"@es ;
+  rdfs:label "longueur d'onde"@fr ;
+  rdfs:label "lunghezza d'onda"@it ;
+  rdfs:label "wavelength"@en ;
+  rdfs:label "длина волны"@ru ;
+  rdfs:label "طول موج"@fa ;
+  rdfs:label "波长"@zh ;
   skos:broader quantitykind:Length ;
 .
 quantitykind:Wavenumber
@@ -21732,9 +23463,24 @@ Or:
   qudt:latexSymbol "\\(\\sigma\\)"^^qudt:LatexString ;
   qudt:plainTextDescription "\"Wavenumber\" is the spatial frequency of a wave - the number of waves that exist over a specified distance. More formally, it is the reciprocal of the wavelength. It is also the magnitude of the wave vector. Light passing through different media keeps its frequency, but not its wavelength or wavenumber. The unit for wavenumber commonly used in spectroscopy is centimetre to power minus one, PER-CM, rather than metre to power minus one, PER-M." ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "wavenumber"@en , "Repetenz"@de , "nombre d'onde"@fr , "número de ola"@es , "número de onda"@pt , "numero d'onda"@it , "valovno število"@sl , "Vlnové číslo"@cs , "Liczba falowa"@pl , "Волновое число"@ru , "dalga sayısı"@tr , "عدد الموجة"@ar , "عدد موج"@fa , "波数"@zh , "波数"@ja , "Bilangan gelombang"@ms ;
-  skos:altLabel "Wellenzahl"@de ;
+  rdfs:label "Bilangan gelombang"@ms ;
+  rdfs:label "Liczba falowa"@pl ;
+  rdfs:label "Repetenz"@de ;
+  rdfs:label "Vlnové číslo"@cs ;
+  rdfs:label "dalga sayısı"@tr ;
+  rdfs:label "nombre d'onde"@fr ;
+  rdfs:label "numero d'onda"@it ;
+  rdfs:label "número de ola"@es ;
+  rdfs:label "número de onda"@pt ;
+  rdfs:label "valovno število"@sl ;
+  rdfs:label "wavenumber"@en ;
+  rdfs:label "Волновое число"@ru ;
+  rdfs:label "عدد الموجة"@ar ;
+  rdfs:label "عدد موج"@fa ;
+  rdfs:label "波数"@ja ;
+  rdfs:label "波数"@zh ;
   rdfs:seeAlso quantitykind:AngularWavenumber ;
+  skos:altLabel "Wellenzahl"@de ;
   skos:broader quantitykind:InverseLength ;
 .
 quantitykind:WebTime
@@ -21896,7 +23642,22 @@ quantitykind:Weight
   qudt:plainTextDescription "The force with which a body is attracted toward an astronomical body.  Or, the product of the mass of a body and the acceleration acting on a body.  In a dynamic situation, the weight can be a multiple of that under resting conditions. Weight also varies on other planets in accordance with their gravity." ;
   qudt:symbol "bold letter W" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Ağırlık"@tr , "Berat"@ms , "Gewicht"@de , "Siła ciężkości"@pl , "forza peso"@it , "greutate"@ro , "peso"@es , "peso"@pt , "poids"@fr , "tíha"@cs , "weight"@en , "Вес"@ru , "وزن"@ar , "وزن"@fa , "重さ"@ja , "重量"@zh ;
+  rdfs:label "Ağırlık"@tr ;
+  rdfs:label "Berat"@ms ;
+  rdfs:label "Gewicht"@de ;
+  rdfs:label "Siła ciężkości"@pl ;
+  rdfs:label "forza peso"@it ;
+  rdfs:label "greutate"@ro ;
+  rdfs:label "peso"@es ;
+  rdfs:label "peso"@pt ;
+  rdfs:label "poids"@fr ;
+  rdfs:label "tíha"@cs ;
+  rdfs:label "weight"@en ;
+  rdfs:label "Вес"@ru ;
+  rdfs:label "وزن"@ar ;
+  rdfs:label "وزن"@fa ;
+  rdfs:label "重さ"@ja ;
+  rdfs:label "重量"@zh ;
   skos:broader quantitykind:Force ;
 .
 quantitykind:Width
@@ -22000,7 +23761,22 @@ quantitykind:Work
   qudt:plainTextDescription "A force is said to do Work when it acts on a body so that there is a displacement of the point of application, however small, in the direction of the force.  The concepts of work and energy are closely tied to the concept of force because an applied force can do work on an object and cause a change in energy. Energy is defined as the ability to do work. Work is done on an object when an applied force moves it through a distance. Kinetic energy is the energy of an object in motion. The net work is equal to the change in kinetic energy." ;
   qudt:symbol "A" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Arbeit"@de , "delo"@sl , "iş"@tr , "kerja"@ms , "lavoro"@it , "lucru mecanic"@ro , "praca"@pl , "práce"@cs , "trabajo"@es , "trabalho"@pt , "travail"@fr , "work"@en , "کار"@fa , "कार्य"@hi , "仕事量"@ja , "功"@zh ;
+  rdfs:label "Arbeit"@de ;
+  rdfs:label "delo"@sl ;
+  rdfs:label "iş"@tr ;
+  rdfs:label "kerja"@ms ;
+  rdfs:label "lavoro"@it ;
+  rdfs:label "lucru mecanic"@ro ;
+  rdfs:label "praca"@pl ;
+  rdfs:label "práce"@cs ;
+  rdfs:label "trabajo"@es ;
+  rdfs:label "trabalho"@pt ;
+  rdfs:label "travail"@fr ;
+  rdfs:label "work"@en ;
+  rdfs:label "کار"@fa ;
+  rdfs:label "कार्य"@hi ;
+  rdfs:label "仕事量"@ja ;
+  rdfs:label "功"@zh ;
   skos:broader quantitykind:Energy ;
 .
 quantitykind:WorkFunction

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -3307,7 +3307,7 @@ unit:CD-PER-LM
   qudt:hasQuantityKind quantitykind:LuminousIntensityDistribution ;
   qudt:symbol "cd/lm" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
-  rdfs:label "Candela per Lumen" ;
+  rdfs:label "Candela per Lumen"@en ;
 .
 unit:CD-PER-M2
   a qudt:DerivedUnit ;
@@ -16562,7 +16562,8 @@ unit:MOL-PER-M2-DAY
   qudt:symbol "mol/(m²⋅day)" ;
   qudt:ucumCode "mol.m-2.d-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
-  rdfs:label "Moles per square metre per day" ;
+  rdfs:label "Moles per Square Metre per Day"@en ;
+  rdfs:label "Moles per Square Metre per Day"@en-us ;
 .
 unit:MOL-PER-M2-SEC
   a qudt:Unit ;
@@ -21442,7 +21443,8 @@ unit:N-M-PER-M-RAD
   qudt:hasQuantityKind quantitykind:ModulusOfRotationalSubgradeReaction ;
   qudt:symbol "N⋅m/(m⋅rad)" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
-  rdfs:label "Newton Metre per Metre per Radians" ;
+  rdfs:label "Newton Meter per Meter per Radian"@en-us ;
+  rdfs:label "Newton Metre per Metre per Radian"@en ;
 .
 unit:N-M-PER-M2
   a qudt:Unit ;
@@ -25909,7 +25911,7 @@ unit:PSU
   qudt:informativeReference "https://en.wikipedia.org/wiki/Salinity#PSU"^^xsd:anyURI ;
   qudt:symbol "PSU" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
-  rdfs:label "Practical salinity unit" ;
+  rdfs:label "Practical Salinity Unit"@en ;
   rdfs:seeAlso unit:PPTH ;
 .
 unit:PT
@@ -27962,7 +27964,7 @@ unit:SUSCEPTIBILITY_ELEC
   qudt:plainTextDescription "Electric susceptibility is a dimensionless proportionality constant that indicates the degree of polarization of a dielectric material in response to an applied electric field. Here P = epsilon_0 * chi_e * E. Where epsilon_0 is the electric permittivity of free space (electric constant), P is the polarization density of the material chi_e is the electric susceptibility and E is the electric field." ;
   qudt:symbol "χ" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
-  rdfs:label "Electric Susceptibility Unit" ;
+  rdfs:label "Electric Susceptibility Unit"@en ;
 .
 unit:SUSCEPTIBILITY_MAG
   a qudt:DerivedUnit ;
@@ -27983,7 +27985,7 @@ unit:SUSCEPTIBILITY_MAG
   qudt:plainTextDescription "Magnetic susceptibility is a dimensionless proportionality constant that indicates the degree of magnetization of a material in response to an applied magnetic field. Here M = chi * H. Where M is the magnetization of the material (the magnetic dipole moment per unit volume), measured in amperes per meter, and H is the magnetic field strength, also measured in amperes per meter. Chi is therefore a dimensionless quantity." ;
   qudt:symbol "χ" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
-  rdfs:label "Magnetic Susceptibility Unit" ;
+  rdfs:label "Magnetic Susceptibility Unit"@en ;
 .
 unit:SV
   a qudt:DerivedUnit ;
@@ -29288,7 +29290,7 @@ unit:V-A
   rdfs:label "voltampère"@fr ;
   rdfs:label "voltiamperio"@es ;
   rdfs:label "вольт-ампер"@ru ;
-  rdfs:label "فولت. أمبير" ;
+  rdfs:label "فولت. أمبير"@ar ;
 .
 unit:V-A-HR
   a qudt:Unit ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -16562,8 +16562,8 @@ unit:MOL-PER-M2-DAY
   qudt:symbol "mol/(m²⋅day)" ;
   qudt:ucumCode "mol.m-2.d-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Moles per Square Meter per Day"@en-us ;
   rdfs:label "Moles per Square Metre per Day"@en ;
-  rdfs:label "Moles per Square Metre per Day"@en-us ;
 .
 unit:MOL-PER-M2-SEC
   a qudt:Unit ;


### PR DESCRIPTION
A small fix to ensure all labels for units and quantity kinds have a language tag.

Note that one commit in this PR is just reserializing the quantity kinds file since it did not match Composer's normal output but contained no modifications otherwise.