### PR TITLE
DRAFT: POC for Using xsd:decimal while maintaining readability

### DIFF
--- a/collections/COLLECTION_QUDT_QA_TESTS_ALL-v2.1.ttl
+++ b/collections/COLLECTION_QUDT_QA_TESTS_ALL-v2.1.ttl
@@ -38,6 +38,10 @@
       sh:namespace "http://www.w3.org/2004/02/skos/core#"^^xsd:anyURI ;
       sh:prefix "skos" ;
     ] ;
+  sh:declare [
+      sh:namespace "http://www.w3.org/2001/XMLSchema#"^^xsd:anyURI ;
+      sh:prefix "xsd" ;
+    ] ;
 .
 qudt:QuantityKind
   sh:property [
@@ -59,7 +63,46 @@ FILTER (?udv != ?qdv) .
         ] ;
     ] ;
 .
-qudt:Unit
+qudt:UnitShape
+  sh:targetClass qudt:Unit;
+    rdfs:comment "qudt:conversionMultiplier must match qudt:conversionMultiplierInScientificNotation if present" ;
+    sh:sparql [
+        a sh:SPARQLConstraint ;
+        sh:minCount 1;
+        sh:message "{$this} qudt:conversionMultiplier is {?actual}, which does not match {?expected}, m:{?m} e:{?e} mNoDot:{?mNoDot} mDigitCount:{?mDigitCount} exponent:{?exponent} startPos:{?startPos} high:{?highDigits} low:{?lowDigits} expected:{?expectedStringValue} result:{?result} " ;
+        sh:prefixes <http://qudt.org/2.1/collection/qa/all> ;
+        sh:select """
+            SELECT $this ?actual ?expected ?m ?e ?exponent ?mNoDot ?mDigitCount ?startPos ?highDigits ?lowDigits ?expectedStringValue ?tmp ?result
+            WHERE {
+                # select both values
+                $this
+                    qudt:conversionMultiplier ?actual ;
+                    qudt:conversionMultiplierInScientificNotation ?expected .
+                BIND(REPLACE(STR(?expected), "[eE]-?\\\\d+$", "") as ?m)               # extract the mantissa (string)
+                BIND(REPLACE(STR(?expected), "^\\\\d(\\\\.\\\\d+)?[eE]", "") as ?e)    # extract the exponent (string)
+                BIND(REPLACE(STR(?m),"\\\\.","") AS ?mNoDot)                           # remove the comma from the mantissa
+                BIND(STRLEN(?mNoDot) as ?mDigitCount)                                  # count the mantissa's characters
+                BIND(xsd:integer(?e) as  ?exponent)                                    # cast e to an integer, called exponent
+                # prepare a string with 200 zeros padding left and right, mantissa in the middle
+                BIND(CONCAT(
+                                    "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                                    ?mNoDot,
+                                    "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000") as ?baseStr)
+                BIND(IF(?exponent > 0, 201, 200 + ?exponent + 1) as ?startPos)         # determine the start position for clipping
+                BIND(IF(?exponent > 0, ?exponent + 1, 1) as ?highDigits)               # determine the number of digits before the comma
+                # determine the number of digits after the comma
+                BIND(IF(?exponent > 0, IF(?mDigitCount - ?exponent > 1, ?mDigitCount - ?exponent - 1, 1), ?mDigitCount - ?exponent - 1) as ?lowDigits)
+                # determine the expected string
+                BIND(CONCAT(SUBSTR(?baseStr, ?startPos, ?highDigits), ".", SUBSTR(?baseStr, ?startPos + ?highDigits, ?lowDigits)) as  ?expectedStringValue)
+                # compare with actual
+                BIND(IF(?expectedStringValue = STR(?actual), "match!", "no match!") as ?result)
+                # only generate message if no match (useful during development)
+                FILTER(?result != "match!")
+            }
+        """ ;
+      ] ;
+
+
   sh:property [
       sh:path qudt:exactMatch ;
       rdfs:comment "Check for non-reciprocal owl:sameAs and qudt:exactMatch triples" ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -519,7 +519,8 @@ unit:ARCSEC
   a qudt:Unit ;
   dcterms:description "\"Arc Second\" is a unit of angular measure, also called the \\(\\textit{second of arc}\\), equal to \\(1/60 \\; arcminute\\). One arcsecond is a very small angle: there are 1,296,000 in a circle. The SI recommends \\(\\textit{double prime}\\) (\\(''\\)) as the symbol for the arcsecond. The symbol has become common in astronomy, where very small angles are stated in milliarcseconds (\\(mas\\))."^^qudt:LatexString ;
   qudt:applicableSystem sou:USCS ;
-  qudt:conversionMultiplier 4.84813681e-06 ;
+  qudt:conversionMultiplier 0.00000484813681 ;
+  qudt:conversionMultiplierInScientificNotation "4.84813681e-06"^^xsd:double ;
   qudt:definedUnitOfSystem sou:USCS ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Angle ;
@@ -600,7 +601,8 @@ unit:ATM
   a qudt:Unit ;
   dcterms:description "The standard atmosphere (symbol: atm) is an international reference pressure defined as \\(101.325 \\,kPa\\) and formerly used as unit of pressure. For practical purposes it has been replaced by the bar which is \\(100 kPa\\). The difference of about 1% is not significant for many applications, and is within the error range of common pressure gauges."^^qudt:LatexString ;
   qudt:applicableSystem sou:CGS ;
-  qudt:conversionMultiplier 1.01325e05 ;
+  qudt:conversionMultiplier 101325.0 ;
+  qudt:conversionMultiplierInScientificNotation "1.01325e05"^^xsd:double ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerArea ;
   qudt:hasQuantityKind quantitykind:VaporPressure ;
@@ -4866,7 +4868,8 @@ unit:DEG_C-WK
   dcterms:description "temperature multiplied by unit of time."@en ;
   qudt:applicableSystem sou:CGS ;
   qudt:applicableSystem sou:SI ;
-  qudt:conversionMultiplier 6.04800e05 ;
+  qudt:conversionMultiplier 604800.0 ;
+  qudt:conversionMultiplierInScientificNotation "6.04800e05"^^xsd:double ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H1T1D0 ;
   qudt:hasQuantityKind quantitykind:TimeTemperature ;
   qudt:symbol "°C/wk" ;
@@ -6328,7 +6331,8 @@ where, \\(e\\) is the elementary charge, \\(\\epsilon_0\\) is the electric const
 unit:EarthMass
   a qudt:Unit ;
   dcterms:description "Earth mass (\\(M_{\\oplus}\\)) is the unit of mass equal to that of the Earth. In SI Units, \\(1 M_{\\oplus} = 5.9722 \\times 10^{24} kg\\). Earth mass is often used to describe masses of rocky terrestrial planets. The four terrestrial planets of the Solar System, Mercury, Venus, Earth, and Mars, have masses of 0.055, 0.815, 1.000, and 0.107 Earth masses respectively."^^qudt:LatexString ;
-  qudt:conversionMultiplier 5.97219e24 ;
+  qudt:conversionMultiplier 5972190000000000000000000.0 ;
+  qudt:conversionMultiplierInScientificNotation "5.97219e24"^^xsd:double ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Earth_mass"^^xsd:anyURI ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Mass ;
@@ -8743,7 +8747,8 @@ unit:GibiBYTE
   qudt:applicableSystem sou:IMPERIAL ;
   qudt:applicableSystem sou:PLANCK ;
   qudt:applicableSystem sou:SI ;
-  qudt:conversionMultiplier 5.9540889436391441429912255610071e09 ;
+  qudt:conversionMultiplier 5954088943.6391441429912255610071 ;
+  qudt:conversionMultiplierInScientificNotation "5.9540889436391441429912255610071e09"^^xsd:double ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Gibibyte"^^xsd:anyURI ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:InformationEntropy ;
@@ -16215,7 +16220,8 @@ unit:MI3
   dcterms:description "A cubic mile is an imperial / U.S. customary unit of volume, used in the United States, Canada, and the United Kingdom. It is defined as the volume of a cube with sides of 1 mile in length. "^^rdf:HTML ;
   qudt:applicableSystem sou:IMPERIAL ;
   qudt:applicableSystem sou:USCS ;
-  qudt:conversionMultiplier 4.168181830e09 ;
+  qudt:conversionMultiplier 4168181830.0 ;
+  qudt:conversionMultiplierInScientificNotation "4.168181830e09"^^xsd:double ;
   qudt:definedUnitOfSystem sou:IMPERIAL ;
   qudt:expression "\\(mi^{3}\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T0D0 ;
@@ -26904,7 +26910,8 @@ unit:PlanckVolt
 unit:PlanckVolume
   a qudt:Unit ;
   qudt:applicableSystem sou:PLANCK ;
-  qudt:conversionMultiplier 4.22419e-105 ;
+qudt:conversionMultiplier 0.00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000422419 ;
+qudt:conversionMultiplierInScientificNotation "4.22419e-105"^^xsd:double ;
   qudt:derivedUnitOfSystem sou:PLANCK ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Volume ;


### PR DESCRIPTION
This is a suggestion regarding #798

The suggestion implemented in this DRAFT PR is
* to use xsd:decimal as the datatype for any number,
* to use an additional property to encode the value as a number in scientific notation, easily verifiable by humans - let's call this the 'proofValue'.

The changes to the units ttl file were made in order to test the SHACL constraint, hopefully covering all the possible cases. The proofValues are added using the property `qudt:conversionMultiplierInScientificNotation`.

Details:
* encoding the proofValue as an xsd:double has the added benefit of syntax checking by the RDF engine.
* the SHACL rule takes the string literal value of the proofValue, transforms it into a digital number in non-scientific notation and compares that to the string literal value of the number in question

Note:
This is just a proof of concept - if adopted the question would be: do we use one proofValue property per value property, or do we use one property holding all proofValues for all numbers in the entity.

The former is straighforward based on this PR. The latter would require a format for the proof values property, such as ([property] [proofValue] [newline] )*, and the SHACL rule would have to do some more work (splitting by newline and selecting the value of [property] for each line).