### PR TITLE
Add FemtoSecond and AttoSecond

### DIFF
--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -835,6 +835,26 @@ unit:AttoJ-SEC
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Attojoule Second"@en ;
 .
+unit:AttoSEC
+  a qudt:Unit ;
+  dcterms:description "0.000000000000000001-fold of the SI base unit second"^^rdf:HTML ;
+  qudt:applicableSystem sou:CGS ;
+  qudt:applicableSystem sou:CGS-EMU ;
+  qudt:applicableSystem sou:CGS-GAUSS ;
+  qudt:applicableSystem sou:IMPERIAL ;
+  qudt:applicableSystem sou:SI ;
+  qudt:applicableSystem sou:USCS ;
+  qudt:conversionMultiplier 1.0e-18 ;
+  qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T1D0 ;
+  qudt:hasQuantityKind quantitykind:Time ;
+  qudt:iec61360Code "0112/2///62720#UAC696" ;
+  qudt:plainTextDescription "0.000000000000000001-fold of the SI base unit second" ;
+  qudt:prefix prefix:Atto ;
+  qudt:symbol "as" ;
+  qudt:ucumCode "as"^^qudt:UCUMcs ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Attosecond"@en ;
+.
 unit:B
   a qudt:DimensionlessUnit ;
   a qudt:LogarithmicUnit ;
@@ -7705,6 +7725,26 @@ unit:FemtoMOL-PER-L
   qudt:ucumCode "fmol.L-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Femtomoles per litre"@en ;
+.
+unit:FemtoSEC
+  a qudt:Unit ;
+  dcterms:description "0.000000000000001-fold of the SI base unit second"^^rdf:HTML ;
+  qudt:applicableSystem sou:CGS ;
+  qudt:applicableSystem sou:CGS-EMU ;
+  qudt:applicableSystem sou:CGS-GAUSS ;
+  qudt:applicableSystem sou:IMPERIAL ;
+  qudt:applicableSystem sou:SI ;
+  qudt:applicableSystem sou:USCS ;
+  qudt:conversionMultiplier 1.0e-15 ;
+  qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T1D0 ;
+  qudt:hasQuantityKind quantitykind:Time ;
+  qudt:iec61360Code "0112/2///62720#UAC697" ;
+  qudt:plainTextDescription "0.000000000000001-fold of the SI base unit second" ;
+  qudt:prefix prefix:Femto ;
+  qudt:symbol "fs" ;
+  qudt:ucumCode "fs"^^qudt:UCUMcs ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Femtosecond"@en ;
 .
 unit:Flight
   a qudt:Unit ;


### PR DESCRIPTION
Add femtosecond and attosecond.
===

Background
---
Chemists and physicists can use ultrafast lasers to measure processes that occur on the 1e-15 to 1e-18 s timescales. QUDT provides units and conversions only down to 1e-12 s (picoseconds); the SI prefixes for femto- and attosecond were not implemented.

Action
---
Entries for unit:FemtoSEC and unit:AttoSEC have been created. Standard SI prefixes, symbols, and labels have been used (FemtoSEC, fs, Femtosecond) and (AttoSEC, as, Attosecond).

The qudt:iec61360Code was located for both units

https://cdd.iec.ch/cdd/iec62720/iec62720.nsf/b2e4f47bf67e3291c12579dd004d0915/6ed66f676e998631c1258a60003e3f3e?OpenDocument&Highlight=0,0112%2F2%2F%2F%2F62720

and

https://cdd.iec.ch/cdd/iec62720/iec62720.nsf/b2e4f47bf67e3291c12579dd004d0915/d2b816c69e6180b9c1258a60003e3f3f?OpenDocument&Highlight=0,0112%2F2%2F%2F%2F62720

No qudt:uneceCommonCode was located.


