### PR TITLE
Add SHACL shapes ensuring correctness of scientific notation values

### DIFF
--- a/collections/COLLECTION_QUDT_QA_TESTS_ALL-v2.1.ttl
+++ b/collections/COLLECTION_QUDT_QA_TESTS_ALL-v2.1.ttl
@@ -413,7 +413,7 @@ qudt:conversionMultiplierSnShape
                             $this
                                 qudt:conversionMultiplier ?valueDecimal ;
                                 qudt:conversionMultiplierSN ?valueSN .
-                            BIND(REPLACE(STR(?valueDecimal), "(\\\\.\\\\d\\\\d*)0+$", "$1") as ?valueDecimalNoTrailingZeros)      # remove trailing zeros from valueDecimal (string)
+                            BIND(REPLACE(STR(?valueDecimal), "(\\\\.\\\\d)(\\\\d*[1-9])?0*$", "$1$2") as ?valueDecimalNoTrailingZeros)      # remove trailing zeros from valueDecimal (string)
                             BIND(REPLACE(STR(?valueSN), "[eE]-?\\\\d+$", "") as ?m)                                           # extract the mantissa (string)
                             BIND(REPLACE(STR(?valueSN), "^\\\\d(\\\\.\\\\d+)?[eE]", "") as ?e)                                    # extract the exponent (string)
                             BIND(REPLACE(STR(?m),"(\\\\.|0+$)","") AS ?mNoDot)                                                # remove the comma and trailing zeros from the mantissa
@@ -456,7 +456,7 @@ qudt:conversionOffsetSnShape
                             $this
                                 qudt:conversionOffset ?valueDecimal ;
                                 qudt:conversionOffsetSN ?valueSN .
-                            BIND(REPLACE(STR(?valueDecimal), "(\\\\.\\\\d\\\\d*)0+$", "$1") as ?valueDecimalNoTrailingZeros)      # remove trailing zeros from valueDecimal (string)
+                            BIND(REPLACE(STR(?valueDecimal), "(\\\\.\\\\d)(\\\\d*[1-9])?0*$", "$1$2") as ?valueDecimalNoTrailingZeros)      # remove trailing zeros from valueDecimal (string)
                             BIND(REPLACE(STR(?valueSN), "[eE]-?\\\\d+$", "") as ?m)                                           # extract the mantissa (string)
                             BIND(REPLACE(STR(?valueSN), "^\\\\d(\\\\.\\\\d+)?[eE]", "") as ?e)                                    # extract the exponent (string)
                             BIND(REPLACE(STR(?m),"(\\\\.|0+$)","") AS ?mNoDot)                                                # remove the comma and trailing zeros from the mantissa
@@ -499,7 +499,7 @@ qudt:standardUncertaintySnShape
                             $this
                                 qudt:standardUncertainty ?valueDecimal ;
                                 qudt:standardUncertaintySN ?valueSN .
-                            BIND(REPLACE(STR(?valueDecimal), "(\\\\.\\\\d\\\\d*)0+$", "$1") as ?valueDecimalNoTrailingZeros)      # remove trailing zeros from valueDecimal (string)
+                            BIND(REPLACE(STR(?valueDecimal), "(\\\\.\\\\d)(\\\\d*[1-9])?0*$", "$1$2") as ?valueDecimalNoTrailingZeros)      # remove trailing zeros from valueDecimal (string)
                             BIND(REPLACE(STR(?valueSN), "[eE]-?\\\\d+$", "") as ?m)                                           # extract the mantissa (string)
                             BIND(REPLACE(STR(?valueSN), "^\\\\d(\\\\.\\\\d+)?[eE]", "") as ?e)                                    # extract the exponent (string)
                             BIND(REPLACE(STR(?m),"(\\\\.|0+$)","") AS ?mNoDot)                                                # remove the comma and trailing zeros from the mantissa
@@ -542,7 +542,7 @@ qudt:valueSnShape
                             $this
                                 qudt:value ?valueDecimal ;
                                 qudt:valueSN ?valueSN .
