### PR TITLE
Fix conversion multiplier of BTU_IT-PER-LB_F-DEG_F

### DIFF
--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -2453,8 +2453,30 @@ unit:BTU_IT-PER-LB_F-DEG_F
   dcterms:description "Unit of heat energy according to the Imperial system of units divided by the product of a pound of force and a degree Fahrenheit"^^rdf:HTML ;
   qudt:applicableSystem sou:IMPERIAL ;
   qudt:applicableSystem sou:USCS ;
-  qudt:conversionMultiplier 4186.8 ;
-  qudt:conversionMultiplierSN 4.1868E3 ;
+  # WRONG MULTIPLIER  : unit:BTU_IT-PER-LB_F-DEG_F - calculated from factors: 426.9347648940976900014802607769946, actual: 4186.8
+  #
+  #  ──┬ unit:BTU_IT-PER-LB_F-DEG_F multiplier: 4186.8 (correct: 426.9347648940976900014802607769946)
+  #    ├──┬ unit:BTU_IT multiplier: 1055.05585262
+  #    │  └──┬ unit:J multiplier: 1.0
+  #    │     ├─── unit:M multiplier: 1.0
+  #    │     └──┬ unit:N multiplier: 1.0
+  #    │        ├──┬ unit:KiloGM multiplier: 1.0
+  #    │        │  └─── unit:GM multiplier: 0.001
+  #    │        ├─── unit:M multiplier: 1.0
+  #    │        └─── unit:SEC^-2 multiplier: 1.0 (multiplier^-2: 1.0)
+  #    ├──┬ unit:LB_F^-1 multiplier: 4.448222 (multiplier^-1: 0.2248089236553391444941372080799924)
+  #    │  ├──┬ unit:FT multiplier: 0.3048
+  #    │  │  └──┬ unit:IN multiplier: 0.0254
+  #    │  │     └─── unit:M multiplier: 1.0
+  #    │  ├─── unit:SEC^-2 multiplier: 1.0 (multiplier^-2: 1.0)
+  #    │  └──┬ unit:SLUG multiplier: 14.593903
+  #    │     └──┬ unit:LB multiplier: 0.45359237
+  #    │        └──┬ unit:KiloGM multiplier: 1.0
+  #    │           └─── unit:GM multiplier: 0.001
+  #    └──┬ unit:DEG_F^-1 multiplier: 0.5555555555555556 (multiplier^-1: 1.799999999999999856000000000000012)
+  #       └─── unit:K multiplier: 1.0
+  qudt:conversionMultiplier 426.9347648940976900014802607769946 ;
+  qudt:conversionMultiplierSN 4.269347648940976900014802607769946E2 ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H-1T0D0 ;
   qudt:hasQuantityKind quantitykind:LinearThermalExpansion ;
   qudt:iec61360Code "0112/2///62720#UAA119" ;


### PR DESCRIPTION
Checks found a wrong multiplier with. 
BTU_IT-PER-LB_F-DEG_F

seems legit, since 

BTU_IT-PER-LB_F-DEG_R 

should have the same multiplier, and now it does (except for the precision)