### PR TITLE
Fix dimension vector and quantity kind of unit:MHO

### DIFF
--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -16489,8 +16489,55 @@ unit:MHO
   qudt:conversionMultiplier 1.0 ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Siemens_%28unit%29"^^xsd:anyURI ;
   qudt:exactMatch unit:S ;
-  qudt:hasDimensionVector qkdv:A0E2L-3I0M-1H0T3D0 ;
-  qudt:hasQuantityKind quantitykind:ElectricConductivity ;
+  # unit:MHO has incorrect dimension vector:
+  # 	http://qudt.org/vocab/dimensionvector/A0E2L-3I0M-1H0T3D0, which should be
+  # 	http://qudt.org/vocab/dimensionvector/A0E2L-2I0M-1H0T3D0
+  # factor unit tree for unit ℧
+  #  ──┬ unit:MHO                      	http://qudt.org/vocab/dimensionvector/A0E2L-3I0M-1H0T3D0
+  #    ├─── unit:A                        	http://qudt.org/vocab/dimensionvector/A0E1L0I0M0H0T0D0
+  #    └──┬ unit:V^-1                     	http://qudt.org/vocab/dimensionvector/A0E1L-2I0M-1H0T3D0
+  #       ├─── unit:A^-1                     	http://qudt.org/vocab/dimensionvector/A0E-1L0I0M0H0T0D0
+  #       └──┬ unit:W                        	http://qudt.org/vocab/dimensionvector/A0E0L2I0M1H0T-3D0
+  #          ├──┬ unit:J                        	http://qudt.org/vocab/dimensionvector/A0E0L2I0M1H0T-2D0
+  #          │  ├─── unit:M                        	http://qudt.org/vocab/dimensionvector/A0E0L1I0M0H0T0D0
+  #          │  └──┬ unit:N                        	http://qudt.org/vocab/dimensionvector/A0E0L1I0M1H0T-2D0
+  #          │     ├──┬ unit:KiloGM                   	http://qudt.org/vocab/dimensionvector/A0E0L0I0M1H0T0D0
+  #          │     │  └─── unit:GM                       	http://qudt.org/vocab/dimensionvector/A0E0L0I0M1H0T0D0
+  #          │     ├─── unit:M                        	http://qudt.org/vocab/dimensionvector/A0E0L1I0M0H0T0D0
+  #          │     └─── unit:SEC^-2                   	http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T-2D0
+  #          └─── unit:SEC^-1                   	http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T-1D0
+  #
+  # the unit has these quantityKinds: ElectricConductivity
+  #  ══╤ qk:ElectricConductivity
+  #    ├─── unit:MHO
+  #    ├─── unit:MHO_Stat
+  #    ├─── unit:MicroMHO
+  #    ├─── unit:S_Ab
+  #    └─── unit:S_Stat
+  # quantity kinds that fit the corrected dimension vector http://qudt.org/vocab/dimensionvector/A0E2L-2I0M-1H0T3D0, and associated units:
+  #  ══╤ qk:Admittance
+  #    ├─── unit:DeciS
+  #    ├─── unit:KiloS
+  #    ├─── unit:MegaS
+  #    ├─── unit:MicroS
+  #    ├─── unit:MilliS
+  #    ├─── unit:NanoS
+  #    ├─── unit:PicoS
+  #    └─── unit:S
+  #  ═══ qk:Susceptance
+  #  ══╤ qk:Conductance
+  #    ├─── unit:DeciS
+  #    ├─── unit:KiloS
+  #    ├─── unit:MegaS
+  #    ├─── unit:MicroS
+  #    ├─── unit:MilliS
+  #    ├─── unit:NanoS
+  #    ├─── unit:PicoS
+  #    └─── unit:S
+  #  ═══ qk:ModulusOfAdmittance
+  qudt:hasDimensionVector qkdv:A0E2L-2I0M-1H0T3D0 .
+  qudt:hasQuantityKind quantitykind:Admittance ;
+  qudt:hasQuantityKind quantitykind:Conductance ;
   qudt:iec61360Code "0112/2///62720#UAB200" ;
   qudt:informativeReference "http://www.simetric.co.uk/siderived.htm"^^xsd:anyURI ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/mho> ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -16535,7 +16535,7 @@ unit:MHO
   #    ├─── unit:PicoS
   #    └─── unit:S
   #  ═══ qk:ModulusOfAdmittance
-  qudt:hasDimensionVector qkdv:A0E2L-2I0M-1H0T3D0 .
+  qudt:hasDimensionVector qkdv:A0E2L-2I0M-1H0T3D0 ;
   qudt:hasQuantityKind quantitykind:Admittance ;
   qudt:hasQuantityKind quantitykind:Conductance ;
   qudt:iec61360Code "0112/2///62720#UAB200" ;