-                            BIND(REPLACE(STR(?valueDecimal), "(\\\\.\\\\d\\\\d*)0+$", "$1") as ?valueDecimalNoTrailingZeros)      # remove trailing zeros from valueDecimal (string)
+                            BIND(REPLACE(STR(?valueDecimal), "(\\\\.\\\\d)(\\\\d*[1-9])?0*$", "$1$2") as ?valueDecimalNoTrailingZeros)     # remove trailing zeros from valueDecimal (string)
                             BIND(REPLACE(STR(?valueSN), "[eE]-?\\\\d+$", "") as ?m)                                           # extract the mantissa (string)
                             BIND(REPLACE(STR(?valueSN), "^\\\\d(\\\\.\\\\d+)?[eE]", "") as ?e)                                    # extract the exponent (string)
                             BIND(REPLACE(STR(?m),"(\\\\.|0+$)","") AS ?mNoDot)                                                # remove the comma and trailing zeros from the mantissa

--- a/collections/COLLECTION_QUDT_QA_TESTS_ALL-v2.1.ttl
+++ b/collections/COLLECTION_QUDT_QA_TESTS_ALL-v2.1.ttl
@@ -74,7 +74,12 @@
       sh:namespace "http://www.w3.org/ns/shacl#"^^xsd:anyURI ;
       sh:prefix "sh" ;
     ] ;
-.
+  sh:declare [
+      a sh:PrefixDeclaration ;
+      sh:namespace "http://www.w3.org/2001/XMLSchema#"^^xsd:anyURI ;
+      sh:prefix "xsd" ;
+    ]
+  .
 qudt:ClosedWorldShape
   a sh:NodeShape ;
   rdfs:isDefinedBy <http://qudt.org/2.1/collection/qa/all> ;
@@ -392,3 +397,175 @@ FILTER (?udv != ?qdv) .
     ] ;
   sh:targetClass qudt:Unit ;
 .
