### PR TITLE
Fix qudt:hasDimensionVector entries

### DIFF
--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -224,7 +224,17 @@ unit:A-PER-J
   qudt:conversionMultiplier 1.0 ;
   qudt:derivedCoherentUnitOfSystem sou:SI ;
   qudt:expression "\\(A/J\\)"^^qudt:LatexString ;
-  qudt:hasDimensionVector qkdv:A0E1L-2I0M-1H0T3D0 ;
+  # factor unit tree for unit A/J
+  #     +-- unit:A-PER-J                  	http://qudt.org/vocab/dimensionvector/A0E1L-2I0M-1H0T3D0
+  #     |   +-- unit:J^-1                     	http://qudt.org/vocab/dimensionvector/A0E0L-2I0M-1H0T2D0
+  #     |   |   +-- unit:N                        	http://qudt.org/vocab/dimensionvector/A0E0L1I0M1H0T-2D0
+  #     |   |   |   +-- unit:KiloGM                   	http://qudt.org/vocab/dimensionvector/A0E0L0I0M1H0T0D0
+  #     |   |   |   +-- unit:M                        	http://qudt.org/vocab/dimensionvector/A0E0L1I0M0H0T0D0
+  #     |   |   |   +-- unit:SEC^-2                   	http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T-2D0
+  #     |   |   +-- unit:M                        	http://qudt.org/vocab/dimensionvector/A0E0L1I0M0H0T0D0
+  #     |   +-- unit:A                        	http://qudt.org/vocab/dimensionvector/A0E1L0I0M0H0T0D0
+  #
+  qudt:hasDimensionVector qkdv:A0E1L-2I0M-1H0T2D0 ;
   qudt:hasQuantityKind quantitykind:ElectricCurrentPerUnitEnergy ;
   qudt:symbol "A/J" ;
   qudt:ucumCode "A.J-1"^^qudt:UCUMcs ;
@@ -695,7 +705,12 @@ unit:A_Ab-CentiM2
   qudt:applicableSystem sou:CGS-EMU ;
   qudt:conversionMultiplier 1.0e09 ;
   qudt:expression "\\(aAcm2\\)"^^qudt:LatexString ;
-  qudt:hasDimensionVector qkdv:A0E2L-3I0M-1H0T3D0 ;
+  # factor unit tree for unit abA⋅cm²
+  #     +-- unit:A_Ab-CentiM2             	http://qudt.org/vocab/dimensionvector/A0E2L-3I0M-1H0T3D0
+  #     |   +-- unit:A_Ab                     	http://qudt.org/vocab/dimensionvector/A0E1L0I0M0H0T0D0
+  #     |   +-- unit:CentiM^2                 	http://qudt.org/vocab/dimensionvector/A0E0L2I0M0H0T0D0
+  #
+  qudt:hasDimensionVector qkdv:A0E1L2I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:ElectricConductivity ;
   qudt:informativeReference "http://wordinfo.info/unit/4266"^^xsd:anyURI ;
   qudt:symbol "abA⋅cm²" ;
@@ -1853,7 +1868,13 @@ unit:BTU_IT-PER-LB-MOL
   qudt:applicableSystem sou:IMPERIAL ;
   qudt:applicableSystem sou:USCS ;
   qudt:expression "\\(Btu/(lb-mol)\\)"^^qudt:LatexString ;
-  qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-2D0 ;
+  # factor unit tree for unit Btu{IT}/(lb⋅mol)
+  #     +-- unit:BTU_IT-PER-LB-MOL        	http://qudt.org/vocab/dimensionvector/A0E0L2I0M0H0T-2D0
+  #     |   +-- unit:LB^-1                    	http://qudt.org/vocab/dimensionvector/A0E0L0I0M-1H0T0D0
+  #     |   +-- unit:MOL^-1                   	http://qudt.org/vocab/dimensionvector/A-1E0L0I0M0H0T0D0
+  #     |   +-- unit:BTU_IT                   	http://qudt.org/vocab/dimensionvector/A0E0L2I0M1H0T-2D0
+  #
+  qudt:hasDimensionVector qkdv:A-1E0L2I0M0H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:EnergyPerMassAmountOfSubstance ;
   qudt:symbol "Btu{IT}/(lb⋅mol)" ;
   qudt:ucumCode "[Btu_IT].[lb_av]-1.mol-1"^^qudt:UCUMcs ;