@@ -19091,8 +19091,57 @@ unit:MicroMHO
   dcterms:description "0.000001-fold of the obsolete unit mho of the electric conductance"^^rdf:HTML ;
   qudt:applicableSystem sou:CGS ;
   qudt:conversionMultiplier 1.0e-06 ;
-  qudt:hasDimensionVector qkdv:A0E2L-3I0M-1H0T3D0 ;
-  qudt:hasQuantityKind quantitykind:ElectricConductivity ;
+  # unit:MicroMHO has incorrect dimension vector:
+  # 	http://qudt.org/vocab/dimensionvector/A0E2L-3I0M-1H0T3D0, which should be
+  # 	http://qudt.org/vocab/dimensionvector/A0E2L-2I0M-1H0T3D0
+  # factor unit tree for unit µ℧
+  #  ──┬ unit:MicroMHO                 	http://qudt.org/vocab/dimensionvector/A0E2L-3I0M-1H0T3D0
+  #    └──┬ unit:MHO                      	http://qudt.org/vocab/dimensionvector/A0E2L-2I0M-1H0T3D0
+  #       ├─── unit:A                        	http://qudt.org/vocab/dimensionvector/A0E1L0I0M0H0T0D0
+  #       └──┬ unit:V^-1                     	http://qudt.org/vocab/dimensionvector/A0E1L-2I0M-1H0T3D0
+  #          ├─── unit:A^-1                     	http://qudt.org/vocab/dimensionvector/A0E-1L0I0M0H0T0D0
+  #          └──┬ unit:W                        	http://qudt.org/vocab/dimensionvector/A0E0L2I0M1H0T-3D0
+  #             ├──┬ unit:J                        	http://qudt.org/vocab/dimensionvector/A0E0L2I0M1H0T-2D0
+  #             │  ├─── unit:M                        	http://qudt.org/vocab/dimensionvector/A0E0L1I0M0H0T0D0
+  #             │  └──┬ unit:N                        	http://qudt.org/vocab/dimensionvector/A0E0L1I0M1H0T-2D0
+  #             │     ├──┬ unit:KiloGM                   	http://qudt.org/vocab/dimensionvector/A0E0L0I0M1H0T0D0
+  #             │     │  └─── unit:GM                       	http://qudt.org/vocab/dimensionvector/A0E0L0I0M1H0T0D0
+  #             │     ├─── unit:M                        	http://qudt.org/vocab/dimensionvector/A0E0L1I0M0H0T0D0
+  #             │     └─── unit:SEC^-2                   	http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T-2D0
+  #             └─── unit:SEC^-1                   	http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T-1D0
+  #
+  # the unit has these quantityKinds: ElectricConductivity
+  #  ══╤ qk:ElectricConductivity
+  #    ├─── unit:MHO_Stat
+  #    ├─── unit:MicroMHO
+  #    ├─── unit:S_Ab
+  #    └─── unit:S_Stat
+  # quantity kinds that fit the corrected dimension vector http://qudt.org/vocab/dimensionvector/A0E2L-2I0M-1H0T3D0, and associated units:
+  #  ══╤ qk:Admittance
+  #    ├─── unit:DeciS
+  #    ├─── unit:KiloS
+  #    ├─── unit:MHO
+  #    ├─── unit:MegaS
+  #    ├─── unit:MicroS
+  #    ├─── unit:MilliS
+  #    ├─── unit:NanoS
+  #    ├─── unit:PicoS
+  #    └─── unit:S
+  #  ══╤ qk:Conductance
+  #    ├─── unit:DeciS
+  #    ├─── unit:KiloS
+  #    ├─── unit:MHO
+  #    ├─── unit:MegaS
+  #    ├─── unit:MicroS
+  #    ├─── unit:MilliS
+  #    ├─── unit:NanoS
+  #    ├─── unit:PicoS
+  #    └─── unit:S
+  #  ═══ qk:Susceptance
+  #  ═══ qk:ModulusOfAdmittance
+  qudt:hasDimensionVector qkdv:A0E2L-2I0M-1H0T3D0 ;
+  qudt:hasQuantityKind quantitykind:Admittance ;
+  qudt:hasQuantityKind quantitykind:Conductance ;
   qudt:iec61360Code "0112/2///62720#UAB201" ;
   qudt:plainTextDescription "0.000001-fold of the obsolete unit mho of the electric conductance" ;
   qudt:prefix prefix:Micro ;


### PR DESCRIPTION
unit:MHO is an exact match of unit:S but its dimensionsion vector and quantity kinds were not the same. Fixed in this PR.