### PR TITLE
Remove erroneous skos:broader triples

### DIFF
--- a/collections/COLLECTION_QUDT_QA_TESTS_ALL-v2.1.ttl
+++ b/collections/COLLECTION_QUDT_QA_TESTS_ALL-v2.1.ttl
@@ -39,7 +39,8 @@
       sh:prefix "skos" ;
     ] ;
 .
-qudt:QuantityKind
+qudt:QuantityKindShape
+  sh:targetClass qudt:QuantityKind ;
   sh:property [
       sh:path qudt:hasDimensionVector ;
       rdfs:comment "Check for inconsistent dimensionvectors in the skos:broader hierarchy" ;
@@ -48,18 +49,38 @@ qudt:QuantityKind
           sh:message "{$this} has a dimension vector that is inconsistent with {?qk} in its skos:broader hierarchy." ;
           sh:prefixes <http://qudt.org/2.1/collection/qa/all> ;
           sh:select """
-SELECT $this ?qk
-WHERE {
-$this qudt:hasDimensionVector  ?udv .
-$this skos:broader* ?qk .
-?qk qudt:hasDimensionVector ?qdv .
-FILTER (?udv != ?qdv) .
-}
-""" ;
-        ] ;
-    ] ;
-.
-qudt:Unit
+                SELECT $this ?qk
+                WHERE {
+                $this qudt:hasDimensionVector  ?udv .
+                $this skos:broader* ?qk .
+                ?qk qudt:hasDimensionVector ?qdv .
+                FILTER (?udv != ?qdv) .
+                }
+          """ ;
+      ] ;
+  ] ;
+  sh:property [
+      sh:path qudt:exactMatch ;
+      rdfs:comment "Check for inconsistent qudt:exactMatch vs skos:broader triples" ;
+      sh:sparql [
+              a sh:SPARQLConstraint ;
+              sh:message "{$this} is skos:broader and qudt:exactMatch with {?qk}." ;
+              sh:prefixes <http://qudt.org/2.1/collection/qa/all> ;
+              sh:select """
+                SELECT DISTINCT $this ?qk
+                WHERE {
+                $this
+                    skos:broader ?qk ;
+                    qudt:exactMatch ?qk .
+                }
+              """ ;
+      ] ;
+  ] .
+
+
+
+qudt:UnitShape
+  sh:targetClass qudt:Unit ;
   sh:property [
       sh:path qudt:exactMatch ;
       rdfs:comment "Check for non-reciprocal owl:sameAs and qudt:exactMatch triples" ;

--- a/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
+++ b/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
@@ -5000,7 +5000,6 @@ quantitykind:DynamicViscosity
   rdfs:label "动力粘度"@zh ;
   rdfs:label "粘度"@ja ;
   skos:altLabel "viscosità di taglio"@it ;
-  skos:broader quantitykind:Viscosity ;
 .
 quantitykind:EarthClosestApproachVehicleVelocity
   a qudt:QuantityKind ;
@@ -5810,7 +5809,6 @@ quantitykind:ElectricPotential
   rdfs:label "電位"@ja ;
   rdfs:label "電勢"@zh ;
   skos:altLabel "vis electromotrix"@la ;
-  skos:broader quantitykind:EnergyPerElectricCharge ;
 .
 quantitykind:ElectricPotentialDifference
   a qudt:QuantityKind ;
@@ -5854,7 +5852,6 @@ quantitykind:ElectricPotentialDifference
   skos:altLabel "tension"@en ;
   skos:altLabel "tensione elettrica"@it ;
   skos:altLabel "tensiune"@ro ;
-  skos:broader quantitykind:EnergyPerElectricCharge ;
 .
 quantitykind:ElectricPower
   a qudt:QuantityKind ;
@@ -11142,7 +11139,6 @@ quantitykind:LinearStrain
   qudt:plainTextDescription "A strain is a normalized measure of deformation representing the displacement between particles in the body relative to a reference length." ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
   rdfs:label "Linear Strain"@en ;
-  skos:broader quantitykind:Strain ;
 .
 quantitykind:LinearThermalExpansion
   a qudt:QuantityKind ;
@@ -16250,7 +16246,6 @@ quantitykind:PlaneAngle
   rdfs:label "क्षेत्र"@hi ;
   rdfs:label "弧度"@ja ;
   rdfs:label "角度"@zh ;
-  skos:broader quantitykind:Angle ;
 .
 quantitykind:PoissonRatio
   a qudt:QuantityKind ;
@@ -22852,7 +22847,6 @@ For an irrotational electric field, the voltage is independent of the path betwe
   qudt:symbol "U" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
   rdfs:label "Voltage"@en ;
-  skos:broader quantitykind:EnergyPerElectricCharge ;
 .
 quantitykind:VoltagePercentage
   a qudt:QuantityKind ;


### PR DESCRIPTION
Fixes #817 

When adding qudt:exactMatch, a number of quantitykinds did not have their skos:broader triples removed. This commit removes them (assuming that in all these cases, the qudt:exactMatch triple was correctly added).

Also, a check for this constellation is added to the collections/COLLECTION_QUDT_QA_TESTS_ALL-v2.1.ttl test file. Moreover, the node shapes in that file is adapted to include an explicit `targetClass` triple as this makes it easier to validate with those files - no need to import the ontology.