@@ -1883,7 +1904,14 @@ unit:BTU_IT-PER-LB_F-DEG_F
   qudt:applicableSystem sou:IMPERIAL ;
   qudt:applicableSystem sou:USCS ;
   qudt:conversionMultiplier 4186.8 ;
-  qudt:hasDimensionVector qkdv:A0E0L2I0M0H-1T-2D0 ;
+  # factor unit tree for unit Btu{IT}/(lbf⋅°F)
+  #     +-- unit:BTU_IT-PER-LB_F-DEG_F    	http://qudt.org/vocab/dimensionvector/A0E0L2I0M0H-1T-2D0
+  #     |   +-- unit:BTU_IT                   	http://qudt.org/vocab/dimensionvector/A0E0L2I0M1H0T-2D0
+  #     |   +-- unit:LB_F^-1                  	http://qudt.org/vocab/dimensionvector/A0E0L-1I0M-1H0T2D0
+  #     |   +-- unit:DEG_F^-1                 	http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H-1T0D0
+  #
+  qudt:hasDimensionVector qkdv:A0E0L1I0M0H-1T0D0 ;
+
   qudt:hasQuantityKind quantitykind:SpecificHeatCapacity ;
   qudt:iec61360Code "0112/2///62720#UAA119" ;
   qudt:plainTextDescription "unit of the heat energy according to the Imperial system of units divided by the product of the units avoirdupois pound according to the avoirdupois system of units and degree Fahrenheit" ;
@@ -1900,7 +1928,13 @@ unit:BTU_IT-PER-LB_F-DEG_R
   qudt:applicableSystem sou:IMPERIAL ;
   qudt:applicableSystem sou:USCS ;
   qudt:conversionMultiplier 426.9 ;
-  qudt:hasDimensionVector qkdv:A0E0L2I0M0H-1T-2D0 ;
+  # factor unit tree for unit Btu{IT}/(lbf⋅°R)
+  #     +-- unit:BTU_IT-PER-LB_F-DEG_R    	http://qudt.org/vocab/dimensionvector/A0E0L2I0M0H-1T-2D0
+  #     |   +-- unit:DEG_R^-1                 	http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H-1T0D0
+  #     |   +-- unit:BTU_IT                   	http://qudt.org/vocab/dimensionvector/A0E0L2I0M1H0T-2D0
+  #     |   +-- unit:LB_F^-1                  	http://qudt.org/vocab/dimensionvector/A0E0L-1I0M-1H0T2D0
+  #
+  qudt:hasDimensionVector qkdv:A0E0L1I0M0H-1T0D0 ;
   qudt:hasQuantityKind quantitykind:SpecificHeatCapacity ;
   qudt:iec61360Code "0112/2///62720#UAB141" ;
   qudt:plainTextDescription "unit of the heat capacity as British thermal unit according to the international table related to degree Rankine according to the Imperial system of units divided by the unit avoirdupois pound according to the avoirdupois system of units" ;
@@ -4932,7 +4966,12 @@ unit:DEG_F-HR
   qudt:definedUnitOfSystem sou:IMPERIAL ;
   qudt:definedUnitOfSystem sou:USCS ;
   qudt:expression "\\(degF-hr\\)"^^qudt:LatexString ;
-  qudt:hasDimensionVector qkdv:A0E0L-1I0M-1H1T3D0 ;
+  # factor unit tree for unit °F⋅hr
+  #     +-- unit:DEG_F-HR                 	http://qudt.org/vocab/dimensionvector/A0E0L-1I0M-1H1T3D0
+  #     |   +-- unit:HR                       	http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T1D0
+  #     |   +-- unit:DEG_F                    	http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H1T0D0
+  #
+  qudt:hasDimensionVector qkdv:A0E0L0I0M0H1T1D0 ;
   qudt:hasQuantityKind quantitykind:ThermalResistivity ;
   qudt:symbol "°F⋅hr" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -6769,7 +6808,12 @@ unit:FT-LA
   qudt:conversionMultiplier 3.4262591 ;
   qudt:definedUnitOfSystem sou:USCS ;
   qudt:expression "\\(ft-L\\)"^^qudt:LatexString ;