+
+qudt:conversionMultiplierSnShape
+  sh:targetClass qudt:Unit;
+    rdfs:comment "qudt:conversionMultiplier must match qudt:conversionMultiplierSN if present" ;
+    sh:sparql [
+        a sh:SPARQLConstraint ;
+        sh:minCount 1;
+        sh:message """{$this} qudt:conversionMultiplier is {?valueDecimalNoTrailingZeros}, which does not match the value of qudt:conversionMultiplierSN, {?valueSN}, converted to decimal notation, {?valueSNStringValue} .  """ ;
+        sh:prefixes <http://qudt.org/2.1/collection/qa/all> ;
+        sh:select """
+            SELECT $this ?valueDecimal ?valueDecimalNoTrailingZeros ?valueSN ?m ?e ?exponent ?mNoDot ?mDigitCount ?valueSNStringValue ?onePos ?lastMantissaDigit ?leftStart ?leftEnd ?rightStart ?rightEnd ?result
+                        WHERE {
+                            # select both values
+                            $this
+                                qudt:conversionMultiplier ?valueDecimal ;
+                                qudt:conversionMultiplierSN ?valueSN .
+                            BIND(REPLACE(STR(?valueDecimal), "(\\\\.\\\\d\\\\d*)0+$", "$1") as ?valueDecimalNoTrailingZeros)      # remove trailing zeros from valueDecimal (string)
+                            BIND(REPLACE(STR(?valueSN), "[eE]-?\\\\d+$", "") as ?m)                                           # extract the mantissa (string)
+                            BIND(REPLACE(STR(?valueSN), "^\\\\d(\\\\.\\\\d+)?[eE]", "") as ?e)                                    # extract the exponent (string)
+                            BIND(REPLACE(STR(?m),"(\\\\.|0+$)","") AS ?mNoDot)                                                # remove the comma and trailing zeros from the mantissa
+                            BIND(STRLEN(?mNoDot) as ?mDigitCount)                                                           # count the mantissa's characters
+                            BIND(xsd:integer(?e) as  ?exponent)                                                             # cast e to an integer, called exponent
+                            # prepare a string with 200 zeros padding left and right, mantissa in the middle
+                            BIND(CONCAT(
+                                                "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                                                ?mNoDot,
+                                                "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000") as ?baseStr)
+                            # first char has index 1 !!!
+                            BIND(201 + ?exponent as ?onePos)
+                            BIND(200 + ?mDigitCount  as ?lastMantissaDigit)
+                            BIND(IF(?onePos > 201, 201, ?onePos) as ?leftStart)
+                            BIND(?onePos+1 as ?leftEnd)
+                            BIND(?onePos+1 as ?rightStart)
+                            BIND(IF(?lastMantissaDigit+1 > ?onePos+2, ?lastMantissaDigit+1, ?onePos+2)  as ?rightEnd)
+                            # determine the expected string
+                            BIND(CONCAT(SUBSTR(?baseStr, ?leftStart, ?leftEnd-?leftStart), ".", SUBSTR(?baseStr, ?rightStart, ?rightEnd - ?rightStart)) as  ?valueSNStringValue)
+                            # compare with actual decimal value
+                            BIND(IF(?valueSNStringValue = STR(?valueDecimalNoTrailingZeros), "match!", "no match!") as ?result)
+                            # only generate message if no match (useful during development)
+                            FILTER(?result != "match!")
+                        }
+        """ ;
+      ] .
+      
+qudt:conversionOffsetSnShape
+  sh:targetClass qudt:Unit;
+    rdfs:comment "qudt:conversionOffset must match qudt:conversionOffsetSN if present" ;
+    sh:sparql [
+        a sh:SPARQLConstraint ;
+        sh:minCount 1;
+        sh:message """{$this} qudt:conversionOffset is {?valueDecimalNoTrailingZeros}, which does not match the value of qudt:conversionOffsetSN, {?valueSN}, converted to decimal notation, {?valueSNStringValue} .  """ ;
+        sh:prefixes <http://qudt.org/2.1/collection/qa/all> ;
+        sh:select """
+            SELECT $this ?valueDecimal ?valueDecimalNoTrailingZeros ?valueSN ?m ?e ?exponent ?mNoDot ?mDigitCount ?valueSNStringValue ?onePos ?lastMantissaDigit ?leftStart ?leftEnd ?rightStart ?rightEnd ?result
+                        WHERE {
+                            # select both values
+                            $this
+                                qudt:conversionOffset ?valueDecimal ;
+                                qudt:conversionOffsetSN ?valueSN .
+                            BIND(REPLACE(STR(?valueDecimal), "(\\\\.\\\\d\\\\d*)0+$", "$1") as ?valueDecimalNoTrailingZeros)      # remove trailing zeros from valueDecimal (string)
+                            BIND(REPLACE(STR(?valueSN), "[eE]-?\\\\d+$", "") as ?m)                                           # extract the mantissa (string)
+                            BIND(REPLACE(STR(?valueSN), "^\\\\d(\\\\.\\\\d+)?[eE]", "") as ?e)                                    # extract the exponent (string)
+                            BIND(REPLACE(STR(?m),"(\\\\.|0+$)","") AS ?mNoDot)                                                # remove the comma and trailing zeros from the mantissa
+                            BIND(STRLEN(?mNoDot) as ?mDigitCount)                                                           # count the mantissa's characters
+                            BIND(xsd:integer(?e) as  ?exponent)                                                             # cast e to an integer, called exponent
+                            # prepare a string with 200 zeros padding left and right, mantissa in the middle
+                            BIND(CONCAT(
+                                                "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                                                ?mNoDot,
+                                                "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000") as ?baseStr)
+                            # first char has index 1 !!!
+                            BIND(201 + ?exponent as ?onePos)
+                            BIND(200 + ?mDigitCount  as ?lastMantissaDigit)
+                            BIND(IF(?onePos > 201, 201, ?onePos) as ?leftStart)
+                            BIND(?onePos+1 as ?leftEnd)
+                            BIND(?onePos+1 as ?rightStart)
+                            BIND(IF(?lastMantissaDigit+1 > ?onePos+2, ?lastMantissaDigit+1, ?onePos+2)  as ?rightEnd)
+                            # determine the expected string
+                            BIND(CONCAT(SUBSTR(?baseStr, ?leftStart, ?leftEnd-?leftStart), ".", SUBSTR(?baseStr, ?rightStart, ?rightEnd - ?rightStart)) as  ?valueSNStringValue)
+                            # compare with actual decimal value
+                            BIND(IF(?valueSNStringValue = STR(?valueDecimalNoTrailingZeros), "match!", "no match!") as ?result)
+                            # only generate message if no match (useful during development)
+                            FILTER(?result != "match!")
+                        }
+        """ ;
+      ] .
+
+qudt:standardUncertaintySnShape
+  sh:targetClass qudt:ConstantValue;
+    rdfs:comment "qudt:standardUncertainty must match qudt:standardUncertaintySN if present" ;
+    sh:sparql [
+        a sh:SPARQLConstraint ;
+        sh:minCount 1;
+        sh:message """{$this} qudt:standardUncertainty is {?valueDecimalNoTrailingZeros}, which does not match the value of qudt:standardUncertaintySN, {?valueSN}, converted to decimal notation, {?valueSNStringValue} .  """ ;
+        sh:prefixes <http://qudt.org/2.1/collection/qa/all> ;
+        sh:select """
+            SELECT $this ?valueDecimal ?valueDecimalNoTrailingZeros ?valueSN ?m ?e ?exponent ?mNoDot ?mDigitCount ?valueSNStringValue ?onePos ?lastMantissaDigit ?leftStart ?leftEnd ?rightStart ?rightEnd ?result
+                        WHERE {
+                            # select both values
+                            $this
+                                qudt:standardUncertainty ?valueDecimal ;
+                                qudt:standardUncertaintySN ?valueSN .
+                            BIND(REPLACE(STR(?valueDecimal), "(\\\\.\\\\d\\\\d*)0+$", "$1") as ?valueDecimalNoTrailingZeros)      # remove trailing zeros from valueDecimal (string)
+                            BIND(REPLACE(STR(?valueSN), "[eE]-?\\\\d+$", "") as ?m)                                           # extract the mantissa (string)
+                            BIND(REPLACE(STR(?valueSN), "^\\\\d(\\\\.\\\\d+)?[eE]", "") as ?e)                                    # extract the exponent (string)
+                            BIND(REPLACE(STR(?m),"(\\\\.|0+$)","") AS ?mNoDot)                                                # remove the comma and trailing zeros from the mantissa
+                            BIND(STRLEN(?mNoDot) as ?mDigitCount)                                                           # count the mantissa's characters
+                            BIND(xsd:integer(?e) as  ?exponent)                                                             # cast e to an integer, called exponent
+                            # prepare a string with 200 zeros padding left and right, mantissa in the middle
+                            BIND(CONCAT(
+                                                "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                                                ?mNoDot,
+                                                "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000") as ?baseStr)
+                            # first char has index 1 !!!
+                            BIND(201 + ?exponent as ?onePos)
+                            BIND(200 + ?mDigitCount  as ?lastMantissaDigit)
+                            BIND(IF(?onePos > 201, 201, ?onePos) as ?leftStart)
+                            BIND(?onePos+1 as ?leftEnd)
+                            BIND(?onePos+1 as ?rightStart)
+                            BIND(IF(?lastMantissaDigit+1 > ?onePos+2, ?lastMantissaDigit+1, ?onePos+2)  as ?rightEnd)
+                            # determine the expected string
+                            BIND(CONCAT(SUBSTR(?baseStr, ?leftStart, ?leftEnd-?leftStart), ".", SUBSTR(?baseStr, ?rightStart, ?rightEnd - ?rightStart)) as  ?valueSNStringValue)
+                            # compare with actual decimal value
+                            BIND(IF(?valueSNStringValue = STR(?valueDecimalNoTrailingZeros), "match!", "no match!") as ?result)
+                            # only generate message if no match (useful during development)
+                            FILTER(?result != "match!")
+                        }
+        """ ;
+      ] .
+
+qudt:valueSnShape
+  sh:targetClass qudt:ConstantValue;
+    rdfs:comment "qudt:value must match qudt:valueSN if present" ;
+    sh:sparql [
+        a sh:SPARQLConstraint ;
+        sh:minCount 1;
+        sh:message """{$this} qudt:value is {?valueDecimalNoTrailingZeros}, which does not match the value of qudt:valueSN, {?valueSN}, converted to decimal notation, {?valueSNStringValue} .  """ ;
+        sh:prefixes <http://qudt.org/2.1/collection/qa/all> ;
+        sh:select """
+            SELECT $this ?valueDecimal ?valueDecimalNoTrailingZeros ?valueSN ?m ?e ?exponent ?mNoDot ?mDigitCount ?valueSNStringValue ?onePos ?lastMantissaDigit ?leftStart ?leftEnd ?rightStart ?rightEnd ?result
+                        WHERE {
+                            # select both values
+                            $this
+                                qudt:value ?valueDecimal ;
+                                qudt:valueSN ?valueSN .
+                            BIND(REPLACE(STR(?valueDecimal), "(\\\\.\\\\d\\\\d*)0+$", "$1") as ?valueDecimalNoTrailingZeros)      # remove trailing zeros from valueDecimal (string)
+                            BIND(REPLACE(STR(?valueSN), "[eE]-?\\\\d+$", "") as ?m)                                           # extract the mantissa (string)
+                            BIND(REPLACE(STR(?valueSN), "^\\\\d(\\\\.\\\\d+)?[eE]", "") as ?e)                                    # extract the exponent (string)
+                            BIND(REPLACE(STR(?m),"(\\\\.|0+$)","") AS ?mNoDot)                                                # remove the comma and trailing zeros from the mantissa
+                            BIND(STRLEN(?mNoDot) as ?mDigitCount)                                                           # count the mantissa's characters
+                            BIND(xsd:integer(?e) as  ?exponent)                                                             # cast e to an integer, called exponent
+                            # prepare a string with 200 zeros padding left and right, mantissa in the middle
+                            BIND(CONCAT(
+                                                "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                                                ?mNoDot,
+                                                "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000") as ?baseStr)
+                            # first char has index 1 !!!
+                            BIND(201 + ?exponent as ?onePos)
+                            BIND(200 + ?mDigitCount  as ?lastMantissaDigit)
+                            BIND(IF(?onePos > 201, 201, ?onePos) as ?leftStart)
+                            BIND(?onePos+1 as ?leftEnd)
+                            BIND(?onePos+1 as ?rightStart)
+                            BIND(IF(?lastMantissaDigit+1 > ?onePos+2, ?lastMantissaDigit+1, ?onePos+2)  as ?rightEnd)
+                            # determine the expected string
+                            BIND(CONCAT(SUBSTR(?baseStr, ?leftStart, ?leftEnd-?leftStart), ".", SUBSTR(?baseStr, ?rightStart, ?rightEnd - ?rightStart)) as  ?valueSNStringValue)
+                            # compare with actual decimal value
+                            BIND(IF(?valueSNStringValue = STR(?valueDecimalNoTrailingZeros), "match!", "no match!") as ?result)
+                            # only generate message if no match (useful during development)
+                            FILTER(?result != "match!")
+                        }
+        """ ;
+      ] .

