### PR TITLE
feat: add the unit decisecond

### DIFF
--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -5881,22 +5881,6 @@ unit:DeciS
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "DeciSiemens"@en ;
 .
-unit:DeciSEC
-  a qudt:DerivedUnit ;
-  a qudt:Unit ;
-  dcterms:description "\"Decisecond\" is an SI unit for 'Time' expressed as \\(ds\\)."^^qudt:LatexString ;
-  qudt:applicableSystem sou:SI ;
-  qudt:conversionMultiplier 0.1 ;
-  qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T1D0 ;
-  qudt:hasQuantityKind quantitykind:Time ;
-  qudt:informativeReference "https://simple.wikipedia.org/w/index.php?title=Decisecond&oldid=8898314"^^xsd:anyURI ;
-  qudt:prefix prefix:Deci ;
-  qudt:symbol "ds" ;
-  qudt:ucumCode "ds"^^qudt:UCUMcs ;
-  qudt:uneceCommonCode "C26" ;
-  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
-  rdfs:label "decisecond"@en ;
-.
 unit:DeciS-PER-M
   a qudt:DerivedUnit ;
   a qudt:Unit ;
@@ -5914,6 +5898,22 @@ unit:DeciS-PER-M
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "decisiemens per meter"@en-us ;
   rdfs:label "decisiemens per metre"@en ;
+.
+unit:DeciSEC
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Decisecond\" is an SI unit for 'Time' expressed as \\(ds\\)."^^qudt:LatexString ;
+  qudt:applicableSystem sou:SI ;
+  qudt:conversionMultiplier 0.1 ;
+  qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T1D0 ;
+  qudt:hasQuantityKind quantitykind:Time ;
+  qudt:informativeReference "https://simple.wikipedia.org/w/index.php?title=Decisecond&oldid=8898314"^^xsd:anyURI ;
+  qudt:prefix prefix:Deci ;
+  qudt:symbol "ds" ;
+  qudt:ucumCode "ds"^^qudt:UCUMcs ;
+  qudt:uneceCommonCode "C26" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "decisecond"@en ;
 .
 unit:DeciTONNE
   a qudt:Unit ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -5881,6 +5881,22 @@ unit:DeciS
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "DeciSiemens"@en ;
 .
+unit:DeciSEC
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Decisecond\" is an SI unit for 'Time' expressed as \\(ds\\)."^^qudt:LatexString ;
+  qudt:applicableSystem sou:SI ;
+  qudt:conversionMultiplier 0.1 ;
+  qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T1D0 ;
+  qudt:hasQuantityKind quantitykind:Time ;
+  qudt:informativeReference "https://simple.wikipedia.org/w/index.php?title=Decisecond&oldid=8898314"^^xsd:anyURI ;
+  qudt:prefix prefix:Deci ;
+  qudt:symbol "ds" ;
+  qudt:ucumCode "ds"^^qudt:UCUMcs ;
+  qudt:uneceCommonCode "C26" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "decisecond"@en ;
+.
 unit:DeciS-PER-M
   a qudt:DerivedUnit ;
   a qudt:Unit ;


### PR DESCRIPTION
This unit is generally used by BACnet protocol, so it's generally relevant for building automation applications. It could also be useful elsewhere, and for the sake of completeness.