-  qudt:hasDimensionVector qkdv:A0E0L-2I1M0H0T0D0 ;
+  # factor unit tree for unit ft⋅L
+  #     +-- unit:FT-LA                    	http://qudt.org/vocab/dimensionvector/A0E0L-2I1M0H0T0D0
+  #     |   +-- unit:LA                       	http://qudt.org/vocab/dimensionvector/A0E0L-2I1M0H0T0D0
+  #     |   +-- unit:FT                       	http://qudt.org/vocab/dimensionvector/A0E0L1I0M0H0T0D0
+  #
+  qudt:hasDimensionVector qkdv:A0E0L-1I1M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Luminance ;
   qudt:symbol "ft⋅L" ;
   qudt:ucumCode "[ft_i].Lmb"^^qudt:UCUMcs ;
@@ -7120,7 +7164,13 @@ unit:FT2-PER-BTU_IT-IN
   qudt:definedUnitOfSystem sou:IMPERIAL ;
   qudt:definedUnitOfSystem sou:USCS ;
   qudt:expression "\\(ft2-per-btu-in\\)"^^qudt:LatexString ;
-  qudt:hasDimensionVector qkdv:A0E0L-1I0M-1H1T3D0 ;
+  # factor unit tree for unit ft²/btu⋅in
+  #     +-- unit:FT2-PER-BTU_IT-IN        	http://qudt.org/vocab/dimensionvector/A0E0L-1I0M-1H1T3D0
+  #     |   +-- unit:FT^2                     	http://qudt.org/vocab/dimensionvector/A0E0L2I0M0H0T0D0
+  #     |   +-- unit:IN^-1                    	http://qudt.org/vocab/dimensionvector/A0E0L-1I0M0H0T0D0
+  #     |   +-- unit:BTU_IT^-1                	http://qudt.org/vocab/dimensionvector/A0E0L-2I0M-1H0T2D0
+  #
+  qudt:hasDimensionVector qkdv:A0E0L-1I0M-1H0T2D0 ;
   qudt:hasQuantityKind quantitykind:ThermalResistivity ;
   qudt:symbol "ft²/btu⋅in" ;
   qudt:ucumCode "[sft_i].[Btu_IT]-1.[in_i]-1"^^qudt:UCUMcs ;
@@ -8117,7 +8167,13 @@ unit:GM-PER-DEG_C
   qudt:applicableSystem sou:CGS ;
   qudt:applicableSystem sou:SI ;
   qudt:expression "\\(g-degC\\)"^^qudt:LatexString ;
-  qudt:hasDimensionVector qkdv:A0E0L0I0M1H1T0D0 ;
+  # factor unit tree for unit g/°C
+  #     +-- unit:GM-PER-DEG_C             	http://qudt.org/vocab/dimensionvector/A0E0L0I0M1H1T0D0
+  #     |   +-- unit:DEG_C^-1                 	http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H-1T0D0
+  #     |   |   +-- unit:K                        	http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H1T0D0
+  #     |   +-- unit:GM                       	http://qudt.org/vocab/dimensionvector/A0E0L0I0M1H0T0D0
+  #
+  qudt:hasDimensionVector qkdv:A0E0L0I0M1H-1T0D0 ;
   qudt:hasQuantityKind quantitykind:MassTemperature ;
   qudt:symbol "g/°C" ;
   qudt:ucumCode "d.Cel-1"^^qudt:UCUMcs ;
@@ -8863,7 +8919,14 @@ unit:GigaC-PER-M3
   qudt:applicableSystem sou:CGS-GAUSS ;
   qudt:applicableSystem sou:SI ;
   qudt:conversionMultiplier 1.0e09 ;