--- a/schema/SCHEMA_QUDT-v2.1.ttl
+++ b/schema/SCHEMA_QUDT-v2.1.ttl
@@ -1037,8 +1037,13 @@ qudt:Quantifiable
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
-      owl:allValuesFrom xsd:double ;
+      owl:allValuesFrom xsd:decimal ;
       owl:onProperty qudt:standardUncertainty ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:allValuesFrom xsd:double ;
+      owl:onProperty qudt:standardUncertaintySN ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
@@ -1074,6 +1079,11 @@ qudt:Quantifiable
       a owl:Restriction ;
       owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onProperty qudt:value ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:valueSN ;
     ] ;
 .
 qudt:Quantity
@@ -1861,6 +1871,16 @@ qudt:Unit
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
+      owl:maxCardinality "1"^^xsd:int ;
+      owl:onProperty qudt:conversionMultiplierSN ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality "1"^^xsd:int ;
+      owl:onProperty qudt:conversionOffsetSN ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
       owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onProperty qudt:hasDimensionVector ;
     ] ;
@@ -2183,6 +2203,20 @@ qudt:conversionOffset
   rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
   rdfs:label "conversion offset" ;
   rdfs:range dtype:numericUnion ;
+.
+qudt:conversionMultiplierSN
+  a owl:DatatypeProperty ;
+  a owl:FunctionalProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "conversion multiplier scientific" ;
+  rdfs:range xsd:decimal ;
+.
+qudt:conversionOffsetSN
+  a owl:DatatypeProperty ;
+  a owl:FunctionalProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "conversion offset scientific" ;
+  rdfs:range xsd:double ;
 .
 qudt:currencyCode
   a owl:DatatypeProperty ;
