### PR TITLE
added 3 units to the list. unit:TONNE-PER-YR, unit:KiloTONNE-PER-YR, unit:KiloGM-PER-YR

### DIFF
--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -29690,6 +29690,65 @@ unit:TONNE-PER-DAY
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Tonne Per Day"@en ;
 .
+
+unit:TONNE-PER-YR
+      a qudt:Unit ;
+      dcterms:description "1,000-fold of the SI base unit kilogram divided by the unit year"^^rdf:HTML ;
+      qudt:applicableSystem sou:CGS ;
+      qudt:applicableSystem sou:CGS-EMU ;
+      qudt:applicableSystem sou:CGS-GAUSS ;
+      qudt:applicableSystem sou:SI ;
+      qudt:conversionMultiplier 3,168808781e-5 ;
+      qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-1D0 ;
+      qudt:hasQuantityKind quantitykind:MassFlowRate ;
+      qudt:plainTextDescription "metric tonne divided by the unit year with 365 days" ;
+      qudt:symbol "t/year" ;
+      qudt:ucumCode "t.a-1"^^qudt:UCUMcs ;
+      qudt:uneceCommonCode "M89" ;
+      rdfs:isDefinedBy <http://qudt.org/vocab/unit> ;
+      rdfs:label "Tonne Per Year"@en ;
+      rdfs:label "Ton Per Jaar"@nl ;
+      qudt:informativeReference "http://dd.eionet.europa.eu/vocabulary/wise/uom/t.a-1"^^xsd:anyURI ;
+.
+
+unit:KiloTONNE-PER-YR
+  a qudt:Unit ;
+  dcterms:description "1,000,000-fold of the SI base unit kilogram divided by the unit year"^^rdf:HTML ;
+  qudt:applicableSystem sou:CGS ;
+  qudt:applicableSystem sou:CGS-EMU ;
+  qudt:applicableSystem sou:CGS-GAUSS ;
+  qudt:applicableSystem sou:SI ;
+  qudt:conversionMultiplier 3,168808781e-2 ;
+  qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-1D0 ;
+  qudt:hasQuantityKind quantitykind:MassFlowRate ;
+  qudt:plainTextDescription "1000 metric tonne divided by the unit year with 365 days" ;
+  qudt:symbol "kt/year" ;
+  qudt:ucumCode "kt.a-1"^^qudt:UCUMcs ;
+  rdfs:isDefinedBy <http://qudt.org/vocab/unit> ;
+  rdfs:label "KiloTonne Per Year"@en ;
+  rdfs:label "KiloTon Per Jaar"@nl ;
+  qudt:informativeReference "http://dd.eionet.europa.eu/vocabulary/wise/uom/1000t.a-1"^^xsd:anyURI ;
+.
+
+unit:KiloGM-PER-YR
+  a qudt:Unit ;
+  dcterms:description "The SI base unit kilogram divided by the unit year"^^rdf:HTML ;
+  qudt:applicableSystem sou:CGS ;
+  qudt:applicableSystem sou:CGS-EMU ;
+  qudt:applicableSystem sou:CGS-GAUSS ;
+  qudt:applicableSystem sou:SI ;
+  qudt:conversionMultiplier 3,168808781e-8 ;
+  qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-1D0 ;
+  qudt:hasQuantityKind quantitykind:MassFlowRate ;
+  qudt:plainTextDescription "kilogram divided by the unit year with 365 days" ;
+  qudt:symbol "kg/year" ;
+  qudt:ucumCode "kg.a-1"^^qudt:UCUMcs ;
+  rdfs:isDefinedBy <http://qudt.org/vocab/unit> ;
+  rdfs:label "Kilogram Per Day"@en ;
+  rdfs:label "Kilogram Per Dag"@nl ;
+  qudt:informativeReference "http://dd.eionet.europa.eu/vocabulary/wise/uom/kg.a-1"^^xsd:anyURI;
+.
+
 unit:TONNE-PER-HA
   a qudt:DerivedUnit ;
   a qudt:Unit ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -29698,7 +29698,7 @@ unit:TONNE-PER-YR
       qudt:applicableSystem sou:CGS-EMU ;
       qudt:applicableSystem sou:CGS-GAUSS ;
       qudt:applicableSystem sou:SI ;
-      qudt:conversionMultiplier 3,168808781e-5 ;
+      qudt:conversionMultiplier 3.168808781e-5 ;
       qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-1D0 ;
       qudt:hasQuantityKind quantitykind:MassFlowRate ;
       qudt:plainTextDescription "metric tonne divided by the unit year with 365 days" ;
@@ -29718,7 +29718,7 @@ unit:KiloTONNE-PER-YR
   qudt:applicableSystem sou:CGS-EMU ;
   qudt:applicableSystem sou:CGS-GAUSS ;
   qudt:applicableSystem sou:SI ;
-  qudt:conversionMultiplier 3,168808781e-2 ;
+  qudt:conversionMultiplier 3.168808781e-2 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:MassFlowRate ;
   qudt:plainTextDescription "1000 metric tonne divided by the unit year with 365 days" ;
@@ -29737,15 +29737,15 @@ unit:KiloGM-PER-YR
   qudt:applicableSystem sou:CGS-EMU ;
   qudt:applicableSystem sou:CGS-GAUSS ;
   qudt:applicableSystem sou:SI ;
-  qudt:conversionMultiplier 3,168808781e-8 ;
+  qudt:conversionMultiplier 3.168808781e-8 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:MassFlowRate ;
   qudt:plainTextDescription "kilogram divided by the unit year with 365 days" ;
   qudt:symbol "kg/year" ;
   qudt:ucumCode "kg.a-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/vocab/unit> ;
-  rdfs:label "Kilogram Per Day"@en ;
-  rdfs:label "Kilogram Per Dag"@nl ;
+  rdfs:label "Kilogram Per Year"@en ;
+  rdfs:label "Kilogram Per Jaar"@nl ;
   qudt:informativeReference "http://dd.eionet.europa.eu/vocabulary/wise/uom/kg.a-1"^^xsd:anyURI;
 .
 


### PR DESCRIPTION


We will use these units to publish the pollution caused by factories on a yearly base, as required by EU-laws.

 

See also :

 http://dd.eionet.europa.eu/vocabulary/wise/uom/kg.a-1


http://dd.eionet.europa.eu/vocabulary/wise/uom/t.a-1

 

https://dd.eionet.europa.eu/vocabularyconcept/wise/uom/1000t.a-1/view

 

 

Kind regards,



Jurgen Meirlaen

Databeheerder

 

VLAAMSE MILIEUMAATSCHAPPIJ

Dienst Informatiebeheer waterketen

Regisseur van de waterketen

M 0487 90 53 42 T 053 72 66 33 

j.meirlaen@vmm.be 

Dokter De Moorstraat 24-26, 9300 Aalst

www.vmm.be