-  qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T-1D0 ;
+  # factor unit tree for unit GC/m³
+  #     +-- unit:GigaC-PER-M3             	http://qudt.org/vocab/dimensionvector/A0E0L1I0M0H0T-1D0
+  #     |   +-- unit:GigaC                    	http://qudt.org/vocab/dimensionvector/A0E1L0I0M0H0T1D0
+  #     |   |   +-- unit:A                        	http://qudt.org/vocab/dimensionvector/A0E1L0I0M0H0T0D0
+  #     |   |   +-- unit:SEC                      	http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T1D0
+  #     |   +-- unit:M^-3                     	http://qudt.org/vocab/dimensionvector/A0E0L-3I0M0H0T0D0
+  #
+  qudt:hasDimensionVector qkdv:A0E1L-3I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Speed ;
   qudt:iec61360Code "0112/2///62720#UAA149" ;
   qudt:plainTextDescription "1 000 000 000-fold of the SI derived unit coulomb divided by the power of the SI base unit metre with the exponent 3" ;
@@ -9704,7 +9767,19 @@ unit:HectoPA-L-PER-SEC
   qudt:applicableSystem sou:CGS-GAUSS ;
   qudt:applicableSystem sou:SI ;
   qudt:conversionMultiplier 0.1 ;
-  qudt:hasDimensionVector qkdv:A0E0L4I0M1H0T-3D0 ;
+  # factor unit tree for unit hPa⋅L/s
+  #     +-- unit:HectoPA-L-PER-SEC        	http://qudt.org/vocab/dimensionvector/A0E0L4I0M1H0T-3D0
+  #     |   +-- unit:L                        	http://qudt.org/vocab/dimensionvector/A0E0L3I0M0H0T0D0
+  #     |   |   +-- unit:DeciM^3                  	http://qudt.org/vocab/dimensionvector/A0E0L3I0M0H0T0D0
+  #     |   +-- unit:SEC^-1                   	http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T-1D0
+  #     |   +-- unit:HectoPA                  	http://qudt.org/vocab/dimensionvector/A0E0L-1I0M1H0T-2D0
+  #     |   |   +-- unit:M^-2                     	http://qudt.org/vocab/dimensionvector/A0E0L-2I0M0H0T0D0
+  #     |   |   +-- unit:N                        	http://qudt.org/vocab/dimensionvector/A0E0L1I0M1H0T-2D0
+  #     |   |   |   +-- unit:SEC^-2                   	http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T-2D0
+  #     |   |   |   +-- unit:M                        	http://qudt.org/vocab/dimensionvector/A0E0L1I0M0H0T0D0
+  #     |   |   |   +-- unit:KiloGM                   	http://qudt.org/vocab/dimensionvector/A0E0L0I0M1H0T0D0
+  #
+  qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:PowerArea ;
   qudt:iec61360Code "0112/2///62720#UAA530" ;
   qudt:plainTextDescription "product out of the 100-fold of the SI derived unit pascal and the unit litre divided by the SI base unit second" ;
@@ -9723,7 +9798,18 @@ unit:HectoPA-M3-PER-SEC
   qudt:applicableSystem sou:CGS-GAUSS ;
   qudt:applicableSystem sou:SI ;
   qudt:conversionMultiplier 100.0 ;
-  qudt:hasDimensionVector qkdv:A0E0L4I0M1H0T-3D0 ;
+  # factor unit tree for unit hPa⋅m³/s
+  #     +-- unit:HectoPA-M3-PER-SEC       	http://qudt.org/vocab/dimensionvector/A0E0L4I0M1H0T-3D0
+  #     |   +-- unit:SEC^-1                   	http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T-1D0
+  #     |   +-- unit:HectoPA                  	http://qudt.org/vocab/dimensionvector/A0E0L-1I0M1H0T-2D0
+  #     |   |   +-- unit:N                        	http://qudt.org/vocab/dimensionvector/A0E0L1I0M1H0T-2D0
+  #     |   |   |   +-- unit:M                        	http://qudt.org/vocab/dimensionvector/A0E0L1I0M0H0T0D0
+  #     |   |   |   +-- unit:KiloGM                   	http://qudt.org/vocab/dimensionvector/A0E0L0I0M1H0T0D0
+  #     |   |   |   +-- unit:SEC^-2                   	http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T-2D0
+  #     |   |   +-- unit:M^-2                     	http://qudt.org/vocab/dimensionvector/A0E0L-2I0M0H0T0D0
+  #     |   +-- unit:M^3                      	http://qudt.org/vocab/dimensionvector/A0E0L3I0M0H0T0D0
+  #
+  qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:PowerArea ;
   qudt:iec61360Code "0112/2///62720#UAA531" ;
   qudt:plainTextDescription "product out of the 100-fold of the SI unit pascal and the power of the SI base unit metre with the exponent 3 divided by the SI base unit second" ;