@@ -3039,6 +3073,13 @@ qudt:standardUncertainty
   dcterms:description "The standard uncertainty of a quantity is the estimated standard deviation of the mean taken from a series of measurements."^^rdf:HTML ;
   rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
   rdfs:label "standard uncertainty" ;
+  rdfs:range xsd:decimal ;
+.
+qudt:standardUncertaintySN
+  a owl:DatatypeProperty ;
+  dcterms:description "The standard uncertainty of a quantity is the estimated standard deviation of the mean taken from a series of measurements."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "standard uncertainty scientific" ;
   rdfs:range xsd:double ;
 .
 qudt:symbol
@@ -3147,6 +3188,12 @@ qudt:value
   dcterms:description "A property to relate an observable thing with a value of any kind"^^rdf:HTML ;
   rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
   rdfs:label "value" ;
+.
+qudt:valueSN
+  a owl:DatatypeProperty ;
+  dcterms:description "A property to relate an observable thing with a value of any kind"^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "value scientific" ;
 .
 qudt:valueQuantity
   a owl:ObjectProperty ;

--- a/schema/SCHEMA_QUDT-v2.1.ttl
+++ b/schema/SCHEMA_QUDT-v2.1.ttl
@@ -2195,14 +2195,14 @@ qudt:conversionMultiplier
   a owl:FunctionalProperty ;
   rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
   rdfs:label "conversion multiplier" ;