@@ -14130,7 +14216,13 @@ unit:LB-MOL-DEG_F
   a qudt:Unit ;
   dcterms:description "\\(\\textbf{Pound Mole Degree Fahrenheit} is a unit for 'Mass Amount Of Substance Temperature' expressed as \\(lb-mol-degF\\)."^^qudt:LatexString ;
   qudt:expression "\\(lb-mol-degF\\)"^^qudt:LatexString ;
-  qudt:hasDimensionVector qkdv:A1E0L0I0M0H1T0D0 ;
+  # factor unit tree for unit lb⋅mol⋅°F
+  #     +-- unit:LB-MOL-DEG_F             	http://qudt.org/vocab/dimensionvector/A1E0L0I0M0H1T0D0
+  #     |   +-- unit:MOL                      	http://qudt.org/vocab/dimensionvector/A1E0L0I0M0H0T0D0
+  #     |   +-- unit:DEG_F                    	http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H1T0D0
+  #     |   +-- unit:LB                       	http://qudt.org/vocab/dimensionvector/A0E0L0I0M1H0T0D0
+  #
+  qudt:hasDimensionVector qkdv:A1E0L0I0M1H1T0D0 ;
   qudt:hasQuantityKind quantitykind:MassAmountOfSubstanceTemperature ;
   qudt:symbol "lb⋅mol⋅°F" ;
   qudt:ucumCode "[lb_av].mol.[degF]"^^qudt:UCUMcs ;
@@ -14740,7 +14832,16 @@ unit:LM-SEC
   qudt:conversionMultiplier 1.0 ;
   qudt:derivedCoherentUnitOfSystem sou:SI ;
   qudt:expression "\\(lm s\\)"^^qudt:LatexString ;
-  qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
+  # factor unit tree for unit lm⋅s
+  #     +-- unit:LM-SEC                   	http://qudt.org/vocab/dimensionvector/A0E0L2I0M1H0T-2D0
+  #     |   +-- unit:LM                       	http://qudt.org/vocab/dimensionvector/A0E0L0I1M0H0T0D0
+  #     |   |   +-- unit:SR                       	http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1
+  #     |   |   |   +-- unit:M^-2                     	http://qudt.org/vocab/dimensionvector/A0E0L-2I0M0H0T0D0
+  #     |   |   |   +-- unit:M^2                      	http://qudt.org/vocab/dimensionvector/A0E0L2I0M0H0T0D0
+  #     |   |   +-- unit:CD                       	http://qudt.org/vocab/dimensionvector/A0E0L0I1M0H0T0D0
+  #     |   +-- unit:SEC                      	http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T1D0
+  #
+  qudt:hasDimensionVector qkdv:A0E0L0I1M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:LuminousEnergy ;
   qudt:iec61360Code "0112/2///62720#UAA722" ;
   qudt:symbol "lm⋅s" ;
@@ -15577,7 +15678,22 @@ unit:M2-PER-V-SEC
   qudt:applicableSystem sou:SI ;
   qudt:conversionMultiplier 1.0 ;
   qudt:expression "\\(m^2/v-s\\)"^^qudt:LatexString ;
-  qudt:hasDimensionVector qkdv:A0E1L0I0M-1H0T4D0 ;
+  # factor unit tree for unit m²/(V⋅s)
+  #     +-- unit:M2-PER-V-SEC             	http://qudt.org/vocab/dimensionvector/A0E1L0I0M-1H0T4D0
+  #     |   +-- unit:SEC^-1                   	http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T-1D0
+  #     |   +-- unit:M^2                      	http://qudt.org/vocab/dimensionvector/A0E0L2I0M0H0T0D0
+  #     |   +-- unit:V^-1                     	http://qudt.org/vocab/dimensionvector/A0E1L-2I0M-1H0T3D0
+  #     |   |   +-- unit:A^-1                     	http://qudt.org/vocab/dimensionvector/A0E-1L0I0M0H0T0D0
+  #     |   |   +-- unit:W                        	http://qudt.org/vocab/dimensionvector/A0E0L2I0M1H0T-3D0
+  #     |   |   |   +-- unit:J                        	http://qudt.org/vocab/dimensionvector/A0E0L2I0M1H0T-2D0
+  #     |   |   |   |   +-- unit:M                        	http://qudt.org/vocab/dimensionvector/A0E0L1I0M0H0T0D0
+  #     |   |   |   |   +-- unit:N                        	http://qudt.org/vocab/dimensionvector/A0E0L1I0M1H0T-2D0
+  #     |   |   |   |   |   +-- unit:M                        	http://qudt.org/vocab/dimensionvector/A0E0L1I0M0H0T0D0
+  #     |   |   |   |   |   +-- unit:SEC^-2                   	http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T-2D0
+  #     |   |   |   |   |   +-- unit:KiloGM                   	http://qudt.org/vocab/dimensionvector/A0E0L0I0M1H0T0D0
+  #     |   |   |   +-- unit:SEC^-1                   	http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T-1D0
+  #
+  qudt:hasDimensionVector qkdv:A0E1L0I0M-1H0T2D0 ;
   qudt:hasQuantityKind quantitykind:Mobility ;
   qudt:iec61360Code "0112/2///62720#UAA748" ;
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
@@ -18020,7 +18136,12 @@ unit:MicroG-PER-CentiM2
   dcterms:description "A unit of mass per area, equivalent to 0.01 grammes per square metre"^^rdf:HTML ;
   qudt:conversionMultiplier 0.01 ;
   qudt:conversionOffset 0.0 ;
-  qudt:hasDimensionVector qkdv:A0E0L-2I0M1H0T0D0 ;
+  # factor unit tree for unit µg/cm²
+  #     +-- unit:MicroG-PER-CentiM2       	http://qudt.org/vocab/dimensionvector/A0E0L-2I0M1H0T0D0
+  #     |   +-- unit:MicroG                   	http://qudt.org/vocab/dimensionvector/A0E0L1I0M0H0T-2D0
+  #     |   +-- unit:CentiM^-2                	http://qudt.org/vocab/dimensionvector/A0E0L-2I0M0H0T0D0
+  #
+  qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:MassPerArea ;
   qudt:plainTextDescription "A unit of mass per area, equivalent to 0.01 grammes per square metre" ;
   qudt:symbol "µg/cm²" ;
@@ -19023,7 +19144,19 @@ unit:MicroSV-PER-HR
   qudt:conversionMultiplier 2.77778e-10 ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Sievert"^^xsd:anyURI ;
   qudt:derivedUnitOfSystem sou:SI ;
-  qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-2D0 ;
+  # factor unit tree for unit µSv/hr
+  #     +-- unit:MicroSV-PER-HR           	http://qudt.org/vocab/dimensionvector/A0E0L2I0M0H0T-2D0
+  #     |   +-- unit:HR^-1                    	http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T-1D0
+  #     |   +-- unit:MicroSV                  	http://qudt.org/vocab/dimensionvector/A0E0L2I0M0H0T-2D0
+  #     |   |   +-- unit:KiloGM^-1                	http://qudt.org/vocab/dimensionvector/A0E0L0I0M-1H0T0D0
+  #     |   |   +-- unit:J                        	http://qudt.org/vocab/dimensionvector/A0E0L2I0M1H0T-2D0
+  #     |   |   |   +-- unit:N                        	http://qudt.org/vocab/dimensionvector/A0E0L1I0M1H0T-2D0
+  #     |   |   |   |   +-- unit:M                        	http://qudt.org/vocab/dimensionvector/A0E0L1I0M0H0T0D0
+  #     |   |   |   |   +-- unit:SEC^-2                   	http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T-2D0
+  #     |   |   |   |   +-- unit:KiloGM                   	http://qudt.org/vocab/dimensionvector/A0E0L0I0M1H0T0D0
+  #     |   |   |   +-- unit:M                        	http://qudt.org/vocab/dimensionvector/A0E0L1I0M0H0T0D0
+  #
+  qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:DoseEquivalent ;
   qudt:iec61360Code "0112/2///62720#UAB466" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Sievert?oldid=495474333"^^xsd:anyURI ;