-  rdfs:range dtype:numericUnion ;
+  rdfs:range xsd:decimal ;
 .
 qudt:conversionOffset
   a owl:DatatypeProperty ;
   a owl:FunctionalProperty ;
   rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
   rdfs:label "conversion offset" ;
-  rdfs:range dtype:numericUnion ;
+  rdfs:range xsd:decimal ;
 .
 qudt:conversionMultiplierSN
   a owl:DatatypeProperty ;

--- a/schema/shacl/SCHEMA_QUDT_NoOWL-v2.1.ttl
+++ b/schema/shacl/SCHEMA_QUDT_NoOWL-v2.1.ttl
@@ -2281,6 +2281,7 @@ qudt:Unit
   sh:property qudt:Unit-conversionMultiplier ;
   sh:property qudt:Unit-conversionMultiplierSN ;
   sh:property qudt:Unit-conversionOffset ;
+  sh:property qudt:Unit-conversionOffsetSN ;
   sh:property qudt:Unit-definedUnitOfSystem ;
   sh:property qudt:Unit-derivedCoherentUnitOfSystem ;
   sh:property qudt:Unit-derivedUnitOfSystem ;

--- a/schema/shacl/SCHEMA_QUDT_NoOWL-v2.1.ttl
+++ b/schema/shacl/SCHEMA_QUDT_NoOWL-v2.1.ttl
@@ -1327,8 +1327,10 @@ qudt:Quantifiable
   sh:property qudt:Quantifiable-hasUnit ;
   sh:property qudt:Quantifiable-relativeStandardUncertainty ;
   sh:property qudt:Quantifiable-standardUncertainty ;
+  sh:property qudt:Quantifiable-standardUncertaintySN ;
   sh:property qudt:Quantifiable-unit ;
   sh:property qudt:Quantifiable-value ;