@@ -24345,7 +24478,17 @@ unit:PER-J-M3
   qudt:applicableSystem sou:SI ;
   qudt:conversionMultiplier 1.0 ;
   qudt:expression "\\(j^{-1}-m^3\\)"^^qudt:LatexString ;
-  qudt:hasDimensionVector qkdv:A0E0L1I0M-1H0T2D0 ;
+  # factor unit tree for unit /(J⋅m³)
+  #     +-- unit:PER-J-M3                 	http://qudt.org/vocab/dimensionvector/A0E0L1I0M-1H0T2D0
+  #     |   +-- unit:J^-1                     	http://qudt.org/vocab/dimensionvector/A0E0L-2I0M-1H0T2D0
+  #     |   |   +-- unit:N                        	http://qudt.org/vocab/dimensionvector/A0E0L1I0M1H0T-2D0
+  #     |   |   |   +-- unit:KiloGM                   	http://qudt.org/vocab/dimensionvector/A0E0L0I0M1H0T0D0
+  #     |   |   |   +-- unit:SEC^-2                   	http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T-2D0
+  #     |   |   |   +-- unit:M                        	http://qudt.org/vocab/dimensionvector/A0E0L1I0M0H0T0D0
+  #     |   |   +-- unit:M                        	http://qudt.org/vocab/dimensionvector/A0E0L1I0M0H0T0D0
+  #     |   +-- unit:M^-3                     	http://qudt.org/vocab/dimensionvector/A0E0L-3I0M0H0T0D0
+  #
+  qudt:hasDimensionVector qkdv:A0E0L-5I0M-1H0T2D0 ;
   qudt:hasQuantityKind quantitykind:EnergyDensityOfStates ;
   qudt:informativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
   qudt:symbol "/(J⋅m³)" ;
@@ -25965,7 +26108,14 @@ unit:PSI-L-PER-SEC
   a qudt:Unit ;
   dcterms:description "product of the composed unit for pressure (pound-force per square inch) and the composed unit for volume flow (litre per second)"^^rdf:HTML ;
   qudt:conversionMultiplier 6.894757 ;
-  qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-3D0 ;
+  # factor unit tree for unit psi⋅L³/s
+  #     +-- unit:PSI-L-PER-SEC            	http://qudt.org/vocab/dimensionvector/A0E0L0I0M1H0T-3D0
+  #     |   +-- unit:L                        	http://qudt.org/vocab/dimensionvector/A0E0L3I0M0H0T0D0
+  #     |   |   +-- unit:DeciM^3                  	http://qudt.org/vocab/dimensionvector/A0E0L3I0M0H0T0D0
+  #     |   +-- unit:SEC^-1                   	http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T-1D0
+  #     |   +-- unit:PSI                      	http://qudt.org/vocab/dimensionvector/A0E0L-1I0M1H0T-2D0
+  #
+  qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:PowerPerArea ;
   qudt:iec61360Code "0112/2///62720#UAA704" ;
   qudt:plainTextDescription "product of the composed unit for pressure (pound-force per square inch) and the composed unit for volume flow (litre per second)" ;
@@ -26444,7 +26594,14 @@ unit:PicoMOL-PER-L-DAY
   dcterms:description "A change in the quantity of matter of 10^-12 moles in the SI unit of volume scaled by 10^-3 over a period of 86400 seconds."@en ;
   qudt:applicableSystem sou:SI ;
   qudt:conversionMultiplier 1.15740740740741e-14 ;
-  qudt:hasDimensionVector qkdv:A0E0L-3I0M1H0T-1D0 ;
+  # factor unit tree for unit pmol/day
+  #     +-- unit:PicoMOL-PER-L-DAY        	http://qudt.org/vocab/dimensionvector/A0E0L-3I0M1H0T-1D0
+  #     |   +-- unit:DAY^-1                   	http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T-1D0
+  #     |   +-- unit:L^-1                     	http://qudt.org/vocab/dimensionvector/A0E0L-3I0M0H0T0D0
+  #     |   |   +-- unit:DeciM^3                  	http://qudt.org/vocab/dimensionvector/A0E0L3I0M0H0T0D0
+  #     |   +-- unit:PicoMOL                  	http://qudt.org/vocab/dimensionvector/A1E0L0I0M0H0T0D0
+  #
+  qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:symbol "pmol/day" ;
   qudt:ucumCode "pmol.L-1.d-1"^^qudt:UCUMcs ;
@@ -26478,7 +26635,13 @@ unit:PicoMOL-PER-M2-DAY
   a qudt:Unit ;
   qudt:applicableSystem sou:SI ;
   qudt:conversionMultiplier 1.15740740740741e-17 ;
-  qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T-1D0 ;
+  # factor unit tree for unit pmol/(m²⋅day)
+  #     +-- unit:PicoMOL-PER-M2-DAY       	http://qudt.org/vocab/dimensionvector/A1E0L-3I0M0H0T-1D0
+  #     |   +-- unit:M^-2                     	http://qudt.org/vocab/dimensionvector/A0E0L-2I0M0H0T0D0
+  #     |   +-- unit:DAY^-1                   	http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T-1D0
+  #     |   +-- unit:PicoMOL                  	http://qudt.org/vocab/dimensionvector/A1E0L0I0M0H0T0D0
+  #
+  qudt:hasDimensionVector qkdv:A1E0L-2I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:symbol "pmol/(m²⋅day)" ;
   qudt:ucumCode "pmol.m-2.d-1"^^qudt:UCUMcs ;
@@ -26535,7 +26698,17 @@ unit:PicoPA-PER-KiloM
   qudt:applicableSystem sou:CGS-GAUSS ;
   qudt:applicableSystem sou:SI ;
   qudt:conversionMultiplier 1.0e-15 ;
-  qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-2D0 ;
+  # factor unit tree for unit pPa/km
+  #     +-- unit:PicoPA-PER-KiloM         	http://qudt.org/vocab/dimensionvector/A0E0L0I0M1H0T-2D0
+  #     |   +-- unit:KiloM^-1                 	http://qudt.org/vocab/dimensionvector/A0E0L-1I0M0H0T0D0
+  #     |   +-- unit:PicoPA                   	http://qudt.org/vocab/dimensionvector/A0E0L-1I0M1H0T-2D0
+  #     |   |   +-- unit:M^-2                     	http://qudt.org/vocab/dimensionvector/A0E0L-2I0M0H0T0D0
+  #     |   |   +-- unit:N                        	http://qudt.org/vocab/dimensionvector/A0E0L1I0M1H0T-2D0
+  #     |   |   |   +-- unit:KiloGM                   	http://qudt.org/vocab/dimensionvector/A0E0L0I0M1H0T0D0
+  #     |   |   |   +-- unit:M                        	http://qudt.org/vocab/dimensionvector/A0E0L1I0M0H0T0D0
+  #     |   |   |   +-- unit:SEC^-2                   	http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T-2D0
+  #
+  qudt:hasDimensionVector qkdv:A0E0L-2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:EnergyPerArea ;
   qudt:hasQuantityKind quantitykind:ForcePerLength ;
   qudt:iec61360Code "0112/2///62720#UAA933" ;


### PR DESCRIPTION
For each fix, a comment is provided that contains the 'factor unit tree' along with the dimension vectors of each the factor, so that reviewers can check the combination of those vectors and verify the error in the existing DV. These comments should be removed after verification of the replaced DVs.

All other dimension vectors are correct or cannot be verified because their factor units' dimension vectors are missing.