+  sh:property qudt:Quantifiable-valueSN ;
 .
 qudt:Quantifiable-dataEncoding
   a sh:PropertyShape ;
@@ -1362,6 +1364,13 @@ qudt:Quantifiable-standardUncertainty
   a sh:PropertyShape ;
   sh:path qudt:standardUncertainty ;
   rdfs:isDefinedBy <http://qudt.org/2.1/schema/shacl/qudt> ;
+  sh:datatype xsd:decimal ;
+  sh:maxCount 1 ;
+.
+qudt:Quantifiable-standardUncertaintySN
+  a sh:PropertyShape ;
+  sh:path qudt:standardUncertaintySN ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/shacl/qudt> ;
   sh:datatype xsd:double ;
   sh:maxCount 1 ;
 .
@@ -1375,6 +1384,12 @@ qudt:Quantifiable-unit
 qudt:Quantifiable-value
   a sh:PropertyShape ;
   sh:path qudt:value ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/shacl/qudt> ;
+  sh:maxCount 1 ;
+.
+qudt:Quantifiable-valueSN
+  a sh:PropertyShape ;
+  sh:path qudt:valueSN ;
   rdfs:isDefinedBy <http://qudt.org/2.1/schema/shacl/qudt> ;
   sh:maxCount 1 ;
 .
@@ -1402,6 +1417,7 @@ as \"fundamental\" in this sense.</p>
   sh:property qudt:Quantity-hasQuantityKind ;
   sh:property qudt:Quantity-isDeltaQuantity ;
   sh:property qudt:Quantity-quantityValue ;
+  sh:property qudt:Quantity-quantityValueSN ;
 .
 qudt:Quantity-hasQuantityKind
   a sh:PropertyShape ;
@@ -2263,6 +2279,7 @@ qudt:Unit
   rdfs:subClassOf qudt:Verifiable ;
   sh:property qudt:Unit-applicableSystem ;
   sh:property qudt:Unit-conversionMultiplier ;
+  sh:property qudt:Unit-conversionMultiplierSN ;
   sh:property qudt:Unit-conversionOffset ;
   sh:property qudt:Unit-definedUnitOfSystem ;
   sh:property qudt:Unit-derivedCoherentUnitOfSystem ;
@@ -2297,34 +2314,28 @@ qudt:Unit-conversionMultiplier
   sh:path qudt:conversionMultiplier ;
   rdfs:isDefinedBy <http://qudt.org/2.1/schema/shacl/qudt> ;
   sh:maxCount 1 ;
-  sh:or (
-      [
-        sh:datatype xsd:decimal ;
-      ]
-      [
-        sh:datatype xsd:double ;
-      ]
-      [
-        sh:datatype xsd:float ;
-      ]
-    ) ;
+  sh:datatype xsd:decimal ;
+.
+qudt:Unit-conversionMultiplierSN
+  a sh:PropertyShape ;
+  sh:path qudt:conversionMultiplierSN ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/shacl/qudt> ;
+  sh:maxCount 1 ;
+  sh:datatype xsd:double ;
 .
 qudt:Unit-conversionOffset
   a sh:PropertyShape ;
   sh:path qudt:conversionOffset ;
   rdfs:isDefinedBy <http://qudt.org/2.1/schema/shacl/qudt> ;
   sh:maxCount 1 ;
-  sh:or (
-      [
-        sh:datatype xsd:decimal ;
-      ]
-      [
-        sh:datatype xsd:double ;
-      ]
-      [
-        sh:datatype xsd:float ;
-      ]
-    ) ;
+  sh:datatype xsd:decimal ;
+.
+qudt:Unit-conversionOffsetSN
+  a sh:PropertyShape ;
+  sh:path qudt:conversionOffsetSN ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/shacl/qudt> ;
+  sh:maxCount 1 ;
+  sh:datatype xsd:double ;
 .
 qudt:Unit-definedUnitOfSystem
   a sh:PropertyShape ;
@@ -2723,6 +2734,16 @@ qudt:conversionOffset
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/2.1/schema/shacl/qudt> ;
   rdfs:label "conversion offset" ;
+.
+qudt:conversionMultiplierSN
+  a rdf:Property ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/shacl/qudt> ;
+  rdfs:label "conversion multiplier scientific" ;
+.
+qudt:conversionOffsetSN
+  a rdf:Property ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/shacl/qudt> ;
+  rdfs:label "conversion offset scientific" ;
 .
 qudt:currencyCode
   a rdf:Property ;
@@ -3478,6 +3499,12 @@ qudt:standardUncertainty
   rdfs:isDefinedBy <http://qudt.org/2.1/schema/shacl/qudt> ;
   rdfs:label "standard uncertainty" ;
 .
+qudt:standardUncertaintySN
+  a rdf:Property ;
+  dcterms:description "The standard uncertainty of a quantity is the estimated standard deviation of the mean taken from a series of measurements."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/shacl/qudt> ;
+  rdfs:label "standard uncertainty scientific" ;
+.
 qudt:symbol
   a rdf:Property ;
   dcterms:description "The symbol is a glyph that is used to represent some concept, typically a unit or a quantity, in a compact form. For example, the symbol for an Ohm is \\(ohm\\). This contrasts with 'unit:abbreviation', which gives a short alphanumeric abbreviation for the unit, 'ohm' for Ohm."^^qudt:LatexString ;
@@ -3566,9 +3593,15 @@ qudt:url
 .
 qudt:value
   a rdf:Property ;
-  dcterms:description "A property to relate an observable thing with a value that can be of any simple XSD type"^^rdf:HTML ;
+  dcterms:description "A property to relate an observable thing with a value expressed as a decimal"^^rdf:HTML ;
   rdfs:isDefinedBy <http://qudt.org/2.1/schema/shacl/qudt> ;
   rdfs:label "value" ;
+.
+qudt:valueSN
+  a rdf:Property ;
+  dcterms:description "A property to relate an observable thing with a value expressed in scientific notation"^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/shacl/qudt> ;
+  rdfs:label "value scientific" ;
 .
 qudt:valueQuantity
   a rdf:Property ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -33380,7 +33380,6 @@ unit:OZ-PER-GAL_UK
   dcterms:description "unit of the density according to the Imperial system of units"^^rdf:HTML ;
   qudt:applicableSystem sou:IMPERIAL ;
   qudt:conversionMultiplier 6.236 ;
-  qudt:conversionMultiplier 6.2360 ;
   qudt:conversionMultiplierSN 6.236E0 ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Density ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -6282,7 +6282,6 @@ unit:DEG_C_GROWING_CEREAL-DAY
   qudt:conversionMultiplier 86400.0 ;
   qudt:conversionMultiplierSN 8.64E4 ;
   qudt:conversionOffset 0.0 ;
-  qudt:conversionOffset "0.0"^^xsd:double ;
   qudt:conversionOffsetSN 0.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H1T1D0 ;
   qudt:hasQuantityKind quantitykind:GrowingDegreeDay_Cereal ;
@@ -13749,7 +13748,6 @@ The magnitude of one <strong>IU/L</strong> depends on the material, so there is 
 </p>"""^^rdf:HTML ;
   qudt:conversionMultiplier 0.000001 ;
   qudt:conversionMultiplierSN 1.0E-6 ;
-  qudt:conversionOffset "0"^^xsd:double ;
   qudt:conversionOffset 0.0 ;
   qudt:conversionOffsetSN 0.0E0 ;
   qudt:hasDimensionVector qkdv:A1E0L0I0M-1H0T0D0 ;
@@ -42967,7 +42965,6 @@ unit:W-HR-PER-M2
   qudt:applicableSystem sou:SI ;
   qudt:conversionMultiplier 3600.0 ;
   qudt:conversionMultiplierSN 3.6E3 ;
-  qudt:conversionOffset "0"^^xsd:double ;
   qudt:conversionOffset 0.0 ;
   qudt:conversionOffsetSN 0.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-2D0 ;


### PR DESCRIPTION
Constraints added for
- qudt:conversionMultiplier(SN)
- qudt:conversionOffset(SN)
- qudt:value(SN)
- qudt:standardUncertainty(SN)