### PR TITLE
Various minor tweaks and additions

### DIFF
--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -103,7 +103,7 @@ unit:A-HR
   qudt:iec61360Code "0112/2///62720#UAA102" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Ampere-hour"^^xsd:anyURI ;
   qudt:informativeReference "http://www.oxfordreference.com/view/10.1093/acref/9780199233991.001.0001/acref-9780199233991-e-86"^^xsd:anyURI ;
-  qudt:symbol "A⋅hr" ;
+  qudt:symbol "A·hr" ;
   qudt:ucumCode "A.h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "AMH" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -190,7 +190,7 @@ unit:A-M2
   qudt:iec61360Code "0112/2///62720#UAA106" ;
   qudt:informativeReference "http://encyclopedia2.thefreedictionary.com/ampere+meter+squared"^^xsd:anyURI ;
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
-  qudt:symbol "A⋅m²" ;
+  qudt:symbol "A·m²" ;
   qudt:ucumCode "A.m2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A5" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -211,7 +211,7 @@ unit:A-M2-PER-J-SEC
   qudt:hasQuantityKind quantitykind:ElectricChargePerMass ;
   qudt:informativeReference "http://encyclopedia2.thefreedictionary.com/ampere+square+meter+per+joule+second"^^xsd:anyURI ;
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
-  qudt:symbol "A⋅m²/(J⋅s)" ;
+  qudt:symbol "A·m²/(J·s)" ;
   qudt:ucumCode "A.m2.J-1.s-1"^^qudt:UCUMcs ;
   qudt:ucumCode "A.m2/(J.s)"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A10" ;
@@ -461,7 +461,7 @@ unit:A-PER-M2-K2
   qudt:hasQuantityKind quantitykind:RichardsonConstant ;
   qudt:iec61360Code "0112/2///62720#UAB353" ;
   qudt:informativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
-  qudt:symbol "A/(m²⋅K²)" ;
+  qudt:symbol "A/(m²·K²)" ;
   qudt:ucumCode "A.m-2.K-2"^^qudt:UCUMcs ;
   qudt:ucumCode "A/(m2.K2)"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A6" ;
@@ -557,7 +557,7 @@ unit:A-SEC
   qudt:iec61360Code "0112/2///62720#UAA107" ;
   qudt:iec61360Code "0112/2///62720#UAD516" ;
   qudt:plainTextDescription "product out of the SI base unit ampere and the SI base unit second" ;
-  qudt:symbol "A⋅s" ;
+  qudt:symbol "A·s" ;
   qudt:ucumCode "A.s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A8" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -629,7 +629,7 @@ unit:AC-FT
   qudt:informativeReference "http://en.wikipedia.org/wiki/Acre-foot"^^xsd:anyURI ;
   qudt:informativeReference "http://www.oxfordreference.com/view/10.1093/acref/9780198605225.001.0001/acref-9780198605225-e-35"^^xsd:anyURI ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/acreFoot> ;
-  qudt:symbol "acre⋅ft" ;
+  qudt:symbol "acre·ft" ;
   qudt:ucumCode "[acr_br].[ft_i]"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Acre Foot"@en ;
@@ -834,7 +834,7 @@ unit:ATM-M3-PER-MOL
   qudt:conversionMultiplierSN 1.01325E5 ;
   qudt:hasDimensionVector qkdv:A-1E0L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:HenrysLawVolatilityConstant ;
-  qudt:symbol "atm⋅m³/mol" ;
+  qudt:symbol "atm·m³/mol" ;
   qudt:ucumCode "atm.m3.mol-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Atmosphere Cubic Meter per Mole"@en-us ;
@@ -958,7 +958,7 @@ unit:A_Ab-CentiM2
   qudt:hasQuantityKind quantitykind:MagneticAreaMoment ;
   qudt:hasQuantityKind quantitykind:MagneticMoment ;
   qudt:informativeReference "http://wordinfo.info/unit/4266"^^xsd:anyURI ;
-  qudt:symbol "abA⋅cm²" ;
+  qudt:symbol "abA·cm²" ;
   qudt:ucumCode "Bi.cm2"^^qudt:UCUMcs ;
   vaem:todo "Determine type for magnetic moment" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -1104,7 +1104,7 @@ unit:AttoJ-SEC
   qudt:hasQuantityKind quantitykind:Action ;
   qudt:iec61360Code "0112/2///62720#UAB151" ;
   qudt:plainTextDescription "unit of the Planck's constant as product of the SI derived unit joule and the SI base unit second" ;
-  qudt:symbol "aJ⋅s" ;
+  qudt:symbol "aJ·s" ;
   qudt:ucumCode "aJ.s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B18" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -1244,7 +1244,7 @@ unit:BAR-L-PER-SEC
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAA326" ;
   qudt:plainTextDescription "product of the unit bar and the unit litre divided by the SI base unit second" ;
-  qudt:symbol "bar⋅L/s" ;
+  qudt:symbol "bar·L/s" ;
   qudt:ucumCode "bar.L.s-1"^^qudt:UCUMcs ;
   qudt:ucumCode "bar.L/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F91" ;
@@ -1262,7 +1262,7 @@ unit:BAR-M3-PER-SEC
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAA814" ;
   qudt:plainTextDescription "product out of the 0.001-fold of the unit bar and the power of the SI base unit metre with the exponent 3 divided by the SI base unit second" ;
-  qudt:symbol "bar⋅m³/s" ;
+  qudt:symbol "bar·m³/s" ;
   qudt:ucumCode "bar.m3.s-1"^^qudt:UCUMcs ;
   qudt:ucumCode "bar.m3/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F92" ;
@@ -1908,7 +1908,7 @@ unit:BQ-SEC-PER-M3
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:AbsoluteActivity ;
-  qudt:symbol "Bq⋅s/m³" ;
+  qudt:symbol "Bq·s/m³" ;
   qudt:ucumCode "Bq.s.m-3"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Becquerels second per cubic metre"@en ;
@@ -1992,7 +1992,7 @@ unit:BTU_IT-FT
   qudt:expression "\\(Btu-ft\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ThermalEnergyLength ;
-  qudt:symbol "Btu{IT}⋅ft" ;
+  qudt:symbol "Btu{IT}·ft" ;
   qudt:ucumCode "[Btu_IT].[ft_i]"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "BTU Foot"@en ;
@@ -2012,7 +2012,7 @@ unit:BTU_IT-FT-PER-FT2-HR-DEG_F
   qudt:informativeReference "http://en.wikipedia.org/wiki/Thermal_conductivity"^^xsd:anyURI ;
   qudt:informativeReference "http://www.translatorscafe.com/cafe/EN/units-converter/thermal-conductivity/c/"^^xsd:anyURI ;
   qudt:plainTextDescription "British thermal unit (international table) foot per hour Square foot degree Fahrenheit is the unit of the thermal conductivity according to the Imperial system of units." ;
-  qudt:symbol "Btu{IT}⋅ft/(ft²⋅hr⋅°F)" ;
+  qudt:symbol "Btu{IT}·ft/(ft²·hr·°F)" ;
   qudt:ucumCode "[Btu_IT].[ft_i].[ft_i]-2.h-1.[degF]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_IT].[ft_i]/([ft_i]2.h.[degF])"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J40" ;
@@ -2033,7 +2033,7 @@ unit:BTU_IT-IN
   qudt:expression "\\(Btu-in\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ThermalEnergyLength ;
-  qudt:symbol "Btu{IT}⋅in" ;
+  qudt:symbol "Btu{IT}·in" ;
   qudt:ucumCode "[Btu_IT].[in_i]"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "BTU Inch"@en ;
@@ -2054,7 +2054,7 @@ unit:BTU_IT-IN-PER-FT2-HR-DEG_F
   qudt:informativeReference "http://www.translatorscafe.com/cafe/EN/units-converter/thermal-conductivity/c/"^^xsd:anyURI ;
   qudt:latexSymbol "\\(Btu_{it} \\cdot in/(hr \\cdot ft^{2}  \\cdot degF)\\)"^^qudt:LatexString ;
   qudt:plainTextDescription "BTU (th) Inch per Square Foot Hour Degree Fahrenheit is an Imperial unit for 'Thermal Conductivity', an International British thermal unit inch per second per square foot per degree Fahrenheit is a unit of thermal conductivity in the US Customary Units and British Imperial Units." ;
-  qudt:symbol "Btu{IT}⋅in/(ft²⋅hr⋅°F)" ;
+  qudt:symbol "Btu{IT}·in/(ft²·hr·°F)" ;
   qudt:ucumCode "[Btu_IT].[in_i].[ft_i]-2.h-1.[degF]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_IT].[in_i]/([ft_i]2.h.[degF])"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J41" ;
@@ -2077,7 +2077,7 @@ unit:BTU_IT-IN-PER-FT2-SEC-DEG_F
   qudt:iec61360Code "0112/2///62720#UAA118" ;
   qudt:informativeReference "http://www.translatorscafe.com/cafe/EN/units-converter/thermal-conductivity/c/"^^xsd:anyURI ;
   qudt:plainTextDescription "British thermal unit (international table) inch per second Square foot degree Fahrenheit is the unit of the thermal conductivity according to the Imperial system of units." ;
-  qudt:symbol "Btu{IT}⋅in/(ft²⋅s⋅°F)" ;
+  qudt:symbol "Btu{IT}·in/(ft²·s·°F)" ;
   qudt:ucumCode "[Btu_IT].[in_i].[ft_i]-2.s-1.[degF]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_IT].[in_i]/([ft_i]2.s.[degF])"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J42" ;
@@ -2096,7 +2096,7 @@ unit:BTU_IT-IN-PER-HR-FT2-DEG_F
   qudt:hasQuantityKind quantitykind:ThermalConductivity ;
   qudt:iec61360Code "0112/2///62720#UAA117" ;
   qudt:plainTextDescription "unit of the thermal conductivity according to the Imperial system of units" ;
-  qudt:symbol "Btu{IT}⋅in/(hr⋅ft²⋅°F)" ;
+  qudt:symbol "Btu{IT}·in/(hr·ft²·°F)" ;
   qudt:ucumCode "[Btu_IT].[in_i].h-1.[ft_i]-2.[degF]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_IT].[in_i]/(h.[ft_i]2.[degF])"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J41" ;
@@ -2115,7 +2115,7 @@ unit:BTU_IT-IN-PER-SEC-FT2-DEG_F
   qudt:hasQuantityKind quantitykind:ThermalConductivity ;
   qudt:iec61360Code "0112/2///62720#UAA118" ;
   qudt:plainTextDescription "unit of the thermal conductivity according to the Imperial system of units" ;
-  qudt:symbol "Btu{IT}⋅in/(s⋅ft²⋅°F)" ;
+  qudt:symbol "Btu{IT}·in/(s·ft²·°F)" ;
   qudt:ucumCode "[Btu_IT].[in_i].s-1.[ft_i]-2.[degF]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_IT].[in_i]/(s.[ft_i]2.[degF])"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J42" ;
@@ -2211,7 +2211,7 @@ unit:BTU_IT-PER-FT2-HR-DEG_F
   qudt:expression "\\(Btu/(hr-ft^{2}-degF)\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H-1T-3D0 ;
   qudt:hasQuantityKind quantitykind:CoefficientOfHeatTransfer ;
-  qudt:symbol "Btu{IT}/(ft²⋅hr⋅°F)" ;
+  qudt:symbol "Btu{IT}/(ft²·hr·°F)" ;
   qudt:ucumCode "[Btu_IT].[ft_i]-2.h-1.[degF]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_IT]/([ft_i]2.h.[degF])"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -2244,7 +2244,7 @@ unit:BTU_IT-PER-FT2-SEC-DEG_F
   qudt:expression "\\(Btu/(ft^{2}-s-degF)\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H-1T-3D0 ;
   qudt:hasQuantityKind quantitykind:CoefficientOfHeatTransfer ;
-  qudt:symbol "Btu{IT}/(ft²⋅s⋅°F)" ;
+  qudt:symbol "Btu{IT}/(ft²·s·°F)" ;
   qudt:ucumCode "[Btu_IT].[ft_i]-2.s-1.[degF]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_IT]/([ft_i]2.s.[degF])"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "N76" ;
@@ -2308,7 +2308,7 @@ unit:BTU_IT-PER-HR-FT2
   qudt:expression "\\(Btu/(hr-ft^{2})\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:PowerPerArea ;
-  qudt:symbol "Btu{IT}/(hr⋅ft²)" ;
+  qudt:symbol "Btu{IT}/(hr·ft²)" ;
   qudt:ucumCode "[Btu_IT].h-1.[ft_i]-2"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_IT]/(h.[ft_i]2)"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -2339,7 +2339,7 @@ unit:BTU_IT-PER-HR-FT2-DEG_R
   qudt:hasQuantityKind quantitykind:CoefficientOfHeatTransfer ;
   qudt:iec61360Code "0112/2///62720#UAB099" ;
   qudt:plainTextDescription "unit of the heat transfer coefficient according to the Imperial system of units" ;
-  qudt:symbol "Btu{IT}/(hr⋅ft²⋅°R)" ;
+  qudt:symbol "Btu{IT}/(hr·ft²·°R)" ;
   qudt:ucumCode "[Btu_IT].h-1.[ft_i]-2.[degR]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_IT]/(h.[ft_i]2.[degR])"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A23" ;
@@ -2398,7 +2398,7 @@ unit:BTU_IT-PER-LB-DEG_F
   qudt:hasQuantityKind quantitykind:SpecificHeatCapacityAtConstantPressure ;
   qudt:hasQuantityKind quantitykind:SpecificHeatCapacityAtConstantVolume ;
   qudt:hasQuantityKind quantitykind:SpecificHeatCapacityAtSaturation ;
-  qudt:symbol "Btu{IT}/(lbm⋅°F)" ;
+  qudt:symbol "Btu{IT}/(lbm·°F)" ;
   qudt:ucumCode "[Btu_IT].[lb_av]-1.[degF]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_IT]/([lb_av].[degF])"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -2416,7 +2416,7 @@ unit:BTU_IT-PER-LB-DEG_R
   qudt:expression "\\(Btu/(lb-degR)\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H-1T-2D0 ;
   qudt:hasQuantityKind quantitykind:SpecificHeatCapacity ;
-  qudt:symbol "Btu{IT}/(lbm⋅°R)" ;
+  qudt:symbol "Btu{IT}/(lbm·°R)" ;
   qudt:ucumCode "[Btu_IT].[lb_av]-1.[degR]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_IT]/([lb_av].[degR])"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -2467,7 +2467,7 @@ unit:BTU_IT-PER-LB_F-DEG_F
   qudt:hasQuantityKind quantitykind:LinearThermalExpansion ;
   qudt:iec61360Code "0112/2///62720#UAA119" ;
   qudt:plainTextDescription "Unit of heat energy according to the Imperial system of units divided by the product of a pound of force and a degree Fahrenheit" ;
-  qudt:symbol "Btu{IT}/(lbf⋅°F)" ;
+  qudt:symbol "Btu{IT}/(lbf·°F)" ;
   qudt:ucumCode "[Btu_IT].[lbf_av]-1.[degF]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_IT]/([lbf_av].[degF])"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J43" ;
@@ -2485,7 +2485,7 @@ unit:BTU_IT-PER-LB_F-DEG_R
   qudt:hasQuantityKind quantitykind:LinearThermalExpansion ;
   qudt:iec61360Code "0112/2///62720#UAB141" ;
   qudt:plainTextDescription "Unit of heat energy according to the Imperial system of units divided by the product of a pound of force and a degree Rankine" ;
-  qudt:symbol "Btu{IT}/(lbf⋅°R)" ;
+  qudt:symbol "Btu{IT}/(lbf·°R)" ;
   qudt:ucumCode "[Btu_IT].[lbf_av]-1.[degR]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_IT]/([lbf_av].[degR])"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A21" ;
@@ -2522,7 +2522,7 @@ unit:BTU_IT-PER-MOL-DEG_F
   qudt:expression "\\(Btu/(lb-mol-degF)\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A-1E0L2I0M1H-1T-2D0 ;
   qudt:hasQuantityKind quantitykind:MolarHeatCapacity ;
-  qudt:symbol "Btu{IT}/(lb-mol⋅°F)" ;
+  qudt:symbol "Btu{IT}/(lb-mol·°F)" ;
   qudt:ucumCode "[Btu_IT].[mol_lb]-1.[degF]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_IT]/([mol_lb].[degF])"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -2557,7 +2557,7 @@ unit:BTU_IT-PER-MOL_LB-DEG_F
   qudt:expression "\\(Btu/(lb-mol-degF)\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A-1E0L2I0M1H-1T-2D0 ;
   qudt:hasQuantityKind quantitykind:MolarHeatCapacity ;
-  qudt:symbol "Btu{IT}/(lb-mol⋅°F)" ;
+  qudt:symbol "Btu{IT}/(lb-mol·°F)" ;
   qudt:ucumCode "[Btu_IT].[mol_lb]-1.[degF]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_IT]/([mol_lb].[degF])"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -2597,7 +2597,7 @@ unit:BTU_IT-PER-SEC-FT-DEG_R
   qudt:hasQuantityKind quantitykind:ThermalConductivity ;
   qudt:iec61360Code "0112/2///62720#UAB107" ;
   qudt:plainTextDescription "unit of the thermal conductivity according to the Imperial system of units" ;
-  qudt:symbol "Btu{IT}/(s⋅ft⋅°R)" ;
+  qudt:symbol "Btu{IT}/(s·ft·°R)" ;
   qudt:ucumCode "[Btu_IT].s-1.[ft_i]-1.[degR]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_IT]/(s.[ft_i].[degR])"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A22" ;
@@ -2617,7 +2617,7 @@ unit:BTU_IT-PER-SEC-FT2
   qudt:expression "\\(Btu/(s-ft^{2})\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:PowerPerArea ;
-  qudt:symbol "Btu{IT}/(s⋅ft²)" ;
+  qudt:symbol "Btu{IT}/(s·ft²)" ;
   qudt:ucumCode "[Btu_IT].s-1.[ft_i]-2"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_IT]/(s.[ft_i]2)"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "N53" ;
@@ -2649,7 +2649,7 @@ unit:BTU_IT-PER-SEC-FT2-DEG_R
   qudt:hasQuantityKind quantitykind:CoefficientOfHeatTransfer ;
   qudt:iec61360Code "0112/2///62720#UAB098" ;
   qudt:plainTextDescription "unit of the heat transfer coefficient according to the Imperial system of units" ;
-  qudt:symbol "Btu{IT}/(s⋅ft²⋅°R)" ;
+  qudt:symbol "Btu{IT}/(s·ft²·°R)" ;
   qudt:ucumCode "[Btu_IT].s-1.[ft_i]-2.[degR]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_IT]/(s.[ft_i]2.[degR])"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A20" ;
@@ -2708,7 +2708,7 @@ unit:BTU_TH-FT-PER-FT2-HR-DEG_F
   qudt:hasQuantityKind quantitykind:ThermalConductivity ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Thermal_conductivity"^^xsd:anyURI ;
   qudt:informativeReference "http://www.translatorscafe.com/cafe/EN/units-converter/thermal-conductivity/c/"^^xsd:anyURI ;
-  qudt:symbol "Btu{th}⋅ft/(ft²⋅hr⋅°F)" ;
+  qudt:symbol "Btu{th}·ft/(ft²·hr·°F)" ;
   qudt:ucumCode "[Btu_IT].[ft_i]-2.h-1.[degF]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_IT]/([ft_i]2.h.[degF])"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -2725,7 +2725,7 @@ unit:BTU_TH-FT-PER-HR-FT2-DEG_F
   qudt:hasQuantityKind quantitykind:ThermalConductivity ;
   qudt:iec61360Code "0112/2///62720#UAA123" ;
   qudt:plainTextDescription "unit of the thermal conductivity according to the Imperial system of units" ;
-  qudt:symbol "Btu{th}⋅ft/(hr⋅ft²⋅°F)" ;
+  qudt:symbol "Btu{th}·ft/(hr·ft²·°F)" ;
   qudt:ucumCode "[Btu_th].[ft_i].h-1.[ft_i]-2.[degF]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_th].[ft_i]/(h.[ft_i]2.[degF])"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J46" ;
@@ -2749,7 +2749,7 @@ unit:BTU_TH-IN-PER-FT2-HR-DEG_F
   qudt:informativeReference "http://www.translatorscafe.com/cafe/EN/units-converter/thermal-conductivity/c/"^^xsd:anyURI ;
   qudt:latexSymbol "\\(Btu_{th} \\cdot in/(hr \\cdot ft^{2}  \\cdot degF)\\)"^^qudt:LatexString ;
   qudt:plainTextDescription "Unit of thermal conductivity according to the Imperial system of units" ;
-  qudt:symbol "Btu{th}⋅in/(ft²⋅hr⋅°F)" ;
+  qudt:symbol "Btu{th}·in/(ft²·hr·°F)" ;
   qudt:ucumCode "[Btu_th].[in_i].[ft_i]-2.h-1.[degF]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_th].[in_i]/([ft_i]2.h.[degF])"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J48" ;
@@ -2772,7 +2772,7 @@ unit:BTU_TH-IN-PER-FT2-SEC-DEG_F
   qudt:iec61360Code "0112/2///62720#UAA126" ;
   qudt:informativeReference "http://www.translatorscafe.com/cafe/EN/units-converter/thermal-conductivity/c/"^^xsd:anyURI ;
   qudt:plainTextDescription "Unit of thermal conductivity according to the Imperial system of units" ;
-  qudt:symbol "Btu{th}⋅in/(ft²⋅s⋅°F)" ;
+  qudt:symbol "Btu{th}·in/(ft²·s·°F)" ;
   qudt:ucumCode "[Btu_th].[in_i].[ft_i]-2.s-1.[degF]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_th].[in_i]/([ft_i]2.s.[degF])"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -2948,7 +2948,7 @@ unit:BTU_TH-PER-LB-DEG_F
   qudt:hasQuantityKind quantitykind:SpecificHeatCapacityAtSaturation ;
   qudt:iec61360Code "0112/2///62720#UAA127" ;
   qudt:plainTextDescription "unit of the thermal conductivity according to the Imperial system of units divided by the units pound and degree Fahrenheit" ;
-  qudt:symbol "Btu{th}/(lbm⋅°F)" ;
+  qudt:symbol "Btu{th}/(lbm·°F)" ;
   qudt:ucumCode "[Btu_th].[lb_av]-1.[degF]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_th]/([lb_av].[degF])"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J50" ;
@@ -3307,7 +3307,7 @@ unit:C-M
   qudt:hasDimensionVector qkdv:A0E1L1I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:ElectricDipoleMoment ;
   qudt:iec61360Code "0112/2///62720#UAA133" ;
-  qudt:symbol "C⋅m" ;
+  qudt:symbol "C·m" ;
   qudt:ucumCode "C.m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A26" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -3342,7 +3342,7 @@ unit:C-M2
   qudt:expression "\\(C m^{2}\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E1L2I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:ElectricQuadrupoleMoment ;
-  qudt:symbol "C⋅m²" ;
+  qudt:symbol "C·m²" ;
   qudt:ucumCode "C.m2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Coulomb Square Meter"@en-us ;
@@ -3379,7 +3379,7 @@ unit:C-M2-PER-V
   qudt:hasDimensionVector qkdv:A0E2L0I0M-1H0T4D0 ;
   qudt:hasQuantityKind quantitykind:Polarizability ;
   qudt:iec61360Code "0112/2///62720#UAB486" ;
-  qudt:symbol "C⋅m²/V" ;
+  qudt:symbol "C·m²/V" ;
   qudt:ucumCode "C.m2.V-1"^^qudt:UCUMcs ;
   qudt:ucumCode "C.m2/V"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A27" ;
@@ -3472,7 +3472,7 @@ unit:C-PER-KiloGM-SEC
   qudt:iec61360Code "0112/2///62720#UAA132" ;
   qudt:informativeReference "http://en.wikibooks.org/wiki/Basic_Physics_of_Nuclear_Medicine/Units_of_Radiation_Measurement"^^xsd:anyURI ;
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
-  qudt:symbol "C/(kg⋅s)" ;
+  qudt:symbol "C/(kg·s)" ;
   qudt:ucumCode "C.kg-1.s-1"^^qudt:UCUMcs ;
   qudt:ucumCode "C/(kg.s)"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A31" ;
@@ -3644,7 +3644,7 @@ unit:C2-M2-PER-J
   qudt:expression "\\(C^{2} m^{2} J^{-1}\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E2L0I0M-1H0T4D0 ;
   qudt:hasQuantityKind quantitykind:Polarizability ;
-  qudt:symbol "C²⋅m²/J" ;
+  qudt:symbol "C²·m²/J" ;
   qudt:ucumCode "C2.m2.J-1"^^qudt:UCUMcs ;
   qudt:ucumCode "C2.m2/J"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -3664,7 +3664,7 @@ unit:C3-M-PER-J2
   qudt:expression "\\(C^{3} m J^{-2}\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E3L-3I0M-2H0T7D0 ;
   qudt:hasQuantityKind quantitykind:ElectricDipoleMoment_CubicPerEnergy_Squared ;
-  qudt:symbol "C³⋅m/J²" ;
+  qudt:symbol "C³·m/J²" ;
   qudt:ucumCode "C3.m.J-2"^^qudt:UCUMcs ;
   qudt:ucumCode "C3.m/J2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -3684,7 +3684,7 @@ unit:C4-M4-PER-J3
   qudt:expression "\\(C^4m^4/J^3\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E4L-2I0M-3H0T10D0 ;
   qudt:hasQuantityKind quantitykind:ElectricDipoleMoment_QuarticPerEnergy_Cubic ;
-  qudt:symbol "C⁴⋅m⁴/J³" ;
+  qudt:symbol "C⁴·m⁴/J³" ;
   qudt:ucumCode "C4.m4.J-3"^^qudt:UCUMcs ;
   qudt:ucumCode "C4.m4/J3"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -3778,7 +3778,7 @@ unit:CAL_IT-PER-GM-DEG_C
   qudt:hasQuantityKind quantitykind:SpecificHeatCapacityAtSaturation ;
   qudt:iec61360Code "0112/2///62720#UAA362" ;
   qudt:plainTextDescription "unit calorieIT divided by the products of the units gram and degree Celsius" ;
-  qudt:symbol "cal{IT}/(g⋅°C)" ;
+  qudt:symbol "cal{IT}/(g·°C)" ;
   qudt:ucumCode "cal_IT.g-1.Cel-1"^^qudt:UCUMcs ;
   qudt:ucumCode "cal_IT/(g.Cel)"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J76" ;
@@ -3801,7 +3801,7 @@ unit:CAL_IT-PER-GM-K
   qudt:hasQuantityKind quantitykind:SpecificHeatCapacityAtSaturation ;
   qudt:iec61360Code "0112/2///62720#UAA363" ;
   qudt:plainTextDescription "unit calorieIT divided by the product of the SI base unit gram and Kelvin" ;
-  qudt:symbol "cal{IT}/(g⋅K)" ;
+  qudt:symbol "cal{IT}/(g·K)" ;
   qudt:ucumCode "cal_IT.g-1.K-1"^^qudt:UCUMcs ;
   qudt:ucumCode "cal_IT/(g.K)"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D76" ;
@@ -3820,7 +3820,7 @@ unit:CAL_IT-PER-SEC-CentiM-K
   qudt:hasQuantityKind quantitykind:ThermalConductivity ;
   qudt:iec61360Code "0112/2///62720#UAB108" ;
   qudt:plainTextDescription "unit of the thermal conductivity according to the Imperial system of units" ;
-  qudt:symbol "cal{IT}/(s⋅cm⋅K)" ;
+  qudt:symbol "cal{IT}/(s·cm·K)" ;
   qudt:ucumCode "cal_IT.s-1.cm-1.K-1"^^qudt:UCUMcs ;
   qudt:ucumCode "cal_IT/(s.cm.K)"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D71" ;
@@ -3840,7 +3840,7 @@ unit:CAL_IT-PER-SEC-CentiM2-K
   qudt:hasQuantityKind quantitykind:CoefficientOfHeatTransfer ;
   qudt:iec61360Code "0112/2///62720#UAB096" ;
   qudt:plainTextDescription "unit of the heat transfer coefficient according to the Imperial system of units" ;
-  qudt:symbol "cal{IT}/(s⋅cm²⋅K)" ;
+  qudt:symbol "cal{IT}/(s·cm²·K)" ;
   qudt:ucumCode "cal_IT.s-1.cm-2.K-1"^^qudt:UCUMcs ;
   qudt:ucumCode "cal_IT/(s.cm2.K)"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D72" ;
@@ -3904,7 +3904,7 @@ unit:CAL_TH-PER-CentiM-SEC-DEG_C
   qudt:hasQuantityKind quantitykind:ThermalConductivity ;
   qudt:iec61360Code "0112/2///62720#UAA365" ;
   qudt:plainTextDescription "unit of the thermal conductivity according to the Imperial system of units" ;
-  qudt:symbol "cal/(cm⋅s⋅°C)" ;
+  qudt:symbol "cal/(cm·s·°C)" ;
   qudt:ucumCode "cal_th.cm-1.s-1.Cel-1"^^qudt:UCUMcs ;
   qudt:ucumCode "cal_th/(cm.s.Cel)"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J78" ;
@@ -4015,7 +4015,7 @@ unit:CAL_TH-PER-GM-DEG_C
   qudt:hasQuantityKind quantitykind:SpecificHeatCapacityAtSaturation ;
   qudt:iec61360Code "0112/2///62720#UAA366" ;
   qudt:plainTextDescription "unit calorie (thermochemical) divided by the product of the unit gram and degree Celsius" ;
-  qudt:symbol "cal/(g⋅°C)" ;
+  qudt:symbol "cal/(g·°C)" ;
   qudt:ucumCode "cal_th.g-1.Cel-1"^^qudt:UCUMcs ;
   qudt:ucumCode "cal_th/(g.Cel)"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J79" ;
@@ -4038,7 +4038,7 @@ unit:CAL_TH-PER-GM-K
   qudt:hasQuantityKind quantitykind:SpecificHeatCapacityAtSaturation ;
   qudt:iec61360Code "0112/2///62720#UAA367" ;
   qudt:plainTextDescription "unit calorie (thermochemical) divided by the product of the SI derived unit gram and the SI base unit Kelvin" ;
-  qudt:symbol "cal/(g⋅K)" ;
+  qudt:symbol "cal/(g·K)" ;
   qudt:ucumCode "cal_th.g-1.K-1"^^qudt:UCUMcs ;
   qudt:ucumCode "cal_th/(g.K)"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D37" ;
@@ -4095,7 +4095,7 @@ unit:CAL_TH-PER-SEC-CentiM-K
   qudt:hasQuantityKind quantitykind:ThermalConductivity ;
   qudt:iec61360Code "0112/2///62720#UAB109" ;
   qudt:plainTextDescription "unit of the thermal conductivity according to the Imperial system of units" ;
-  qudt:symbol "cal/(s⋅cm⋅K)" ;
+  qudt:symbol "cal/(s·cm·K)" ;
   qudt:ucumCode "cal_th.s-1.cm-1.K-1"^^qudt:UCUMcs ;
   qudt:ucumCode "cal_th/(s.cm.K)"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D38" ;
@@ -4115,7 +4115,7 @@ unit:CAL_TH-PER-SEC-CentiM2-K
   qudt:hasQuantityKind quantitykind:CoefficientOfHeatTransfer ;
   qudt:iec61360Code "0112/2///62720#UAB097" ;
   qudt:plainTextDescription "unit of the heat transfer coefficient according to the Imperial system of units" ;
-  qudt:symbol "cal/(s⋅cm²⋅K)" ;
+  qudt:symbol "cal/(s·cm²·K)" ;
   qudt:ucumCode "cal_th.s-1.cm-2.K-1"^^qudt:UCUMcs ;
   qudt:ucumCode "cal_th/(s.cm2.K)"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D39" ;
@@ -4861,7 +4861,7 @@ unit:CentiM-SEC-DEG_C
   qudt:expression "\\(cm-s-degC\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H1T1D0 ;
   qudt:hasQuantityKind quantitykind:LengthTemperatureTime ;
-  qudt:symbol "cm⋅s⋅°C" ;
+  qudt:symbol "cm·s·°C" ;
   qudt:ucumCode "cm.s.Cel-1"^^qudt:UCUMcs ;
   qudt:ucumCode "cm.s/Cel"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -4906,7 +4906,7 @@ unit:CentiM2-MIN
   qudt:expression "\\(cm^{2}m\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:AreaTime ;
-  qudt:symbol "cm²⋅min" ;
+  qudt:symbol "cm²·min" ;
   qudt:ucumCode "cm2.min"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Square Centimeter Minute"@en-us ;
@@ -5004,7 +5004,7 @@ unit:CentiM2-SEC
   qudt:expression "\\(cm^2 . s\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:AreaTime ;
-  qudt:symbol "cm²⋅s" ;
+  qudt:symbol "cm²·s" ;
   qudt:ucumCode "cm2.s"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Square Centimeter Second"@en-us ;
@@ -5096,7 +5096,7 @@ unit:CentiM3-PER-DAY-BAR
   qudt:hasDimensionVector qkdv:A0E0L4I0M-1H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA390" ;
-  qudt:symbol "cm³/(d⋅bar)" ;
+  qudt:symbol "cm³/(d·bar)" ;
   qudt:ucumCode "cm3.d-1.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G78" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -5110,7 +5110,7 @@ unit:CentiM3-PER-DAY-K
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA389" ;
-  qudt:symbol "cm³/(d⋅K)" ;
+  qudt:symbol "cm³/(d·K)" ;
   qudt:ucumCode "cm3.d-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G61" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -5169,7 +5169,7 @@ unit:CentiM3-PER-HR-BAR
   qudt:hasDimensionVector qkdv:A0E0L4I0M-1H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA393" ;
-  qudt:symbol "cm³/(h⋅bar)" ;
+  qudt:symbol "cm³/(h·bar)" ;
   qudt:ucumCode "cm3.h-1.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G79" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -5183,7 +5183,7 @@ unit:CentiM3-PER-HR-K
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA392" ;
-  qudt:symbol "cm³/(h⋅K)" ;
+  qudt:symbol "cm³/(h·K)" ;
   qudt:ucumCode "cm3.h-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G62" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -5258,7 +5258,7 @@ unit:CentiM3-PER-MIN-BAR
   qudt:hasDimensionVector qkdv:A0E0L4I0M-1H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA397" ;
-  qudt:symbol "cm³/(min⋅bar)" ;
+  qudt:symbol "cm³/(min·bar)" ;
   qudt:ucumCode "cm3.min-1.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G80" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -5272,7 +5272,7 @@ unit:CentiM3-PER-MIN-K
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA396" ;
-  qudt:symbol "cm³/(min⋅K)" ;
+  qudt:symbol "cm³/(min·K)" ;
   qudt:ucumCode "cm3.min-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G63" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -5307,7 +5307,7 @@ unit:CentiM3-PER-MOL-SEC
   qudt:hasDimensionVector qkdv:A-1E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:AtmosphericHydroxylationRate ;
   qudt:hasQuantityKind quantitykind:SecondOrderReactionRateConstant ;
-  qudt:symbol "cm³/(mol⋅s)" ;
+  qudt:symbol "cm³/(mol·s)" ;
   qudt:ucumCode "cm3.mol-1.s-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Cubic Centimeter per Mole Second"@en ;
@@ -5343,7 +5343,6 @@ unit:CentiM3-PER-SEC-BAR
   qudt:hasDimensionVector qkdv:A0E0L4I0M-1H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA401" ;
-  qudt:symbol "cm³/(s⋅bar)" ;
   qudt:symbol "cm³/(s·bar)" ;
   qudt:ucumCode "cm3.s-1.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G81" ;
@@ -5358,7 +5357,6 @@ unit:CentiM3-PER-SEC-K
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA400" ;
-  qudt:symbol "cm³/(s⋅K)" ;
   qudt:symbol "cm³/(s·K)" ;
   qudt:ucumCode "cm3.s-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G64" ;
@@ -5545,7 +5543,7 @@ unit:CentiN-M
   qudt:hasQuantityKind quantitykind:Torque ;
   qudt:iec61360Code "0112/2///62720#UAA355" ;
   qudt:plainTextDescription "0.01-fold of the product of the SI derived unit newton and SI base unit metre" ;
-  qudt:symbol "cN⋅m" ;
+  qudt:symbol "cN·m" ;
   qudt:ucumCode "cN.m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J72" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -6134,7 +6132,7 @@ unit:DEG_C-CentiM
   qudt:expression "\\(cm-degC\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H1T0D0 ;
   qudt:hasQuantityKind quantitykind:LengthTemperature ;
-  qudt:symbol "°C⋅cm" ;
+  qudt:symbol "°C·cm" ;
   qudt:ucumCode "Cel.cm"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Degree Celsius Centimeter"@en-us ;
@@ -6149,7 +6147,7 @@ unit:DEG_C-KiloGM-PER-M2
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M1H1T0D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "°C⋅kg/m²" ;
+  qudt:symbol "°C·kg/m²" ;
   qudt:ucumCode "Cel.kg.m-2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Degrees Celsius kilogram per square metre"@en ;
@@ -6275,7 +6273,7 @@ unit:DEG_C-WK
   qudt:conversionMultiplierSN 6.048E5 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H1T1D0 ;
   qudt:hasQuantityKind quantitykind:TimeTemperature ;
-  qudt:symbol "°C⋅wk" ;
+  qudt:symbol "°C·wk" ;
   qudt:ucumCode "Cel.wk"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Degree Celsius week"@en ;
@@ -6347,7 +6345,7 @@ unit:DEG_F-HR
   qudt:expression "\\(degF-hr\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H1T1D0 ;
   qudt:hasQuantityKind quantitykind:TimeTemperature ;
-  qudt:symbol "°F⋅hr" ;
+  qudt:symbol "°F·hr" ;
   qudt:ucumCode "[degF].h"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Degree Fahrenheit Hour"@en ;
@@ -6363,7 +6361,7 @@ unit:DEG_F-HR-FT2-PER-BTU_IT
   qudt:hasQuantityKind quantitykind:ThermalInsulance ;
   qudt:iec61360Code "0112/2///62720#UAA043" ;
   qudt:plainTextDescription "unit of the thermal resistor according to the Imperial system of units" ;
-  qudt:symbol "°F⋅hr⋅ft²/Btu{IT}" ;
+  qudt:symbol "°F·hr·ft²/Btu{IT}" ;
   qudt:ucumCode "[degF].h-1.[ft_i]-2.[Btu_IT]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[degF]/(h.[ft_i]2.[Btu_IT])"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J22" ;
@@ -6378,7 +6376,7 @@ unit:DEG_F-HR-FT2-PER-BTU_IT-IN
   qudt:hasDimensionVector qkdv:A0E0L-1I0M-1H1T3D0 ;
   qudt:hasQuantityKind quantitykind:ThermalResistivity ;
   qudt:iec61360Code "0112/2///62720#UAB252" ;
-  qudt:symbol "°F⋅hr⋅ft²/(Btu{IT}⋅in)" ;
+  qudt:symbol "°F·hr·ft²/(Btu{IT}·in)" ;
   qudt:ucumCode "[degF].h.[ft_i]2.[Btu_IT]-1.[in_i]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "N88" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -6395,7 +6393,7 @@ unit:DEG_F-HR-FT2-PER-BTU_TH
   qudt:hasQuantityKind quantitykind:ThermalInsulance ;
   qudt:iec61360Code "0112/2///62720#UAA040" ;
   qudt:plainTextDescription "unit of the thermal resistor according to the according to the Imperial system of units" ;
-  qudt:symbol "°F⋅hr⋅ft²/Btu{th}" ;
+  qudt:symbol "°F·hr·ft²/Btu{th}" ;
   qudt:ucumCode "[degF].h-1.[ft_i]-2.[Btu_th]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[degF]/(h.[ft_i]2.[Btu_th])"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J19" ;
@@ -6410,7 +6408,7 @@ unit:DEG_F-HR-FT2-PER-BTU_TH-IN
   qudt:hasDimensionVector qkdv:A0E0L-1I0M-1H1T3D0 ;
   qudt:hasQuantityKind quantitykind:ThermalResistivity ;
   qudt:iec61360Code "0112/2///62720#UAB253" ;
-  qudt:symbol "°F⋅hr⋅ft²/(Btu{th}⋅in)" ;
+  qudt:symbol "°F·hr·ft²/(Btu{th}·in)" ;
   qudt:ucumCode "[degF].h.[ft_i]2.[Btu_th]-1.[in_i]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "N89" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -6429,7 +6427,7 @@ unit:DEG_F-HR-PER-BTU_IT
   qudt:expression "\\(degF-hr/Btu\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M-1H1T3D0 ;
   qudt:hasQuantityKind quantitykind:ThermalResistance ;
-  qudt:symbol "°F⋅hr/Btu{IT}" ;
+  qudt:symbol "°F·hr/Btu{IT}" ;
   qudt:ucumCode "[degF].h.[Btu_IT]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[degF].h/[Btu_IT]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "N84" ;
@@ -6575,7 +6573,7 @@ unit:DEG_F-SEC-PER-BTU_IT
   qudt:hasDimensionVector qkdv:A0E0L-2I0M-1H1T3D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAB250" ;
-  qudt:symbol "°F⋅s/Btu{IT}" ;
+  qudt:symbol "°F·s/Btu{IT}" ;
   qudt:ucumCode "[degF].s.[Btu_IT]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "N86" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -6589,7 +6587,7 @@ unit:DEG_F-SEC-PER-BTU_TH
   qudt:hasDimensionVector qkdv:A0E0L-2I0M-1H1T3D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAB251" ;
-  qudt:symbol "°F⋅s/Btu{th}" ;
+  qudt:symbol "°F·s/Btu{th}" ;
   qudt:ucumCode "[degF].s.[Btu_th]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "N87" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -6790,7 +6788,7 @@ unit:DYN-CentiM
   qudt:hasQuantityKind quantitykind:MomentOfForce ;
   qudt:hasQuantityKind quantitykind:Torque ;
   qudt:iec61360Code "0112/2///62720#UAA423" ;
-  qudt:symbol "dyn⋅cm" ;
+  qudt:symbol "dyn·cm" ;
   qudt:ucumCode "dyn.cm"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J94" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -6863,7 +6861,7 @@ unit:DYN-SEC-PER-CentiM
   qudt:hasQuantityKind quantitykind:MassFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAB144" ;
   qudt:plainTextDescription "CGS unit of the mechanical impedance" ;
-  qudt:symbol "dyn⋅s/cm" ;
+  qudt:symbol "dyn·s/cm" ;
   qudt:ucumCode "dyn.s.cm-1"^^qudt:UCUMcs ;
   qudt:ucumCode "dyn.s/cm"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A51" ;
@@ -6882,7 +6880,7 @@ unit:DYN-SEC-PER-CentiM3
   qudt:hasQuantityKind quantitykind:MassPerAreaTime ;
   qudt:iec61360Code "0112/2///62720#UAB102" ;
   qudt:plainTextDescription "CGS unit of the acoustic image impedance of the medium" ;
-  qudt:symbol "dyn⋅s/cm³" ;
+  qudt:symbol "dyn·s/cm³" ;
   qudt:ucumCode "dyn.s.cm-3"^^qudt:UCUMcs ;
   qudt:ucumCode "dyn.s/cm3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A50" ;
@@ -7135,7 +7133,7 @@ unit:DeciB-MilliW
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAD891" ;
-  qudt:symbol "dB⋅mW" ;
+  qudt:symbol "dB·mW" ;
   qudt:ucumCode "dB.mW"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "DBM" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -7608,7 +7606,7 @@ unit:DeciN-M
   qudt:hasQuantityKind quantitykind:Torque ;
   qudt:iec61360Code "0112/2///62720#UAB084" ;
   qudt:plainTextDescription "0.1-fold of the product of the derived SI unit joule and the SI base unit metre" ;
-  qudt:symbol "dN⋅m" ;
+  qudt:symbol "dN·m" ;
   qudt:ucumCode "dN.m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "DN" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -7835,7 +7833,7 @@ unit:ERG-PER-CentiM2-SEC
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:PowerPerArea ;
   qudt:iec61360Code "0112/2///62720#UAB055" ;
-  qudt:symbol "erg/(cm²⋅s)" ;
+  qudt:symbol "erg/(cm²·s)" ;
   qudt:ucumCode "erg.cm-2.s-1"^^qudt:UCUMcs ;
   qudt:ucumCode "erg/(cm2.s)"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A65" ;
@@ -7914,7 +7912,7 @@ unit:ERG-PER-GM-SEC
   qudt:hasQuantityKind quantitykind:SpecificPower ;
   qudt:iec61360Code "0112/2///62720#UAB147" ;
   qudt:plainTextDescription "CGS unit of the mass-related power" ;
-  qudt:symbol "erg/(g⋅s)" ;
+  qudt:symbol "erg/(g·s)" ;
   qudt:ucumCode "erg.g-1.s-1"^^qudt:UCUMcs ;
   qudt:ucumCode "erg/(g.s)"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A62" ;
@@ -7954,7 +7952,7 @@ unit:ERG-SEC
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:AngularImpulse ;
   qudt:hasQuantityKind quantitykind:AngularMomentum ;
-  qudt:symbol "erg⋅s" ;
+  qudt:symbol "erg·s" ;
   qudt:ucumCode "erg.s"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Erg Second"@en ;
@@ -8014,7 +8012,7 @@ unit:EUR-PER-KiloW-HR
   qudt:hasDimensionVector qkdv:A0E0L-2I0M-1H0T2D0 ;
   qudt:hasQuantityKind quantitykind:CostPerUnitEnergy ;
   qudt:plainTextDescription "Unit for measuring the cost of electricity." ;
-  qudt:symbol "€/(kW⋅hr)" ;
+  qudt:symbol "€/(kW·hr)" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Euro per kilowatt hour"@en ;
 .
@@ -8050,7 +8048,7 @@ unit:EUR-PER-W-HR
   qudt:hasDimensionVector qkdv:A0E0L-2I0M-1H0T2D0 ;
   qudt:hasQuantityKind quantitykind:CostPerUnitEnergy ;
   qudt:plainTextDescription "Unit for measuring the cost of electricity." ;
-  qudt:symbol "€/(W⋅hr)" ;
+  qudt:symbol "€/(W·hr)" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Euro per watt hour"@en ;
 .
@@ -8062,7 +8060,7 @@ unit:EUR-PER-W-SEC
   qudt:hasDimensionVector qkdv:A0E0L-2I0M-1H0T2D0 ;
   qudt:hasQuantityKind quantitykind:CostPerUnitEnergy ;
   qudt:plainTextDescription "Unit for measuring the cost of electricity." ;
-  qudt:symbol "€/(W⋅s)" ;
+  qudt:symbol "€/(W·s)" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Euro per watt second"@en ;
 .
@@ -8198,7 +8196,7 @@ unit:EV-SEC
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:AngularImpulse ;
   qudt:hasQuantityKind quantitykind:AngularMomentum ;
-  qudt:symbol "eV⋅s" ;
+  qudt:symbol "eV·s" ;
   qudt:ucumCode "eV.s"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Electron Volt Second"@en ;
@@ -8838,7 +8836,7 @@ unit:FT-LA
   qudt:hasDimensionVector qkdv:A0E0L-2I1M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Luminance ;
   qudt:iec61360Code "0112/2///62720#UAB258" ;
-  qudt:symbol "ft⋅L" ;
+  qudt:symbol "ft·L" ;
   qudt:ucumCode "[ft_i].Lmb"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P29" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -8861,7 +8859,7 @@ unit:FT-LB_F
   qudt:hasQuantityKind quantitykind:Torque ;
   qudt:iec61360Code "0112/2///62720#UAA443" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Foot-pound_force?oldid=453269257"^^xsd:anyURI ;
-  qudt:symbol "ft⋅lbf" ;
+  qudt:symbol "ft·lbf" ;
   qudt:ucumCode "[ft_i].[lbf_av]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "85" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -8880,7 +8878,7 @@ unit:FT-LB_F-PER-FT2
   qudt:expression "\\(ft-lbf/ft^{2}\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:EnergyPerArea ;
-  qudt:symbol "ft⋅lbf/ft²" ;
+  qudt:symbol "ft·lbf/ft²" ;
   qudt:ucumCode "[ft_i].[lbf_av].[sft_i]-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Foot Pound per Square Foot"@en ;
@@ -8898,7 +8896,7 @@ unit:FT-LB_F-PER-FT2-SEC
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:PowerPerArea ;
   qudt:latexSymbol "\\(ft \\cdot lbf/(ft^2 \\cdot s)\\)"^^qudt:LatexString ;
-  qudt:symbol "ft⋅lbf/(ft²⋅s)" ;
+  qudt:symbol "ft·lbf/(ft²·s)" ;
   qudt:ucumCode "[ft_i].[lbf_av].[sft_i]-1.s-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Foot Pound Force per Square Foot Second"@en ;
@@ -8917,7 +8915,7 @@ unit:FT-LB_F-PER-HR
   qudt:hasQuantityKind quantitykind:ActivePower ;
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAA444" ;
-  qudt:symbol "ft⋅lbf/hr" ;
+  qudt:symbol "ft·lbf/hr" ;
   qudt:ucumCode "[ft_i].[lbf_av].h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K15" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -8932,7 +8930,7 @@ unit:FT-LB_F-PER-M2
   qudt:expression "\\(ft-lbf/m^{2}\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:EnergyPerArea ;
-  qudt:symbol "ft⋅lbf/m²" ;
+  qudt:symbol "ft·lbf/m²" ;
   qudt:ucumCode "[ft_i].[lbf_av].m-2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Foot Pound Force per Square Meter"@en-us ;
@@ -8952,7 +8950,7 @@ unit:FT-LB_F-PER-MIN
   qudt:hasQuantityKind quantitykind:ActivePower ;
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAA445" ;
-  qudt:symbol "ft⋅lbf/min" ;
+  qudt:symbol "ft·lbf/min" ;
   qudt:ucumCode "[ft_i].[lbf_av].min-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K16" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -8972,7 +8970,7 @@ unit:FT-LB_F-PER-SEC
   qudt:hasQuantityKind quantitykind:ActivePower ;
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAA446" ;
-  qudt:symbol "ft⋅lbf/s" ;
+  qudt:symbol "ft·lbf/s" ;
   qudt:ucumCode "[ft_i].[lbf_av].s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A74" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -8989,7 +8987,7 @@ unit:FT-LB_F-SEC
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:AngularImpulse ;
   qudt:hasQuantityKind quantitykind:AngularMomentum ;
-  qudt:symbol "ft⋅lbf⋅s" ;
+  qudt:symbol "ft·lbf·s" ;
   qudt:ucumCode "[ft_i].[lbf_av].s"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Foot Pound Force Second"@en ;
@@ -9007,7 +9005,7 @@ unit:FT-PDL
   qudt:hasQuantityKind quantitykind:Energy ;
   qudt:iec61360Code "0112/2///62720#UAB220" ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/footPoundal> ;
-  qudt:symbol "ft⋅pdl" ;
+  qudt:symbol "ft·pdl" ;
   qudt:ucumCode "[ft_i].[lb_av].[ft_i].s-2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "N46" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -9252,7 +9250,7 @@ unit:FT2-DEG_F
   qudt:expression "\\(ft^{2}-degF\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H1T0D0 ;
   qudt:hasQuantityKind quantitykind:AreaTemperature ;
-  qudt:symbol "ft²⋅°F" ;
+  qudt:symbol "ft²·°F" ;
   qudt:ucumCode "[sft_i].[degF]"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Square Foot Degree Fahrenheit"@en ;
@@ -9270,7 +9268,7 @@ unit:FT2-HR-DEG_F
   qudt:expression "\\(ft^{2}-hr-degF\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H1T1D0 ;
   qudt:hasQuantityKind quantitykind:AreaTimeTemperature ;
-  qudt:symbol "ft²⋅hr⋅°F" ;
+  qudt:symbol "ft²·hr·°F" ;
   qudt:ucumCode "[sft_i].h.[degF]"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Square Foot Hour Degree Fahrenheit"@en ;
@@ -9288,7 +9286,7 @@ unit:FT2-HR-DEG_F-PER-BTU_IT
   qudt:expression "\\(sqft-hr-degF/btu\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M-1H1T3D0 ;
   qudt:hasQuantityKind quantitykind:ThermalInsulance ;
-  qudt:symbol "ft²⋅hr⋅°F/Btu{IT}" ;
+  qudt:symbol "ft²·hr·°F/Btu{IT}" ;
   qudt:ucumCode "[sft_i].h.[degF].[Btu_IT]-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Square Foot Hour Degree Fahrenheit per BTU"@en ;
@@ -9305,7 +9303,7 @@ unit:FT2-PER-BTU_IT-IN
   qudt:expression "\\(ft2-per-btu-in\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M-1H0T2D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "ft²/(Btu{IT}⋅in)" ;
+  qudt:symbol "ft²/(Btu{IT}·in)" ;
   qudt:ucumCode "[sft_i].[Btu_IT]-1.[in_i]-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Square Foot per BTU Inch"@en ;
@@ -9362,7 +9360,7 @@ unit:FT2-SEC-DEG_F
   qudt:expression "\\(ft^{2}-s-degF\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H1T1D0 ;
   qudt:hasQuantityKind quantitykind:AreaTimeTemperature ;
-  qudt:symbol "ft²⋅s⋅°F" ;
+  qudt:symbol "ft²·s·°F" ;
   qudt:ucumCode "[sft_i].s.[degF]"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Square Foot Second Degree Fahrenheit"@en ;
@@ -9490,7 +9488,7 @@ unit:FT3-PER-MIN-FT2
   qudt:hasQuantityKind quantitykind:Speed ;
   qudt:iec61360Code "0112/2///62720#UAB086" ;
   qudt:plainTextDescription "unit of the volume flow rate according to the Anglio-American and imperial system of units cubic foot per minute related to the transfer area according to the Anglian American and Imperial system of units square foot" ;
-  qudt:symbol "ft³/(min⋅ft²)" ;
+  qudt:symbol "ft³/(min·ft²)" ;
   qudt:ucumCode "[cft_i].min-1.[sft_i]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "36" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -10574,7 +10572,7 @@ unit:GM-MilliM
   qudt:hasQuantityKind quantitykind:LengthMass ;
   qudt:iec61360Code "0112/2///62720#UAB381" ;
   qudt:plainTextDescription "unit of the imbalance as product of the 0.001-fold of the SI base unit kilogram and the 0.001-fold of the SI base unit metre" ;
-  qudt:symbol "g⋅mm" ;
+  qudt:symbol "g·mm" ;
   qudt:ucumCode "g.mm"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H84" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -10603,7 +10601,7 @@ unit:GM-PER-CentiM-BAR
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T2D0 ;
   qudt:hasQuantityKind quantitykind:Time_Squared ;
   qudt:iec61360Code "0112/2///62720#UAA471" ;
-  qudt:symbol "g/(cm³⋅bar)" ;
+  qudt:symbol "g/(cm³·bar)" ;
   qudt:ucumCode "g.cm-1.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G11" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -10655,7 +10653,7 @@ unit:GM-PER-CentiM2-YR
   qudt:conversionMultiplierSN 3.16880878140289E-7 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:MassPerAreaTime ;
-  qudt:symbol "g/(cm²⋅yr)" ;
+  qudt:symbol "g/(cm²·yr)" ;
   qudt:ucumCode "g.cm-2.a-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Grams per square centimetre year"@en ;
@@ -10704,7 +10702,6 @@ unit:GM-PER-CentiM3-K
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H-1T0D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA470" ;
-  qudt:symbol "g/(cm³⋅K)" ;
   qudt:symbol "g/(cm³·K)" ;
   qudt:ucumCode "g.cm-3.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G33" ;
@@ -10738,7 +10735,6 @@ unit:GM-PER-DAY-BAR
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA474" ;
-  qudt:symbol "g/(d⋅bar)" ;
   qudt:symbol "g/(d·bar)" ;
   qudt:ucumCode "g.d-1.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F62" ;
@@ -10824,7 +10820,6 @@ unit:GM-PER-DeciM3-BAR
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T2D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA477" ;
-  qudt:symbol "g/(dm³⋅bar)" ;
   qudt:symbol "g/(dm³·bar)" ;
   qudt:ucumCode "g.dm-3.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G12" ;
@@ -10905,7 +10900,6 @@ unit:GM-PER-HR-K
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA479" ;
-  qudt:symbol "g/(h⋅K)" ;
   qudt:symbol "g/(h·K)" ;
   qudt:ucumCode "g.h-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F36" ;
@@ -11009,7 +11003,6 @@ unit:GM-PER-L-BAR
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T2D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA484" ;
-  qudt:symbol "g/(l⋅bar)" ;
   qudt:symbol "g/(l·bar)" ;
   qudt:ucumCode "g.L-1.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G13" ;
@@ -11037,7 +11030,6 @@ unit:GM-PER-L-K
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H-1T0D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA483" ;
-  qudt:symbol "g/(l⋅K)" ;
   qudt:symbol "g/(l·K)" ;
   qudt:ucumCode "g.L-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G35" ;
@@ -11137,7 +11129,7 @@ unit:GM-PER-M2-DAY
   qudt:hasDimensionVector qkdv:A0E0L-2I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:MassPerAreaTime ;
   qudt:plainTextDescription "A metric unit of volume over time indicating the amount generated across one square meter over a day." ;
-  qudt:symbol "g/(m²⋅day)" ;
+  qudt:symbol "g/(m²·day)" ;
   qudt:ucumCode "g.m-2.d-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "grams per square meter day"@en-us ;
@@ -11173,7 +11165,6 @@ unit:GM-PER-M3-BAR
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T2D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA489" ;
-  qudt:symbol "g/(m³⋅bar)" ;
   qudt:symbol "g/(m³·bar)" ;
   qudt:ucumCode "g.m-3.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G14" ;
@@ -11201,7 +11192,6 @@ unit:GM-PER-M3-K
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H-1T0D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA488" ;
-  qudt:symbol "g/(m³⋅K)" ;
   qudt:symbol "g/(m³·K)" ;
   qudt:ucumCode "g.m-3.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G36" ;
@@ -11274,7 +11264,6 @@ unit:GM-PER-MIN-BAR
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA492" ;
-  qudt:symbol "g/(min⋅bar)" ;
   qudt:symbol "g/(min·bar)" ;
   qudt:ucumCode "g.min-1.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F64" ;
@@ -11354,7 +11343,6 @@ unit:GM-PER-MilliL-K
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H-1T0D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA494" ;
-  qudt:symbol "g/(ml⋅K)" ;
   qudt:symbol "g/(ml·K)" ;
   qudt:ucumCode "g.mL-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G37" ;
@@ -11389,7 +11377,7 @@ unit:GM-PER-MilliM-BAR
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T2D0 ;
   qudt:hasQuantityKind quantitykind:Time_Squared ;
   qudt:iec61360Code "0112/2///62720#UAA495" ;
-  qudt:symbol "g/(ml⋅bar)" ;
+  qudt:symbol "g/(ml·bar)" ;
   qudt:ucumCode "g.mm-1.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G15" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -11450,7 +11438,6 @@ unit:GM-PER-SEC-K
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA498" ;
-  qudt:symbol "g/(s⋅K)" ;
   qudt:symbol "g/(s·K)" ;
   qudt:ucumCode "g.s-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F38" ;
@@ -11544,7 +11531,7 @@ unit:GM_Carbon-PER-M2-DAY
   qudt:hasDimensionVector qkdv:A0E0L-2I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:MassPerAreaTime ;
   qudt:plainTextDescription "A metric unit of volume over time indicating the amount generated across one square meter over a day. Used to express productivity of an ecosystem." ;
-  qudt:symbol "g{carbon}/(m²⋅day)" ;
+  qudt:symbol "g{carbon}/(m²·day)" ;
   qudt:ucumCode "g.m-2.d-1{C}"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "grams Carbon per square meter day"@en-us ;
@@ -11591,7 +11578,7 @@ unit:GM_Nitrogen-PER-M2-DAY
   qudt:hasDimensionVector qkdv:A0E0L-2I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:MassPerAreaTime ;
   qudt:plainTextDescription "A metric unit of volume over time indicating the amount of Nitrogen generated across one square meter over a day. Used to express productivity of an ecosystem." ;
-  qudt:symbol "g{nitrogen}/(m²⋅day)" ;
+  qudt:symbol "g{nitrogen}/(m²·day)" ;
   qudt:ucumCode "g.m-2.d-1{N}"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "grams Nitrogen per square meter day"@en-us ;
@@ -12222,7 +12209,7 @@ unit:GigaHZ-M
   qudt:hasQuantityKind quantitykind:Velocity ;
   qudt:iec61360Code "0112/2///62720#UAA151" ;
   qudt:plainTextDescription "product of the 1 000 000 000-fold of the SI derived unit hertz and the SI base unit metre" ;
-  qudt:symbol "GHz⋅m" ;
+  qudt:symbol "GHz·m" ;
   qudt:ucumCode "GHz.m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M18" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -12400,7 +12387,7 @@ unit:GigaPA-CentiM3-PER-GM
   qudt:exactMatch unit:KiloM2-PER-SEC2 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:SpecificModulus ;
-  qudt:symbol "GPa⋅cm³/g" ;
+  qudt:symbol "GPa·cm³/g" ;
   qudt:ucumCode "GPa.cm3.g-1"^^qudt:UCUMcs ;
   qudt:ucumCode "GPa.cm3/g"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -12442,7 +12429,7 @@ unit:GigaV-A_Reactive
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:ReactivePower ;
   qudt:iec61360Code "0112/2///62720#UAC508" ;
-  qudt:symbol "GV⋅A{Reactive}" ;
+  qudt:symbol "GV·A{Reactive}" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "gigavolt ampere reactive" ;
 .
@@ -12481,7 +12468,7 @@ unit:GigaW-HR
   qudt:hasQuantityKind quantitykind:Energy ;
   qudt:iec61360Code "0112/2///62720#UAA155" ;
   qudt:plainTextDescription "1 000 000 000-fold of the product of the SI derived unit watt and the unit hour" ;
-  qudt:symbol "GW⋅hr" ;
+  qudt:symbol "GW·hr" ;
   qudt:ucumCode "GW.h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "GWH" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -12815,7 +12802,7 @@ unit:HR-FT2
   qudt:expression "\\(hr-ft^{2}\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:AreaTime ;
-  qudt:symbol "hr⋅ft²" ;
+  qudt:symbol "hr·ft²" ;
   qudt:ucumCode "h.[ft_i]2"^^qudt:UCUMcs ;
   qudt:ucumCode "h.[sft_i]"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -12916,7 +12903,7 @@ unit:HZ-M
   qudt:hasQuantityKind quantitykind:Speed ;
   qudt:iec61360Code "0112/2///62720#UAA171" ;
   qudt:plainTextDescription "product of the SI derived unit hertz and the SI base unit metre" ;
-  qudt:symbol "Hz⋅m" ;
+  qudt:symbol "Hz·m" ;
   qudt:ucumCode "Hz.m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H34" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -13190,7 +13177,7 @@ unit:HectoPA-L-PER-SEC
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAA530" ;
   qudt:plainTextDescription "product out of the 100-fold of the SI derived unit pascal and the unit litre divided by the SI base unit second" ;
-  qudt:symbol "hPa⋅L/s" ;
+  qudt:symbol "hPa·L/s" ;
   qudt:ucumCode "hPa.L.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F93" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -13210,7 +13197,7 @@ unit:HectoPA-M3-PER-SEC
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAA531" ;
   qudt:plainTextDescription "product out of the 100-fold of the SI unit pascal and the power of the SI base unit metre with the exponent 3 divided by the SI base unit second" ;
-  qudt:symbol "hPa⋅m³/s" ;
+  qudt:symbol "hPa·m³/s" ;
   qudt:ucumCode "hPa.m3.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F94" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -13872,7 +13859,7 @@ unit:J-M-PER-MOL
   qudt:expression "\\(J m mol^{-1}\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A-1E0L3I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:LengthMolarEnergy ;
-  qudt:symbol "J⋅m/mol" ;
+  qudt:symbol "J·m/mol" ;
   qudt:ucumCode "J.m.mol-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Joule Meter per Mole"@en-us ;
@@ -13891,7 +13878,7 @@ unit:J-M2
   qudt:hasQuantityKind quantitykind:TotalAtomicStoppingPower ;
   qudt:iec61360Code "0112/2///62720#UAA181" ;
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
-  qudt:symbol "J⋅m²" ;
+  qudt:symbol "J·m²" ;
   qudt:ucumCode "J.m2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D73" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -13912,7 +13899,7 @@ unit:J-M2-PER-KiloGM
   qudt:hasQuantityKind quantitykind:TotalMassStoppingPower ;
   qudt:iec61360Code "0112/2///62720#UAB487" ;
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
-  qudt:symbol "J⋅m²/kg" ;
+  qudt:symbol "J·m²/kg" ;
   qudt:ucumCode "J.m2.kg-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B20" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -13951,7 +13938,7 @@ unit:J-PER-CentiM2-DAY
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:PowerPerArea ;
   qudt:hasQuantityKind quantitykind:Radiosity ;
-  qudt:symbol "J/(cm²⋅day)" ;
+  qudt:symbol "J/(cm²·day)" ;
   qudt:ucumCode "J.cm-2.d-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Joules per square centimetre day"@en ;
@@ -14001,7 +13988,7 @@ unit:J-PER-GM-DEG_C
   qudt:hasQuantityKind quantitykind:SpecificHeatCapacityAtConstantVolume ;
   qudt:hasQuantityKind quantitykind:SpecificHeatCapacityAtSaturation ;
   qudt:plainTextDescription "Unit for expressing the specific heat capacity." ;
-  qudt:symbol "J/(g⋅°C)" ;
+  qudt:symbol "J/(g·°C)" ;
   qudt:ucumCode "J.g-1.Cel-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "joule per gram degree celsius"@en ;
@@ -14024,7 +14011,7 @@ unit:J-PER-GM-K
   qudt:iec61360Code "0112/2///62720#UAA176" ;
   qudt:latexSymbol "\\(\\frac{J}{g \\cdot K}\\)"^^qudt:LatexString ;
   qudt:plainTextDescription "Unit for expressing the specific heat capacity." ;
-  qudt:symbol "J/(g⋅K)" ;
+  qudt:symbol "J/(g·K)" ;
   qudt:ucumCode "J.g-1.K-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Joule per Gram Kelvin"@en ;
@@ -14124,7 +14111,7 @@ unit:J-PER-KiloGM-DEG_C
   qudt:hasQuantityKind quantitykind:SpecificHeatCapacityAtConstantVolume ;
   qudt:hasQuantityKind quantitykind:SpecificHeatCapacityAtSaturation ;
   qudt:plainTextDescription "Unit for expressing the specific heat capacity." ;
-  qudt:symbol "J/(kg⋅°C)" ;
+  qudt:symbol "J/(kg·°C)" ;
   qudt:ucumCode "J.kg-1.Cel-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Joule je Kilogramm Grad Celsius"@de ;
@@ -14159,7 +14146,7 @@ unit:J-PER-KiloGM-K
   qudt:hasQuantityKind quantitykind:SpecificHeatCapacityAtSaturation ;
   qudt:iec61360Code "0112/2///62720#UAA176" ;
   qudt:latexSymbol "\\(J/(kg \\cdot K)\\)"^^qudt:LatexString ;
-  qudt:symbol "J/(kg⋅K)" ;
+  qudt:symbol "J/(kg·K)" ;
   qudt:ucumCode "J.kg-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B11" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -14176,7 +14163,7 @@ unit:J-PER-KiloGM-K-M3
   qudt:expression "\\(j-per-kg-k-m3\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H-1T-2D0 ;
   qudt:hasQuantityKind quantitykind:SpecificHeatVolume ;
-  qudt:symbol "J/(kg⋅K⋅m³)" ;
+  qudt:symbol "J/(kg·K·m³)" ;
   qudt:ucumCode "J.kg-1.K.m-3"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Joule per Kilogram Kelvin Cubic Meter"@en-us ;
@@ -14193,7 +14180,7 @@ unit:J-PER-KiloGM-K-PA
   qudt:expression "\\(j-per-kg-k-pa\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M-1H-1T0D0 ;
   qudt:hasQuantityKind quantitykind:SpecificHeatPressure ;
-  qudt:symbol "J/(kg⋅K⋅Pa)" ;
+  qudt:symbol "J/(kg·K·Pa)" ;
   qudt:ucumCode "J.kg-1.K-1.Pa-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Joule per Kilogram Kelvin Pascal"@en ;
@@ -14287,7 +14274,7 @@ unit:J-PER-M3-K
   qudt:expression "\\(J/(m^{3} K)\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H-1T-2D0 ;
   qudt:hasQuantityKind quantitykind:VolumetricHeatCapacity ;
-  qudt:symbol "J/(m³⋅K)" ;
+  qudt:symbol "J/(m³·K)" ;
   qudt:ucumCode "J.m-3.K-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Joule per Cubic Meter Kelvin"@en-us ;
@@ -14380,7 +14367,7 @@ unit:J-PER-MOL-K
   qudt:hasQuantityKind quantitykind:MolarEntropy ;
   qudt:hasQuantityKind quantitykind:MolarHeatCapacity ;
   qudt:iec61360Code "0112/2///62720#UAA184" ;
-  qudt:symbol "J/(mol⋅K)" ;
+  qudt:symbol "J/(mol·K)" ;
   qudt:ucumCode "J.mol-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B16" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -14478,7 +14465,7 @@ unit:J-SEC
   qudt:hasQuantityKind quantitykind:AngularImpulse ;
   qudt:hasQuantityKind quantitykind:AngularMomentum ;
   qudt:iec61360Code "0112/2///62720#UAB151" ;
-  qudt:symbol "J⋅s" ;
+  qudt:symbol "J·s" ;
   qudt:ucumCode "J.s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B18" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -14511,7 +14498,7 @@ unit:J-SEC-PER-MOL
   qudt:expression "\\(J s mol^{-1}\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A-1E0L2I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:MolarAngularMomentum ;
-  qudt:symbol "J⋅s/mol" ;
+  qudt:symbol "J·s/mol" ;
   qudt:ucumCode "J.s.mol-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Joule Second per Mole"@en ;
@@ -14571,7 +14558,7 @@ unit:K-DAY
   qudt:conversionMultiplierSN 8.64E4 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H1T1D0 ;
   qudt:hasQuantityKind quantitykind:TimeTemperature ;
-  qudt:symbol "K⋅day" ;
+  qudt:symbol "K·day" ;
   qudt:ucumCode "K.d"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kelvin day"@en ;
@@ -14583,7 +14570,7 @@ unit:K-M
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H1T0D0 ;
   qudt:hasQuantityKind quantitykind:LengthTemperature ;
-  qudt:symbol "K⋅m" ;
+  qudt:symbol "K·m" ;
   qudt:ucumCode "K.m"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kelvin metres"@en ;
@@ -14595,7 +14582,7 @@ unit:K-M-PER-SEC
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "K⋅m/s" ;
+  qudt:symbol "K·m/s" ;
   qudt:ucumCode "K.m.s-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kelvin metres per second"@en ;
@@ -14610,7 +14597,7 @@ unit:K-M-PER-W
   qudt:hasQuantityKind quantitykind:ThermalResistivity ;
   qudt:iec61360Code "0112/2///62720#UAB488" ;
   qudt:plainTextDescription "product of the SI base unit kelvin and the SI base unit metre divided by the derived SI unit watt" ;
-  qudt:symbol "K⋅m/W" ;
+  qudt:symbol "K·m/W" ;
   qudt:ucumCode "K.m.W-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H35" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -14624,7 +14611,7 @@ unit:K-M2-PER-KiloGM-SEC
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M-1H1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "K⋅m²/(kg⋅s)" ;
+  qudt:symbol "K·m²/(kg·s)" ;
   qudt:ucumCode "K.m2.kg-1.s-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kelvin square metres per kilogram second"@en ;
@@ -14636,7 +14623,7 @@ unit:K-PA-PER-SEC
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H1T-3D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "K⋅Pa/s" ;
+  qudt:symbol "K·Pa/s" ;
   qudt:ucumCode "K.Pa.s-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kelvin Pascals per second"@en ;
@@ -14809,7 +14796,7 @@ unit:K-SEC
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H1T1D0 ;
   qudt:hasQuantityKind quantitykind:TimeTemperature ;
-  qudt:symbol "K⋅s" ;
+  qudt:symbol "K·s" ;
   qudt:ucumCode "K.s"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kelvin second"@en ;
@@ -15148,7 +15135,7 @@ unit:KiloA-HR
   qudt:hasQuantityKind quantitykind:ElectricCharge ;
   qudt:iec61360Code "0112/2///62720#UAB053" ;
   qudt:plainTextDescription "product of the 1 000-fold of the SI base unit ampere and the unit hour" ;
-  qudt:symbol "kA⋅hr" ;
+  qudt:symbol "kA·hr" ;
   qudt:ucumCode "kA.h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "TAH" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -15536,7 +15523,7 @@ unit:KiloCAL-PER-CentiM-SEC-DEG_C
   qudt:expression "\\(kilocal-per-cm-sec-degc\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H-1T-3D0 ;
   qudt:hasQuantityKind quantitykind:ThermalConductivity ;
-  qudt:symbol "kcal/(cm⋅s⋅°C)" ;
+  qudt:symbol "kcal/(cm·s·°C)" ;
   qudt:ucumCode "kcal.cm-1.s-1.Cel-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kilocalorie per Centimeter Second Degree Celsius"@en-us ;
@@ -15572,7 +15559,7 @@ unit:KiloCAL-PER-CentiM2-MIN
   qudt:expression "\\(kcal/(cm^{2}-min)\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:PowerPerArea ;
-  qudt:symbol "kcal/(cm²⋅min)" ;
+  qudt:symbol "kcal/(cm²·min)" ;
   qudt:ucumCode "kcal.cm-2.min-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kilocalorie per Square Centimeter Minute"@en-us ;
@@ -15590,7 +15577,7 @@ unit:KiloCAL-PER-CentiM2-SEC
   qudt:expression "\\(kcal/(cm^{2}-s)\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:PowerPerArea ;
-  qudt:symbol "kcal/(cm²⋅s)" ;
+  qudt:symbol "kcal/(cm²·s)" ;
   qudt:ucumCode "kcal.cm-2.s-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kilocalorie per Square Centimeter Second"@en-us ;
@@ -15629,7 +15616,7 @@ unit:KiloCAL-PER-GM-DEG_C
   qudt:hasQuantityKind quantitykind:SpecificHeatCapacityAtConstantPressure ;
   qudt:hasQuantityKind quantitykind:SpecificHeatCapacityAtConstantVolume ;
   qudt:hasQuantityKind quantitykind:SpecificHeatCapacityAtSaturation ;
-  qudt:symbol "kcal/(g⋅°C)" ;
+  qudt:symbol "kcal/(g·°C)" ;
   qudt:ucumCode "cal.g-1.Cel-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Calorie per Gram Degree Celsius"@en ;
@@ -15683,7 +15670,7 @@ unit:KiloCAL-PER-MOL-DEG_C
   qudt:expression "\\(kcal/(mol-degC)\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A-1E0L2I0M1H-1T-2D0 ;
   qudt:hasQuantityKind quantitykind:MolarHeatCapacity ;
-  qudt:symbol "kcal/(mol⋅°C)" ;
+  qudt:symbol "kcal/(mol·°C)" ;
   qudt:ucumCode "kcal.mol-1.Cel-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kilocalorie per Mole Degree Celsius"@en ;
@@ -15752,7 +15739,7 @@ unit:KiloCAL_IT-PER-HR-M-DEG_C
   qudt:hasQuantityKind quantitykind:ThermalConductivity ;
   qudt:iec61360Code "0112/2///62720#UAA588" ;
   qudt:plainTextDescription "1 000-fold of the no longer approved unit international calorie for energy divided by the product of the SI base unit metre, the unit hour for time and the unit degree Celsius for temperature" ;
-  qudt:symbol "kcal{IT}/(hr⋅m⋅°C)" ;
+  qudt:symbol "kcal{IT}/(hr·m·°C)" ;
   qudt:ucumCode "kcal_IT.h-1.m-1.Cel-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K52" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -16021,7 +16008,7 @@ unit:KiloGM-CentiM2
   qudt:hasQuantityKind quantitykind:RotationalMass ;
   qudt:iec61360Code "0112/2///62720#UAA600" ;
   qudt:plainTextDescription "product of the SI base unit kilogram and the 0 0001fold of the power of the SI base unit metre with the exponent 2" ;
-  qudt:symbol "kg⋅cm²" ;
+  qudt:symbol "kg·cm²" ;
   qudt:ucumCode "kg.cm2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F18" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -16039,7 +16026,7 @@ unit:KiloGM-K
   qudt:expression "\\(kg-K\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H1T0D0 ;
   qudt:hasQuantityKind quantitykind:MassTemperature ;
-  qudt:symbol "kg⋅K" ;
+  qudt:symbol "kg·K" ;
   qudt:ucumCode "kg.K"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kilogram Kelvin"@en ;
@@ -16073,7 +16060,7 @@ unit:KiloGM-M-PER-SEC
   qudt:hasQuantityKind quantitykind:LinearMomentum ;
   qudt:hasQuantityKind quantitykind:Momentum ;
   qudt:iec61360Code "0112/2///62720#UAA615" ;
-  qudt:symbol "kg⋅m/s" ;
+  qudt:symbol "kg·m/s" ;
   qudt:ucumCode "kg.m.s-1"^^qudt:UCUMcs ;
   qudt:ucumCode "kg.m/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B31" ;
@@ -16118,7 +16105,7 @@ unit:KiloGM-M2
   qudt:hasQuantityKind quantitykind:MomentOfInertia ;
   qudt:hasQuantityKind quantitykind:RotationalMass ;
   qudt:iec61360Code "0112/2///62720#UAA622" ;
-  qudt:symbol "kg⋅m²" ;
+  qudt:symbol "kg·m²" ;
   qudt:ucumCode "kg.m2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B32" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -16155,7 +16142,7 @@ unit:KiloGM-M2-PER-SEC
   qudt:hasQuantityKind quantitykind:AngularImpulse ;
   qudt:hasQuantityKind quantitykind:AngularMomentum ;
   qudt:iec61360Code "0112/2///62720#UAA623" ;
-  qudt:symbol "kg⋅m²/s" ;
+  qudt:symbol "kg·m²/s" ;
   qudt:ucumCode "kg.m2.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B33" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -16176,7 +16163,7 @@ unit:KiloGM-MilliM2
   qudt:hasQuantityKind quantitykind:RotationalMass ;
   qudt:iec61360Code "0112/2///62720#UAA627" ;
   qudt:plainTextDescription "product of the SI base kilogram and the  0.001-fold of the power of the SI base metre with the exponent 2" ;
-  qudt:symbol "kg⋅mm²" ;
+  qudt:symbol "kg·mm²" ;
   qudt:ucumCode "kg.mm2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F19" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -16246,7 +16233,6 @@ unit:KiloGM-PER-CentiM3-BAR
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T2D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA599" ;
-  qudt:symbol "kg/(cm³⋅bar)" ;
   qudt:symbol "kg/(cm³·bar)" ;
   qudt:ucumCode "kg.cm-3.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G16" ;
@@ -16261,7 +16247,6 @@ unit:KiloGM-PER-CentiM3-K
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H-1T0D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA598" ;
-  qudt:symbol "kg/(cm³⋅K)" ;
   qudt:symbol "kg/(cm³·K)" ;
   qudt:ucumCode "kg.cm-3.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G38" ;
@@ -16295,7 +16280,6 @@ unit:KiloGM-PER-DAY-BAR
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA603" ;
-  qudt:symbol "kg/(d⋅bar)" ;
   qudt:symbol "kg/(d·bar)" ;
   qudt:ucumCode "kg.d-1.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F66" ;
@@ -16310,7 +16294,6 @@ unit:KiloGM-PER-DAY-K
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA602" ;
-  qudt:symbol "kg/(d⋅K)" ;
   qudt:symbol "kg/(d·K)" ;
   qudt:ucumCode "kg.d-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F39" ;
@@ -16346,7 +16329,6 @@ unit:KiloGM-PER-DeciM3-BAR
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T2D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA606" ;
-  qudt:symbol "kg/(dm³⋅bar)" ;
   qudt:symbol "kg/(dm³·bar)" ;
   qudt:ucumCode "kg.dm-3.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H55" ;
@@ -16361,7 +16343,6 @@ unit:KiloGM-PER-DeciM3-K
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H-1T0D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA605" ;
-  qudt:symbol "kg/(dm³⋅K)" ;
   qudt:symbol "kg/(dm³·K)" ;
   qudt:ucumCode "kg.dm-3.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H54" ;
@@ -16452,7 +16433,6 @@ unit:KiloGM-PER-HR-BAR
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA609" ;
-  qudt:symbol "kg/(h⋅bar)" ;
   qudt:symbol "kg/(h·bar)" ;
   qudt:ucumCode "kg.h-1.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F67" ;
@@ -16467,7 +16447,6 @@ unit:KiloGM-PER-HR-K
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA608" ;
-  qudt:symbol "kg/(h⋅K)" ;
   qudt:symbol "kg/(h·K)" ;
   qudt:ucumCode "kg.h-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F40" ;
@@ -16606,7 +16585,6 @@ unit:KiloGM-PER-L-BAR
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T2D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA614" ;
-  qudt:symbol "kg/(l⋅bar)" ;
   qudt:symbol "kg/(l·bar)" ;
   qudt:ucumCode "kg.L-1.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G17" ;
@@ -16621,7 +16599,6 @@ unit:KiloGM-PER-L-K
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H-1T0D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA613" ;
-  qudt:symbol "kg/(l⋅K)" ;
   qudt:symbol "kg/(l·K)" ;
   qudt:ucumCode "kg.L-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G39" ;
@@ -16680,7 +16657,7 @@ unit:KiloGM-PER-M-HR
   qudt:hasQuantityKind quantitykind:DynamicViscosity ;
   qudt:hasQuantityKind quantitykind:Viscosity ;
   qudt:iec61360Code "0112/2///62720#UAB432" ;
-  qudt:symbol "kg/(m⋅hr)" ;
+  qudt:symbol "kg/(m·hr)" ;
   qudt:ucumCode "kg.m-1.h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "N40" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -16714,7 +16691,7 @@ unit:KiloGM-PER-M-SEC
   qudt:hasQuantityKind quantitykind:Viscosity ;
   qudt:iec61360Code "0112/2///62720#UAB429" ;
   qudt:iec61360Code "0112/2///62720#UAD529" ;
-  qudt:symbol "kg/(m⋅s)" ;
+  qudt:symbol "kg/(m·s)" ;
   qudt:ucumCode "kg.m-1.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "N37" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -16738,7 +16715,7 @@ unit:KiloGM-PER-M-SEC2
   qudt:hasQuantityKind quantitykind:VaporPressure ;
   qudt:iec61360Code "0112/2///62720#UAD540" ;
   qudt:siUnitsExpression "kg/m/s^2" ;
-  qudt:symbol "kg/(m⋅s²)" ;
+  qudt:symbol "kg/(m·s²)" ;
   qudt:ucumCode "kg.m-1.s-2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kilograms per metre square second"@en ;
@@ -16784,7 +16761,7 @@ unit:KiloGM-PER-M2-PA-SEC
   qudt:hasQuantityKind quantitykind:VaporPermeability ;
   qudt:iec61360Code "0112/2///62720#UAB481" ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Perm_(unit)"^^xsd:anyURI ;
-  qudt:symbol "kg/(m²⋅Pa⋅s)" ;
+  qudt:symbol "kg/(m²·Pa·s)" ;
   qudt:ucumCode "kg.m-2.Pa-1.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "Q28" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -16801,7 +16778,7 @@ unit:KiloGM-PER-M2-SEC
   qudt:exactMatch unit:KiloGM-PER-SEC-M2 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:MassPerAreaTime ;
-  qudt:symbol "kg/(m²⋅s)" ;
+  qudt:symbol "kg/(m²·s)" ;
   qudt:ucumCode "kg.m-2.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H56" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -16818,7 +16795,7 @@ unit:KiloGM-PER-M2-SEC2
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:PressureLossPerLength ;
-  qudt:symbol "kg/(m²⋅s²)" ;
+  qudt:symbol "kg/(m²·s²)" ;
   qudt:ucumCode "kg.m-2.s-2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kilogram per Square Meter Square Second"@en-us ;
@@ -16878,7 +16855,6 @@ unit:KiloGM-PER-M3-BAR
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T2D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA621" ;
-  qudt:symbol "kg/(m³⋅bar)" ;
   qudt:symbol "kg/(m³·bar)" ;
   qudt:ucumCode "kg.m-3.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G18" ;
@@ -16894,7 +16870,6 @@ unit:KiloGM-PER-M3-K
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA620" ;
   qudt:iec61360Code "0112/2///62720#UAD685" ;
-  qudt:symbol "kg/(m³⋅K)" ;
   qudt:symbol "kg/(m³·K)" ;
   qudt:ucumCode "kg.m-3.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G40" ;
@@ -16925,7 +16900,7 @@ unit:KiloGM-PER-M3-SEC
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "kg/(m³⋅s)" ;
+  qudt:symbol "kg/(m³·s)" ;
   qudt:ucumCode "kg.m-3.s-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kilograms per cubic metre second"@en ;
@@ -16958,7 +16933,6 @@ unit:KiloGM-PER-MIN-BAR
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA626" ;
-  qudt:symbol "kg/(min⋅bar)" ;
   qudt:symbol "kg/(min·bar)" ;
   qudt:ucumCode "kg.min-1.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F68" ;
@@ -16973,7 +16947,6 @@ unit:KiloGM-PER-MIN-K
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA625" ;
-  qudt:symbol "kg/(min⋅K)" ;
   qudt:symbol "kg/(min·K)" ;
   qudt:ucumCode "kg.min-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F41" ;
@@ -17060,7 +17033,7 @@ unit:KiloGM-PER-PA-SEC-M
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:WaterVaporDiffusionCoefficient ;
   qudt:plainTextDescription "Common unit for the Water vapour diffusion coefficient" ;
-  qudt:symbol "kg/(Pa⋅s⋅m)" ;
+  qudt:symbol "kg/(Pa·s·m)" ;
   qudt:ucumCode "kg.Pa-1.s-1.m-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kilogramm je Pascal Sekunde Meter"@de ;
@@ -17109,7 +17082,6 @@ unit:KiloGM-PER-SEC-BAR
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA631" ;
-  qudt:symbol "kg/(s⋅bar)" ;
   qudt:symbol "kg/(s·bar)" ;
   qudt:ucumCode "kg.s-1.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F69" ;
@@ -17125,7 +17097,6 @@ unit:KiloGM-PER-SEC-K
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA630" ;
   qudt:iec61360Code "0112/2///62720#UAD687" ;
-  qudt:symbol "kg/(s⋅K)" ;
   qudt:symbol "kg/(s·K)" ;
   qudt:ucumCode "kg.s-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F42" ;
@@ -17146,7 +17117,7 @@ unit:KiloGM-PER-SEC-M2
   qudt:hasQuantityKind quantitykind:MassPerAreaTime ;
   qudt:iec61360Code "0112/2///62720#UAA618" ;
   qudt:plainTextDescription "SI base unit kilogram divided by the product of the power of the SI base unit metre with the exponent 2 and the SI base unit second" ;
-  qudt:symbol "kg/(s⋅m²)" ;
+  qudt:symbol "kg/(s·m²)" ;
   qudt:ucumCode "kg.(s.m2)-1"^^qudt:UCUMcs ;
   qudt:ucumCode "kg.s-1.m-2"^^qudt:UCUMcs ;
   qudt:ucumCode "kg/(s.m2)"^^qudt:UCUMcs ;
@@ -17198,7 +17169,7 @@ unit:KiloGM-PER-SEC3-K
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H-1T-3D0 ;
   qudt:hasQuantityKind quantitykind:CoefficientOfHeatTransfer ;
   qudt:plainTextDescription "Unit commonly used for the coefficient of heat transfer" ;
-  qudt:symbol "kg/(s³⋅K)" ;
+  qudt:symbol "kg/(s³·K)" ;
   qudt:ucumCode "kg.s-3.K-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kilogramm je Kubiksekunde Kelvin"@de ;
@@ -17247,7 +17218,7 @@ unit:KiloGM-SEC2
   qudt:expression "\\(kilog-sec2\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T2D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "kg⋅s²" ;
+  qudt:symbol "kg·s²" ;
   qudt:ucumCode "kg.s2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kilogram Square Second"@en ;
@@ -17294,7 +17265,7 @@ unit:KiloGM_F-M
   qudt:hasQuantityKind quantitykind:Torque ;
   qudt:iec61360Code "0112/2///62720#UAA634" ;
   qudt:plainTextDescription "product of the unit kilogram-force and the SI base unit metre" ;
-  qudt:symbol "kgf⋅m" ;
+  qudt:symbol "kgf·m" ;
   qudt:ucumCode "kgf.m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B38" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -17310,7 +17281,7 @@ unit:KiloGM_F-M-PER-CentiM2
   qudt:hasQuantityKind quantitykind:ForcePerLength ;
   qudt:iec61360Code "0112/2///62720#UAB189" ;
   qudt:plainTextDescription "product of the unit kilogram-force and the SI base unit metre divided by the 0.0001-fold of the power of the SI base unit metre by exponent 2" ;
-  qudt:symbol "kgf⋅m/cm²" ;
+  qudt:symbol "kgf·m/cm²" ;
   qudt:ucumCode "kgf.m.cm-2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E44" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -17326,7 +17297,7 @@ unit:KiloGM_F-M-PER-SEC
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAB154" ;
   qudt:plainTextDescription "product of the SI base unit metre and the unit kilogram-force according to the Anglo-American and Imperial system of units divided by the SI base unit second" ;
-  qudt:symbol "kgf⋅m/s" ;
+  qudt:symbol "kgf·m/s" ;
   qudt:ucumCode "kgf.m.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B39" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -17448,7 +17419,7 @@ unit:KiloHZ-M
   qudt:hasQuantityKind quantitykind:SoundParticleVelocity ;
   qudt:iec61360Code "0112/2///62720#UAA567" ;
   qudt:plainTextDescription "product of the 1 000-fold of the SI derived unit hertz and the SI base unit metre" ;
-  qudt:symbol "kHz⋅m" ;
+  qudt:symbol "kHz·m" ;
   qudt:ucumCode "kHz.m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M17" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -17555,7 +17526,7 @@ unit:KiloJ-PER-KiloGM-K
   qudt:hasQuantityKind quantitykind:SpecificHeatCapacityAtSaturation ;
   qudt:iec61360Code "0112/2///62720#UAA571" ;
   qudt:plainTextDescription "1 000-fold of the SI derived unit joule divided by the product of the SI base unit kilogram and the SI base unit kelvin" ;
-  qudt:symbol "kJ/(kg⋅K)" ;
+  qudt:symbol "kJ/(kg·K)" ;
   qudt:ucumCode "kJ.(kg.K)-1"^^qudt:UCUMcs ;
   qudt:ucumCode "kJ.kg-1.K-1"^^qudt:UCUMcs ;
   qudt:ucumCode "kJ/(kg.K)"^^qudt:UCUMcs ;
@@ -17697,7 +17668,7 @@ unit:KiloLB_F-FT-PER-A
   qudt:hasQuantityKind quantitykind:MagneticFlux ;
   qudt:iec61360Code "0112/2///62720#UAB483" ;
   qudt:plainTextDescription "product of the Anglo-American unit pound-force and foot divided by the SI base unit ampere" ;
-  qudt:symbol "klbf⋅ft/A" ;
+  qudt:symbol "klbf·ft/A" ;
   qudt:ucumCode "[lbf_av].[ft_i].A-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F22" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -17714,7 +17685,7 @@ unit:KiloLB_F-FT-PER-LB
   qudt:hasQuantityKind quantitykind:SpecificEnergy ;
   qudt:iec61360Code "0112/2///62720#UAB484" ;
   qudt:plainTextDescription "product of the Anglo-American unit pound-force and the Anglo-American unit foot divided by the Anglo-American unit pound (US) of mass" ;
-  qudt:symbol "klbf⋅ft/lbm" ;
+  qudt:symbol "klbf·ft/lbm" ;
   qudt:ucumCode "[lbf_av].[ft_i].[lb_av]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G20" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -18105,7 +18076,7 @@ unit:KiloN-M
   qudt:hasQuantityKind quantitykind:Torque ;
   qudt:iec61360Code "0112/2///62720#UAA574" ;
   qudt:plainTextDescription "1 000-fold of the product of the SI derived unit newton and the SI base unit metre" ;
-  qudt:symbol "kN⋅m" ;
+  qudt:symbol "kN·m" ;
   qudt:ucumCode "kN.m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B48" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -18120,7 +18091,7 @@ unit:KiloN-M-PER-DEG
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:TorsionalSpringConstant ;
   qudt:plainTextDescription "Unit for expressing the value of the torsional spring constant" ;
-  qudt:symbol "kN⋅m/°" ;
+  qudt:symbol "kN·m/°" ;
   qudt:ucumCode "kN.m.deg-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kilonewton Metre per Degree"@en ;
@@ -18133,7 +18104,7 @@ unit:KiloN-M-PER-DEG-M
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ModulusOfRotationalSubgradeReaction ;
   qudt:plainTextDescription "A common unit for measuring the modulus of rotational subgrade reaction." ;
-  qudt:symbol "kN⋅m/(°·m)" ;
+  qudt:symbol "kN·m/(°·m)" ;
   qudt:ucumCode "kN.m.deg-1.m-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "kilonewton metre per degree metre"@en ;
@@ -18148,7 +18119,7 @@ unit:KiloN-M-PER-M
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:TorquePerLength ;
   qudt:plainTextDescription "Scaling of the base unit for expressing the rolling resistance, nM/m, by a factor of 1000" ;
-  qudt:symbol "kN⋅m/m" ;
+  qudt:symbol "kN·m/m" ;
   qudt:ucumCode "kN.m.m-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kilonewton Metre per metre"@en ;
@@ -18178,7 +18149,7 @@ unit:KiloN-M2
   qudt:conversionMultiplierSN 1.0E3 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:WarpingMoment ;
-  qudt:symbol "kN⋅m²" ;
+  qudt:symbol "kN·m²" ;
   qudt:ucumCode "kN.m2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kilo Newton Square Meter"@en-us ;
@@ -18206,7 +18177,7 @@ unit:KiloN-PER-M2
   qudt:conversionMultiplier 1000.0 ;
   qudt:conversionMultiplierSN 1.0E3 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
-  qudt:hasQuantityKind quantitykind:Pressure ;
+  qudt:hasQuantityKind quantitykind:ForcePerArea ;
   qudt:symbol "kN/m²" ;
   qudt:ucumCode "kN.m-2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -18350,7 +18321,7 @@ unit:KiloPA-M2-PER-GM
   qudt:hasQuantityKind quantitykind:LinearAcceleration ;
   qudt:iec61360Code "0112/2///62720#UAB130" ;
   qudt:plainTextDescription "sector-specific unit of the burst index as 1 000-fold of the derived unit for pressure pascal related to the substance, represented as a quotient from the 0.001-fold of the SI base unit kilogram divided by the power of the SI base unit metre by exponent 2" ;
-  qudt:symbol "kPa⋅m²/g" ;
+  qudt:symbol "kPa·m²/g" ;
   qudt:ucumCode "kPa.m2.g-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "33" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -18640,7 +18611,7 @@ unit:KiloV-A
   qudt:hasQuantityKind quantitykind:ComplexPower ;
   qudt:iec61360Code "0112/2///62720#UAA581" ;
   qudt:plainTextDescription "1 000-fold of the product of the SI derived unit volt and the SI base unit ampere" ;
-  qudt:symbol "kV⋅A" ;
+  qudt:symbol "kV·A" ;
   qudt:ucumCode "kV.A"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "KVA" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -18658,7 +18629,7 @@ unit:KiloV-A-HR
   qudt:hasQuantityKind quantitykind:Energy ;
   qudt:iec61360Code "0112/2///62720#UAB160" ;
   qudt:plainTextDescription "product of the 1 000-fold of the unit for apparent by ampere and the unit hour" ;
-  qudt:symbol "kV⋅A⋅hr" ;
+  qudt:symbol "kV·A·hr" ;
   qudt:ucumCode "kV.A.h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C79" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -18686,7 +18657,7 @@ unit:KiloV-A_Reactive
   qudt:hasQuantityKind quantitykind:ReactivePower ;
   qudt:iec61360Code "0112/2///62720#UAA648" ;
   qudt:plainTextDescription "1 000-fold of the unit var" ;
-  qudt:symbol "kV⋅A{Reactive}" ;
+  qudt:symbol "kV·A{Reactive}" ;
   qudt:ucumCode "kV.A{reactive}"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "KVR" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -18701,7 +18672,7 @@ unit:KiloV-A_Reactive-HR
   qudt:hasQuantityKind quantitykind:Energy ;
   qudt:iec61360Code "0112/2///62720#UAB195" ;
   qudt:plainTextDescription "product of the 1 000-fold of the unit volt ampere reactive and the unit hour" ;
-  qudt:symbol "kV⋅A{Reactive}⋅hr" ;
+  qudt:symbol "kV·A{Reactive}·hr" ;
   qudt:ucumCode "kV.A.h{reactive}"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K3" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -18775,7 +18746,7 @@ unit:KiloW-HR
   qudt:hasQuantityKind quantitykind:Energy ;
   qudt:iec61360Code "0112/2///62720#UAA584" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Kilowatt_hour?oldid=494927235"^^xsd:anyURI ;
-  qudt:symbol "kW⋅hr" ;
+  qudt:symbol "kW·hr" ;
   qudt:ucumCode "kW.h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "KWH" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -18795,7 +18766,7 @@ unit:KiloW-HR-PER-M2
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:EnergyPerArea ;
   qudt:plainTextDescription "A unit of energy per unit area, equivalent to 3 600 000 joules per square metre." ;
-  qudt:symbol "kW⋅hr/m²" ;
+  qudt:symbol "kW·hr/m²" ;
   qudt:ucumCode "kW.h.m-2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kilowatt hour per square metre"@en ;
@@ -18966,7 +18937,6 @@ unit:L-PER-DAY-BAR
   qudt:hasDimensionVector qkdv:A0E0L4I0M-1H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA654" ;
-  qudt:symbol "l/(d⋅bar)" ;
   qudt:symbol "l/(d·bar)" ;
   qudt:ucumCode "L.d-1.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G82" ;
@@ -18981,7 +18951,6 @@ unit:L-PER-DAY-K
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA653" ;
-  qudt:symbol "l/(d⋅K)" ;
   qudt:symbol "l/(d·K)" ;
   qudt:ucumCode "L.d-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G65" ;
@@ -19018,7 +18987,6 @@ unit:L-PER-HR-BAR
   qudt:hasDimensionVector qkdv:A0E0L4I0M-1H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA657" ;
-  qudt:symbol "l/(h⋅bar)" ;
   qudt:symbol "l/(h·bar)" ;
   qudt:ucumCode "L.h-1.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G83" ;
@@ -19033,7 +19001,6 @@ unit:L-PER-HR-K
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA656" ;
-  qudt:symbol "l/(h⋅K)" ;
   qudt:symbol "l/(h·K)" ;
   qudt:ucumCode "L.h-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G66" ;
@@ -19131,7 +19098,6 @@ unit:L-PER-MIN-BAR
   qudt:hasDimensionVector qkdv:A0E0L4I0M-1H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA661" ;
-  qudt:symbol "l/(min⋅bar)" ;
   qudt:symbol "l/(min·bar)" ;
   qudt:ucumCode "L.min-1.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G84" ;
@@ -19146,7 +19112,6 @@ unit:L-PER-MIN-K
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA660" ;
-  qudt:symbol "l/(min⋅K)" ;
   qudt:symbol "l/(min·K)" ;
   qudt:ucumCode "L.min-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G67" ;
@@ -19229,7 +19194,6 @@ unit:L-PER-SEC-BAR
   qudt:hasDimensionVector qkdv:A0E0L4I0M-1H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA666" ;
-  qudt:symbol "l/(s⋅bar)" ;
   qudt:symbol "l/(s·bar)" ;
   qudt:ucumCode "L.s-1.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G85" ;
@@ -19244,7 +19208,6 @@ unit:L-PER-SEC-K
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA665" ;
-  qudt:symbol "l/(s⋅K)" ;
   qudt:symbol "l/(s·K)" ;
   qudt:ucumCode "L.s-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G68" ;
@@ -19263,7 +19226,7 @@ unit:L-PER-SEC-M2
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VentilationRatePerFloorArea ;
   qudt:plainTextDescription "Ventilation rate in Litres per second divided by the floor area" ;
-  qudt:symbol "L/(s⋅m²)" ;
+  qudt:symbol "L/(s·m²)" ;
   qudt:ucumCode "L.s-1.m-2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Liter per Second Square Meter"@en-us ;
@@ -19349,7 +19312,7 @@ unit:LB-DEG_F
   qudt:expression "\\(lb-degF\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H1T0D0 ;
   qudt:hasQuantityKind quantitykind:MassTemperature ;
-  qudt:symbol "lbm⋅°F" ;
+  qudt:symbol "lbm·°F" ;
   qudt:ucumCode "[lb_av].[degF]"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Pound Degree Fahrenheit"@en ;
@@ -19366,7 +19329,7 @@ unit:LB-DEG_R
   qudt:expression "\\(lb-degR\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H1T0D0 ;
   qudt:hasQuantityKind quantitykind:MassTemperature ;
-  qudt:symbol "lbm⋅°R" ;
+  qudt:symbol "lbm·°R" ;
   qudt:ucumCode "[lb_av].[degR]"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Pound Degree Rankine"@en ;
@@ -19397,7 +19360,7 @@ unit:LB-FT2
   qudt:hasQuantityKind quantitykind:RotationalMass ;
   qudt:iec61360Code "0112/2///62720#UAA671" ;
   qudt:plainTextDescription "product of the unit pound according to the avoirdupois system of units and the power of the unit foot according to the Anglo-American and the Imperial system of units with the exponent 2" ;
-  qudt:symbol "lbm⋅ft²" ;
+  qudt:symbol "lbm·ft²" ;
   qudt:ucumCode "[lb_av].[sft_i]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K65" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -19554,7 +19517,7 @@ unit:LB-HR-PER-GAL_UK2
   qudt:hasDimensionVector qkdv:A0E0L-6I0M1H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAC861" ;
-  qudt:symbol "lbm⋅hr/gal{UK}²" ;
+  qudt:symbol "lbm·hr/gal{UK}²" ;
   qudt:ucumCode "[lb_av].h.[gal_br]-2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "pound hour per square gallon (UK)" ;
@@ -19687,7 +19650,7 @@ unit:LB-IN
   qudt:hasQuantityKind quantitykind:LengthMass ;
   qudt:iec61360Code "0112/2///62720#UAB194" ;
   qudt:plainTextDescription "unit of the unbalance (product of avoirdupois pound according to the avoirdupois system of units and inch according to the Anglo-American and Imperial system of units)" ;
-  qudt:symbol "lbm⋅in" ;
+  qudt:symbol "lbm·in" ;
   qudt:ucumCode "[lb_av].[in_i]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "IA" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -19719,7 +19682,7 @@ unit:LB-IN2
   qudt:hasQuantityKind quantitykind:RotationalMass ;
   qudt:iec61360Code "0112/2///62720#UAA672" ;
   qudt:plainTextDescription "product of the unit pound according to the avoirdupois system of units and the power of the unit inch according to the Anglo-American and the Imperial system of units with the exponent 2" ;
-  qudt:symbol "lbm⋅in²" ;
+  qudt:symbol "lbm·in²" ;
   qudt:ucumCode "[lb_av].[sin_i]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F20" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -20038,7 +20001,7 @@ unit:LB-MOL-DEG_F
   qudt:expression "\\(lb-mol-degF\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A1E0L0I0M0H1T0D0 ;
   qudt:hasQuantityKind quantitykind:MassAmountOfSubstanceTemperature ;
-  qudt:symbol "lb-mol⋅°F" ;
+  qudt:symbol "lb-mol·°F" ;
   qudt:ucumCode "[mol_lb].[degF]"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Pound Mole Degree Fahrenheit"@en ;
@@ -20122,7 +20085,7 @@ unit:LB-PER-FT-HR
   qudt:hasQuantityKind quantitykind:DynamicViscosity ;
   qudt:hasQuantityKind quantitykind:Viscosity ;
   qudt:iec61360Code "0112/2///62720#UAA674" ;
-  qudt:symbol "lbm/(ft⋅hr)" ;
+  qudt:symbol "lbm/(ft·hr)" ;
   qudt:ucumCode "[lb_av].[ft_i]-1.h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K67" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -20169,7 +20132,7 @@ unit:LB-PER-FT-SEC
   qudt:hasQuantityKind quantitykind:DynamicViscosity ;
   qudt:hasQuantityKind quantitykind:Viscosity ;
   qudt:iec61360Code "0112/2///62720#UAA675" ;
-  qudt:symbol "lbm/(ft⋅s)" ;
+  qudt:symbol "lbm/(ft·s)" ;
   qudt:ucumCode "[lb_av].[ft_i]-1.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K68" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -20885,7 +20848,7 @@ unit:LB_F-FT
   qudt:hasQuantityKind quantitykind:MomentOfForce ;
   qudt:hasQuantityKind quantitykind:Torque ;
   qudt:iec61360Code "0112/2///62720#UAA697" ;
-  qudt:symbol "lbf⋅ft" ;
+  qudt:symbol "lbf·ft" ;
   qudt:ucumCode "[lbf_av].[ft_i]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M92" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -20919,7 +20882,7 @@ unit:LB_F-IN
   qudt:hasQuantityKind quantitykind:MomentOfForce ;
   qudt:hasQuantityKind quantitykind:Torque ;
   qudt:iec61360Code "0112/2///62720#UAA699" ;
-  qudt:symbol "lbf⋅in" ;
+  qudt:symbol "lbf·in" ;
   qudt:ucumCode "[lbf_av].[in_i]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F21" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -21033,7 +20996,7 @@ unit:LB_F-PER-IN2-DEG_F
   qudt:hasQuantityKind quantitykind:VolumetricHeatCapacity ;
   qudt:iec61360Code "0112/2///62720#UAA702" ;
   qudt:plainTextDescription "composed unit for pressure (pound-force per square inch) divided by the unit degree Fahrenheit for temperature" ;
-  qudt:symbol "lbf/(in²⋅°F)" ;
+  qudt:symbol "lbf/(in²·°F)" ;
   qudt:ucumCode "[lbf_av].[sin_i]-1.[degF]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K86" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -21049,7 +21012,7 @@ unit:LB_F-PER-IN2-SEC
   qudt:expression "\\(lbf / in^{2}-s\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerAreaTime ;
-  qudt:symbol "lbf/(in²⋅s)" ;
+  qudt:symbol "lbf/(in²·s)" ;
   qudt:ucumCode "[lbf_av].[sin_i]-1.s-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Pound Force per Square Inch Second"@en ;
@@ -21099,7 +21062,7 @@ unit:LB_F-SEC-PER-FT2
   qudt:hasQuantityKind quantitykind:DynamicViscosity ;
   qudt:hasQuantityKind quantitykind:Viscosity ;
   qudt:iec61360Code "0112/2///62720#UAA707" ;
-  qudt:symbol "lbf⋅s/ft²" ;
+  qudt:symbol "lbf·s/ft²" ;
   qudt:ucumCode "[lbf_av].s.[sft_i]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K91" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -21119,7 +21082,7 @@ unit:LB_F-SEC-PER-IN2
   qudt:hasQuantityKind quantitykind:DynamicViscosity ;
   qudt:hasQuantityKind quantitykind:Viscosity ;
   qudt:iec61360Code "0112/2///62720#UAA708" ;
-  qudt:symbol "lbf⋅s/in²" ;
+  qudt:symbol "lbf·s/in²" ;
   qudt:ucumCode "[lbf_av].s.[sin_i]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K92" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -21279,7 +21242,7 @@ unit:LM-SEC
   qudt:hasDimensionVector qkdv:A0E0L0I1M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:LuminousEnergy ;
   qudt:iec61360Code "0112/2///62720#UAA722" ;
-  qudt:symbol "lm⋅s" ;
+  qudt:symbol "lm·s" ;
   qudt:ucumCode "lm.s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B62" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -21346,7 +21309,7 @@ unit:LUX-HR
   qudt:iec61360Code "0112/2///62720#UAA724" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Lux?oldid=494700274"^^xsd:anyURI ;
   qudt:siUnitsExpression "lm-hr/m^2" ;
-  qudt:symbol "lx⋅hr" ;
+  qudt:symbol "lx·hr" ;
   qudt:ucumCode "lx.h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B63" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -21455,7 +21418,7 @@ unit:M-K
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H1T0D0 ;
   qudt:hasQuantityKind quantitykind:LengthTemperature ;
   qudt:iec61360Code "0112/2///62720#UAB170" ;
-  qudt:symbol "m⋅K" ;
+  qudt:symbol "m·K" ;
   qudt:ucumCode "m.K"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D18" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -21479,7 +21442,7 @@ unit:M-K-PER-W
   qudt:expression "\\(K-m/W\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M-1H1T3D0 ;
   qudt:hasQuantityKind quantitykind:ThermalResistivity ;
-  qudt:symbol "m⋅K/W" ;
+  qudt:symbol "m·K/W" ;
   qudt:ucumCode "m.K.W-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H35" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -21500,7 +21463,7 @@ unit:M-KiloGM
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:LengthMass ;
   qudt:iec61360Code "0112/2///62720#UAD674" ;
-  qudt:symbol "m⋅kg" ;
+  qudt:symbol "m·kg" ;
   qudt:ucumCode "m.kg"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Meter Kilogram"@en-us ;
@@ -21898,7 +21861,7 @@ unit:M2-HR-DEG_C-PER-KiloCAL_IT
   qudt:hasQuantityKind quantitykind:ThermalInsulance ;
   qudt:iec61360Code "0112/2///62720#UAA749" ;
   qudt:plainTextDescription "product of the power of the SI base unit metre with the exponent 2, of the unit hour for time and the unit degree Celsius for temperature divided by the 1000-fold of the out of use unit for energy international calorie" ;
-  qudt:symbol "m²⋅hr⋅°C/kcal{IT}" ;
+  qudt:symbol "m²·hr·°C/kcal{IT}" ;
   qudt:ucumCode "m2.h.Cel/kcal_IT"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L14" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -21915,7 +21878,7 @@ unit:M2-HZ
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:AreaPerTime ;
-  qudt:symbol "m²⋅Hz" ;
+  qudt:symbol "m²·Hz" ;
   qudt:ucumCode "m2.Hz"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Square metres Hertz"@en ;
@@ -21930,7 +21893,7 @@ unit:M2-HZ2
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "m²⋅Hz²" ;
+  qudt:symbol "m²·Hz²" ;
   qudt:ucumCode "m2.Hz2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Square Metres square Hertz"@en ;
@@ -21945,7 +21908,7 @@ unit:M2-HZ3
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "m²⋅Hz³" ;
+  qudt:symbol "m²·Hz³" ;
   qudt:ucumCode "m2.Hz3"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Square metres cubic Hertz"@en ;
@@ -21960,7 +21923,7 @@ unit:M2-HZ4
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-4D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "m²⋅Hz⁴" ;
+  qudt:symbol "m²·Hz⁴" ;
   qudt:ucumCode "m2.Hz4"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Square metres Hertz^4"@en ;
@@ -21977,7 +21940,7 @@ unit:M2-K
   qudt:expression "\\(m^{2}-K\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H1T0D0 ;
   qudt:hasQuantityKind quantitykind:AreaTemperature ;
-  qudt:symbol "m²⋅K" ;
+  qudt:symbol "m²·K" ;
   qudt:ucumCode "m2.K"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Square Meter Kelvin"@en-us ;
@@ -21997,7 +21960,7 @@ unit:M2-K-PER-W
   qudt:hasQuantityKind quantitykind:ThermalInsulance ;
   qudt:iec61360Code "0112/2///62720#UAA746" ;
   qudt:informativeReference "http://physics.nist.gov/Pubs/SP811/appenB9.html"^^xsd:anyURI ;
-  qudt:symbol "m²⋅K/W" ;
+  qudt:symbol "m²·K/W" ;
   qudt:ucumCode "m2.K.W-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D19" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -22070,7 +22033,7 @@ unit:M2-PER-HZ-DEG
   qudt:conversionMultiplierSN 5.72957795130823E1 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "m²/(Hz⋅°)" ;
+  qudt:symbol "m²/(Hz·°)" ;
   qudt:ucumCode "m2.Hz-1.deg-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Square metres per Hertz degree"@en ;
@@ -22308,7 +22271,7 @@ unit:M2-PER-SEC-BAR
   qudt:hasDimensionVector qkdv:A0E0L3I0M-1H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAB493" ;
-  qudt:symbol "m²/(s⋅bar)" ;
+  qudt:symbol "m²/(s·bar)" ;
   qudt:ucumCode "m2.s-1.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G41" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -22323,7 +22286,6 @@ unit:M2-PER-SEC-K
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA753" ;
   qudt:iec61360Code "0112/2///62720#UAD680" ;
-  qudt:symbol "m²/(s⋅K)" ;
   qudt:symbol "m²/(s·K)" ;
   qudt:ucumCode "m2.s-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G09" ;
@@ -22370,7 +22332,7 @@ unit:M2-PER-SEC2-K
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H-1T-2D0 ;
   qudt:hasQuantityKind quantitykind:SpecificHeatCapacity ;
   qudt:plainTextDescription "Unit for expressing the specific heat capacity." ;
-  qudt:symbol "m²/(s²⋅K)" ;
+  qudt:symbol "m²/(s²·K)" ;
   qudt:ucumCode "m2.s2-1.K-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "square metre per square second kelvin"@en ;
@@ -22414,7 +22376,7 @@ unit:M2-PER-SR-J
   qudt:hasQuantityKind quantitykind:SpectralAngularCrossSection ;
   qudt:iec61360Code "0112/2///62720#UAA756" ;
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
-  qudt:symbol "m²/(sr⋅J)" ;
+  qudt:symbol "m²/(sr·J)" ;
   qudt:ucumCode "m2.sr-1.J-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D25" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -22434,7 +22396,7 @@ unit:M2-PER-V-SEC
   qudt:hasQuantityKind quantitykind:Mobility ;
   qudt:iec61360Code "0112/2///62720#UAA748" ;
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
-  qudt:symbol "m²/(V⋅s)" ;
+  qudt:symbol "m²/(V·s)" ;
   qudt:ucumCode "m2.V-1.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D26" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -22478,7 +22440,7 @@ unit:M2-SEC-PER-RAD
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "m²⋅s/rad" ;
+  qudt:symbol "m²·s/rad" ;
   qudt:ucumCode "m2.s.rad-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Square metre seconds per radian"@en ;
@@ -22498,7 +22460,7 @@ unit:M2-SR
   qudt:expression "\\(m^{2}-sr\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:AreaAngle ;
-  qudt:symbol "m²⋅sr" ;
+  qudt:symbol "m²·sr" ;
   qudt:ucumCode "m2.sr"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Square Meter Steradian"@en-us ;
@@ -22612,7 +22574,6 @@ unit:M3-PER-DAY-BAR
   qudt:hasDimensionVector qkdv:A0E0L4I0M-1H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA762" ;
-  qudt:symbol "m³/(d⋅bar)" ;
   qudt:symbol "m³/(d·bar)" ;
   qudt:ucumCode "m3.d-1.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G86" ;
@@ -22627,7 +22588,6 @@ unit:M3-PER-DAY-K
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA761" ;
-  qudt:symbol "m³/(d⋅K)" ;
   qudt:symbol "m³/(d·K)" ;
   qudt:ucumCode "m3.d-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G69" ;
@@ -22683,7 +22643,6 @@ unit:M3-PER-HR-BAR
   qudt:hasDimensionVector qkdv:A0E0L4I0M-1H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA765" ;
-  qudt:symbol "m³/(h⋅bar)" ;
   qudt:symbol "m³/(h·bar)" ;
   qudt:ucumCode "m3.h-1.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G87" ;
@@ -22698,7 +22657,6 @@ unit:M3-PER-HR-K
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA764" ;
-  qudt:symbol "m³/(h⋅K)" ;
   qudt:symbol "m³/(h·K)" ;
   qudt:ucumCode "m3.h-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G70" ;
@@ -22762,7 +22720,7 @@ unit:M3-PER-KiloGM-SEC2
   qudt:expression "\\(m^{3} kg^{-1} s^{-2}\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M-1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "m³/(kg⋅s²)" ;
+  qudt:symbol "m³/(kg·s²)" ;
   qudt:ucumCode "m3.(kg.s2)-1"^^qudt:UCUMcs ;
   qudt:ucumCode "m3.kg-1.s-2"^^qudt:UCUMcs ;
   qudt:ucumCode "m3/(kg.s2)"^^qudt:UCUMcs ;
@@ -22839,7 +22797,6 @@ unit:M3-PER-MIN-BAR
   qudt:hasDimensionVector qkdv:A0E0L4I0M-1H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA770" ;
-  qudt:symbol "m³/(min⋅bar)" ;
   qudt:symbol "m³/(min·bar)" ;
   qudt:ucumCode "m3.min-1.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G88" ;
@@ -22854,7 +22811,6 @@ unit:M3-PER-MIN-K
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA769" ;
-  qudt:symbol "m³/(min⋅K)" ;
   qudt:symbol "m³/(min·K)" ;
   qudt:ucumCode "m3.min-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G71" ;
@@ -22908,7 +22864,7 @@ unit:M3-PER-MOL-SEC
   qudt:hasDimensionVector qkdv:A-1E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:AtmosphericHydroxylationRate ;
   qudt:hasQuantityKind quantitykind:SecondOrderReactionRateConstant ;
-  qudt:symbol "m³/(mol⋅s)" ;
+  qudt:symbol "m³/(mol·s)" ;
   qudt:ucumCode "m3.mol-1.s-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Cubic Centimeter per Mole Second"@en ;
@@ -22964,7 +22920,6 @@ unit:M3-PER-SEC-BAR
   qudt:hasDimensionVector qkdv:A0E0L4I0M-1H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA774" ;
-  qudt:symbol "m³/(s⋅bar)" ;
   qudt:symbol "m³/(s·bar)" ;
   qudt:ucumCode "m3.s-1.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G89" ;
@@ -22980,7 +22935,6 @@ unit:M3-PER-SEC-K
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA773" ;
   qudt:iec61360Code "0112/2///62720#UAD701" ;
-  qudt:symbol "m³/(s⋅K)" ;
   qudt:symbol "m³/(s·K)" ;
   qudt:ucumCode "m3.s-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G72" ;
@@ -23638,7 +23592,7 @@ unit:MOL-DEG_C
   qudt:expression "\\(mol-degC\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A1E0L0I0M0H1T0D0 ;
   qudt:hasQuantityKind quantitykind:TemperatureAmountOfSubstance ;
-  qudt:symbol "mol⋅°C" ;
+  qudt:symbol "mol·°C" ;
   qudt:ucumCode "mol.Cel"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Mole Degree Celsius"@en ;
@@ -23654,7 +23608,7 @@ unit:MOL-K
   qudt:derivedCoherentUnitOfSystem sou:SI ;
   qudt:hasDimensionVector qkdv:A1E0L0I0M0H1T0D0 ;
   qudt:hasQuantityKind quantitykind:TemperatureAmountOfSubstance ;
-  qudt:symbol "mol⋅K" ;
+  qudt:symbol "mol·K" ;
   qudt:ucumCode "mol.K"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Mole Kelvin"@en ;
@@ -23686,7 +23640,7 @@ unit:MOL-PER-GM-HR
   qudt:conversionMultiplierSN 2.77777777777778E-1 ;
   qudt:hasDimensionVector qkdv:A1E0L0I0M-1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "mol/(g⋅hr)" ;
+  qudt:symbol "mol/(g·hr)" ;
   qudt:ucumCode "mol.g-1.h-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Moles per gram hour"@en ;
@@ -23770,7 +23724,7 @@ unit:MOL-PER-KiloGM-PA
   qudt:hasDimensionVector qkdv:A1E0L1I0M-2H0T2D0 ;
   qudt:hasQuantityKind quantitykind:AmountOfSubstancePerUnitMassPressure ;
   qudt:iec61360Code "0112/2///62720#UAB317" ;
-  qudt:symbol "mol/(kg⋅Pa)" ;
+  qudt:symbol "mol/(kg·Pa)" ;
   qudt:ucumCode "mol.kg-1.Pa-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P51" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -23845,7 +23799,7 @@ unit:MOL-PER-M2-DAY
   qudt:conversionMultiplierSN 1.15740740740741E-5 ;
   qudt:hasDimensionVector qkdv:A1E0L-2I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "mol/(m²⋅day)" ;
+  qudt:symbol "mol/(m²·day)" ;
   qudt:ucumCode "mol.m-2.d-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Moles per Square Meter Day"@en-us ;
@@ -23859,7 +23813,7 @@ unit:MOL-PER-M2-SEC
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A1E0L-2I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "mol/(m²⋅s)" ;
+  qudt:symbol "mol/(m²·s)" ;
   qudt:ucumCode "mol.m-2.s-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Moles per square metre second"@en ;
@@ -23871,7 +23825,7 @@ unit:MOL-PER-M2-SEC-M
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "mol/(m²⋅s⋅m)" ;
+  qudt:symbol "mol/(m²·s·m)" ;
   qudt:ucumCode "mol.m-2.s-1.m-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Moles per square metre second metre"@en ;
@@ -23883,7 +23837,7 @@ unit:MOL-PER-M2-SEC-M-SR
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "mol/(m²⋅s⋅m⋅sr)" ;
+  qudt:symbol "mol/(m²·s·m·sr)" ;
   qudt:ucumCode "mol.m-2.s-1.m-1.sr-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Moles per square metre second metre steradian"@en ;
@@ -23895,7 +23849,7 @@ unit:MOL-PER-M2-SEC-SR
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A1E0L-2I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "mol/(m²⋅s⋅sr)" ;
+  qudt:symbol "mol/(m²·s·sr)" ;
   qudt:ucumCode "mol.m-2.s-1.sr-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Moles per square metre second steradian"@en ;
@@ -23975,7 +23929,7 @@ unit:MOL-PER-M3-SEC
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "mol/(m³⋅s)" ;
+  qudt:symbol "mol/(m³·s)" ;
   qudt:ucumCode "mol.m-3.s-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Moles per cubic metre second"@en ;
@@ -24067,7 +24021,7 @@ unit:MOL_LB-DEG_F
   qudt:expression "\\(lb-mol-degF\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A1E0L0I0M0H1T0D0 ;
   qudt:hasQuantityKind quantitykind:MassAmountOfSubstanceTemperature ;
-  qudt:symbol "lb-mol⋅°F" ;
+  qudt:symbol "lb-mol·°F" ;
   qudt:ucumCode "[mol_lb].[degF]"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Pound Mole Degree Fahrenheit"@en ;
@@ -24581,7 +24535,7 @@ unit:MegaEV-FemtoM
   qudt:hasDimensionVector qkdv:A0E0L3I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:LengthEnergy ;
   qudt:prefix prefix:Mega ;
-  qudt:symbol "MeV⋅fm" ;
+  qudt:symbol "MeV·fm" ;
   qudt:ucumCode "MeV.fm"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Mega Electron Volt Femtometer"@en-us ;
@@ -24737,7 +24691,7 @@ unit:MegaHZ-M
   qudt:hasQuantityKind quantitykind:Speed ;
   qudt:iec61360Code "0112/2///62720#UAA210" ;
   qudt:plainTextDescription "product of the 1,000,000-fold of the SI derived unit hertz and the 1 000-fold of the SI base unit metre" ;
-  qudt:symbol "MHz⋅m" ;
+  qudt:symbol "MHz·m" ;
   qudt:ucumCode "MHz.m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H39" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -24973,7 +24927,7 @@ unit:MegaN-M
   qudt:hasQuantityKind quantitykind:Torque ;
   qudt:iec61360Code "0112/2///62720#UAA214" ;
   qudt:plainTextDescription "1,000,000-fold of the product of the SI derived unit newton and the SI base unit metre" ;
-  qudt:symbol "MN⋅m" ;
+  qudt:symbol "MN·m" ;
   qudt:ucumCode "MN.m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B74" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -25022,7 +24976,7 @@ unit:MegaOHM-KiloM
   qudt:hasDimensionVector qkdv:A0E-2L3I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAB406" ;
-  qudt:symbol "MΩ⋅km" ;
+  qudt:symbol "MΩ·km" ;
   qudt:ucumCode "MOhm.km"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H88" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -25132,7 +25086,7 @@ unit:MegaPA-L-PER-SEC
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAA218" ;
   qudt:plainTextDescription "product out of the 1,000,000-fold of the SI derived unit pascal and the unit litre divided by the SI base unit second" ;
-  qudt:symbol "MPa⋅L/s" ;
+  qudt:symbol "MPa·L/s" ;
   qudt:ucumCode "MPa.L.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F97" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -25190,7 +25144,7 @@ unit:MegaPA-M3-PER-SEC
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAA219" ;
   qudt:plainTextDescription "product out of the 1,000,000-fold of the SI derived unit pascal and the power of the SI base unit metre with the exponent 3 divided by the SI base unit second" ;
-  qudt:symbol "MPa⋅m³/s" ;
+  qudt:symbol "MPa·m³/s" ;
   qudt:ucumCode "MPa.m3.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F98" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -25369,7 +25323,7 @@ unit:MegaV-A
   qudt:hasQuantityKind quantitykind:ComplexPower ;
   qudt:iec61360Code "0112/2///62720#UAA222" ;
   qudt:plainTextDescription "1,000,000-fold of the product of the SI derived unit volt and the SI base unit ampere" ;
-  qudt:symbol "MV⋅A" ;
+  qudt:symbol "MV·A" ;
   qudt:ucumCode "MV.A"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "MVA" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -25386,7 +25340,7 @@ unit:MegaV-A-HR
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Energy ;
   qudt:plainTextDescription "product of the 1,000,000-fold of the unit for apparent by ampere and the unit hour" ;
-  qudt:symbol "MV⋅A⋅hr" ;
+  qudt:symbol "MV·A·hr" ;
   qudt:ucumCode "MV.A.h"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Megavolt Ampere Hour"@en ;
@@ -25400,7 +25354,7 @@ unit:MegaV-A_Reactive
   qudt:hasQuantityKind quantitykind:ReactivePower ;
   qudt:iec61360Code "0112/2///62720#UAB199" ;
   qudt:plainTextDescription "1,000,000-fold of the unit volt ampere reactive" ;
-  qudt:symbol "MV⋅A{Reactive}" ;
+  qudt:symbol "MV·A{Reactive}" ;
   qudt:ucumCode "MV.A{reactive}"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "MAR" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -25415,7 +25369,7 @@ unit:MegaV-A_Reactive-HR
   qudt:hasQuantityKind quantitykind:Energy ;
   qudt:iec61360Code "0112/2///62720#UAB198" ;
   qudt:plainTextDescription "product of the 1,000,000-fold of the unit volt ampere reactive and the unit hour" ;
-  qudt:symbol "MV⋅A{Reactive}⋅hr" ;
+  qudt:symbol "MV·A{Reactive}·hr" ;
   qudt:ucumCode "MV.A{reactive}.h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "MAH" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -25474,7 +25428,7 @@ unit:MegaW-HR
   qudt:hasQuantityKind quantitykind:Energy ;
   qudt:iec61360Code "0112/2///62720#UAA225" ;
   qudt:plainTextDescription "1 000 000-fold of the product of the SI derived unit watt and the unit hour" ;
-  qudt:symbol "MW⋅hr" ;
+  qudt:symbol "MW·hr" ;
   qudt:ucumCode "MW.h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "MWH" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -25859,7 +25813,7 @@ unit:MicroGM-PER-CentiM2-WK
   qudt:conversionMultiplierSN 1.6534392E-11 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:MassPerAreaTime ;
-  qudt:symbol "μg/(cm²⋅wk)" ;
+  qudt:symbol "μg/(cm²·wk)" ;
   qudt:ucumCode "µg.cm-2.wk-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Micrograms per square centimeter week"@en-us ;
@@ -25979,7 +25933,7 @@ unit:MicroGM-PER-L-HR
   qudt:conversionMultiplierSN 2.77777777777778E-10 ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "μg/(L⋅hr)" ;
+  qudt:symbol "μg/(L·hr)" ;
   qudt:ucumCode "ug.L-1.h-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Micrograms per litre hour"@en ;
@@ -25994,7 +25948,7 @@ unit:MicroGM-PER-M2-DAY
   qudt:conversionMultiplierSN 1.15740740740741E-14 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:MassPerAreaTime ;
-  qudt:symbol "μg/(m²⋅day)" ;
+  qudt:symbol "μg/(m²·day)" ;
   qudt:ucumCode "ug.m-2.d-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Micrograms per square metre day"@en ;
@@ -26045,7 +25999,7 @@ unit:MicroGM-PER-M3-HR
   qudt:conversionMultiplierSN 2.77777777777778E-13 ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "μg/(m³⋅hr)" ;
+  qudt:symbol "μg/(m³·hr)" ;
   qudt:ucumCode "ug.m-3.h-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Micrograms per cubic metre hour"@en ;
@@ -26393,7 +26347,7 @@ unit:MicroM-PER-L-DAY
   qudt:conversionMultiplierSN 1.15740740740741E-8 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "µm/(L⋅day)" ;
+  qudt:symbol "µm/(L·day)" ;
   qudt:ucumCode "um.L-1.d-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Micromoles per litre day"@en ;
@@ -26603,7 +26557,7 @@ unit:MicroMOL-PER-GM-HR
   qudt:conversionMultiplierSN 2.77777777777778E-7 ;
   qudt:hasDimensionVector qkdv:A1E0L0I0M-1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "µmol/(g⋅hr)" ;
+  qudt:symbol "µmol/(g·hr)" ;
   qudt:ucumCode "umol.g-1.h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "umol/g/h"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -26616,7 +26570,7 @@ unit:MicroMOL-PER-GM-SEC
   qudt:conversionMultiplierSN 1.0E-3 ;
   qudt:hasDimensionVector qkdv:A1E0L0I0M-1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "μmol/(g⋅s)" ;
+  qudt:symbol "μmol/(g·s)" ;
   qudt:ucumCode "umol.g-1.s-1"^^qudt:UCUMcs ;
   qudt:ucumCode "umol/g/s"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -26657,7 +26611,7 @@ unit:MicroMOL-PER-L-HR
   qudt:conversionMultiplierSN 2.77777777777778E-7 ;
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "µmol/(L⋅hr)" ;
+  qudt:symbol "µmol/(L·hr)" ;
   qudt:ucumCode "umol.L-1.h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "umol/L/h"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -26684,7 +26638,7 @@ unit:MicroMOL-PER-M2-DAY
   qudt:conversionMultiplierSN 1.15740740740741E-11 ;
   qudt:hasDimensionVector qkdv:A1E0L-2I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "µmol/(m²⋅day)" ;
+  qudt:symbol "µmol/(m²·day)" ;
   qudt:ucumCode "umol.m-2.d-1"^^qudt:UCUMcs ;
   qudt:ucumCode "umol/m2/d"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -26697,7 +26651,7 @@ unit:MicroMOL-PER-M2-HR
   qudt:conversionMultiplierSN 2.77777777777778E-10 ;
   qudt:hasDimensionVector qkdv:A1E0L-2I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "µmol/(m²⋅hr)" ;
+  qudt:symbol "µmol/(m²·hr)" ;
   qudt:ucumCode "umol.m-2.h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "umol/m2/h"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -26711,7 +26665,7 @@ unit:MicroMOL-PER-M2-SEC
   qudt:conversionMultiplierSN 1.0E-6 ;
   qudt:hasDimensionVector qkdv:A1E0L-2I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:PhotosyntheticPhotonFluxDensity ;
-  qudt:symbol "µmol/(m²⋅s)" ;
+  qudt:symbol "µmol/(m²·s)" ;
   qudt:ucumCode "umol.m-2.s-1"^^qudt:UCUMcs ;
   qudt:ucumCode "umol/m2/s"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -26739,7 +26693,7 @@ unit:MicroMOL-PER-MicroMOL-DAY
   qudt:conversionMultiplierSN 1.15740740740741E-5 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "μmol/(µmol⋅day)" ;
+  qudt:symbol "μmol/(µmol·day)" ;
   qudt:ucumCode "umol.umol-1.d-1"^^qudt:UCUMcs ;
   qudt:ucumCode "umol/umol/d"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -26793,7 +26747,7 @@ unit:MicroN-M
   qudt:hasQuantityKind quantitykind:Torque ;
   qudt:iec61360Code "0112/2///62720#UAA071" ;
   qudt:plainTextDescription "0.000001-fold of the product out of the derived SI newton and the SI base unit metre" ;
-  qudt:symbol "μN⋅m" ;
+  qudt:symbol "μN·m" ;
   qudt:ucumCode "uN.m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B93" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -27155,7 +27109,7 @@ unit:MicroV-A_Reactive
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:ReactivePower ;
   qudt:iec61360Code "0112/2///62720#UAC506" ;
-  qudt:symbol "µV⋅A{Reactive}" ;
+  qudt:symbol "µV·A{Reactive}" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "microvolt ampere reactive" ;
 .
@@ -27273,7 +27227,7 @@ unit:MilliA-HR
   qudt:hasQuantityKind quantitykind:ElectricCharge ;
   qudt:iec61360Code "0112/2///62720#UAA777" ;
   qudt:plainTextDescription "product of the 0.001-fold of the SI base unit ampere and the unit hour" ;
-  qudt:symbol "mA⋅hr" ;
+  qudt:symbol "mA·hr" ;
   qudt:ucumCode "mA.h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E09" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -27289,7 +27243,7 @@ unit:MilliA-HR-PER-GM
   qudt:conversionOffsetSN 0.0E0 ;
   qudt:hasDimensionVector qkdv:A0E1L0I0M-1H0T1D0 ;
   qudt:hasQuantityKind quantitykind:SpecificElectricCharge ;
-  qudt:symbol "mA⋅h/g" ;
+  qudt:symbol "mA·h/g" ;
   qudt:ucumCode "mA.h.g-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Milliampere Hour per Gram"@en ;
@@ -27302,7 +27256,7 @@ unit:MilliA-IN2-PER-LB_F
   qudt:hasDimensionVector qkdv:A0E1L1I0M-1H0T2D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAB494" ;
-  qudt:symbol "mA⋅in²/lbf" ;
+  qudt:symbol "mA·in²/lbf" ;
   qudt:ucumCode "mA.[in_i]2.[lbf_av]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F57" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -27373,7 +27327,7 @@ unit:MilliA-PER-LB_F-IN2
   qudt:hasDimensionVector qkdv:A0E1L-3I0M-1H0T2D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAB494" ;
-  qudt:symbol "mA/(lbf⋅in²)" ;
+  qudt:symbol "mA/(lbf·in²)" ;
   qudt:ucumCode "mA.[lbf_av]-1.[in_i]-2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F57" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -27458,7 +27412,7 @@ unit:MilliBAR-L-PER-SEC
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAA813" ;
   qudt:plainTextDescription "product out of the 0.001-fold of the unit bar and the unit litre divided by the SI base unit second" ;
-  qudt:symbol "mbar⋅L/s" ;
+  qudt:symbol "mbar·L/s" ;
   qudt:ucumCode "mbar.L.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F95" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -27475,7 +27429,7 @@ unit:MilliBAR-M3-PER-SEC
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAA327" ;
   qudt:plainTextDescription "product of the unit bar and the power of the SI base unit metre with the exponent 3 divided by the SI base unit second" ;
-  qudt:symbol "mbar⋅m³/s" ;
+  qudt:symbol "mbar·m³/s" ;
   qudt:ucumCode "mbar.m3.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F96" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -27590,7 +27544,7 @@ unit:MilliBQ-PER-M2-DAY
   qudt:conversionMultiplierSN 1.15740740740741E-8 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "mBq/(m²⋅day)" ;
+  qudt:symbol "mBq/(m²·day)" ;
   qudt:ucumCode "mBq.m-2.d-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Millibecquerels per square metre day"@en ;
@@ -28049,7 +28003,6 @@ unit:MilliGM-PER-DAY-BAR
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA821" ;
-  qudt:symbol "mg/(d⋅bar)" ;
   qudt:symbol "mg/(d·bar)" ;
   qudt:ucumCode "mg.d-1.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F70" ;
@@ -28064,7 +28017,6 @@ unit:MilliGM-PER-DAY-K
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA820" ;
-  qudt:symbol "mg/(d⋅K)" ;
   qudt:symbol "mg/(d·K)" ;
   qudt:ucumCode "mg.d-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F43" ;
@@ -28159,7 +28111,6 @@ unit:MilliGM-PER-HR-BAR
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA825" ;
-  qudt:symbol "mg/(h⋅bar)" ;
   qudt:symbol "mg/(h·bar)" ;
   qudt:ucumCode "mg.h-1.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F71" ;
@@ -28174,7 +28125,6 @@ unit:MilliGM-PER-HR-K
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA824" ;
-  qudt:symbol "mg/(h⋅K)" ;
   qudt:symbol "mg/(h·K)" ;
   qudt:ucumCode "mg.h-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F44" ;
@@ -28342,7 +28292,7 @@ unit:MilliGM-PER-M2-DAY
   qudt:conversionMultiplierSN 1.15740740740741E-11 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:MassPerAreaTime ;
-  qudt:symbol "mg/(m²⋅day)" ;
+  qudt:symbol "mg/(m²·day)" ;
   qudt:ucumCode "mg.m-2.d-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Milligrams per square metre day"@en ;
@@ -28357,7 +28307,7 @@ unit:MilliGM-PER-M2-HR
   qudt:conversionMultiplierSN 2.77777777777778E-10 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:MassPerAreaTime ;
-  qudt:symbol "mg/(m²⋅hr)" ;
+  qudt:symbol "mg/(m²·hr)" ;
   qudt:ucumCode "mg.m-2.h-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Milligrams per square metre hour"@en ;
@@ -28372,7 +28322,7 @@ unit:MilliGM-PER-M2-SEC
   qudt:conversionMultiplierSN 1.0E-6 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:MassPerAreaTime ;
-  qudt:symbol "mg/(m²⋅s)" ;
+  qudt:symbol "mg/(m²·s)" ;
   qudt:ucumCode "mg.m-2.s-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Milligrams per square metre second"@en ;
@@ -28436,7 +28386,7 @@ unit:MilliGM-PER-M3-DAY
   qudt:conversionMultiplierSN 1.15740740740741E-11 ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "mg/(m³⋅day)" ;
+  qudt:symbol "mg/(m³·day)" ;
   qudt:ucumCode "mg.m-3.d-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Milligrams per cubic metre day"@en ;
@@ -28451,7 +28401,7 @@ unit:MilliGM-PER-M3-HR
   qudt:conversionMultiplierSN 2.77777777777778E-10 ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "mg/(m³⋅hr)" ;
+  qudt:symbol "mg/(m³·hr)" ;
   qudt:ucumCode "mg.m-3.h-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Milligrams per cubic metre hour"@en ;
@@ -28519,7 +28469,7 @@ unit:MilliGM-PER-M3-SEC
   qudt:conversionMultiplierSN 1.0E-6 ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "mg/(m³⋅s)" ;
+  qudt:symbol "mg/(m³·s)" ;
   qudt:ucumCode "mg.m-3.s-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Milligrams per cubic metre second"@en ;
@@ -28551,7 +28501,6 @@ unit:MilliGM-PER-MIN-BAR
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA835" ;
-  qudt:symbol "mg/(min⋅bar)" ;
   qudt:symbol "mg/(min·bar)" ;
   qudt:ucumCode "mg.min-1.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F72" ;
@@ -28566,7 +28515,6 @@ unit:MilliGM-PER-MIN-K
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA834" ;
-  qudt:symbol "mg/(min⋅K)" ;
   qudt:symbol "mg/(min·K)" ;
   qudt:ucumCode "mg.min-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F45" ;
@@ -28621,7 +28569,6 @@ unit:MilliGM-PER-SEC-BAR
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA838" ;
-  qudt:symbol "mg/(s⋅bar)" ;
   qudt:symbol "mg/(s·bar)" ;
   qudt:ucumCode "mg.s-1.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F73" ;
@@ -28636,7 +28583,6 @@ unit:MilliGM-PER-SEC-K
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA837" ;
-  qudt:symbol "mg/(s⋅K)" ;
   qudt:symbol "mg/(s·K)" ;
   qudt:ucumCode "mg.s-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F46" ;
@@ -29033,7 +28979,7 @@ unit:MilliL-PER-CentiM2-MIN
   qudt:hasQuantityKind quantitykind:VolumetricFlux ;
   qudt:iec61360Code "0112/2///62720#UAA858" ;
   qudt:plainTextDescription "quotient of the 0.001-fold of the unit litre and the unit minute divided by the 0.0001-fold of the power of the SI base unit metre with the exponent 2" ;
-  qudt:symbol "mL/(cm²⋅min)" ;
+  qudt:symbol "mL/(cm²·min)" ;
   qudt:ucumCode "mL.cm-2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "35" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -29053,7 +28999,7 @@ unit:MilliL-PER-CentiM2-SEC
   qudt:hasQuantityKind quantitykind:VolumetricFlux ;
   qudt:iec61360Code "0112/2///62720#UAB085" ;
   qudt:plainTextDescription "unit of the volume flow rate millilitre divided by second related to the transfer area as 0.0001-fold of the power of the SI base unit metre by exponent 2" ;
-  qudt:symbol "mL/(cm²⋅s)" ;
+  qudt:symbol "mL/(cm²·s)" ;
   qudt:ucumCode "mL.cm-2.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "35" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -29089,7 +29035,6 @@ unit:MilliL-PER-DAY-BAR
   qudt:hasDimensionVector qkdv:A0E0L4I0M-1H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA849" ;
-  qudt:symbol "ml/(d⋅bar)" ;
   qudt:symbol "ml/(d·bar)" ;
   qudt:ucumCode "mL.d-1.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G90" ;
@@ -29104,7 +29049,6 @@ unit:MilliL-PER-DAY-K
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA848" ;
-  qudt:symbol "ml/(d⋅K)" ;
   qudt:symbol "ml/(d·K)" ;
   qudt:ucumCode "mL.d-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G73" ;
@@ -29162,7 +29106,6 @@ unit:MilliL-PER-HR-BAR
   qudt:hasDimensionVector qkdv:A0E0L4I0M-1H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA852" ;
-  qudt:symbol "ml/(h⋅bar)" ;
   qudt:symbol "ml/(h·bar)" ;
   qudt:ucumCode "mL.h-1.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G91" ;
@@ -29177,7 +29120,6 @@ unit:MilliL-PER-HR-K
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA851" ;
-  qudt:symbol "ml/(h⋅K)" ;
   qudt:symbol "ml/(h·K)" ;
   qudt:ucumCode "mL.h-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G74" ;
@@ -29253,7 +29195,7 @@ unit:MilliL-PER-M2-DAY
   qudt:conversionMultiplierSN 1.15740740740741E-11 ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "mL/(m²⋅day)" ;
+  qudt:symbol "mL/(m²·day)" ;
   qudt:ucumCode "mL.m-2.d-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Millilitres per square metre day"@en ;
@@ -29309,7 +29251,6 @@ unit:MilliL-PER-MIN-BAR
   qudt:hasDimensionVector qkdv:A0E0L4I0M-1H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA857" ;
-  qudt:symbol "ml/(min⋅bar)" ;
   qudt:symbol "ml/(min·bar)" ;
   qudt:ucumCode "mL.min-1.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G92" ;
@@ -29324,7 +29265,6 @@ unit:MilliL-PER-MIN-K
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA856" ;
-  qudt:symbol "ml/(min⋅K)" ;
   qudt:symbol "ml/(min·K)" ;
   qudt:ucumCode "mL.min-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G75" ;
@@ -29360,7 +29300,6 @@ unit:MilliL-PER-SEC-BAR
   qudt:hasDimensionVector qkdv:A0E0L4I0M-1H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA861" ;
-  qudt:symbol "ml/(s⋅bar)" ;
   qudt:symbol "ml/(s·bar)" ;
   qudt:ucumCode "mL.s-1.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G93" ;
@@ -29375,7 +29314,6 @@ unit:MilliL-PER-SEC-K
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA860" ;
-  qudt:symbol "ml/(s⋅K)" ;
   qudt:symbol "ml/(s·K)" ;
   qudt:ucumCode "mL.s-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G76" ;
@@ -29830,7 +29768,7 @@ unit:MilliMOL-PER-M2-DAY
   qudt:conversionMultiplierSN 1.15740740740741E-8 ;
   qudt:hasDimensionVector qkdv:A1E0L-2I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "mmol/(m²⋅day)" ;
+  qudt:symbol "mmol/(m²·day)" ;
   qudt:ucumCode "mmol.m-2.d-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Millimoles per square metre day"@en ;
@@ -29842,7 +29780,7 @@ unit:MilliMOL-PER-M2-SEC
   qudt:conversionMultiplierSN 1.0E-3 ;
   qudt:hasDimensionVector qkdv:A1E0L-2I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "mmol/(m²⋅s)" ;
+  qudt:symbol "mmol/(m²·s)" ;
   qudt:ucumCode "mmol.m-2.s-1"^^qudt:UCUMcs ;
   qudt:ucumCode "mmol/m2/s1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -29871,7 +29809,7 @@ unit:MilliMOL-PER-M3-DAY
   qudt:conversionMultiplierSN 1.15740740740741E-8 ;
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "mmol/(m³⋅day)" ;
+  qudt:symbol "mmol/(m³·day)" ;
   qudt:ucumCode "mmol.m-3.d-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Millimoles per cubic metre day"@en ;
@@ -29979,7 +29917,7 @@ unit:MilliN-M
   qudt:hasQuantityKind quantitykind:Torque ;
   qudt:iec61360Code "0112/2///62720#UAA794" ;
   qudt:plainTextDescription "0.001-fold of the product of the SI derived unit newton and the SI base unit metre" ;
-  qudt:symbol "mN⋅m" ;
+  qudt:symbol "mN·m" ;
   qudt:ucumCode "mN.m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D83" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -30145,7 +30083,7 @@ unit:MilliPA-SEC
   qudt:hasQuantityKind quantitykind:Viscosity ;
   qudt:iec61360Code "0112/2///62720#UAA797" ;
   qudt:plainTextDescription "0.001-fold of the product of the SI derived unit pascal and the SI base unit second" ;
-  qudt:symbol "mPa⋅s" ;
+  qudt:symbol "mPa·s" ;
   qudt:ucumCode "mPa.s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C24" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -30161,7 +30099,7 @@ unit:MilliPA-SEC-PER-BAR
   qudt:hasQuantityKind quantitykind:Time ;
   qudt:iec61360Code "0112/2///62720#UAA799" ;
   qudt:plainTextDescription "0.001-fold of the product of the SI derived unit pascal and the SI base unit second divided by the unit of the pressure bar" ;
-  qudt:symbol "mPa⋅s/bar" ;
+  qudt:symbol "mPa·s/bar" ;
   qudt:ucumCode "mPa.s.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L16" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -30495,7 +30433,7 @@ unit:MilliV-A_Reactive
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:ReactivePower ;
   qudt:iec61360Code "0112/2///62720#UAC507" ;
-  qudt:symbol "mV⋅A{Reactive}" ;
+  qudt:symbol "mV·A{Reactive}" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "millivolt ampere reactive" ;
 .
@@ -30589,7 +30527,7 @@ unit:MilliW-PER-CentiM2-MicroM-SR
   qudt:conversionMultiplierSN 1.0E7 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "mW/(cm²⋅µm⋅sr)" ;
+  qudt:symbol "mW/(cm²·µm·sr)" ;
   qudt:ucumCode "mW.cm-2.um-1.sr-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Milliwatts per square centimetre micrometre steradian"@en ;
@@ -30624,7 +30562,7 @@ unit:MilliW-PER-M2-NanoM
   qudt:conversionMultiplierSN 1.0E6 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "mW/(m²⋅nm)" ;
+  qudt:symbol "mW/(m²·nm)" ;
   qudt:ucumCode "mW.m-2.nm-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Milliwatts per square metre nanometre"@en ;
@@ -30639,7 +30577,7 @@ unit:MilliW-PER-M2-NanoM-SR
   qudt:conversionMultiplierSN 1.0E6 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "mW/(cm⋅nm⋅sr)" ;
+  qudt:symbol "mW/(cm·nm·sr)" ;
   qudt:ucumCode "mW.m-2.nm-1.sr-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Milliwatts per square metre nanometre steradian"@en ;
@@ -30754,7 +30692,7 @@ unit:N-CentiM
   qudt:hasQuantityKind quantitykind:Torque ;
   qudt:iec61360Code "0112/2///62720#UAA237" ;
   qudt:plainTextDescription "product of the SI derived unit newton and the 0.01-fold of the SI base unit metre" ;
-  qudt:symbol "N⋅cm" ;
+  qudt:symbol "N·cm" ;
   qudt:ucumCode "N.cm"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F88" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -30781,7 +30719,7 @@ unit:N-M
   qudt:iec61360Code "0112/2///62720#UAA239" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Newton_metre?oldid=493923333"^^xsd:anyURI ;
   qudt:siUnitsExpression "N.m" ;
-  qudt:symbol "N⋅m" ;
+  qudt:symbol "N·m" ;
   qudt:ucumCode "N.m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "NU" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -30819,7 +30757,7 @@ unit:N-M-PER-A
   qudt:hasQuantityKind quantitykind:MagneticFlux ;
   qudt:iec61360Code "0112/2///62720#UAA241" ;
   qudt:plainTextDescription "product of the SI derived unit newton and the SI base unit metre divided by the SI base unit ampere" ;
-  qudt:symbol "N⋅m/A" ;
+  qudt:symbol "N·m/A" ;
   qudt:ucumCode "N.m.A-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F90" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -30863,7 +30801,7 @@ unit:N-M-PER-DEG-M
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ModulusOfRotationalSubgradeReaction ;
   qudt:plainTextDescription "A common unit for measuring the modulus of rotational subgrade reaction." ;
-  qudt:symbol "N⋅m/(°·m)" ;
+  qudt:symbol "N·m/(°·m)" ;
   qudt:ucumCode "N.m.deg-1.m-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Newton metre per degree metre"@en ;
@@ -30881,7 +30819,7 @@ unit:N-M-PER-KiloGM
   qudt:hasQuantityKind quantitykind:SpecificEnergy ;
   qudt:iec61360Code "0112/2///62720#UAB490" ;
   qudt:plainTextDescription "product of the derived SI unit newton and the SI base unit metre divided by the SI base unit kilogram" ;
-  qudt:symbol "N⋅m/kg" ;
+  qudt:symbol "N·m/kg" ;
   qudt:ucumCode "N.m.kg-1"^^qudt:UCUMcs ;
   qudt:udunitsCode "gp" ;
   qudt:uneceCommonCode "G19" ;
@@ -30904,7 +30842,7 @@ unit:N-M-PER-M
   qudt:hasQuantityKind quantitykind:TorquePerLength ;
   qudt:iec61360Code "0112/2///62720#UAB463" ;
   qudt:plainTextDescription "This is the SI unit for the rolling resistance, which is equivalent to drag force in newton" ;
-  qudt:symbol "N⋅m/m" ;
+  qudt:symbol "N·m/m" ;
   qudt:ucumCode "N.m.m-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "Q27" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -30923,7 +30861,7 @@ unit:N-M-PER-M-RAD
   qudt:exactMatch unit:N-PER-RAD ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ModulusOfRotationalSubgradeReaction ;
-  qudt:symbol "N⋅m/(m⋅rad)" ;
+  qudt:symbol "N·m/(m·rad)" ;
   qudt:ucumCode "N.m.m-1.rad-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Newton Meter per Meter Radian"@en-us ;
@@ -30943,7 +30881,7 @@ unit:N-M-PER-M2
   qudt:hasQuantityKind quantitykind:ForcePerLength ;
   qudt:iec61360Code "0112/2///62720#UAA244" ;
   qudt:plainTextDescription "product of the SI derived unit newton and the SI base unit metre divided by the power of the SI base unit metre with the exponent 2" ;
-  qudt:symbol "N⋅m/m²" ;
+  qudt:symbol "N·m/m²" ;
   qudt:ucumCode "N.m.m-2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H86" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -30980,7 +30918,7 @@ unit:N-M-PER-RAD
   qudt:hasQuantityKind quantitykind:TorsionalSpringConstant ;
   qudt:iec61360Code "0112/2///62720#UAB309" ;
   qudt:plainTextDescription "Newton Meter per Radian is the SI unit for Torsion Constant" ;
-  qudt:symbol "N⋅m/rad" ;
+  qudt:symbol "N·m/rad" ;
   qudt:ucumCode "N.m.rad-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M93" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -31020,7 +30958,7 @@ unit:N-M-SEC
   qudt:informativeReference "http://en.wikipedia.org/wiki/SI_derived_unit"^^xsd:anyURI ;
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31889"^^xsd:anyURI ;
   qudt:siUnitsExpression "N.m.sec" ;
-  qudt:symbol "N⋅m⋅s" ;
+  qudt:symbol "N·m·s" ;
   qudt:ucumCode "N.m.s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C53" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -31058,7 +30996,7 @@ unit:N-M-SEC-PER-M
   qudt:hasQuantityKind quantitykind:LinearMomentum ;
   qudt:hasQuantityKind quantitykind:Momentum ;
   qudt:plainTextDescription "Newton metre seconds measured per metre" ;
-  qudt:symbol "N⋅m⋅s/m" ;
+  qudt:symbol "N·m·s/m" ;
   qudt:ucumCode "N.m.s.m-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Newton meter seconds per meter"@en-us ;
@@ -31079,7 +31017,7 @@ unit:N-M-SEC-PER-RAD
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:AngularMomentumPerAngle ;
   qudt:plainTextDescription "Newton metre seconds measured per radian" ;
-  qudt:symbol "N⋅m⋅s/rad" ;
+  qudt:symbol "N·m·s/rad" ;
   qudt:ucumCode "N.m.s.rad-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Newton meter seconds per radian"@en-us ;
@@ -31097,7 +31035,7 @@ unit:N-M2
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:WarpingMoment ;
-  qudt:symbol "N⋅m²" ;
+  qudt:symbol "N·m²" ;
   qudt:ucumCode "N.m2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Newton Square Meter"@en-us ;
@@ -31116,7 +31054,7 @@ unit:N-M2-PER-A
   qudt:hasDimensionVector qkdv:A0E-1L3I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:MagneticDipoleMoment ;
   qudt:iec61360Code "0112/2///62720#UAB332" ;
-  qudt:symbol "N⋅m²/A" ;
+  qudt:symbol "N·m²/A" ;
   qudt:ucumCode "N.m2.A-1"^^qudt:UCUMcs ;
   qudt:ucumCode "N.m2/A"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P49" ;
@@ -31137,7 +31075,7 @@ unit:N-M2-PER-KiloGM2
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAB491" ;
   qudt:plainTextDescription "unit of gravitational constant as product of the derived SI unit newton, the power of the SI base unit metre with the exponent 2 divided by the power of the SI base unit kilogram with the exponent 2" ;
-  qudt:symbol "N⋅m²/kg²" ;
+  qudt:symbol "N·m²/kg²" ;
   qudt:ucumCode "N.m2.kg-2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C54" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -31404,7 +31342,7 @@ unit:N-SEC
   qudt:hasQuantityKind quantitykind:Momentum ;
   qudt:iec61360Code "0112/2///62720#UAA251" ;
   qudt:plainTextDescription "product of the SI derived unit newton and the SI base unit second" ;
-  qudt:symbol "N⋅s" ;
+  qudt:symbol "N·s" ;
   qudt:ucumCode "N.s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C57" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -31443,7 +31381,7 @@ unit:N-SEC-PER-M
   qudt:hasQuantityKind quantitykind:MassPerTime ;
   qudt:iec61360Code "0112/2///62720#UAA252" ;
   qudt:plainTextDescription "Newton second measured per metre" ;
-  qudt:symbol "N⋅s/m" ;
+  qudt:symbol "N·s/m" ;
   qudt:ucumCode "N.s.m-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C58" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -31480,7 +31418,7 @@ unit:N-SEC-PER-M3
   qudt:hasDimensionVector qkdv:A0E0L-2I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:SpecificAcousticImpedance ;
   qudt:latexSymbol "\\(N \\cdot s \\cdot m^{-3}\\)"^^qudt:LatexString ;
-  qudt:symbol "N⋅s/m³" ;
+  qudt:symbol "N·s/m³" ;
   qudt:ucumCode "N.s.m-3"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Newton second per Cubic Meter"@en-us ;
@@ -31500,7 +31438,7 @@ unit:N-SEC-PER-RAD
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:MomentumPerAngle ;
   qudt:plainTextDescription "Newton seconds measured per radian" ;
-  qudt:symbol "N⋅s/rad" ;
+  qudt:symbol "N·s/rad" ;
   qudt:ucumCode "N.s.rad-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Newton seconds per radian"@en ;
@@ -31635,7 +31573,7 @@ unit:NUM-PER-CentiM-KiloYR
   qudt:conversionMultiplierSN 3.168808781402895023702689684893655E-9 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "/(cm⋅1000 yr)" ;
+  qudt:symbol "/(cm·1000 yr)" ;
   qudt:ucumCode "{#}.cm-2.ka-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Number per square centimetre thousand years"@en ;
@@ -31740,7 +31678,7 @@ unit:NUM-PER-M2-DAY
   qudt:conversionMultiplierSN 1.15740740740741E-5 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Flux ;
-  qudt:symbol "/(m²⋅day)" ;
+  qudt:symbol "/(m²·day)" ;
   qudt:ucumCode "{#}.m-2.d-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Number per square metre day"@en ;
@@ -32017,7 +31955,7 @@ unit:NanoGM-PER-CentiM2-DAY
   qudt:conversionMultiplierSN 1.1574074E-13 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:MassPerAreaTime ;
-  qudt:symbol "ng/(cm²⋅day)" ;
+  qudt:symbol "ng/(cm²·day)" ;
   qudt:ucumCode "ng.cm-2.d-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Nanograms per square centimeter day"@en-us ;
@@ -32108,7 +32046,7 @@ unit:NanoGM-PER-M2-PA-SEC
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:VaporPermeability ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Perm_(unit)"^^xsd:anyURI ;
-  qudt:symbol "kg/(m²⋅s⋅Pa)" ;
+  qudt:symbol "kg/(m²·s·Pa)" ;
   qudt:ucumCode "ng.m-2.Pa-1.s-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Nanograms per square metre Pascal second"@en ;
@@ -32344,7 +32282,7 @@ unit:NanoM-PER-CentiM-MegaPA
   qudt:qkdvDenominator qkdv:A0E0L0I0M1H0T-2D0 ;
   qudt:qkdvNumerator qkdv:A0E0L1I0M0H0T0D0 ;
   qudt:siUnitsExpression "nm/cm/MPa" ;
-  qudt:symbol "nm/(cm⋅MPa)" ;
+  qudt:symbol "nm/(cm·MPa)" ;
   qudt:ucumCode "nm.cm-1.MPa-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Nanometer Per Centimeter Megapascal"@en ;
@@ -32359,7 +32297,7 @@ unit:NanoM-PER-CentiM-PSI
   qudt:qkdvDenominator qkdv:A0E0L0I0M1H0T-2D0 ;
   qudt:qkdvNumerator qkdv:A0E0L1I0M0H0T0D0 ;
   qudt:siUnitsExpression "nm/cm/PSI" ;
-  qudt:symbol "nm/(cm⋅psi)" ;
+  qudt:symbol "nm/(cm·psi)" ;
   qudt:ucumCode "nm.cm-1.PSI-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Nanometer Per Centimeter PSI"@en ;
@@ -32378,7 +32316,7 @@ unit:NanoM-PER-MilliM-MegaPA
   qudt:qkdvDenominator qkdv:A0E0L0I0M1H0T-2D0 ;
   qudt:qkdvNumerator qkdv:A0E0L1I0M0H0T0D0 ;
   qudt:siUnitsExpression "nm/mm/MPa" ;
-  qudt:symbol "nm/(mm⋅MPa)" ;
+  qudt:symbol "nm/(mm·MPa)" ;
   qudt:ucumCode "nm.mm-1.MPa-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Nanometer Per Millimeter Megapascal"@en ;
@@ -32427,7 +32365,7 @@ unit:NanoMOL-PER-CentiM3-HR
   qudt:conversionMultiplierSN 2.77777777777778E-7 ;
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "nmol/(cm³⋅hr)" ;
+  qudt:symbol "nmol/(cm³·hr)" ;
   qudt:ucumCode "nmol.cm-3.h-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Nanomoles per cubic centimetre hour"@en ;
@@ -32439,7 +32377,7 @@ unit:NanoMOL-PER-GM-SEC
   qudt:conversionMultiplierSN 1.0E-6 ;
   qudt:hasDimensionVector qkdv:A1E0L0I0M-1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "nmol/(g⋅s)" ;
+  qudt:symbol "nmol/(g·s)" ;
   qudt:ucumCode "nmol.g-1.s-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Nanomoles per gram second"@en ;
@@ -32479,7 +32417,7 @@ unit:NanoMOL-PER-L-DAY
   qudt:conversionMultiplierSN 1.15740740740741E-11 ;
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "nmol/(L⋅day)" ;
+  qudt:symbol "nmol/(L·day)" ;
   qudt:ucumCode "nmol.L-1.d-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Nanomoles per litre day"@en ;
@@ -32491,7 +32429,7 @@ unit:NanoMOL-PER-L-HR
   qudt:conversionMultiplierSN 2.77777777777778E-10 ;
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "nmol/(L⋅hr)" ;
+  qudt:symbol "nmol/(L·hr)" ;
   qudt:ucumCode "nmol.L-1.h-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Nanomoles per litre hour"@en ;
@@ -32503,7 +32441,7 @@ unit:NanoMOL-PER-M2-DAY
   qudt:conversionMultiplierSN 1.15740740740741E-14 ;
   qudt:hasDimensionVector qkdv:A1E0L-2I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "nmol/(m²⋅day)" ;
+  qudt:symbol "nmol/(m²·day)" ;
   qudt:ucumCode "nmol.m-2.d-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Nanomoles per square metre day"@en ;
@@ -32515,7 +32453,7 @@ unit:NanoMOL-PER-MicroGM-HR
   qudt:conversionMultiplierSN 2.77777777777778E-4 ;
   qudt:hasDimensionVector qkdv:A1E0L0I0M-1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "nmol/(µg⋅hr)" ;
+  qudt:symbol "nmol/(µg·hr)" ;
   qudt:ucumCode "nmol.ug-1.h-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Nanomoles per microgram hour"@en ;
@@ -32544,7 +32482,7 @@ unit:NanoMOL-PER-MicroMOL-DAY
   qudt:conversionMultiplierSN 1.15740740740741E-8 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "nmol/(µmol⋅day)" ;
+  qudt:symbol "nmol/(µmol·day)" ;
   qudt:ucumCode "nmol.umol-1.d-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Nanomoles per micromole day"@en ;
@@ -32751,7 +32689,7 @@ unit:NanoV-A_Reactive
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:ReactivePower ;
   qudt:iec61360Code "0112/2///62720#UAC505" ;
-  qudt:symbol "nV⋅A{Reactive}" ;
+  qudt:symbol "nV·A{Reactive}" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "nanovolt ampere reactive" ;
 .
@@ -32868,7 +32806,7 @@ unit:OERSTED-CentiM
   qudt:expression "\\(Oe-cm\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E1L0I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:MagnetomotiveForce ;
-  qudt:symbol "Oe⋅cm" ;
+  qudt:symbol "Oe·cm" ;
   qudt:ucumCode "Oe.cm"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Oersted Centimeter"@en-us ;
@@ -32932,7 +32870,7 @@ unit:OHM-CentiM
   qudt:hasDimensionVector qkdv:A0E-2L3I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:Resistivity ;
   qudt:iec61360Code "0112/2///62720#UAB090" ;
-  qudt:symbol "Ω⋅cm" ;
+  qudt:symbol "Ω·cm" ;
   qudt:ucumCode "Ohm.cm"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C60" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -32965,7 +32903,7 @@ unit:OHM-M
   qudt:hasQuantityKind quantitykind:Resistivity ;
   qudt:iec61360Code "0112/2///62720#UAA020" ;
   qudt:informativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
-  qudt:symbol "Ω⋅m" ;
+  qudt:symbol "Ω·m" ;
   qudt:ucumCode "Ohm.m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C61" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -32996,7 +32934,7 @@ unit:OHM-M2-PER-M
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E-2L3I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:Resistivity ;
-  qudt:symbol "Ω⋅m²/m" ;
+  qudt:symbol "Ω·m²/m" ;
   qudt:ucumCode "Ohm2.m.m-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Ohm Square Meter per Meter"@en-us ;
@@ -33094,7 +33032,7 @@ unit:OHM_CIRC-MIL-PER-FT
   qudt:hasDimensionVector qkdv:A0E-2L3I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAB215" ;
-  qudt:symbol "Ω⋅cmil/ft" ;
+  qudt:symbol "Ω·cmil/ft" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "ohm circular mil per foot" ;
 .
@@ -33172,7 +33110,7 @@ unit:OZ-FT
   qudt:hasQuantityKind quantitykind:LengthMass ;
   qudt:iec61360Code "0112/2///62720#UAB133" ;
   qudt:plainTextDescription "unit of the unbalance as a product of avoirdupois ounce according to  the avoirdupois system of units and foot according to the Anglo-American and Imperial system of units" ;
-  qudt:symbol "oz⋅ft" ;
+  qudt:symbol "oz·ft" ;
   qudt:ucumCode "[oz_av].[ft_i]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "4R" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -33293,7 +33231,7 @@ unit:OZ-IN
   qudt:hasQuantityKind quantitykind:LengthMass ;
   qudt:iec61360Code "0112/2///62720#UAB132" ;
   qudt:plainTextDescription "unit of the unbalance as a product of avoirdupois ounce according to  the avoirdupois system of units and inch according to the Anglo-American and Imperial system of units" ;
-  qudt:symbol "oz⋅in" ;
+  qudt:symbol "oz·in" ;
   qudt:ucumCode "[oz_av].[in_i]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "4Q" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -33685,7 +33623,7 @@ unit:OZ_F-IN
   qudt:hasQuantityKind quantitykind:MomentOfForce ;
   qudt:hasQuantityKind quantitykind:Torque ;
   qudt:iec61360Code "0112/2///62720#UAA927" ;
-  qudt:symbol "ozf⋅in" ;
+  qudt:symbol "ozf·in" ;
   qudt:ucumCode "[ozf_av].[in_i]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L41" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -33989,7 +33927,7 @@ unit:PA-L-PER-SEC
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAA261" ;
   qudt:plainTextDescription "product out of the SI derived unit pascal and the unit litre divided by the SI base unit second" ;
-  qudt:symbol "Pa⋅L/s" ;
+  qudt:symbol "Pa·L/s" ;
   qudt:ucumCode "Pa.L.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F99" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -34006,7 +33944,7 @@ unit:PA-M
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "Pa⋅m" ;
+  qudt:symbol "Pa·m" ;
   qudt:ucumCode "Pa.m"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Pascal metres"@en ;
@@ -34021,7 +33959,7 @@ unit:PA-M-PER-SEC
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "Pa⋅m/s" ;
+  qudt:symbol "Pa·m/s" ;
   qudt:ucumCode "Pa.m.s-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Pascal metres per second"@en ;
@@ -34036,7 +33974,7 @@ unit:PA-M-PER-SEC2
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-4D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "Pa⋅m/s²" ;
+  qudt:symbol "Pa·m/s²" ;
   qudt:ucumCode "Pa.m.s-2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Pascal metres per square second"@en ;
@@ -34104,7 +34042,7 @@ unit:PA-M3-PER-SEC
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAA264" ;
   qudt:plainTextDescription "product out of the SI derived unit pascal and the power of the SI base unit metre with the exponent 3 divided by the SI base unit second" ;
-  qudt:symbol "Pa⋅m³/s" ;
+  qudt:symbol "Pa·m³/s" ;
   qudt:ucumCode "Pa.m3.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G01" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -34234,7 +34172,7 @@ unit:PA-SEC
   qudt:hasQuantityKind quantitykind:Viscosity ;
   qudt:iec61360Code "0112/2///62720#UAA265" ;
   qudt:siUnitsExpression "Pa.s" ;
-  qudt:symbol "Pa⋅s" ;
+  qudt:symbol "Pa·s" ;
   qudt:ucumCode "Pa.s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C65" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -34267,7 +34205,7 @@ unit:PA-SEC-PER-BAR
   qudt:hasQuantityKind quantitykind:Time ;
   qudt:iec61360Code "0112/2///62720#UAA267" ;
   qudt:plainTextDescription "product out of the SI derived unit pascal and the SI base unit second divided by the unit bar" ;
-  qudt:symbol "Pa⋅s/bar" ;
+  qudt:symbol "Pa·s/bar" ;
   qudt:ucumCode "Pa.s.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H07" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -34281,7 +34219,6 @@ unit:PA-SEC-PER-K
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA266" ;
-  qudt:symbol "Pa⋅s/K" ;
   qudt:symbol "Pa·s/K" ;
   qudt:ucumCode "Pa.s.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F77" ;
@@ -34318,7 +34255,7 @@ unit:PA-SEC-PER-M
   qudt:iec61360Code "0112/2///62720#UAA268" ;
   qudt:informativeReference "http://www.efunda.com/glossary/units/units--specific_acoustic_impedance--pascal_second_per_meter.cfm"^^xsd:anyURI ;
   qudt:siUnitsExpression "Pa.s/m" ;
-  qudt:symbol "Pa⋅s/m" ;
+  qudt:symbol "Pa·s/m" ;
   qudt:ucumCode "Pa.s.m-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C67" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -34341,7 +34278,7 @@ unit:PA-SEC-PER-M3
   qudt:iec61360Code "0112/2///62720#UAA263" ;
   qudt:informativeReference "http://www.efunda.com/glossary/units/units--acoustic_impedance--pascal_second_per_cubic_meter.cfm"^^xsd:anyURI ;
   qudt:siUnitsExpression "Pa.s/m3" ;
-  qudt:symbol "Pa⋅s/m³" ;
+  qudt:symbol "Pa·s/m³" ;
   qudt:ucumCode "Pa.s.m-3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C66" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -34394,7 +34331,7 @@ unit:PA2-SEC
   qudt:iec61360Code "0112/2///62720#UAB339" ;
   qudt:informativeReference "http://www.efunda.com/glossary/units/units--specific_acoustic_impedance--pascal_second_per_meter.cfm"^^xsd:anyURI ;
   qudt:siUnitsExpression "Pa2.s" ;
-  qudt:symbol "Pa²⋅s" ;
+  qudt:symbol "Pa²·s" ;
   qudt:ucumCode "Pa2.s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P42" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -34876,7 +34813,7 @@ unit:PER-J-M3
   qudt:hasQuantityKind quantitykind:EnergyDensityOfStates ;
   qudt:iec61360Code "0112/2///62720#UAB165" ;
   qudt:informativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
-  qudt:symbol "/(J⋅m³)" ;
+  qudt:symbol "/(J·m³)" ;
   qudt:ucumCode "J-1.m-3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C90" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -34999,7 +34936,7 @@ unit:PER-KiloV-A-HR
   qudt:hasQuantityKind quantitykind:InverseEnergy ;
   qudt:iec61360Code "0112/2///62720#UAA098" ;
   qudt:plainTextDescription "reciprocal of the 1,000-fold of the product of the SI derived unit volt and the SI base unit ampere and the unit hour" ;
-  qudt:symbol "/(kV⋅A⋅hr)" ;
+  qudt:symbol "/(kV·A·hr)" ;
   qudt:ucumCode "kV-1.A-1.h-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Reciprocal Kilovolt Ampere Hour"@en ;
@@ -35079,7 +35016,7 @@ unit:PER-M-K
   qudt:expression "\\(/m.k\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H-1T0D0 ;
   qudt:hasQuantityKind quantitykind:InverseLengthTemperature ;
-  qudt:symbol "/(m⋅K)" ;
+  qudt:symbol "/(m·K)" ;
   qudt:ucumCode "m-1.K-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Reciprocal Meter Kelvin"@en-us ;
@@ -35095,7 +35032,7 @@ unit:PER-M-NanoM
   qudt:conversionMultiplierSN 1.0E9 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "/(m⋅nm)" ;
+  qudt:symbol "/(m·nm)" ;
   qudt:ucumCode "m-1.nm-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Reciprocal metre per nanometre"@en ;
@@ -35110,7 +35047,7 @@ unit:PER-M-NanoM-SR
   qudt:conversionMultiplierSN 1.0E9 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "/(m⋅nm⋅sr)" ;
+  qudt:symbol "/(m·nm·sr)" ;
   qudt:ucumCode "m-1.nm-1.sr-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Reciprocal metre nanometre steradian"@en ;
@@ -35125,7 +35062,7 @@ unit:PER-M-SEC
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "/(m⋅s)" ;
+  qudt:symbol "/(m·s)" ;
   qudt:ucumCode "m-1.s-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Reciprocal metre per second"@en ;
@@ -35140,7 +35077,7 @@ unit:PER-M-SR
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "/(m⋅sr)" ;
+  qudt:symbol "/(m·sr)" ;
   qudt:ucumCode "m-1.sr-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Reciprocal metre per steradian"@en ;
@@ -35185,7 +35122,7 @@ unit:PER-M2-SEC
   qudt:hasQuantityKind quantitykind:ParticleFluenceRate ;
   qudt:iec61360Code "0112/2///62720#UAB157" ;
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
-  qudt:symbol "/(m²⋅s)" ;
+  qudt:symbol "/(m²·s)" ;
   qudt:ucumCode "m-2.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B81" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -35234,7 +35171,7 @@ unit:PER-M3-SEC
   qudt:hasQuantityKind quantitykind:Slowing-DownDensity ;
   qudt:iec61360Code "0112/2///62720#UAB163" ;
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
-  qudt:symbol "/(m³⋅s)" ;
+  qudt:symbol "/(m³·s)" ;
   qudt:ucumCode "m-3.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C87" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -35400,7 +35337,7 @@ unit:PER-MicroMOL-L
   qudt:conversionMultiplierSN 1.0E9 ;
   qudt:hasDimensionVector qkdv:A-1E0L-3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "/(µmol⋅L)" ;
+  qudt:symbol "/(µmol·L)" ;
   qudt:ucumCode "umol-1.L-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Reciprocal micromole per litre"@en ;
@@ -35580,7 +35517,7 @@ unit:PER-PA-SEC
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M-1H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "/(Pa⋅s)" ;
+  qudt:symbol "/(Pa·s)" ;
   qudt:ucumCode "Pa-1.s-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Reciprocal Pascal per second"@en ;
@@ -35712,7 +35649,7 @@ unit:PER-SEC-M2
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Flux ;
   qudt:iec61360Code "0112/2///62720#UAA974" ;
-  qudt:symbol "/s⋅m²" ;
+  qudt:symbol "/s·m²" ;
   qudt:symbol "s⁻¹/m²" ;
   qudt:ucumCode "/(s1.m2)"^^qudt:UCUMcs ;
   qudt:ucumCode "s-1.m-2"^^qudt:UCUMcs ;
@@ -35733,7 +35670,7 @@ unit:PER-SEC-M2-SR
   qudt:expression "\\(/sec-m^2-sr\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:PhotonRadiance ;
-  qudt:symbol "/(s⋅m²⋅sr)" ;
+  qudt:symbol "/(s·m²·sr)" ;
   qudt:ucumCode "/(s.m2.sr)"^^qudt:UCUMcs ;
   qudt:ucumCode "s-1.m-2.sr-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D2" ;
@@ -35771,7 +35708,7 @@ unit:PER-SEC-SR
   qudt:hasQuantityKind quantitykind:PhotonIntensity ;
   qudt:hasQuantityKind quantitykind:TemporalSummationFunction ;
   qudt:iec61360Code "0112/2///62720#UAA976" ;
-  qudt:symbol "/s⋅sr" ;
+  qudt:symbol "/s·sr" ;
   qudt:ucumCode "/(s.sr)"^^qudt:UCUMcs ;
   qudt:ucumCode "s-1.sr-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D1" ;
@@ -35837,7 +35774,7 @@ unit:PER-T-M
   qudt:hasDimensionVector qkdv:A0E1L-1I0M-1H0T2D0 ;
   qudt:hasQuantityKind quantitykind:MagneticReluctivity ;
   qudt:latexSymbol "\\(m^{-1} \\cdot T^{-1}\\)"^^qudt:LatexString ;
-  qudt:symbol "/(T⋅m)" ;
+  qudt:symbol "/(T·m)" ;
   qudt:ucumCode "T-1.m-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Reciprocal Tesla Meter"@en-us ;
@@ -35855,7 +35792,7 @@ unit:PER-T-SEC
   qudt:expression "\\(/s . T\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E1L0I0M-1H0T1D0 ;
   qudt:hasQuantityKind quantitykind:ElectricChargePerMass ;
-  qudt:symbol "/(T⋅s)" ;
+  qudt:symbol "/(T·s)" ;
   qudt:ucumCode "T-1.s-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Reciprocal Tesla Second Unit"@en ;
@@ -37663,7 +37600,7 @@ unit:PSI-IN3-PER-SEC
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAA703" ;
   qudt:plainTextDescription "product of the composed unit for pressure (pound-force per square inch) and the composed unit for volume flow (cubic inch per second)" ;
-  qudt:symbol "psi⋅in³/s" ;
+  qudt:symbol "psi·in³/s" ;
   qudt:ucumCode "[psi].[cin_i].s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K87" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -37678,7 +37615,7 @@ unit:PSI-L-PER-SEC
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAA704" ;
   qudt:plainTextDescription "product of the composed unit for pressure (pound-force per square inch) and the composed unit for volume flow (litre per second)" ;
-  qudt:symbol "psi⋅L/s" ;
+  qudt:symbol "psi·L/s" ;
   qudt:ucumCode "[psi].L.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K88" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -37694,7 +37631,7 @@ unit:PSI-M3-PER-SEC
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAA705" ;
   qudt:plainTextDescription "product of the composed unit for pressure (pound-force per square inch) and the composed unit for volume flow (cubic metre per second)" ;
-  qudt:symbol "psi⋅m³/s" ;
+  qudt:symbol "psi·m³/s" ;
   qudt:ucumCode "[psi].m3.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K89" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -37743,7 +37680,7 @@ unit:PSI-YD3-PER-SEC
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAA706" ;
   qudt:plainTextDescription "product of the composed unit for pressure (pound-force per square inch) and the square inch) and the composed unit for volume flow (cubic yard per second)" ;
-  qudt:symbol "psi⋅yd³/s" ;
+  qudt:symbol "psi·yd³/s" ;
   qudt:ucumCode "[psi].[cyd_i].s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K90" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -38096,7 +38033,7 @@ unit:PicoA-PER-MicroMOL-L
   qudt:conversionMultiplierSN 1.0E-3 ;
   qudt:hasDimensionVector qkdv:A-1E1L-3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "pA/(µmol⋅L)" ;
+  qudt:symbol "pA/(µmol·L)" ;
   qudt:ucumCode "pA.umol-1.L-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Picoamps per micromole litre"@en ;
@@ -38408,7 +38345,7 @@ unit:PicoMOL-PER-L-DAY
   qudt:conversionMultiplierSN 1.15740740740741E-14 ;
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:CatalyticActivityConcentration ;
-  qudt:symbol "pmol/(L⋅day)" ;
+  qudt:symbol "pmol/(L·day)" ;
   qudt:ucumCode "pmol.L-1.d-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Picomoles per litre day"@en ;
@@ -38421,7 +38358,7 @@ unit:PicoMOL-PER-L-HR
   qudt:conversionMultiplierSN 2.77777777777778E-13 ;
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:CatalyticActivityConcentration ;
-  qudt:symbol "pmol/(L⋅hr)" ;
+  qudt:symbol "pmol/(L·hr)" ;
   qudt:ucumCode "pmol.L-1.h-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Picomoles per litre hour"@en ;
@@ -38433,7 +38370,7 @@ unit:PicoMOL-PER-M-W-SEC
   qudt:conversionMultiplierSN 1.0E-12 ;
   qudt:hasDimensionVector qkdv:A1E0L-3I0M-1H0T2D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "pmol/(m⋅W⋅s)" ;
+  qudt:symbol "pmol/(m·W·s)" ;
   qudt:ucumCode "pmol.m-1.W-1.s-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Picomoles per metre watt second"@en ;
@@ -38445,7 +38382,7 @@ unit:PicoMOL-PER-M2-DAY
   qudt:conversionMultiplierSN 1.15740740740741E-17 ;
   qudt:hasDimensionVector qkdv:A1E0L-2I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:PhotosyntheticPhotonFluxDensity ;
-  qudt:symbol "pmol/(m²⋅day)" ;
+  qudt:symbol "pmol/(m²·day)" ;
   qudt:ucumCode "pmol.m-2.d-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Picomoles per square metre day"@en ;
@@ -38471,7 +38408,7 @@ unit:PicoMOL-PER-M3-SEC
   qudt:conversionMultiplierSN 1.0E-12 ;
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "pmol/(m³⋅s)" ;
+  qudt:symbol "pmol/(m³·s)" ;
   qudt:ucumCode "pmol.m-3.s-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Picomoles per cubic metre second"@en ;
@@ -38611,7 +38548,7 @@ unit:PicoV-A_Reactive
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:ReactivePower ;
   qudt:iec61360Code "0112/2///62720#UAC504" ;
-  qudt:symbol "pV⋅A{Reactive}" ;
+  qudt:symbol "pV·A{Reactive}" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "picovolt ampere reactive" ;
 .
@@ -38648,7 +38585,7 @@ unit:PicoW-PER-CentiM2-L
   qudt:conversionMultiplierSN 1.0E-5 ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "pW/(cm²⋅L)" ;
+  qudt:symbol "pW/(cm²·L)" ;
   qudt:ucumCode "pW.cm-2.L-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Picowatts per square centimetre litre"@en ;
@@ -39273,7 +39210,7 @@ unit:RAD-M2-PER-KiloGM
   qudt:hasDimensionVector qkdv:A0E0L2I0M-1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:SpecificOpticalRotatoryPower ;
   qudt:iec61360Code "0112/2///62720#UAB162" ;
-  qudt:symbol "rad⋅m²/kg" ;
+  qudt:symbol "rad·m²/kg" ;
   qudt:ucumCode "rad.m2.kg-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C83" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -39289,7 +39226,7 @@ unit:RAD-M2-PER-MOL
   qudt:hasDimensionVector qkdv:A-1E0L2I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:MolarOpticalRotatoryPower ;
   qudt:iec61360Code "0112/2///62720#UAB161" ;
-  qudt:symbol "rad⋅m²/mol" ;
+  qudt:symbol "rad·m²/mol" ;
   qudt:ucumCode "rad.m2.mol-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C82" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -39733,7 +39670,7 @@ unit:S-M2-PER-MOL
   qudt:hasDimensionVector qkdv:A-1E2L0I0M-1H0T3D0 ;
   qudt:hasQuantityKind quantitykind:MolarConductivity ;
   qudt:iec61360Code "0112/2///62720#UAA280" ;
-  qudt:symbol "S⋅m²/mol" ;
+  qudt:symbol "S·m²/mol" ;
   qudt:ucumCode "S.m2.mol-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D12" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -39875,7 +39812,7 @@ unit:SEC-FT2
   qudt:expression "\\(s-ft^2\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:AreaTime ;
-  qudt:symbol "s⋅ft²" ;
+  qudt:symbol "s·ft²" ;
   qudt:ucumCode "s.[ft_i]2"^^qudt:UCUMcs ;
   qudt:ucumCode "s.[sft_i]"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -39952,7 +39889,7 @@ unit:SEC-PER-RAD-M3
   qudt:hasQuantityKind quantitykind:DensityOfStates ;
   qudt:iec61360Code "0112/2///62720#UAB352" ;
   qudt:informativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
-  qudt:symbol "s/(rad⋅m³)" ;
+  qudt:symbol "s/(rad·m³)" ;
   qudt:ucumCode "s.rad-1.m-3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "Q22" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -40100,7 +40037,7 @@ unit:SLUG-PER-FT-SEC
   qudt:hasQuantityKind quantitykind:DynamicViscosity ;
   qudt:hasQuantityKind quantitykind:Viscosity ;
   qudt:iec61360Code "0112/2///62720#UAA980" ;
-  qudt:symbol "slug/(ft⋅s)" ;
+  qudt:symbol "slug/(ft·s)" ;
   qudt:uneceCommonCode "L64" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Slug per Foot Second"@en ;
@@ -40642,7 +40579,7 @@ unit:T-M
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E-1L1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:MagneticFluxPerUnitLength ;
-  qudt:symbol "T⋅m" ;
+  qudt:symbol "T·m" ;
   qudt:ucumCode "T.m"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "T-M"@en ;
@@ -40656,7 +40593,7 @@ unit:T-SEC
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E-1L0I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:MassPerElectricCharge ;
-  qudt:symbol "T⋅s" ;
+  qudt:symbol "T·s" ;
   qudt:ucumCode "T.s"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "T-SEC"@en ;
@@ -40924,7 +40861,7 @@ unit:TONNE-PER-HA-YR
   qudt:hasDimensionVector qkdv:A0E0L-2I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:MassPerAreaTime ;
   qudt:plainTextDescription "A measure of density equivalent to 1000kg per hectare per year or one Megagram per hectare per year, typically used to express a volume of biomass or crop yield." ;
-  qudt:symbol "t/(ha⋅yr)" ;
+  qudt:symbol "t/(ha·yr)" ;
   qudt:ucumCode "t.har-1.year-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "tonne per hectare year"@en ;
@@ -41214,7 +41151,7 @@ unit:TON_FG-HR
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ThermalEnergy ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Ton_of_refrigeration?oldid=494342824"^^xsd:anyURI ;
-  qudt:symbol "TOR⋅hr" ;
+  qudt:symbol "TOR·hr" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Ton of Refrigeration Hour"@en ;
 .
@@ -41670,7 +41607,7 @@ unit:TON_SHORT-PER-HR-DEG_F
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAB015" ;
-  qudt:symbol "ton{short}/(hr⋅°F)" ;
+  qudt:symbol "ton{short}/(hr·°F)" ;
   qudt:ucumCode "[ston_av].h-1.[degF]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L89" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -41684,7 +41621,7 @@ unit:TON_SHORT-PER-HR-PSI
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAB016" ;
-  qudt:symbol "ton{short}/(hr⋅psi)" ;
+  qudt:symbol "ton{short}/(hr·psi)" ;
   qudt:ucumCode "[ston_av].h-1.[psi]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L90" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -42191,7 +42128,7 @@ unit:TeraV-A_Reactive
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAC509" ;
-  qudt:symbol "TV⋅A{Reactive}" ;
+  qudt:symbol "TV·A{Reactive}" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "teravolt ampere reactive" ;
 .
@@ -42230,7 +42167,7 @@ unit:TeraW-HR
   qudt:hasQuantityKind quantitykind:Energy ;
   qudt:iec61360Code "0112/2///62720#UAA290" ;
   qudt:plainTextDescription "1,000,000,000,000-fold of the product of the SI derived unit watt and the unit hour" ;
-  qudt:symbol "TW⋅hr" ;
+  qudt:symbol "TW·hr" ;
   qudt:ucumCode "TW/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D32" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -42460,7 +42397,7 @@ unit:V-A
   qudt:hasQuantityKind quantitykind:NonActivePower ;
   qudt:iec61360Code "0112/2///62720#UAA298" ;
   qudt:plainTextDescription "product of the SI derived unit volt and the SI base unit ampere" ;
-  qudt:symbol "V⋅A" ;
+  qudt:symbol "V·A" ;
   qudt:ucumCode "V.A"^^qudt:UCUMcs ;
   qudt:udunitsCode "VA" ;
   qudt:uneceCommonCode "D46" ;
@@ -42485,7 +42422,7 @@ unit:V-A-HR
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Energy ;
   qudt:plainTextDescription "product of the unit for apparent by ampere and the unit hour" ;
-  qudt:symbol "V⋅A⋅hr" ;
+  qudt:symbol "V·A·hr" ;
   qudt:ucumCode "V.A.h"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Volt Ampere Hour"@en ;
@@ -42512,7 +42449,7 @@ unit:V-A_Reactive
   qudt:hasQuantityKind quantitykind:ReactivePower ;
   qudt:iec61360Code "0112/2///62720#UAB023" ;
   qudt:plainTextDescription "unit with special name for reactive power" ;
-  qudt:symbol "V⋅A{Reactive}" ;
+  qudt:symbol "V·A{Reactive}" ;
   qudt:ucumCode "V.A{reactive}"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D44" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -42526,7 +42463,7 @@ unit:V-A_Reactive-HR
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Energy ;
   qudt:plainTextDescription "product of the unit volt ampere reactive and the unit hour" ;
-  qudt:symbol "V⋅A{reactive}⋅hr" ;
+  qudt:symbol "V·A{reactive}·hr" ;
   qudt:ucumCode "V.A{reactive}.h"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Volt Ampere Reactive Hour"@en ;
@@ -42564,7 +42501,7 @@ unit:V-M
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E-1L3I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:ElectricFlux ;
-  qudt:symbol "V⋅m" ;
+  qudt:symbol "V·m" ;
   qudt:ucumCode "V.m"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "V-M"@en ;
@@ -42807,7 +42744,7 @@ unit:V-SEC-PER-M
   qudt:hasQuantityKind quantitykind:ScalarMagneticPotential ;
   qudt:iec61360Code "0112/2///62720#UAA303" ;
   qudt:plainTextDescription "product of the SI derived unit volt and the SI base unit second divided by the SI base unit metre" ;
-  qudt:symbol "V⋅s/m" ;
+  qudt:symbol "V·s/m" ;
   qudt:ucumCode "V.s.m-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H45" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -42883,7 +42820,7 @@ unit:V_Ab-SEC
   qudt:hasDimensionVector qkdv:A0E-1L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:MagneticFlux ;
   qudt:informativeReference "http://www.oxfordreference.com/view/10.1093/acref/9780198605225.001.0001/acref-9780198605225-e-820"^^xsd:anyURI ;
-  qudt:symbol "abV⋅s" ;
+  qudt:symbol "abV·s" ;
   qudt:ucumCode "10.nV.s"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Abvolt Second"@en ;
@@ -42917,7 +42854,7 @@ unit:V_Stat-CentiM
   qudt:expression "\\(statvolt-centimeter\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E-1L3I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:ElectricFlux ;
-  qudt:symbol "statV⋅cm" ;
+  qudt:symbol "statV·cm" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "V_Stat-CentiM"@en ;
 .
@@ -43001,7 +42938,7 @@ unit:W-HR
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Energy ;
   qudt:iec61360Code "0112/2///62720#UAA308" ;
-  qudt:symbol "W⋅hr" ;
+  qudt:symbol "W·hr" ;
   qudt:ucumCode "W.h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "WHR" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -43047,7 +42984,7 @@ unit:W-HR-PER-M2
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:EnergyPerArea ;
   qudt:plainTextDescription "A unit of energy per unit area, equivalent to 3,600 joules per square metre." ;
-  qudt:symbol "W⋅hr/m²" ;
+  qudt:symbol "W·hr/m²" ;
   qudt:ucumCode "W.h.m-2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Watt hour per square metre"@en ;
@@ -43063,7 +43000,7 @@ unit:W-HR-PER-M3
   qudt:conversionMultiplierSN 3.6E3 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:EnergyDensity ;
-  qudt:symbol "W⋅hr/m³" ;
+  qudt:symbol "W·hr/m³" ;
   qudt:ucumCode "W.h.m-3"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Watthour per Cubic meter"@en-us ;
@@ -43080,7 +43017,7 @@ unit:W-M-PER-M2-SR
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "W⋅m/(m²⋅sr)" ;
+  qudt:symbol "W·m/(m²·sr)" ;
   qudt:ucumCode "W.m-2.m.sr-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Watt metre per square metre steradian"@en ;
@@ -43097,7 +43034,7 @@ unit:W-M2
   qudt:hasDimensionVector qkdv:A0E0L4I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:PowerArea ;
   qudt:iec61360Code "0112/2///62720#UAB350" ;
-  qudt:symbol "W⋅m²" ;
+  qudt:symbol "W·m²" ;
   qudt:ucumCode "W.m2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "Q21" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -43113,7 +43050,7 @@ unit:W-M2-PER-SR
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L4I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:PowerAreaPerSolidAngle ;
-  qudt:symbol "W⋅m²/sr" ;
+  qudt:symbol "W·m²/sr" ;
   qudt:ucumCode "W.m2.sr-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "W-M2-PER-SR"@en ;
@@ -43272,7 +43209,7 @@ unit:W-PER-M-K
   qudt:iec61360Code "0112/2///62720#UAA309" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Thermal_conductivity"^^xsd:anyURI ;
   qudt:latexSymbol "\\(W \\cdot m^{-1} \\cdot K^{-1}\\)"^^qudt:LatexString ;
-  qudt:symbol "W/(m⋅K)" ;
+  qudt:symbol "W/(m·K)" ;
   qudt:ucumCode "W.m-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D53" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -43337,7 +43274,7 @@ unit:W-PER-M2-K
   qudt:hasQuantityKind quantitykind:CombinedNonEvaporativeHeatTransferCoefficient ;
   qudt:hasQuantityKind quantitykind:SurfaceCoefficientOfHeatTransfer ;
   qudt:iec61360Code "0112/2///62720#UAA311" ;
-  qudt:symbol "W/(m²⋅K)" ;
+  qudt:symbol "W/(m²·K)" ;
   qudt:ucumCode "W.m-2.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D55" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -43355,7 +43292,7 @@ unit:W-PER-M2-K4
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H-4T-3D0 ;
   qudt:hasQuantityKind quantitykind:PowerPerAreaQuarticTemperature ;
   qudt:iec61360Code "0112/2///62720#UAB175" ;
-  qudt:symbol "W/(m²⋅K⁴)" ;
+  qudt:symbol "W/(m²·K⁴)" ;
   qudt:ucumCode "W.m-2.K-4"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D56" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -43372,7 +43309,7 @@ unit:W-PER-M2-M
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "W/(m²⋅m)" ;
+  qudt:symbol "W/(m²·m)" ;
   qudt:ucumCode "W.m-2.m-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Watts per square metre metre"@en ;
@@ -43387,7 +43324,7 @@ unit:W-PER-M2-M-SR
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "W/(m²⋅m⋅sr)" ;
+  qudt:symbol "W/(m²·m·sr)" ;
   qudt:ucumCode "W.m-2.m-1.sr-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Watts per square metre metre steradian"@en ;
@@ -43402,7 +43339,7 @@ unit:W-PER-M2-NanoM
   qudt:conversionMultiplierSN 1.0E9 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "W/(m²⋅nm)" ;
+  qudt:symbol "W/(m²·nm)" ;
   qudt:ucumCode "W.m-2.nm-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Watts per square metre nanometre"@en ;
@@ -43417,7 +43354,7 @@ unit:W-PER-M2-NanoM-SR
   qudt:conversionMultiplierSN 1.0E9 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "W/(m²⋅nm⋅sr)" ;
+  qudt:symbol "W/(m²·nm·sr)" ;
   qudt:ucumCode "W.m-2.nm-1.sr-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Watts per square metre nanometre steradian"@en ;
@@ -43436,7 +43373,7 @@ unit:W-PER-M2-PA
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:EvaporativeHeatTransferCoefficient ;
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=43012"^^xsd:anyURI ;
-  qudt:symbol "W/(m²⋅Pa)" ;
+  qudt:symbol "W/(m²·Pa)" ;
   qudt:ucumCode "W.m-2.Pa-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Watt per Square Meter Pascal"@en-us ;
@@ -43461,7 +43398,7 @@ unit:W-PER-M2-SR
   qudt:informativeReference "http://asd-www.larc.nasa.gov/Instrument/ceres_units.html"^^xsd:anyURI ;
   qudt:informativeReference "http://www.efunda.com/glossary/units/units--radiance--watt_per_square_meter_per_steradian.cfm"^^xsd:anyURI ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Radiance"^^xsd:anyURI ;
-  qudt:symbol "W/(m²⋅sr)" ;
+  qudt:symbol "W/(m²·sr)" ;
   qudt:ucumCode "W.m-2.sr-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D58" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -43537,7 +43474,7 @@ unit:W-SEC
   qudt:hasQuantityKind quantitykind:Energy ;
   qudt:iec61360Code "0112/2///62720#UAA313" ;
   qudt:plainTextDescription "product of the SI derived unit watt and SI base unit second" ;
-  qudt:symbol "W⋅s" ;
+  qudt:symbol "W·s" ;
   qudt:ucumCode "W.s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J55" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -43553,7 +43490,7 @@ unit:W-SEC-PER-M2
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:EnergyPerArea ;
-  qudt:symbol "W⋅s/m²" ;
+  qudt:symbol "W·s/m²" ;
   qudt:ucumCode "W.s.m-2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Watt seconds per square metre"@en ;
@@ -43619,7 +43556,7 @@ unit:WB-M
   qudt:hasQuantityKind quantitykind:MagneticDipoleMoment ;
   qudt:iec61360Code "0112/2///62720#UAB333" ;
   qudt:informativeReference "http://www.simetric.co.uk/siderived.htm"^^xsd:anyURI ;
-  qudt:symbol "Wb⋅m" ;
+  qudt:symbol "Wb·m" ;
   qudt:ucumCode "Wb.m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P50" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -29790,6 +29790,7 @@ unit:MilliMOL-PER-KiloGM
 .
 unit:MilliMOL-PER-L
   a qudt:DerivedUnit ;
+  a qudt:Unit ;
   dcterms:description "The SI derived unit for amount-of-substance concentration is the mmo/L."^^rdf:HTML ;
   qudt:applicableSystem sou:SI ;
   qudt:conversionMultiplier 1.0 ;
@@ -29799,9 +29800,12 @@ unit:MilliMOL-PER-L
   qudt:hasQuantityKind quantitykind:AmountOfSubstancePerUnitVolume ;
   qudt:hasQuantityKind quantitykind:BloodGlucoseLevel ;
   qudt:hasQuantityKind quantitykind:Solubility_Water ;
+  qudt:iec61360Code "0112/2///62720#UAB500" ;
   qudt:symbol "mmol/L" ;
   qudt:ucumCode "mmol.L-1"^^qudt:UCUMcs ;
   qudt:ucumCode "mmol/L"^^qudt:UCUMcs ;
+  qudt:uneceCommonCode "M33" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "millimoles per litre"@en ;
   rdfs:label "millimoles per litre"@en-us ;
 .
@@ -30688,16 +30692,6 @@ unit:MillionUSD-PER-YR
   qudt:symbol "$M/yr" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Million US Dollars per Year"@en ;
-.
-unit:MilloMOL-PER-L
-  a qudt:Unit ;
-  dcterms:description "0.001-fold of the SI base unit mole divided by the unit litre" ;
-  qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T0D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:iec61360Code "0112/2///62720#UAB500" ;
-  qudt:uneceCommonCode "M33" ;
-  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
-  rdfs:label "millimole per litre" ;
 .
 unit:N
   a qudt:DerivedUnit ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -917,6 +917,7 @@ unit:AWG
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAD909" ;
+  qudt:symbol "AWG" ;
   qudt:uneceCommonCode "AWG" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "american wire gage" ;
@@ -4284,6 +4285,7 @@ unit:CD_IN
   qudt:hasDimensionVector qkdv:A0E0L0I1M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAB440" ;
+  qudt:symbol "international candle" ;
   qudt:uneceCommonCode "P36" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "international candle" ;
@@ -4349,6 +4351,7 @@ unit:CI-PER-KiloGM
   qudt:hasDimensionVector qkdv:A0E0L0I0M-1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAB091" ;
+  qudt:symbol "Ci/kg" ;
   qudt:uneceCommonCode "A42" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "curie per kilogram" ;
@@ -4635,6 +4638,7 @@ unit:CentiGRAY
   qudt:hasQuantityKind quantitykind:AbsorbedDose ;
   qudt:hasQuantityKind quantitykind:Kerma ;
   qudt:iec61360Code "0112/2///62720#UAB503" ;
+  qudt:symbol "cGy" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "centigray" ;
 .
@@ -5478,6 +5482,7 @@ unit:CentiM_H2O_4DEG_C
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAB236" ;
+  qudt:symbol "cmH₂0 (4 °C)" ;
   qudt:uneceCommonCode "N14" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "centimetre of water (4 ºC)" ;
@@ -7733,6 +7738,7 @@ unit:ENZ
   qudt:hasDimensionVector qkdv:A1E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAB600" ;
+  qudt:symbol "U" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "enzyme unit" ;
 .
@@ -7742,6 +7748,7 @@ unit:ENZ-PER-L
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAB601" ;
+  qudt:symbol "U/L" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "enzyme units per litre" ;
 .
@@ -9678,6 +9685,7 @@ unit:FemtoFARAD
   qudt:hasDimensionVector qkdv:A0E2L-2I0M-1H0T4D0 ;
   qudt:hasQuantityKind quantitykind:Capacitance ;
   qudt:iec61360Code "0112/2///62720#UAB588" ;
+  qudt:symbol "fF" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "femtofarad" ;
 .
@@ -12168,6 +12176,7 @@ unit:GigaFLOPS
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:FloatingPointCalculationCapability ;
   qudt:iec61360Code "0112/2///62720#UAB592" ;
+  qudt:symbol "GFLOPS" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "gigafloatingpoint operations per second" ;
 .
@@ -12433,6 +12442,7 @@ unit:GigaV-A_Reactive
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:ReactivePower ;
   qudt:iec61360Code "0112/2///62720#UAC508" ;
+  qudt:symbol "GV⋅A{Reactive}" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "gigavolt ampere reactive" ;
 .
@@ -12671,6 +12681,7 @@ unit:HK
   qudt:hasDimensionVector qkdv:A0E0L0I1M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAB439" ;
+  qudt:symbol "HK" ;
   qudt:uneceCommonCode "P35" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Hefner‑Kerze" ;
@@ -13039,6 +13050,7 @@ unit:HeartBeat
   qudt:applicableSystem sou:SI ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Dimensionless ;
+  qudt:symbol "heartbeat" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Heart Beat"@en ;
 .
@@ -15233,6 +15245,7 @@ unit:KiloBD
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA560" ;
+  qudt:symbol "kBd" ;
   qudt:uneceCommonCode "K50" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "kilobaud" ;
@@ -15845,6 +15858,7 @@ unit:KiloCD
   qudt:hasDimensionVector qkdv:A0E0L0I1M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:LuminousIntensity ;
   qudt:iec61360Code "0112/2///62720#UAB365" ;
+  qudt:symbol "kCd" ;
   qudt:uneceCommonCode "P33" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "kilocandela" ;
@@ -15912,6 +15926,7 @@ unit:KiloFARAD
   qudt:hasDimensionVector qkdv:A0E2L-2I0M-1H0T4D0 ;
   qudt:hasQuantityKind quantitykind:Capacitance ;
   qudt:iec61360Code "0112/2///62720#UAB384" ;
+  qudt:symbol "kF" ;
   qudt:uneceCommonCode "N90" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "kilofarad" ;
@@ -17378,6 +17393,7 @@ unit:KiloGRAY
   qudt:hasQuantityKind quantitykind:AbsorbedDose ;
   qudt:hasQuantityKind quantitykind:Kerma ;
   qudt:iec61360Code "0112/2///62720#UAB504" ;
+  qudt:symbol "kGy" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "kilogray" ;
 .
@@ -17389,6 +17405,7 @@ unit:KiloH
   qudt:hasDimensionVector qkdv:A0E-2L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Inductance ;
   qudt:iec61360Code "0112/2///62720#UAB386" ;
+  qudt:symbol "kH" ;
   qudt:uneceCommonCode "P24" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "kilohenry" ;
@@ -18527,6 +18544,7 @@ unit:KiloT
   qudt:hasQuantityKind quantitykind:MagneticField ;
   qudt:hasQuantityKind quantitykind:MagneticFluxDensity ;
   qudt:iec61360Code "0112/2///62720#UAB385" ;
+  qudt:symbol "kT" ;
   qudt:uneceCommonCode "P13" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "kilotesla" ;
@@ -24121,6 +24139,7 @@ unit:MO_MeanGREGORIAN
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Time ;
   qudt:informativeReference "http://aurora.regenstrief.org/~ucum/ucum.html#iso1000"^^xsd:anyURI ;
+  qudt:symbol "mo{Gregorian}" ;
   qudt:ucumCode "mo_g"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "MON" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -24131,6 +24150,7 @@ unit:MO_MeanJulian
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Time ;
   qudt:informativeReference "http://aurora.regenstrief.org/~ucum/ucum.html#iso1000"^^xsd:anyURI ;
+  qudt:symbol "mo{mean Julian}" ;
   qudt:ucumCode "mo_j"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Mean Julian Month"@en ;
@@ -24142,6 +24162,7 @@ unit:MO_Synodic
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Time ;
   qudt:informativeReference "http://www.thefreedictionary.com/Synodal+month"^^xsd:anyURI ;
+  qudt:symbol "mo{synodic}" ;
   qudt:ucumCode "mo_s"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Synodic month"@en ;
@@ -24170,6 +24191,7 @@ unit:M_H2O
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAB362" ;
+  qudt:symbol "mH₂0" ;
   qudt:uneceCommonCode "N23" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "conventional metre of water" ;
@@ -24676,6 +24698,7 @@ unit:MegaGRAY
   qudt:hasQuantityKind quantitykind:AbsorbedDose ;
   qudt:hasQuantityKind quantitykind:Kerma ;
   qudt:iec61360Code "0112/2///62720#UAB505" ;
+  qudt:symbol "MGy" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "megagray" ;
 .
@@ -25294,6 +25317,7 @@ unit:MegaTON
   qudt:conversionMultiplierSN 9.0718474E8 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Mass ;
+  qudt:symbol "Mtn" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "megaton" ;
 .
@@ -27131,6 +27155,7 @@ unit:MicroV-A_Reactive
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:ReactivePower ;
   qudt:iec61360Code "0112/2///62720#UAC506" ;
+  qudt:symbol "µV⋅A{Reactive}" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "microvolt ampere reactive" ;
 .
@@ -27660,6 +27685,7 @@ unit:MilliCD
   qudt:hasDimensionVector qkdv:A0E0L0I1M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:LuminousIntensity ;
   qudt:iec61360Code "0112/2///62720#UAB369" ;
+  qudt:symbol "mCd" ;
   qudt:uneceCommonCode "P34" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "millicandela" ;
@@ -28822,6 +28848,7 @@ unit:MilliHZ
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Frequency ;
   qudt:iec61360Code "0112/2///62720#UAB698" ;
+  qudt:symbol "mHz" ;
   qudt:uneceCommonCode "MTZ" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "millihertz" ;
@@ -29763,13 +29790,11 @@ unit:MilliMOL-PER-KiloGM
 .
 unit:MilliMOL-PER-L
   a qudt:DerivedUnit ;
-  a qudt:Unit ;
   dcterms:description "The SI derived unit for amount-of-substance concentration is the mmo/L."^^rdf:HTML ;
   qudt:applicableSystem sou:SI ;
   qudt:conversionMultiplier 1.0 ;
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:expression "\\(mmo/L\\)"^^qudt:LatexString ;
-  qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:AmountOfSubstanceConcentration ;
   qudt:hasQuantityKind quantitykind:AmountOfSubstancePerUnitVolume ;
   qudt:hasQuantityKind quantitykind:BloodGlucoseLevel ;
@@ -29777,8 +29802,6 @@ unit:MilliMOL-PER-L
   qudt:symbol "mmol/L" ;
   qudt:ucumCode "mmol.L-1"^^qudt:UCUMcs ;
   qudt:ucumCode "mmol/L"^^qudt:UCUMcs ;
-  qudt:uneceCommonCode "M33" ;
-  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "millimoles per litre"@en ;
   rdfs:label "millimoles per litre"@en-us ;
 .
@@ -30468,6 +30491,7 @@ unit:MilliV-A_Reactive
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:ReactivePower ;
   qudt:iec61360Code "0112/2///62720#UAC507" ;
+  qudt:symbol "mV⋅A{Reactive}" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "millivolt ampere reactive" ;
 .
@@ -30661,6 +30685,7 @@ unit:MillionUSD-PER-YR
   qudt:expression "\\(\\(M\\$/yr\\)\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:symbol "$M/yr" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Million US Dollars per Year"@en ;
 .
@@ -32732,6 +32757,7 @@ unit:NanoV-A_Reactive
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:ReactivePower ;
   qudt:iec61360Code "0112/2///62720#UAC505" ;
+  qudt:symbol "nV⋅A{Reactive}" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "nanovolt ampere reactive" ;
 .
@@ -33074,6 +33100,7 @@ unit:OHM_CIRC-MIL-PER-FT
   qudt:hasDimensionVector qkdv:A0E-2L3I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAB215" ;
+  qudt:symbol "Ω⋅cmil/ft" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "ohm circular mil per foot" ;
 .
@@ -36275,6 +36302,7 @@ unit:PERCENT-PER-10KiloCount
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA004" ;
+  qudt:symbol "%/10k" ;
   qudt:uneceCommonCode "H91" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "percent per ten thousand" ;
@@ -36824,6 +36852,7 @@ unit:PERM_Metric_0DEG_C
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAB294" ;
+  qudt:symbol "perm (0 ºC)" ;
   qudt:uneceCommonCode "P91" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "perm (0 ºC)" ;
@@ -36834,6 +36863,7 @@ unit:PERM_Metric_23DEG_C
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAB295" ;
+  qudt:symbol "perm (23 ºC)" ;
   qudt:uneceCommonCode "P92" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "perm (23 ºC)" ;
@@ -37961,6 +37991,7 @@ unit:PetaFLOPS
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:FloatingPointCalculationCapability ;
   qudt:iec61360Code "0112/2///62720#UAB594" ;
+  qudt:symbol "PFLOPS" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "petafloating point operations per second" ;
 .
@@ -37972,6 +38003,7 @@ unit:PetaHZ
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Frequency ;
   qudt:iec61360Code "0112/2///62720#UAB699" ;
+  qudt:symbol "PHz" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "petahertz" ;
 .
@@ -38585,6 +38617,7 @@ unit:PicoV-A_Reactive
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:ReactivePower ;
   qudt:iec61360Code "0112/2///62720#UAC504" ;
+  qudt:symbol "pV⋅A{Reactive}" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "picovolt ampere reactive" ;
 .
@@ -40185,6 +40218,7 @@ unit:SPIN_QUANTUM_NUMBER
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAB604" ;
+  qudt:symbol "Q" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "spin quantum number" ;
 .
@@ -40679,9 +40713,11 @@ unit:TEX
 unit:THERM_EC
   a qudt:Unit ;
   dcterms:description "unit of heat energy in commercial use, within the EU defined: 1 thm (EC) = 100 000 BtuIT" ;
+  qudt:exactMatch unit:THM_EEC ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAB222" ;
+  qudt:symbol "thm{EC}" ;
   qudt:uneceCommonCode "N71" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "therm (EC)" ;
@@ -40689,9 +40725,11 @@ unit:THERM_EC
 unit:THERM_US
   a qudt:Unit ;
   dcterms:description "unit of heat energy in commercial use" ;
+  qudt:exactMatch unit:THM_US ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAB223" ;
+  qudt:symbol "thm{US}" ;
   qudt:uneceCommonCode "N72" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "therm (U.S.)" ;
@@ -42049,6 +42087,7 @@ unit:TeraFLOPS
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:FloatingPointCalculationCapability ;
   qudt:iec61360Code "0112/2///62720#UAB593" ;
+  qudt:symbol "TFLOPS" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "terafloating point operations per second" ;
 .
@@ -42158,6 +42197,7 @@ unit:TeraV-A_Reactive
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAC509" ;
+  qudt:symbol "TV⋅A{Reactive}" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "teravolt ampere reactive" ;
 .
@@ -42342,6 +42382,7 @@ unit:UNKNOWN
   dcterms:description "Placeholder unit for abstract quantities" ;
   qudt:hasDimensionVector qkdv:NotApplicable ;
   qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:symbol "Unknown" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Unknown"@en ;
 .

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -1932,9 +1932,9 @@ unit:BTU_39DEG_F
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAB216" ;
-  qudt:symbol "Btu (39 ºF)" ;
+  qudt:symbol "Btu (39 °F)" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
-  rdfs:label "British thermal unit (39 ºF)" ;
+  rdfs:label "British thermal unit (39 °F)" ;
 .
 unit:BTU_59DEG_F
   a qudt:Unit ;
@@ -1942,10 +1942,10 @@ unit:BTU_59DEG_F
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAB217" ;
-  qudt:symbol "Btu (59 ºF)" ;
+  qudt:symbol "Btu (59 °F)" ;
   qudt:uneceCommonCode "N67" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
-  rdfs:label "British thermal unit (59 ºF)" ;
+  rdfs:label "British thermal unit (59 °F)" ;
 .
 unit:BTU_60DEG_F
   a qudt:Unit ;
@@ -1953,9 +1953,9 @@ unit:BTU_60DEG_F
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAB218" ;
-  qudt:symbol "Btu (60 ºF)" ;
+  qudt:symbol "Btu (60 °F)" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
-  rdfs:label "British thermal unit (60 ºF)" ;
+  rdfs:label "British thermal unit (60 °F)" ;
 .
 unit:BTU_IT
   a qudt:Unit ;
@@ -2322,7 +2322,7 @@ unit:BTU_IT-PER-HR-FT2-DEG_F
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H-1T-3D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAB276" ;
-  qudt:symbol "BtuIT/(h·ft²·ºF)" ;
+  qudt:symbol "BtuIT/(h·ft²·°F)" ;
   qudt:ucumCode "[Btu_IT].h-1.[ft_i]-2.[degF]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "N74" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -2632,7 +2632,7 @@ unit:BTU_IT-PER-SEC-FT2-DEG_F
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H-1T-3D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAB278" ;
-  qudt:symbol "BtuIT/(s·ft²·ºF)" ;
+  qudt:symbol "BtuIT/(s·ft²·°F)" ;
   qudt:ucumCode "[Btu_IT].s-1.[ft_i]-2.[degF]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "N76" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -2786,7 +2786,7 @@ unit:BTU_TH-PER-DEG_F
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H-1T-2D0 ;
   qudt:hasQuantityKind quantitykind:ThermalCapacitance ;
   qudt:iec61360Code "0112/2///62720#UAB272" ;
-  qudt:symbol "Btuth/ºF" ;
+  qudt:symbol "Btuth/°F" ;
   qudt:ucumCode "[Btu_th].[degF]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "N61" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -2800,7 +2800,7 @@ unit:BTU_TH-PER-DEG_R
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H-1T-2D0 ;
   qudt:hasQuantityKind quantitykind:ThermalCapacitance ;
   qudt:iec61360Code "0112/2///62720#UAB274" ;
-  qudt:symbol "Btuth/ºR" ;
+  qudt:symbol "Btuth/°R" ;
   qudt:ucumCode "[Btu_th].[degR]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "N63" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -2909,7 +2909,7 @@ unit:BTU_TH-PER-HR-FT2-DEG_F
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H-1T-3D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAB277" ;
-  qudt:symbol "Btuth/(h·ft²·ºF)" ;
+  qudt:symbol "Btuth/(h·ft²·°F)" ;
   qudt:ucumCode "[Btu_th].h-1.[ft_i]-2.[degF]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "N75" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -3012,7 +3012,7 @@ unit:BTU_TH-PER-SEC-FT2-DEG_F
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H-1T-3D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAB279" ;
-  qudt:symbol "Btuth/(s·ft²·ºF)" ;
+  qudt:symbol "Btuth/(s·ft²·°F)" ;
   qudt:ucumCode "[Btu_th].s-1.[ft_i]-2.[degF]-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "British thermal unit (thermochemical) per second square foot degree Fahrenheit" ;
@@ -3718,7 +3718,7 @@ unit:CAL_20DEG_C
   qudt:symbol "cal₂₀" ;
   qudt:uneceCommonCode "N69" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
-  rdfs:label "calorie (20 ºC)" ;
+  rdfs:label "calorie (20 °C)" ;
 .
 unit:CAL_IT
   a qudt:Unit ;
@@ -5450,7 +5450,7 @@ unit:CentiM_H20_4DEG_C
   qudt:symbol "cmH₂O (4 °C)" ;
   qudt:uneceCommonCode "N14" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
-  rdfs:label "centimetre of water (4 ºC)" ;
+  rdfs:label "centimetre of water (4 °C)" ;
 .
 unit:CentiM_H2O
   a qudt:Unit ;
@@ -5483,7 +5483,7 @@ unit:CentiM_H2O_4DEG_C
   qudt:symbol "cmH₂0 (4 °C)" ;
   qudt:uneceCommonCode "N14" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
-  rdfs:label "centimetre of water (4 ºC)" ;
+  rdfs:label "centimetre of water (4 °C)" ;
 .
 unit:CentiM_HG
   a qudt:Unit ;
@@ -5510,10 +5510,10 @@ unit:CentiM_HG_0DEG_C
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAB235" ;
-  qudt:symbol "cmHg (0 ºC)" ;
+  qudt:symbol "cmHg (0 °C)" ;
   qudt:uneceCommonCode "N13" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
-  rdfs:label "centimetre of mercury (0 ºC)" ;
+  rdfs:label "centimetre of mercury (0 °C)" ;
 .
 unit:CentiN
   a qudt:Unit ;
@@ -6442,7 +6442,7 @@ unit:DEG_F-HR-PER-BTU_TH
   qudt:hasDimensionVector qkdv:A0E0L-2I0M-1H1T3D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAB249" ;
-  qudt:symbol "ºF/(Btuth/h)" ;
+  qudt:symbol "°F/(Btuth/h)" ;
   qudt:ucumCode "[degF].h.[Btu_th]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "N85" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -9568,10 +9568,10 @@ unit:FT_H2O_39dot2DEG_F
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAB237" ;
-  qudt:symbol "ftH₂O (39.2 ºF)" ;
+  qudt:symbol "ftH₂O (39.2 °F)" ;
   qudt:uneceCommonCode "N15" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
-  rdfs:label "foot of water (39.2 ºF)" ;
+  rdfs:label "foot of water (39.2 °F)" ;
 .
 unit:FT_HG
   a qudt:Unit ;
@@ -13661,10 +13661,10 @@ unit:IN_H2O_39dot2DEG_F
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAB240" ;
-  qudt:symbol "inH₂O (39.2 ºF)" ;
+  qudt:symbol "inH₂O (39.2 °F)" ;
   qudt:uneceCommonCode "N18" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
-  rdfs:label "inch of water (39.2 ºF)" ;
+  rdfs:label "inch of water (39.2 °F)" ;
 .
 unit:IN_H2O_60DEG_F
   a qudt:Unit ;
@@ -13672,10 +13672,10 @@ unit:IN_H2O_60DEG_F
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAB241" ;
-  qudt:symbol "inH₂O (60 ºF)" ;
+  qudt:symbol "inH₂O (60 °F)" ;
   qudt:uneceCommonCode "N19" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
-  rdfs:label "inch of water (60 ºF)" ;
+  rdfs:label "inch of water (60 °F)" ;
 .
 unit:IN_HG
   a qudt:Unit ;
@@ -13703,10 +13703,10 @@ unit:IN_HG_32DEG_F
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAB238" ;
-  qudt:symbol "inHg (32 ºF)" ;
+  qudt:symbol "inHg (32 °F)" ;
   qudt:uneceCommonCode "N16" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
-  rdfs:label "inch of mercury (32 ºF)" ;
+  rdfs:label "inch of mercury (32 °F)" ;
 .
 unit:IN_HG_60DEG_F
   a qudt:Unit ;
@@ -13714,10 +13714,10 @@ unit:IN_HG_60DEG_F
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAB239" ;
-  qudt:symbol "inHg (60 ºF)" ;
+  qudt:symbol "inHg (60 °F)" ;
   qudt:uneceCommonCode "N17" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
-  rdfs:label "inch of mercury (60 ºF)" ;
+  rdfs:label "inch of mercury (60 °F)" ;
 .
 unit:IU
   a qudt:Unit ;
@@ -36749,10 +36749,10 @@ unit:PERM_0DEG_C
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:WaterVapourPermeability ;
   qudt:iec61360Code "0112/2///62720#UAB294" ;
-  qudt:symbol "perm (0 ºC)" ;
+  qudt:symbol "perm (0 °C)" ;
   qudt:uneceCommonCode "P91" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
-  rdfs:label "perm (0 ºC)" ;
+  rdfs:label "perm (0 °C)" ;
 .
 unit:PERM_23DEG_C
   a qudt:Unit ;
@@ -36760,10 +36760,10 @@ unit:PERM_23DEG_C
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:WaterVapourPermeability ;
   qudt:iec61360Code "0112/2///62720#UAB295" ;
-  qudt:symbol "perm (23 ºC)" ;
+  qudt:symbol "perm (23 °C)" ;
   qudt:uneceCommonCode "P92" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
-  rdfs:label "perm (23 ºC)" ;
+  rdfs:label "perm (23 °C)" ;
 .
 unit:PERM_Metric
   a qudt:Unit ;
@@ -36783,10 +36783,10 @@ unit:PERM_Metric_0DEG_C
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAB294" ;
-  qudt:symbol "perm (0 ºC)" ;
+  qudt:symbol "perm (0 °C)" ;
   qudt:uneceCommonCode "P91" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
-  rdfs:label "perm (0 ºC)" ;
+  rdfs:label "perm (0 °C)" ;
 .
 unit:PERM_Metric_23DEG_C
   a qudt:Unit ;
@@ -36794,10 +36794,10 @@ unit:PERM_Metric_23DEG_C
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAB295" ;
-  qudt:symbol "perm (23 ºC)" ;
+  qudt:symbol "perm (23 °C)" ;
   qudt:uneceCommonCode "P92" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
-  rdfs:label "perm (23 ºC)" ;
+  rdfs:label "perm (23 °C)" ;
 .
 unit:PERM_US
   a qudt:Unit ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -5096,7 +5096,7 @@ unit:CentiM3-PER-DAY-BAR
   qudt:hasDimensionVector qkdv:A0E0L4I0M-1H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA390" ;
-  qudt:symbol "cm³/(d.bar)" ;
+  qudt:symbol "cm³/(d⋅bar)" ;
   qudt:ucumCode "cm3.d-1.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G78" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -5110,7 +5110,7 @@ unit:CentiM3-PER-DAY-K
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA389" ;
-  qudt:symbol "cm³/(d.K)" ;
+  qudt:symbol "cm³/(d⋅K)" ;
   qudt:ucumCode "cm3.d-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G61" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -5169,7 +5169,7 @@ unit:CentiM3-PER-HR-BAR
   qudt:hasDimensionVector qkdv:A0E0L4I0M-1H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA393" ;
-  qudt:symbol "cm³/(h.bar)" ;
+  qudt:symbol "cm³/(h⋅bar)" ;
   qudt:ucumCode "cm3.h-1.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G79" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -5183,7 +5183,7 @@ unit:CentiM3-PER-HR-K
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA392" ;
-  qudt:symbol "cm³/(h.K)" ;
+  qudt:symbol "cm³/(h⋅K)" ;
   qudt:ucumCode "cm3.h-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G62" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -5258,7 +5258,7 @@ unit:CentiM3-PER-MIN-BAR
   qudt:hasDimensionVector qkdv:A0E0L4I0M-1H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA397" ;
-  qudt:symbol "cm³/(min.bar)" ;
+  qudt:symbol "cm³/(min⋅bar)" ;
   qudt:ucumCode "cm3.min-1.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G80" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -5272,7 +5272,7 @@ unit:CentiM3-PER-MIN-K
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA396" ;
-  qudt:symbol "cm³/(min.K)" ;
+  qudt:symbol "cm³/(min⋅K)" ;
   qudt:ucumCode "cm3.min-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G63" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -5343,7 +5343,7 @@ unit:CentiM3-PER-SEC-BAR
   qudt:hasDimensionVector qkdv:A0E0L4I0M-1H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA401" ;
-  qudt:symbol "cm³/(s.bar)" ;
+  qudt:symbol "cm³/(s⋅bar)" ;
   qudt:symbol "cm³/(s·bar)" ;
   qudt:ucumCode "cm3.s-1.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G81" ;
@@ -5358,7 +5358,7 @@ unit:CentiM3-PER-SEC-K
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA400" ;
-  qudt:symbol "cm³/(s.K)" ;
+  qudt:symbol "cm³/(s⋅K)" ;
   qudt:symbol "cm³/(s·K)" ;
   qudt:ucumCode "cm3.s-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G64" ;
@@ -10603,7 +10603,7 @@ unit:GM-PER-CentiM-BAR
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T2D0 ;
   qudt:hasQuantityKind quantitykind:Time_Squared ;
   qudt:iec61360Code "0112/2///62720#UAA471" ;
-  qudt:symbol "g/(cm³.bar)" ;
+  qudt:symbol "g/(cm³⋅bar)" ;
   qudt:ucumCode "g.cm-1.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G11" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -10704,7 +10704,7 @@ unit:GM-PER-CentiM3-K
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H-1T0D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA470" ;
-  qudt:symbol "g/(cm³.K)" ;
+  qudt:symbol "g/(cm³⋅K)" ;
   qudt:symbol "g/(cm³·K)" ;
   qudt:ucumCode "g.cm-3.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G33" ;
@@ -10738,7 +10738,7 @@ unit:GM-PER-DAY-BAR
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA474" ;
-  qudt:symbol "g/(d.bar)" ;
+  qudt:symbol "g/(d⋅bar)" ;
   qudt:symbol "g/(d·bar)" ;
   qudt:ucumCode "g.d-1.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F62" ;
@@ -10824,7 +10824,7 @@ unit:GM-PER-DeciM3-BAR
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T2D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA477" ;
-  qudt:symbol "g/(dm³.bar)" ;
+  qudt:symbol "g/(dm³⋅bar)" ;
   qudt:symbol "g/(dm³·bar)" ;
   qudt:ucumCode "g.dm-3.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G12" ;
@@ -10905,7 +10905,7 @@ unit:GM-PER-HR-K
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA479" ;
-  qudt:symbol "g/(h.K)" ;
+  qudt:symbol "g/(h⋅K)" ;
   qudt:symbol "g/(h·K)" ;
   qudt:ucumCode "g.h-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F36" ;
@@ -11009,7 +11009,7 @@ unit:GM-PER-L-BAR
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T2D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA484" ;
-  qudt:symbol "g/(l.bar)" ;
+  qudt:symbol "g/(l⋅bar)" ;
   qudt:symbol "g/(l·bar)" ;
   qudt:ucumCode "g.L-1.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G13" ;
@@ -11037,7 +11037,7 @@ unit:GM-PER-L-K
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H-1T0D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA483" ;
-  qudt:symbol "g/(l.K)" ;
+  qudt:symbol "g/(l⋅K)" ;
   qudt:symbol "g/(l·K)" ;
   qudt:ucumCode "g.L-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G35" ;
@@ -11173,7 +11173,7 @@ unit:GM-PER-M3-BAR
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T2D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA489" ;
-  qudt:symbol "g/(m³.bar)" ;
+  qudt:symbol "g/(m³⋅bar)" ;
   qudt:symbol "g/(m³·bar)" ;
   qudt:ucumCode "g.m-3.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G14" ;
@@ -11201,7 +11201,7 @@ unit:GM-PER-M3-K
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H-1T0D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA488" ;
-  qudt:symbol "g/(m³.K)" ;
+  qudt:symbol "g/(m³⋅K)" ;
   qudt:symbol "g/(m³·K)" ;
   qudt:ucumCode "g.m-3.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G36" ;
@@ -11274,7 +11274,7 @@ unit:GM-PER-MIN-BAR
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA492" ;
-  qudt:symbol "g/(min.bar)" ;
+  qudt:symbol "g/(min⋅bar)" ;
   qudt:symbol "g/(min·bar)" ;
   qudt:ucumCode "g.min-1.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F64" ;
@@ -11354,7 +11354,7 @@ unit:GM-PER-MilliL-K
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H-1T0D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA494" ;
-  qudt:symbol "g/(ml.K)" ;
+  qudt:symbol "g/(ml⋅K)" ;
   qudt:symbol "g/(ml·K)" ;
   qudt:ucumCode "g.mL-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G37" ;
@@ -11389,7 +11389,7 @@ unit:GM-PER-MilliM-BAR
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T2D0 ;
   qudt:hasQuantityKind quantitykind:Time_Squared ;
   qudt:iec61360Code "0112/2///62720#UAA495" ;
-  qudt:symbol "g/(ml.bar)" ;
+  qudt:symbol "g/(ml⋅bar)" ;
   qudt:ucumCode "g.mm-1.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G15" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -11450,7 +11450,7 @@ unit:GM-PER-SEC-K
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA498" ;
-  qudt:symbol "g/(s.K)" ;
+  qudt:symbol "g/(s⋅K)" ;
   qudt:symbol "g/(s·K)" ;
   qudt:ucumCode "g.s-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F38" ;
@@ -16246,7 +16246,7 @@ unit:KiloGM-PER-CentiM3-BAR
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T2D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA599" ;
-  qudt:symbol "kg/(cm³.bar)" ;
+  qudt:symbol "kg/(cm³⋅bar)" ;
   qudt:symbol "kg/(cm³·bar)" ;
   qudt:ucumCode "kg.cm-3.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G16" ;
@@ -16261,7 +16261,7 @@ unit:KiloGM-PER-CentiM3-K
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H-1T0D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA598" ;
-  qudt:symbol "kg/(cm³.K)" ;
+  qudt:symbol "kg/(cm³⋅K)" ;
   qudt:symbol "kg/(cm³·K)" ;
   qudt:ucumCode "kg.cm-3.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G38" ;
@@ -16295,7 +16295,7 @@ unit:KiloGM-PER-DAY-BAR
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA603" ;
-  qudt:symbol "kg/(d.bar)" ;
+  qudt:symbol "kg/(d⋅bar)" ;
   qudt:symbol "kg/(d·bar)" ;
   qudt:ucumCode "kg.d-1.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F66" ;
@@ -16310,7 +16310,7 @@ unit:KiloGM-PER-DAY-K
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA602" ;
-  qudt:symbol "kg/(d.K)" ;
+  qudt:symbol "kg/(d⋅K)" ;
   qudt:symbol "kg/(d·K)" ;
   qudt:ucumCode "kg.d-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F39" ;
@@ -16346,7 +16346,7 @@ unit:KiloGM-PER-DeciM3-BAR
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T2D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA606" ;
-  qudt:symbol "kg/(dm³.bar)" ;
+  qudt:symbol "kg/(dm³⋅bar)" ;
   qudt:symbol "kg/(dm³·bar)" ;
   qudt:ucumCode "kg.dm-3.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H55" ;
@@ -16361,7 +16361,7 @@ unit:KiloGM-PER-DeciM3-K
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H-1T0D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA605" ;
-  qudt:symbol "kg/(dm³.K)" ;
+  qudt:symbol "kg/(dm³⋅K)" ;
   qudt:symbol "kg/(dm³·K)" ;
   qudt:ucumCode "kg.dm-3.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H54" ;
@@ -16452,7 +16452,7 @@ unit:KiloGM-PER-HR-BAR
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA609" ;
-  qudt:symbol "kg/(h.bar)" ;
+  qudt:symbol "kg/(h⋅bar)" ;
   qudt:symbol "kg/(h·bar)" ;
   qudt:ucumCode "kg.h-1.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F67" ;
@@ -16467,7 +16467,7 @@ unit:KiloGM-PER-HR-K
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA608" ;
-  qudt:symbol "kg/(h.K)" ;
+  qudt:symbol "kg/(h⋅K)" ;
   qudt:symbol "kg/(h·K)" ;
   qudt:ucumCode "kg.h-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F40" ;
@@ -16606,7 +16606,7 @@ unit:KiloGM-PER-L-BAR
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T2D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA614" ;
-  qudt:symbol "kg/(l.bar)" ;
+  qudt:symbol "kg/(l⋅bar)" ;
   qudt:symbol "kg/(l·bar)" ;
   qudt:ucumCode "kg.L-1.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G17" ;
@@ -16621,7 +16621,7 @@ unit:KiloGM-PER-L-K
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H-1T0D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA613" ;
-  qudt:symbol "kg/(l.K)" ;
+  qudt:symbol "kg/(l⋅K)" ;
   qudt:symbol "kg/(l·K)" ;
   qudt:ucumCode "kg.L-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G39" ;
@@ -16878,7 +16878,7 @@ unit:KiloGM-PER-M3-BAR
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T2D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA621" ;
-  qudt:symbol "kg/(m³.bar)" ;
+  qudt:symbol "kg/(m³⋅bar)" ;
   qudt:symbol "kg/(m³·bar)" ;
   qudt:ucumCode "kg.m-3.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G18" ;
@@ -16894,7 +16894,7 @@ unit:KiloGM-PER-M3-K
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA620" ;
   qudt:iec61360Code "0112/2///62720#UAD685" ;
-  qudt:symbol "kg/(m³.K)" ;
+  qudt:symbol "kg/(m³⋅K)" ;
   qudt:symbol "kg/(m³·K)" ;
   qudt:ucumCode "kg.m-3.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G40" ;
@@ -16958,7 +16958,7 @@ unit:KiloGM-PER-MIN-BAR
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA626" ;
-  qudt:symbol "kg/(min.bar)" ;
+  qudt:symbol "kg/(min⋅bar)" ;
   qudt:symbol "kg/(min·bar)" ;
   qudt:ucumCode "kg.min-1.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F68" ;
@@ -16973,7 +16973,7 @@ unit:KiloGM-PER-MIN-K
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA625" ;
-  qudt:symbol "kg/(min.K)" ;
+  qudt:symbol "kg/(min⋅K)" ;
   qudt:symbol "kg/(min·K)" ;
   qudt:ucumCode "kg.min-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F41" ;
@@ -17109,7 +17109,7 @@ unit:KiloGM-PER-SEC-BAR
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA631" ;
-  qudt:symbol "kg/(s.bar)" ;
+  qudt:symbol "kg/(s⋅bar)" ;
   qudt:symbol "kg/(s·bar)" ;
   qudt:ucumCode "kg.s-1.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F69" ;
@@ -17125,7 +17125,7 @@ unit:KiloGM-PER-SEC-K
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA630" ;
   qudt:iec61360Code "0112/2///62720#UAD687" ;
-  qudt:symbol "kg/(s.K)" ;
+  qudt:symbol "kg/(s⋅K)" ;
   qudt:symbol "kg/(s·K)" ;
   qudt:ucumCode "kg.s-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F42" ;
@@ -18966,7 +18966,7 @@ unit:L-PER-DAY-BAR
   qudt:hasDimensionVector qkdv:A0E0L4I0M-1H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA654" ;
-  qudt:symbol "l/(d.bar)" ;
+  qudt:symbol "l/(d⋅bar)" ;
   qudt:symbol "l/(d·bar)" ;
   qudt:ucumCode "L.d-1.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G82" ;
@@ -18981,7 +18981,7 @@ unit:L-PER-DAY-K
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA653" ;
-  qudt:symbol "l/(d.K)" ;
+  qudt:symbol "l/(d⋅K)" ;
   qudt:symbol "l/(d·K)" ;
   qudt:ucumCode "L.d-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G65" ;
@@ -19018,7 +19018,7 @@ unit:L-PER-HR-BAR
   qudt:hasDimensionVector qkdv:A0E0L4I0M-1H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA657" ;
-  qudt:symbol "l/(h.bar)" ;
+  qudt:symbol "l/(h⋅bar)" ;
   qudt:symbol "l/(h·bar)" ;
   qudt:ucumCode "L.h-1.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G83" ;
@@ -19033,7 +19033,7 @@ unit:L-PER-HR-K
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA656" ;
-  qudt:symbol "l/(h.K)" ;
+  qudt:symbol "l/(h⋅K)" ;
   qudt:symbol "l/(h·K)" ;
   qudt:ucumCode "L.h-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G66" ;
@@ -19131,7 +19131,7 @@ unit:L-PER-MIN-BAR
   qudt:hasDimensionVector qkdv:A0E0L4I0M-1H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA661" ;
-  qudt:symbol "l/(min.bar)" ;
+  qudt:symbol "l/(min⋅bar)" ;
   qudt:symbol "l/(min·bar)" ;
   qudt:ucumCode "L.min-1.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G84" ;
@@ -19146,7 +19146,7 @@ unit:L-PER-MIN-K
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA660" ;
-  qudt:symbol "l/(min.K)" ;
+  qudt:symbol "l/(min⋅K)" ;
   qudt:symbol "l/(min·K)" ;
   qudt:ucumCode "L.min-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G67" ;
@@ -19229,7 +19229,7 @@ unit:L-PER-SEC-BAR
   qudt:hasDimensionVector qkdv:A0E0L4I0M-1H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA666" ;
-  qudt:symbol "l/(s.bar)" ;
+  qudt:symbol "l/(s⋅bar)" ;
   qudt:symbol "l/(s·bar)" ;
   qudt:ucumCode "L.s-1.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G85" ;
@@ -19244,7 +19244,7 @@ unit:L-PER-SEC-K
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA665" ;
-  qudt:symbol "l/(s.K)" ;
+  qudt:symbol "l/(s⋅K)" ;
   qudt:symbol "l/(s·K)" ;
   qudt:ucumCode "L.s-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G68" ;
@@ -22308,7 +22308,7 @@ unit:M2-PER-SEC-BAR
   qudt:hasDimensionVector qkdv:A0E0L3I0M-1H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAB493" ;
-  qudt:symbol "m²/(s.bar)" ;
+  qudt:symbol "m²/(s⋅bar)" ;
   qudt:ucumCode "m2.s-1.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G41" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -22323,7 +22323,7 @@ unit:M2-PER-SEC-K
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA753" ;
   qudt:iec61360Code "0112/2///62720#UAD680" ;
-  qudt:symbol "m²/(s.K)" ;
+  qudt:symbol "m²/(s⋅K)" ;
   qudt:symbol "m²/(s·K)" ;
   qudt:ucumCode "m2.s-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G09" ;
@@ -22612,7 +22612,7 @@ unit:M3-PER-DAY-BAR
   qudt:hasDimensionVector qkdv:A0E0L4I0M-1H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA762" ;
-  qudt:symbol "m³/(d.bar)" ;
+  qudt:symbol "m³/(d⋅bar)" ;
   qudt:symbol "m³/(d·bar)" ;
   qudt:ucumCode "m3.d-1.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G86" ;
@@ -22627,7 +22627,7 @@ unit:M3-PER-DAY-K
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA761" ;
-  qudt:symbol "m³/(d.K)" ;
+  qudt:symbol "m³/(d⋅K)" ;
   qudt:symbol "m³/(d·K)" ;
   qudt:ucumCode "m3.d-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G69" ;
@@ -22683,7 +22683,7 @@ unit:M3-PER-HR-BAR
   qudt:hasDimensionVector qkdv:A0E0L4I0M-1H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA765" ;
-  qudt:symbol "m³/(h.bar)" ;
+  qudt:symbol "m³/(h⋅bar)" ;
   qudt:symbol "m³/(h·bar)" ;
   qudt:ucumCode "m3.h-1.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G87" ;
@@ -22698,7 +22698,7 @@ unit:M3-PER-HR-K
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA764" ;
-  qudt:symbol "m³/(h.K)" ;
+  qudt:symbol "m³/(h⋅K)" ;
   qudt:symbol "m³/(h·K)" ;
   qudt:ucumCode "m3.h-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G70" ;
@@ -22839,7 +22839,7 @@ unit:M3-PER-MIN-BAR
   qudt:hasDimensionVector qkdv:A0E0L4I0M-1H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA770" ;
-  qudt:symbol "m³/(min.bar)" ;
+  qudt:symbol "m³/(min⋅bar)" ;
   qudt:symbol "m³/(min·bar)" ;
   qudt:ucumCode "m3.min-1.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G88" ;
@@ -22854,7 +22854,7 @@ unit:M3-PER-MIN-K
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA769" ;
-  qudt:symbol "m³/(min.K)" ;
+  qudt:symbol "m³/(min⋅K)" ;
   qudt:symbol "m³/(min·K)" ;
   qudt:ucumCode "m3.min-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G71" ;
@@ -22964,7 +22964,7 @@ unit:M3-PER-SEC-BAR
   qudt:hasDimensionVector qkdv:A0E0L4I0M-1H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA774" ;
-  qudt:symbol "m³/(s.bar)" ;
+  qudt:symbol "m³/(s⋅bar)" ;
   qudt:symbol "m³/(s·bar)" ;
   qudt:ucumCode "m3.s-1.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G89" ;
@@ -22980,7 +22980,7 @@ unit:M3-PER-SEC-K
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA773" ;
   qudt:iec61360Code "0112/2///62720#UAD701" ;
-  qudt:symbol "m³/(s.K)" ;
+  qudt:symbol "m³/(s⋅K)" ;
   qudt:symbol "m³/(s·K)" ;
   qudt:ucumCode "m3.s-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G72" ;
@@ -28049,7 +28049,7 @@ unit:MilliGM-PER-DAY-BAR
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA821" ;
-  qudt:symbol "mg/(d.bar)" ;
+  qudt:symbol "mg/(d⋅bar)" ;
   qudt:symbol "mg/(d·bar)" ;
   qudt:ucumCode "mg.d-1.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F70" ;
@@ -28064,7 +28064,7 @@ unit:MilliGM-PER-DAY-K
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA820" ;
-  qudt:symbol "mg/(d.K)" ;
+  qudt:symbol "mg/(d⋅K)" ;
   qudt:symbol "mg/(d·K)" ;
   qudt:ucumCode "mg.d-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F43" ;
@@ -28159,7 +28159,7 @@ unit:MilliGM-PER-HR-BAR
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA825" ;
-  qudt:symbol "mg/(h.bar)" ;
+  qudt:symbol "mg/(h⋅bar)" ;
   qudt:symbol "mg/(h·bar)" ;
   qudt:ucumCode "mg.h-1.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F71" ;
@@ -28174,7 +28174,7 @@ unit:MilliGM-PER-HR-K
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA824" ;
-  qudt:symbol "mg/(h.K)" ;
+  qudt:symbol "mg/(h⋅K)" ;
   qudt:symbol "mg/(h·K)" ;
   qudt:ucumCode "mg.h-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F44" ;
@@ -28551,7 +28551,7 @@ unit:MilliGM-PER-MIN-BAR
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA835" ;
-  qudt:symbol "mg/(min.bar)" ;
+  qudt:symbol "mg/(min⋅bar)" ;
   qudt:symbol "mg/(min·bar)" ;
   qudt:ucumCode "mg.min-1.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F72" ;
@@ -28566,7 +28566,7 @@ unit:MilliGM-PER-MIN-K
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA834" ;
-  qudt:symbol "mg/(min.K)" ;
+  qudt:symbol "mg/(min⋅K)" ;
   qudt:symbol "mg/(min·K)" ;
   qudt:ucumCode "mg.min-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F45" ;
@@ -28621,7 +28621,7 @@ unit:MilliGM-PER-SEC-BAR
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA838" ;
-  qudt:symbol "mg/(s.bar)" ;
+  qudt:symbol "mg/(s⋅bar)" ;
   qudt:symbol "mg/(s·bar)" ;
   qudt:ucumCode "mg.s-1.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F73" ;
@@ -28636,7 +28636,7 @@ unit:MilliGM-PER-SEC-K
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA837" ;
-  qudt:symbol "mg/(s.K)" ;
+  qudt:symbol "mg/(s⋅K)" ;
   qudt:symbol "mg/(s·K)" ;
   qudt:ucumCode "mg.s-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F46" ;
@@ -29089,7 +29089,7 @@ unit:MilliL-PER-DAY-BAR
   qudt:hasDimensionVector qkdv:A0E0L4I0M-1H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA849" ;
-  qudt:symbol "ml/(d.bar)" ;
+  qudt:symbol "ml/(d⋅bar)" ;
   qudt:symbol "ml/(d·bar)" ;
   qudt:ucumCode "mL.d-1.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G90" ;
@@ -29104,7 +29104,7 @@ unit:MilliL-PER-DAY-K
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA848" ;
-  qudt:symbol "ml/(d.K)" ;
+  qudt:symbol "ml/(d⋅K)" ;
   qudt:symbol "ml/(d·K)" ;
   qudt:ucumCode "mL.d-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G73" ;
@@ -29162,7 +29162,7 @@ unit:MilliL-PER-HR-BAR
   qudt:hasDimensionVector qkdv:A0E0L4I0M-1H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA852" ;
-  qudt:symbol "ml/(h.bar)" ;
+  qudt:symbol "ml/(h⋅bar)" ;
   qudt:symbol "ml/(h·bar)" ;
   qudt:ucumCode "mL.h-1.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G91" ;
@@ -29177,7 +29177,7 @@ unit:MilliL-PER-HR-K
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA851" ;
-  qudt:symbol "ml/(h.K)" ;
+  qudt:symbol "ml/(h⋅K)" ;
   qudt:symbol "ml/(h·K)" ;
   qudt:ucumCode "mL.h-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G74" ;
@@ -29309,7 +29309,7 @@ unit:MilliL-PER-MIN-BAR
   qudt:hasDimensionVector qkdv:A0E0L4I0M-1H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA857" ;
-  qudt:symbol "ml/(min.bar)" ;
+  qudt:symbol "ml/(min⋅bar)" ;
   qudt:symbol "ml/(min·bar)" ;
   qudt:ucumCode "mL.min-1.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G92" ;
@@ -29324,7 +29324,7 @@ unit:MilliL-PER-MIN-K
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA856" ;
-  qudt:symbol "ml/(min.K)" ;
+  qudt:symbol "ml/(min⋅K)" ;
   qudt:symbol "ml/(min·K)" ;
   qudt:ucumCode "mL.min-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G75" ;
@@ -29360,7 +29360,7 @@ unit:MilliL-PER-SEC-BAR
   qudt:hasDimensionVector qkdv:A0E0L4I0M-1H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA861" ;
-  qudt:symbol "ml/(s.bar)" ;
+  qudt:symbol "ml/(s⋅bar)" ;
   qudt:symbol "ml/(s·bar)" ;
   qudt:ucumCode "mL.s-1.bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G93" ;
@@ -29375,7 +29375,7 @@ unit:MilliL-PER-SEC-K
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA860" ;
-  qudt:symbol "ml/(s.K)" ;
+  qudt:symbol "ml/(s⋅K)" ;
   qudt:symbol "ml/(s·K)" ;
   qudt:ucumCode "mL.s-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G76" ;
@@ -34281,7 +34281,7 @@ unit:PA-SEC-PER-K
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA266" ;
-  qudt:symbol "Pa.s/K" ;
+  qudt:symbol "Pa⋅s/K" ;
   qudt:symbol "Pa·s/K" ;
   qudt:ucumCode "Pa.s.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F77" ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -32926,11 +32926,11 @@ unit:OHM
 .
 unit:OHM-CentiM
   a qudt:Unit ;
-  dcterms:description "product of the SI derived unit ohm and the 0.01-fold of the SI base unit metre" ;
+  dcterms:description "product of the SI derived unit ohm and the 0.01-fold of the SI base unit metre"@en ;
   qudt:conversionMultiplier 0.01 ;
   qudt:conversionMultiplierSN 1.0E-2 ;
   qudt:hasDimensionVector qkdv:A0E-2L3I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:Resistivity ;
   qudt:iec61360Code "0112/2///62720#UAB090" ;
   qudt:symbol "Ω⋅cm" ;
   qudt:ucumCode "Ohm.cm"^^qudt:UCUMcs ;
@@ -34069,7 +34069,7 @@ unit:PA-M0pt5
   qudt:conversionMultiplier 1.0 ;
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:deprecated true ;
-  qudt:hasDimensionVector qkdv:A0E0L-0pt5I0M1H0T-2D0 ;
+  qudt:hasDimensionVector qkdv:A0E0L-0dot5I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:StressIntensityFactor ;
   qudt:plainTextDescription "A metric unit for stress intensity factor and fracture toughness." ;
   qudt:symbol "Pa√m" ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -14,10 +14,10 @@
 @prefix qudt: <http://qudt.org/schema/qudt/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix si-unit: <https://si-digital-framework.org/SI/units/> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix sou: <http://qudt.org/vocab/sou/> .
 @prefix unit: <http://qudt.org/vocab/unit/> .
-@prefix si-unit: <https://si-digital-framework.org/SI/units/> .
 @prefix vaem: <http://www.linkedmodel.org/schema/vaem#> .
 @prefix voag: <http://voag.linkedmodel.org/schema/voag#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
@@ -38,7 +38,6 @@ unit:A
   dcterms:description """The  \\(\\textit{ampere}\\), often shortened to \\(\\textit{amp}\\), is the SI unit of electric current and is one of the seven SI base units.
 \\(\\text{A}\\ \\equiv\\ \\text{amp (or ampere)}\\ \\equiv\\ \\frac{\\text{C}}{\\text{s}}\\ \\equiv\\ \\frac{\\text{coulomb}}{\\text{second}}\\ \\equiv\\ \\frac{\\text{J}}{\\text{Wb}}\\ \\equiv\\ \\frac{\\text{joule}}{\\text{weber}}\\)
 Note that SI supports only the use of symbols and deprecates the use of any abbreviations for units."""^^qudt:LatexString ;
-  qudt:siExactMatch si-unit:ampere ;
   qudt:applicableSystem sou:CGS-EMU ;
   qudt:applicableSystem sou:CGS-GAUSS ;
   qudt:applicableSystem sou:PLANCK ;
@@ -58,6 +57,7 @@ Note that SI supports only the use of symbols and deprecates the use of any abbr
   qudt:iec61360Code "0112/2///62720#UAD717" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Ampere?oldid=494026699"^^xsd:anyURI ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/ampere> ;
+  qudt:siExactMatch si-unit:ampere ;
   qudt:symbol "A" ;
   qudt:ucumCode "A"^^qudt:UCUMcs ;
   qudt:udunitsCode "A" ;
@@ -701,7 +701,6 @@ unit:ARCMIN
   a qudt:DerivedUnit ;
   a qudt:Unit ;
   dcterms:description "A minute of arc, arcminute, or minute arc (MOA), is a unit of angular measurement equal to one sixtieth (1/60) of one degree (circle/21,600), or \\(\\pi /10,800 radians\\). In turn, a second of arc or arcsecond is one sixtieth (1/60) of one minute of arc. Since one degree is defined as one three hundred and sixtieth (1/360) of a rotation, one minute of arc is 1/21,600 of a rotation. "^^qudt:LatexString ;
-  qudt:siExactMatch si-unit:arcminute ;
   qudt:applicableSystem sou:USCS ;
   qudt:conversionMultiplier 0.000290888209 ;
   qudt:conversionMultiplierSN 2.90888209E-4 ;
@@ -712,6 +711,7 @@ unit:ARCMIN
   qudt:hasQuantityKind quantitykind:PlaneAngle ;
   qudt:iec61360Code "0112/2///62720#UAA097" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Minute_of_arc"^^xsd:anyURI ;
+  qudt:siExactMatch si-unit:arcminute ;
   qudt:siUnitsExpression "1" ;
   qudt:symbol "'" ;
   qudt:ucumCode "'"^^qudt:UCUMcs ;
@@ -724,7 +724,6 @@ unit:ARCSEC
   a qudt:DerivedUnit ;
   a qudt:Unit ;
   dcterms:description "\"Arc Second\" is a unit of angular measure, also called the \\(\\textit{second of arc}\\), equal to \\(1/60 \\; arcminute\\). One arcsecond is a very small angle: there are 1,296,000 in a circle. The SI recommends \\(\\textit{double prime}\\) (\\(''\\)) as the symbol for the arcsecond. The symbol has become common in astronomy, where very small angles are stated in milliarcseconds (\\(mas\\))."^^qudt:LatexString ;
-  qudt:siExactMatch si-unit:arcsecond ;
   qudt:applicableSystem sou:USCS ;
   qudt:conversionMultiplier 0.00000484813681 ;
   qudt:conversionMultiplierSN 4.84813681E-6 ;
@@ -734,6 +733,7 @@ unit:ARCSEC
   qudt:hasQuantityKind quantitykind:PlaneAngle ;
   qudt:iec61360Code "0112/2///62720#UAA096" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Minute_of_arc#Symbols.2C_abbreviations_and_subdivisions"^^xsd:anyURI ;
+  qudt:siExactMatch si-unit:arcsecond ;
   qudt:symbol "\"" ;
   qudt:ucumCode "''"^^qudt:UCUMcs ;
   qudt:udunitsCode "″" ;
@@ -890,7 +890,6 @@ unit:ATM_T-PER-M
 unit:AU
   a qudt:Unit ;
   dcterms:description "An astronomical unit (abbreviated as AU, au, a.u., or ua) is a unit of length equal to \\(149,597,870,700 metres\\) (\\(92,955,807.273 mi\\)) or approximately the mean Earth Sun distance."^^qudt:LatexString ;
-  qudt:siExactMatch si-unit:astronomicalunit ;
   qudt:applicableSystem sou:CGS ;
   qudt:applicableSystem sou:CGS-EMU ;
   qudt:applicableSystem sou:CGS-GAUSS ;
@@ -903,6 +902,7 @@ unit:AU
   qudt:iec61360Code "0112/2///62720#UAB066" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Astronomical_unit"^^xsd:anyURI ;
   qudt:plainTextDescription "An astronomical unit (abbreviated as AU, au, a.u., or ua) is a unit of length equal to 149,597,870,700 metres (92,955,807.273 mi) or approximately the mean Earth Sun distance. The symbol ua is recommended by the International Bureau of Weights and Measures, and the international standard ISO 80000, while au is recommended by the International Astronomical Union, and is more common in Anglosphere countries. In general, the International System of Units only uses capital letters for the symbols of units which are named after individual scientists, while au or a.u. can also mean atomic unit or even arbitrary unit. However, the use of AU to refer to the astronomical unit is widespread. The astronomical constant whose value is one astronomical unit is referred to as unit distance and is given the symbol A. [Wikipedia]" ;
+  qudt:siExactMatch si-unit:astronomicalunit ;
   qudt:symbol "AU" ;
   qudt:ucumCode "AU"^^qudt:UCUMcs ;
   qudt:udunitsCode "au" ;
@@ -1135,7 +1135,6 @@ unit:B
   a qudt:LogarithmicUnit ;
   a qudt:Unit ;
   dcterms:description "A logarithmic unit of sound pressure equal to 10 decibels (dB),  It is defined as: \\(1 B = (1/2) \\log_{10}(Np)\\)"^^qudt:LatexString ;
-  qudt:siExactMatch si-unit:bel ;
   qudt:applicableSystem sou:ASU ;
   qudt:applicableSystem sou:CGS ;
   qudt:applicableSystem sou:CGS-EMU ;
@@ -1152,6 +1151,7 @@ unit:B
   qudt:hasQuantityKind quantitykind:SoundReductionIndex ;
   qudt:iec61360Code "0112/2///62720#UAB351" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Sound_unit"^^xsd:anyURI ;
+  qudt:siExactMatch si-unit:bel ;
   qudt:symbol "B" ;
   qudt:ucumCode "B"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M72" ;
@@ -1764,7 +1764,6 @@ unit:BQ
   a qudt:DerivedUnit ;
   a qudt:Unit ;
   dcterms:description "The SI derived unit of activity, usually meaning radioactivity. \"Radioactivity\" is caused when atoms disintegrate, ejecting energetic particles. One becquerel is the radiation caused by one disintegration per second; this is equivalent to about 27.0270 picocuries (pCi). The unit is named for a French physicist, Antoine-Henri Becquerel (1852-1908), the discoverer of radioactivity. Note: both the becquerel and the hertz are basically defined as one event per second, yet they measure different things. The hertz is used to measure the rates of events that happen periodically in a fixed and definite cycle. The becquerel is used to measure the rates of events that happen sporadically and unpredictably, not in a definite cycle."^^rdf:HTML ;
-  qudt:siExactMatch si-unit:becquerel ;
   qudt:applicableSystem sou:CGS ;
   qudt:applicableSystem sou:CGS-EMU ;
   qudt:applicableSystem sou:CGS-GAUSS ;
@@ -1781,6 +1780,7 @@ unit:BQ
   qudt:iec61360Code "0112/2///62720#UAA111" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Becquerel?oldid=493710036"^^xsd:anyURI ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/becquerel> ;
+  qudt:siExactMatch si-unit:becquerel ;
   qudt:symbol "Bq" ;
   qudt:ucumCode "Bq"^^qudt:UCUMcs ;
   qudt:udunitsCode "Bq" ;
@@ -2460,28 +2460,6 @@ unit:BTU_IT-PER-LB_F-DEG_F
   dcterms:description "Unit of heat energy according to the Imperial system of units divided by the product of a pound of force and a degree Fahrenheit"^^rdf:HTML ;
   qudt:applicableSystem sou:IMPERIAL ;
   qudt:applicableSystem sou:USCS ;
-  # WRONG MULTIPLIER  : unit:BTU_IT-PER-LB_F-DEG_F - calculated from factors: 426.9347648940976900014802607769946, actual: 4186.8
-  #
-  #  ──┬ unit:BTU_IT-PER-LB_F-DEG_F multiplier: 4186.8 (correct: 426.9347648940976900014802607769946)
-  #    ├──┬ unit:BTU_IT multiplier: 1055.05585262
-  #    │  └──┬ unit:J multiplier: 1.0
-  #    │     ├─── unit:M multiplier: 1.0
-  #    │     └──┬ unit:N multiplier: 1.0
-  #    │        ├──┬ unit:KiloGM multiplier: 1.0
-  #    │        │  └─── unit:GM multiplier: 0.001
-  #    │        ├─── unit:M multiplier: 1.0
-  #    │        └─── unit:SEC^-2 multiplier: 1.0 (multiplier^-2: 1.0)
-  #    ├──┬ unit:LB_F^-1 multiplier: 4.448222 (multiplier^-1: 0.2248089236553391444941372080799924)
-  #    │  ├──┬ unit:FT multiplier: 0.3048
-  #    │  │  └──┬ unit:IN multiplier: 0.0254
-  #    │  │     └─── unit:M multiplier: 1.0
-  #    │  ├─── unit:SEC^-2 multiplier: 1.0 (multiplier^-2: 1.0)
-  #    │  └──┬ unit:SLUG multiplier: 14.593903
-  #    │     └──┬ unit:LB multiplier: 0.45359237
-  #    │        └──┬ unit:KiloGM multiplier: 1.0
-  #    │           └─── unit:GM multiplier: 0.001
-  #    └──┬ unit:DEG_F^-1 multiplier: 0.5555555555555556 (multiplier^-1: 1.799999999999999856000000000000012)
-  #       └─── unit:K multiplier: 1.0
   qudt:conversionMultiplier 426.9347648940976900014802607769946 ;
   qudt:conversionMultiplierSN 4.269347648940976900014802607769946E2 ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H-1T0D0 ;
@@ -3268,7 +3246,6 @@ unit:C
   a qudt:DerivedUnit ;
   a qudt:Unit ;
   dcterms:description "The SI unit of electric charge. One coulomb is the amount of charge accumulated in one second by a current of one ampere. Electricity is actually a flow of charged particles, such as electrons, protons, or ions. The charge on one of these particles is a whole-number multiple of the charge e on a single electron, and one coulomb represents a charge of approximately 6.241 506 x 1018 e. The coulomb is named for a French physicist, Charles-Augustin de Coulomb (1736-1806), who was the first to measure accurately the forces exerted between electric charges."^^rdf:HTML ;
-  qudt:siExactMatch si-unit:coulomb ;
   qudt:applicableSystem sou:CGS ;
   qudt:applicableSystem sou:CGS-EMU ;
   qudt:applicableSystem sou:CGS-GAUSS ;
@@ -3284,6 +3261,7 @@ unit:C
   qudt:iec61360Code "0112/2///62720#UAA130" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Coulomb?oldid=491815163"^^xsd:anyURI ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/coulomb> ;
+  qudt:siExactMatch si-unit:coulomb ;
   qudt:symbol "C" ;
   qudt:ucumCode "C"^^qudt:UCUMcs ;
   qudt:udunitsCode "C" ;
@@ -4194,7 +4172,6 @@ unit:CASES-PER-KiloINDIV-YR
 unit:CD
   a qudt:Unit ;
   dcterms:description "\\(\\textit{Candela}\\) is a unit for  'Luminous Intensity' expressed as \\(cd\\).  The candela is the SI base unit of luminous intensity; that is, power emitted by a light source in a particular direction, weighted by the luminosity function (a standardized model of the sensitivity of the human eye to different wavelengths, also known as the luminous efficiency function). A common candle emits light with a luminous intensity of roughly one candela."^^qudt:LatexString ;
-  qudt:siExactMatch si-unit:candela ;
   qudt:applicableSystem sou:SI ;
   qudt:conversionMultiplier 1.0 ;
   qudt:conversionMultiplierSN 1.0E0 ;
@@ -4206,6 +4183,7 @@ unit:CD
   qudt:informativeReference "http://en.wikipedia.org/wiki/Candela?oldid=484253082"^^xsd:anyURI ;
   qudt:informativeReference "http://www.simetric.co.uk/siderived.htm"^^xsd:anyURI ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/candela> ;
+  qudt:siExactMatch si-unit:candela ;
   qudt:symbol "cd" ;
   qudt:ucumCode "cd"^^qudt:UCUMcs ;
   qudt:udunitsCode "cd" ;
@@ -5687,7 +5665,6 @@ unit:DARCY
 unit:DAY
   a qudt:Unit ;
   dcterms:description "Mean solar day"^^rdf:HTML ;
-  qudt:siExactMatch si-unit:day ;
   qudt:applicableSystem sou:CGS ;
   qudt:applicableSystem sou:CGS-EMU ;
   qudt:applicableSystem sou:CGS-GAUSS ;
@@ -5705,6 +5682,7 @@ unit:DAY
   qudt:iec61360Code "0112/2///62720#UAA407" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Day?oldid=494970012"^^xsd:anyURI ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/day> ;
+  qudt:siExactMatch si-unit:day ;
   qudt:symbol "day" ;
   qudt:ucumCode "d"^^qudt:UCUMcs ;
   qudt:udunitsCode "d" ;
@@ -5813,7 +5791,6 @@ unit:DECADE
 unit:DEG
   a qudt:Unit ;
   dcterms:description "A degree (in full, a degree of arc, arc degree, or arcdegree), usually denoted by \\(^\\circ\\) (the degree symbol), is a measurement of plane angle, representing 1/360 of a full rotation; one degree is equivalent to  \\(2\\pi /360 rad\\), \\(0.017453 rad\\). It is not an SI unit, as the SI unit for angles is radian, but is an accepted SI unit."^^qudt:LatexString ;
-  qudt:siExactMatch si-unit:degree ;
   qudt:applicableSystem sou:ASU ;
   qudt:applicableSystem sou:CGS ;
   qudt:applicableSystem sou:CGS-EMU ;
@@ -5830,6 +5807,7 @@ unit:DEG
   qudt:iec61360Code "0112/2///62720#UAA024" ;
   qudt:informativeReference "http://www.oxfordreference.com/view/10.1093/acref/9780198605225.001.0001/acref-9780198605225-e-331"^^xsd:anyURI ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/degree> ;
+  qudt:siExactMatch si-unit:degree ;
   qudt:symbol "°" ;
   qudt:ucumCode "deg"^^qudt:UCUMcs ;
   qudt:udunitsCode "°" ;
@@ -6090,7 +6068,6 @@ unit:DEG_C
   a qudt:DerivedUnit ;
   a qudt:Unit ;
   dcterms:description "\\(\\textit{Celsius}\\), also known as centigrade, is a scale and unit of measurement for temperature. It can refer to a specific temperature on the Celsius scale as well as a unit to indicate a temperature interval, a difference between two temperatures or an uncertainty. This definition fixes the magnitude of both the degree Celsius and the kelvin as precisely 1 part in 273.16 (approximately 0.00366) of the difference between absolute zero and the triple point of water. Thus, it sets the magnitude of one degree Celsius and that of one kelvin as exactly the same. Additionally, it establishes the difference between the two scales' null points as being precisely \\(273.15\\,^{\\circ}{\\rm C}\\).</p>"^^qudt:LatexString ;
-  qudt:siExactMatch si-unit:degreeCelsius ;
   qudt:applicableSystem sou:CGS ;
   qudt:applicableSystem sou:SI ;
   qudt:conversionMultiplier 1.0 ;
@@ -6110,6 +6087,7 @@ unit:DEG_C
   qudt:informativeReference "http://en.wikipedia.org/wiki/Celsius?oldid=494152178"^^xsd:anyURI ;
   qudt:latexDefinition "\\(\\,^{\\circ}{\\rm C}\\)"^^qudt:LatexString ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/degreeCelsius> ;
+  qudt:siExactMatch si-unit:degreeCelsius ;
   qudt:symbol "°C" ;
   qudt:ucumCode "Cel"^^qudt:UCUMcs ;
   qudt:udunitsCode "°C" ;
@@ -6924,7 +6902,6 @@ unit:DYN-SEC-PER-CentiM5
 unit:Da
   a qudt:Unit ;
   dcterms:description "The unified atomic mass unit (symbol: \\(\\mu\\)) or dalton (symbol: Da) is a unit that is used for indicating mass on an atomic or molecular scale. It is defined as one twelfth of the rest mass of an unbound atom of carbon-12 in its nuclear and electronic ground state, and has a value of \\(1.660538782(83) \\times 10^{-27} kg\\). One \\(Da\\) is approximately equal to the mass of one proton or one neutron. The CIPM have categorised it as a \"non-SI unit whose values in SI units must be obtained experimentally\"."^^qudt:LatexString ;
-  qudt:siExactMatch si-unit:dalton ;
   qudt:applicableSystem sou:CGS ;
   qudt:conversionMultiplier 0.00000000000000000000000000166053878283 ;
   qudt:conversionMultiplierSN 1.66053878283E-27 ;
@@ -6935,6 +6912,7 @@ unit:Da
   qudt:hasQuantityKind quantitykind:MolecularMass ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Atomic_mass_unit"^^xsd:anyURI ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Dalton?oldid=495038954"^^xsd:anyURI ;
+  qudt:siExactMatch si-unit:dalton ;
   qudt:symbol "Da" ;
   qudt:ucumCode "u"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D43" ;
@@ -8084,7 +8062,6 @@ unit:EUR-PER-W-SEC
 unit:EV
   a qudt:Unit ;
   dcterms:description "An electron volt (eV) is the energy that an electron gains when it travels through a potential of one volt. You can imagine that the electron starts at the negative plate of a parallel plate capacitor and accelerates to the positive plate, which is at one volt higher potential. Numerically \\(1 eV\\) approximates \\(1.6x10^{-19} joules\\), where \\(1 joule\\) is \\(6.2x10^{18} eV\\). For example, it would take \\(6.2x10^{20} eV/sec\\) to light a 100 watt light bulb."^^qudt:LatexString ;
-  qudt:siExactMatch si-unit:electronvolt ;
   qudt:applicableSystem sou:CGS ;
   qudt:applicableSystem sou:CGS-EMU ;
   qudt:applicableSystem sou:CGS-GAUSS ;
@@ -8097,6 +8074,7 @@ unit:EV
   qudt:iec61360Code "0112/2///62720#UAA425" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Electron_volt?oldid=344021738"^^xsd:anyURI ;
   qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
+  qudt:siExactMatch si-unit:electronvolt ;
   qudt:symbol "eV" ;
   qudt:ucumCode "eV"^^qudt:UCUMcs ;
   qudt:udunitsCode "eV" ;
@@ -8500,7 +8478,6 @@ unit:FARAD
   a qudt:DerivedUnit ;
   a qudt:Unit ;
   dcterms:description "The SI unit of electric capacitance. Very early in the study of electricity scientists discovered that a pair of conductors separated by an insulator can store a much larger charge than an isolated conductor can store. The better the insulator, the larger the charge that the conductors can hold. This property of a circuit is called capacitance, and it is measured in farads. One farad is defined as the ability to store one coulomb of charge per volt of potential difference between the two conductors. This is a natural definition, but the unit it defines is very large. In practical circuits, capacitance is often measured in microfarads, nanofarads, or sometimes even in picofarads (10-12 farad, or trillionths of a farad). The unit is named for the British physicist Michael Faraday (1791-1867), who was known for his work in electricity and electrochemistry."^^rdf:HTML ;
-  qudt:siExactMatch si-unit:farad ;
   qudt:applicableSystem sou:CGS ;
   qudt:applicableSystem sou:CGS-EMU ;
   qudt:applicableSystem sou:CGS-GAUSS ;
@@ -8516,6 +8493,7 @@ unit:FARAD
   qudt:iec61360Code "0112/2///62720#UAA144" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Farad?oldid=493070876"^^xsd:anyURI ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/farad> ;
+  qudt:siExactMatch si-unit:farad ;
   qudt:siUnitsExpression "C/V" ;
   qudt:symbol "F" ;
   qudt:ucumCode "F"^^qudt:UCUMcs ;
@@ -11763,7 +11741,6 @@ unit:GRAY
   a qudt:DerivedUnit ;
   a qudt:Unit ;
   dcterms:description "The SI unit of radiation dose. Radiation carries energy, and when it is absorbed by matter the matter receives this energy. The dose is the amount of energy deposited per unit of mass. One gray is defined to be the dose of one joule of energy absorbed per kilogram of matter, or 100 rad. The unit is named for the British physician L. Harold Gray (1905-1965), an authority on the use of radiation in the treatment of cancer."^^rdf:HTML ;
-  qudt:siExactMatch si-unit:gray ;
   qudt:applicableSystem sou:CGS ;
   qudt:applicableSystem sou:CGS-EMU ;
   qudt:applicableSystem sou:CGS-GAUSS ;
@@ -11779,6 +11756,7 @@ unit:GRAY
   qudt:iec61360Code "0112/2///62720#UAA163" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Grey?oldid=494774160"^^xsd:anyURI ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/gray> ;
+  qudt:siExactMatch si-unit:gray ;
   qudt:siUnitsExpression "J/kg" ;
   qudt:symbol "Gy" ;
   qudt:ucumCode "Gy"^^qudt:UCUMcs ;
@@ -12525,7 +12503,6 @@ unit:H
   a qudt:DerivedUnit ;
   a qudt:Unit ;
   dcterms:description "The SI unit of electric inductance. A changing magnetic field induces an electric current in a loop of wire (or in a coil of many loops) located in the field. Although the induced voltage depends only on the rate at which the magnetic flux changes, measured in webers per second, the amount of the current depends also on the physical properties of the coil. A coil with an inductance of one henry requires a flux of one weber for each ampere of induced current. If, on the other hand, it is the current which changes, then the induced field will generate a potential difference within the coil: if the inductance is one henry a current change of one ampere per second generates a potential difference of one volt. The henry is a large unit; inductances in practical circuits are measured in millihenrys (mH) or microhenrys (u03bc H). The unit is named for the American physicist Joseph Henry (1797-1878), one of several scientists who discovered independently how magnetic fields can be used to generate alternating currents. \\(\\text{H} \\; \\equiv \\; \\text{henry}\\; \\equiv\\; \\frac{\\text{Wb}}{\\text{A}}\\; \\equiv\\; \\frac{\\text{weber}}{\\text{amp}}\\; \\equiv\\ \\frac{\\text{V}\\cdot\\text{s}}{\\text{A}}\\; \\equiv\\; \\frac{\\text{volt} \\cdot \\text{second}}{\\text{amp}}\\; \\equiv\\ \\Omega\\cdot\\text{s}\\; \\equiv\\; \\text{ohm.second}\\)"^^qudt:LatexString ;
-  qudt:siExactMatch si-unit:henry ;
   qudt:applicableSystem sou:CGS-EMU ;
   qudt:applicableSystem sou:CGS-GAUSS ;
   qudt:applicableSystem sou:SI ;
@@ -12539,6 +12516,7 @@ unit:H
   qudt:iec61360Code "0112/2///62720#UAA165" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Henry?oldid=491435978"^^xsd:anyURI ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/henry> ;
+  qudt:siExactMatch si-unit:henry ;
   qudt:siUnitsExpression "Wb/A" ;
   qudt:symbol "H" ;
   qudt:ucumCode "H"^^qudt:UCUMcs ;
@@ -12629,7 +12607,6 @@ unit:H-PER-OHM
 unit:HA
   a qudt:Unit ;
   dcterms:description "The customary metric unit of land area, equal to 100 ares. One hectare is a square hectometer, that is, the area of a square 100 meters on each side: exactly 10 000 square meters or approximately 107 639.1 square feet, 11 959.9 square yards, or 2.471 054 acres."^^rdf:HTML ;
-  qudt:siExactMatch si-unit:hectare ;
   qudt:applicableSystem sou:CGS ;
   qudt:applicableSystem sou:CGS-EMU ;
   qudt:applicableSystem sou:CGS-GAUSS ;
@@ -12641,6 +12618,7 @@ unit:HA
   qudt:hasQuantityKind quantitykind:Area ;
   qudt:iec61360Code "0112/2///62720#UAA532" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Hectare?oldid=494256954"^^xsd:anyURI ;
+  qudt:siExactMatch si-unit:hectare ;
   qudt:symbol "ha" ;
   qudt:ucumCode "har"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "HAR" ;
@@ -12790,7 +12768,6 @@ unit:HP_Metric
 unit:HR
   a qudt:Unit ;
   dcterms:description "The hour (common symbol: h or hr) is a unit of measurement of time. In modern usage, an hour comprises 60 minutes, or 3,600 seconds. It is approximately 1/24 of a mean solar day. An hour in the Universal Coordinated Time (UTC) time standard can include a negative or positive leap second, and may therefore have a duration of 3,599 or 3,601 seconds for adjustment purposes. Although it is not a standard defined by the International System of Units, the hour is a unit accepted for use with SI, represented by the symbol h."^^rdf:HTML ;
-  qudt:siExactMatch si-unit:hour ;
   qudt:applicableSystem sou:CGS ;
   qudt:applicableSystem sou:CGS-EMU ;
   qudt:applicableSystem sou:CGS-GAUSS ;
@@ -12806,6 +12783,7 @@ unit:HR
   qudt:iec61360Code "0112/2///62720#UAA525" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Hour?oldid=495040268"^^xsd:anyURI ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/hour> ;
+  qudt:siExactMatch si-unit:hour ;
   qudt:symbol "hr" ;
   qudt:ucumCode "h"^^qudt:UCUMcs ;
   qudt:udunitsCode "h" ;
@@ -12868,7 +12846,6 @@ unit:HZ
   a qudt:DerivedUnit ;
   a qudt:Unit ;
   dcterms:description "The hertz (symbol Hz) is the SI unit of frequency defined as the number of cycles per second of a periodic phenomenon. One of its most common uses is the description of the sine wave, particularly those used in radio and audio applications, such as the frequency of musical tones. The word \"hertz\" is named for Heinrich Rudolf Hertz, who was the first to conclusively prove the existence of electromagnetic waves."^^rdf:HTML ;
-  qudt:siExactMatch si-unit:hertz ;
   qudt:applicableSystem sou:CGS ;
   qudt:applicableSystem sou:CGS-EMU ;
   qudt:applicableSystem sou:CGS-GAUSS ;
@@ -12885,6 +12862,7 @@ unit:HZ
   qudt:hasQuantityKind quantitykind:Frequency ;
   qudt:iec61360Code "0112/2///62720#UAA170" ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/hertz> ;
+  qudt:siExactMatch si-unit:hertz ;
   qudt:symbol "Hz" ;
   qudt:ucumCode "Hz"^^qudt:UCUMcs ;
   qudt:udunitsCode "Hz" ;
@@ -13824,7 +13802,6 @@ unit:J
   a qudt:DerivedUnit ;
   a qudt:Unit ;
   dcterms:description "The SI unit of work or energy, defined to be the work done by a force of one newton acting to move an object through a distance of one meter in the direction in which the force is applied. Equivalently, since kinetic energy is one half the mass times the square of the velocity, one joule is the kinetic energy of a mass of two kilograms moving at a velocity of \\(1 m/s\\)."^^qudt:LatexString ;
-  qudt:siExactMatch si-unit:joule ;
   qudt:applicableSystem sou:CGS ;
   qudt:applicableSystem sou:CGS-EMU ;
   qudt:applicableSystem sou:CGS-GAUSS ;
@@ -13845,6 +13822,7 @@ unit:J
   qudt:latexDefinition "\\(\\text{J}\\ \\equiv\\ \\text{joule}\\ \\equiv\\ \\text{CV}\\ \\equiv\\ \\text{coulomb.volt}\\ \\equiv\\ \\frac{\\text{eV}}{1.602\\ 10^{-19}}\\ \\equiv\\ \\frac{\\text{electron.volt}}{1.602\\ 10^{-19}}\\)"^^qudt:LatexString ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/joule> ;
   qudt:plainTextDescription "The SI unit of work or energy, defined to be the work done by a force of one newton acting to move an object through a distance of one meter in the direction in which the force is applied. Equivalently, since kinetic energy is one half the mass times the square of the velocity, one joule is the kinetic energy of a mass of two kilograms moving at a velocity of 1 m/s. This is the same as 107 ergs in the CGS system, or approximately 0.737 562 foot-pound in the traditional English system. In other energy units, one joule equals about 9.478 170 x 10-4 Btu, 0.238 846 (small) calories, or 2.777 778 x 10-4 watt hour. The joule is named for the British physicist James Prescott Joule (1818-1889), who demonstrated the equivalence of mechanical and thermal energy in a famous experiment in 1843. " ;
+  qudt:siExactMatch si-unit:joule ;
   qudt:symbol "J" ;
   qudt:ucumCode "J"^^qudt:UCUMcs ;
   qudt:udunitsCode "J" ;
@@ -14529,7 +14507,6 @@ unit:J-SEC-PER-MOL
 unit:K
   a qudt:Unit ;
   dcterms:description "\\(The SI base unit of temperature, previously called the degree Kelvin. One kelvin represents the same temperature difference as one degree Celsius. In 1967 the General Conference on Weights and Measures defined the temperature of the triple point of water (the temperature at which water exists simultaneously in the gaseous, liquid, and solid states) to be exactly 273.16 kelvins. Since this temperature is also equal to 0.01 u00b0C, the temperature in kelvins is always equal to 273.15 plus the temperature in degrees Celsius. The kelvin equals exactly 1.8 degrees Fahrenheit. The unit is named for the British mathematician and physicist William Thomson (1824-1907), later known as Lord Kelvin after he was named Baron Kelvin of Largs.\\)"^^qudt:LatexString ;
-  qudt:siExactMatch si-unit:kelvin ;
   qudt:applicableSystem sou:SI ;
   qudt:conversionMultiplier 1.0 ;
   qudt:conversionMultiplierSN 1.0E0 ;
@@ -14545,6 +14522,7 @@ unit:K
   qudt:iec61360Code "0112/2///62720#UAD721" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Kelvin?oldid=495075694"^^xsd:anyURI ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/kelvin> ;
+  qudt:siExactMatch si-unit:kelvin ;
   qudt:symbol "K" ;
   qudt:ucumCode "K"^^qudt:UCUMcs ;
   qudt:udunitsCode "K" ;
@@ -14840,7 +14818,6 @@ unit:KAT
   a qudt:DerivedUnit ;
   a qudt:Unit ;
   dcterms:description "A unit of catalytic activity used especially in the chemistry of enzymes. A catalyst is a substance that starts or speeds a chemical reaction. Enzymes are proteins that act as catalysts within the bodies of living plants and animals. A catalyst has an activity of one katal if it enables a reaction to proceed at the rate of one mole per second. "^^rdf:HTML ;
-  qudt:siExactMatch si-unit:katal ;
   qudt:applicableSystem sou:SI ;
   qudt:conversionMultiplier 1.0 ;
   qudt:conversionMultiplierSN 1.0E0 ;
@@ -14852,6 +14829,7 @@ unit:KAT
   qudt:iec61360Code "0112/2///62720#UAB196" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Katal?oldid=486431865"^^xsd:anyURI ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/katal> ;
+  qudt:siExactMatch si-unit:katal ;
   qudt:symbol "kat" ;
   qudt:ucumCode "kat"^^qudt:UCUMcs ;
   qudt:udunitsCode "kat" ;
@@ -15956,7 +15934,6 @@ unit:KiloGAUSS
 unit:KiloGM
   a qudt:Unit ;
   dcterms:description "The kilogram or kilogramme (SI symbol: kg), also known as the kilo, is the base unit of mass in the International System of Units and is defined as being equal to the mass of the International Prototype Kilogram (IPK), which is almost exactly equal to the mass of one liter of water. The avoirdupois (or international) pound, used in both the Imperial system and U.S. customary units, is defined as exactly 0.45359237 kg, making one kilogram approximately equal to 2.2046 avoirdupois pounds."^^rdf:HTML ;
-  qudt:siExactMatch si-unit:kilogram ;
   qudt:applicableSystem sou:CGS ;
   qudt:applicableSystem sou:CGS-EMU ;
   qudt:applicableSystem sou:CGS-GAUSS ;
@@ -15971,6 +15948,7 @@ unit:KiloGM
   qudt:iec61360Code "0112/2///62720#UAD720" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Kilogram?oldid=493633626"^^xsd:anyURI ;
   qudt:plainTextDescription "The kilogram or kilogramme (SI symbol: kg), also known as the kilo, is the base unit of mass in the International System of Units and is defined as being equal to the mass of the International Prototype Kilogram (IPK), which is almost exactly equal to the mass of one liter of water. The avoirdupois (or international) pound, used in both the Imperial system and U.S. customary units, is defined as exactly 0.45359237 kg, making one kilogram approximately equal to 2.2046 avoirdupois pounds." ;
+  qudt:siExactMatch si-unit:kilogram ;
   qudt:symbol "kg" ;
   qudt:ucumCode "kg"^^qudt:UCUMcs ;
   qudt:udunitsCode "kg" ;
@@ -18902,7 +18880,6 @@ unit:KiloYR
 unit:L
   a qudt:Unit ;
   dcterms:description "The \\(litre\\) (American spelling: \\(\\textit{liter}\\); SI symbol \\(l\\) or \\(L\\)) is a non-SI metric system unit of volume equal to \\(1 \\textit{cubic decimetre}\\) (\\(dm^3\\)), 1,000 cubic centimetres (\\(cm^3\\)) or \\(1/1000 \\textit{cubic metre}\\). If the lower case \"L\" is used as the symbol, it is sometimes rendered as a cursive \"l\" to help distinguish it from the capital \"I\", although this usage has no official approval by any international bureau."^^qudt:LatexString ;
-  qudt:siExactMatch si-unit:litre ;
   qudt:applicableSystem sou:CGS ;
   qudt:applicableSystem sou:CGS-EMU ;
   qudt:applicableSystem sou:CGS-GAUSS ;
@@ -18916,6 +18893,7 @@ unit:L
   qudt:iec61360Code "0112/2///62720#UAA649" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Litre?oldid=494846400"^^xsd:anyURI ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/litre> ;
+  qudt:siExactMatch si-unit:litre ;
   qudt:symbol "L" ;
   qudt:ucumCode "L"^^qudt:UCUMcs ;
   qudt:ucumCode "l"^^qudt:UCUMcs ;
@@ -21171,7 +21149,6 @@ unit:LM
   a qudt:DerivedUnit ;
   a qudt:Unit ;
   dcterms:description "The SI unit for measuring the flux of light being produced by a light source or received by a surface. The intensity of a light source is measured in candelas. One lumen represents the total flux of light emitted, equal to the intensity in candelas multiplied by the solid angle in steradians into which the light is emitted. A full sphere has a solid angle of \\(4\\cdot\\pi\\) steradians. A light source that uniformly radiates one candela in all directions has a total luminous flux of \\(1 cd\\cdot 4 \\pi sr = 4 \\pi cd \\cdot sr \\approx 12.57 \\; \\text{lumens}\\). \"Lumen\" is a Latin word for light."^^qudt:LatexString ;
-  qudt:siExactMatch si-unit:lumen ;
   qudt:applicableSystem sou:SI ;
   qudt:conversionMultiplier 1.0 ;
   qudt:conversionMultiplierSN 1.0E0 ;
@@ -21183,6 +21160,7 @@ unit:LM
   qudt:iec61360Code "0112/2///62720#UAA718" ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Lumen_(unit)"^^xsd:anyURI ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/lumen> ;
+  qudt:siExactMatch si-unit:lumen ;
   qudt:siUnitsExpression "cd.sr" ;
   qudt:symbol "lm" ;
   qudt:ucumCode "lm"^^qudt:UCUMcs ;
@@ -21295,7 +21273,6 @@ unit:LUX
   a qudt:DerivedUnit ;
   a qudt:Unit ;
   dcterms:description "The SI unit for measuring the illumination (illuminance) of a surface. One lux is defined as an illumination of one lumen per square meter or 0.0001 phot. In considering the various light units, it's useful to think about light originating at a point and shining upon a surface. The intensity of the light source is measured in candelas; the total light flux in transit is measured in lumens (1 lumen = 1 candelau00b7steradian); and the amount of light received per unit of surface area is measured in lux (1 lux = 1 lumen/square meter). One lux is equal to approximately 0.09290 foot candle."^^rdf:HTML ;
-  qudt:siExactMatch si-unit:lux ;
   qudt:applicableSystem sou:SI ;
   qudt:conversionMultiplier 1.0 ;
   qudt:conversionMultiplierSN 1.0E0 ;
@@ -21307,6 +21284,7 @@ unit:LUX
   qudt:iec61360Code "0112/2///62720#UAA723" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Lux?oldid=494700274"^^xsd:anyURI ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/lux> ;
+  qudt:siExactMatch si-unit:lux ;
   qudt:siUnitsExpression "lm/m^2" ;
   qudt:symbol "lx" ;
   qudt:ucumCode "lx"^^qudt:UCUMcs ;
@@ -21402,7 +21380,6 @@ unit:LunarMass
 unit:M
   a qudt:Unit ;
   dcterms:description "The metric and SI base unit of distance.  The 17th General Conference on Weights and Measures in 1983 defined the meter as that distance that makes the speed of light in a vacuum equal to exactly 299 792 458 meters per second. The speed of light in a vacuum, \\(c\\), is one of the fundamental constants of nature. The meter is equal to approximately 1.093 613 3 yards, 3.280 840 feet, or 39.370 079 inches."^^qudt:LatexString ;
-  qudt:siExactMatch si-unit:metre ;
   qudt:applicableSystem sou:CGS ;
   qudt:applicableSystem sou:CGS-EMU ;
   qudt:applicableSystem sou:CGS-GAUSS ;
@@ -21418,6 +21395,7 @@ unit:M
   qudt:informativeReference "http://en.wikipedia.org/wiki/Metre?oldid=495145797"^^xsd:anyURI ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/metre> ;
   qudt:plainTextDescription "The metric and SI base unit of distance.   The meter is equal to approximately 1.093 613 3 yards, 3.280 840 feet, or 39.370 079 inches." ;
+  qudt:siExactMatch si-unit:metre ;
   qudt:symbol "m" ;
   qudt:ucumCode "m"^^qudt:UCUMcs ;
   qudt:udunitsCode "m" ;
@@ -23372,7 +23350,6 @@ unit:MIL_Circ
 unit:MIN
   a qudt:Unit ;
   dcterms:description "A minute is a unit of measurement of time. The minute is a unit of time equal to 1/60 (the first sexagesimal fraction of an hour or 60 seconds. In the UTC time scale, a minute on rare occasions has 59 or 61 seconds; see leap second. The minute is not an SI unit; however, it is accepted for use with SI units. The SI symbol for minute or minutes is min (for time measurement) or the prime symbol after a number, e.g. 5' (for angle measurement, even if it is informally used for time)."^^rdf:HTML ;
-  qudt:siExactMatch si-unit:minute ;
   qudt:applicableSystem sou:CGS ;
   qudt:applicableSystem sou:CGS-EMU ;
   qudt:applicableSystem sou:CGS-GAUSS ;
@@ -23386,6 +23363,7 @@ unit:MIN
   qudt:hasQuantityKind quantitykind:Time ;
   qudt:iec61360Code "0112/2///62720#UAA842" ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/minute-Time> ;
+  qudt:siExactMatch si-unit:minute ;
   qudt:symbol "min" ;
   qudt:ucumCode "min"^^qudt:UCUMcs ;
   qudt:udunitsCode "min" ;
@@ -23589,7 +23567,6 @@ unit:MOHM
 unit:MOL
   a qudt:Unit ;
   dcterms:description "The mole is a unit of measurement used in chemistry to express amounts of a chemical substance. The official definition, adopted as part of the SI system in 1971, is that one mole of a substance contains just as many elementary entities (atoms, molecules, ions, or other kinds of particles) as there are atoms in 12 grams of carbon-12 (carbon-12 is the most common atomic form of carbon, consisting of atoms having 6 protons and 6 neutrons).  This corresponds to a value of \\(6.02214179(30) \\times 10^{23}\\) elementary entities of the substance. It is one of the base units in the International System of Units, and has the unit symbol \\(mol\\). A Mole is the SI base unit of the amount of a substance (as distinct from its mass or weight). Moles measure the actual number of atoms or molecules in an object. An earlier name is gram molecular weight, because one mole of a chemical compound is the same number of grams as the molecular weight of a molecule of that compound measured in atomic mass units."^^qudt:LatexString ;
-  qudt:siExactMatch si-unit:mole ;
   qudt:applicableSystem sou:SI ;
   qudt:conversionMultiplier 1.0 ;
   qudt:conversionMultiplierSN 1.0E0 ;
@@ -23601,6 +23578,7 @@ unit:MOL
   qudt:iec61360Code "0112/2///62720#UAD716" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Mole_(unit)"^^xsd:anyURI ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/mole> ;
+  qudt:siExactMatch si-unit:mole ;
   qudt:symbol "mol" ;
   qudt:ucumCode "mol"^^qudt:UCUMcs ;
   qudt:udunitsCode "mol" ;
@@ -30700,7 +30678,6 @@ unit:N
   a qudt:DerivedUnit ;
   a qudt:Unit ;
   dcterms:description "The \"Newton\" is the SI unit of force. A force of one newton will accelerate a mass of one kilogram at the rate of one meter per second per second. The newton is named for Isaac Newton (1642-1727), the British mathematician, physicist, and natural philosopher. He was the first person to understand clearly the relationship between force (F), mass (m), and acceleration (a) expressed by the formula \\(F = m \\cdot a\\)."^^qudt:LatexString ;
-  qudt:siExactMatch si-unit:newton ;
   qudt:applicableSystem sou:CGS ;
   qudt:applicableSystem sou:CGS-EMU ;
   qudt:applicableSystem sou:CGS-GAUSS ;
@@ -30714,6 +30691,7 @@ unit:N
   qudt:iec61360Code "0112/2///62720#UAA235" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Newton?oldid=488427661"^^xsd:anyURI ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/newton> ;
+  qudt:siExactMatch si-unit:newton ;
   qudt:symbol "N" ;
   qudt:ucumCode "N"^^qudt:UCUMcs ;
   qudt:udunitsCode "N" ;
@@ -31554,13 +31532,13 @@ unit:NP
   a qudt:LogarithmicUnit ;
   a qudt:Unit ;
   dcterms:description "The neper is a logarithmic unit for ratios of measurements of physical field and power quantities, such as gain and loss of electronic signals. It has the unit symbol Np. The unit's name is derived from the name of John Napier, the inventor of logarithms. As is the case for the decibel and bel, the neper is not a unit in the International System of Units (SI), but it is accepted for use alongside the SI. Like the decibel, the neper is a unit in a logarithmic scale. While the bel uses the decadic (base-10) logarithm to compute ratios, the neper uses the natural logarithm, based on Euler's number"^^rdf:HTML ;
-  qudt:siExactMatch si-unit:neper ;
   qudt:applicableSystem sou:SI ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Neper"^^xsd:anyURI ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Dimensionless ;
   qudt:iec61360Code "0112/2///62720#UAA253" ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Neper"^^xsd:anyURI ;
+  qudt:siExactMatch si-unit:neper ;
   qudt:symbol "Np" ;
   qudt:ucumCode "Np"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C50" ;
@@ -32880,7 +32858,6 @@ unit:OHM
   a qudt:DerivedUnit ;
   a qudt:Unit ;
   dcterms:description "The \\textit{ohm} is the SI derived unit of electrical resistance, named after German physicist Georg Simon Ohm. \\(\\Omega \\equiv\\ \\frac{\\text{V}}{\\text{A}}\\ \\equiv\\ \\frac{\\text{volt}}{\\text{amp}}\\ \\equiv\\ \\frac{\\text{W}}{\\text {A}^{2}}\\ \\equiv\\ \\frac{\\text{watt}}{\\text{amp}^{2}}\\ \\equiv\\ \\frac{\\text{H}}{\\text {s}}\\ \\equiv\\ \\frac{\\text{henry}}{\\text{second}}\\)"^^qudt:LatexString ;
-  qudt:siExactMatch si-unit:ohm ;
   qudt:applicableSystem sou:CGS-EMU ;
   qudt:applicableSystem sou:CGS-GAUSS ;
   qudt:applicableSystem sou:PLANCK ;
@@ -32896,6 +32873,7 @@ unit:OHM
   qudt:iec61360Code "0112/2///62720#UAA017" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Ohm?oldid=494685555"^^xsd:anyURI ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/ohm> ;
+  qudt:siExactMatch si-unit:ohm ;
   qudt:siUnitsExpression "V/A" ;
   qudt:symbol "Ω" ;
   qudt:ucumCode "Ohm"^^qudt:UCUMcs ;
@@ -33927,7 +33905,6 @@ unit:PA
   a qudt:DerivedUnit ;
   a qudt:Unit ;
   dcterms:description "The SI unit of pressure. The pascal is the standard pressure unit in the MKS metric system, equal to one newton per square meter or one \"kilogram per meter per second per second.\" The unit is named for Blaise Pascal (1623-1662), French philosopher and mathematician, who was the first person to use a barometer to measure differences in altitude."^^rdf:HTML ;
-  qudt:siExactMatch si-unit:pascal ;
   qudt:applicableSystem sou:CGS ;
   qudt:applicableSystem sou:CGS-EMU ;
   qudt:applicableSystem sou:CGS-GAUSS ;
@@ -33947,6 +33924,7 @@ unit:PA
   qudt:iec61360Code "0112/2///62720#UAA258" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Pascal?oldid=492989202"^^xsd:anyURI ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/pascal> ;
+  qudt:siExactMatch si-unit:pascal ;
   qudt:siUnitsExpression "N/m^2" ;
   qudt:symbol "Pa" ;
   qudt:ucumCode "Pa"^^qudt:UCUMcs ;
@@ -39208,7 +39186,6 @@ unit:RAD
   a qudt:DerivedUnit ;
   a qudt:Unit ;
   dcterms:description "The radian is the standard unit of angular measure, used in many areas of mathematics. It describes the plane angle subtended by a circular arc as the length of the arc divided by the radius of the arc. In the absence of any symbol radians are assumed, and when degrees are meant the symbol \\(^{\\ circ}\\) is used. "^^qudt:LatexString ;
-  qudt:siExactMatch si-unit:radian ;
   qudt:applicableSystem sou:CGS ;
   qudt:applicableSystem sou:CGS-EMU ;
   qudt:applicableSystem sou:CGS-GAUSS ;
@@ -39226,6 +39203,7 @@ unit:RAD
   qudt:informativeReference "http://en.wikipedia.org/wiki/Radian?oldid=492309312"^^xsd:anyURI ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/radian> ;
   qudt:plainTextDescription "The radian is the standard unit of angular measure, used in many areas of mathematics. It describes the plane angle subtended by a circular arc as the length of the arc divided by the radius of the arc. The unit was formerly a SI supplementary unit, but this category was abolished in 1995 and the radian is now considered a SI derived unit. The SI unit of solid angle measurement is the steradian.  The radian is represented by the symbol \"rad\" or, more rarely, by the superscript c (for \"circular measure\"). For example, an angle of 1.2 radians would be written as \"1.2 rad\" or \"1.2c\" (the second symbol is often mistaken for a degree: \"1.2u00b0\"). As the ratio of two lengths, the radian is a \"pure number\" that needs no unit symbol, and in mathematical writing the symbol \"rad\" is almost always omitted. In the absence of any symbol radians are assumed, and when degrees are meant the symbol u00b0 is used. [Wikipedia]" ;
+  qudt:siExactMatch si-unit:radian ;
   qudt:symbol "rad" ;
   qudt:ucumCode "rad"^^qudt:UCUMcs ;
   qudt:udunitsCode "rad" ;
@@ -39672,7 +39650,6 @@ unit:S
   a qudt:DerivedUnit ;
   a qudt:Unit ;
   dcterms:description "\\(\\textbf{Siemens}\\) is the SI unit of electric conductance, susceptance, and admittance. The most important property of a conductor is the amount of current it will carry when a voltage is applied. Current flow is opposed by resistance in all circuits, and by also by reactance and impedance in alternating current circuits. Conductance, susceptance, and admittance are the inverses of resistance, reactance, and impedance, respectively. To measure these properties, the siemens is the reciprocal of the ohm. In other words, the conductance, susceptance, or admittance, in siemens, is simply 1 divided by the resistance, reactance or impedance, respectively, in ohms. The unit is named for the German electrical engineer Werner von Siemens (1816-1892). \\(\\  \\text{Siemens}\\equiv\\frac{\\text{A}}{\\text{V}}\\equiv\\frac{\\text{amp}}{\\text{volt}}\\equiv\\frac{\\text{F}}{\\text {s}}\\equiv\\frac{\\text{farad}}{\\text{second}}\\)"^^qudt:LatexString ;
-  qudt:siExactMatch si-unit:siemens ;
   qudt:applicableSystem sou:CGS-EMU ;
   qudt:applicableSystem sou:CGS-GAUSS ;
   qudt:applicableSystem sou:PLANCK ;
@@ -39689,6 +39666,7 @@ unit:S
   qudt:informativeReference "http://www.simetric.co.uk/siderived.htm"^^xsd:anyURI ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Siemens_(unit)"^^xsd:anyURI ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/siemens> ;
+  qudt:siExactMatch si-unit:siemens ;
   qudt:siUnitsExpression "A/V" ;
   qudt:symbol "S" ;
   qudt:ucumCode "S"^^qudt:UCUMcs ;
@@ -39811,7 +39789,6 @@ unit:SEC
   a qudt:Unit ;
   dcterms:description """The \\(Second\\) (symbol: \\(s\\)) is the base unit of time in the International System of Units (SI) and is also a unit of time in other systems of measurement. Between the years1000 (when al-Biruni used seconds) and 1960 the second was defined as \\(1/86400\\) of a mean solar day (that definition still applies in some astronomical and legal contexts). Between 1960 and 1967, it was defined in terms of the period of the Earth's orbit around the Sun in 1900, but it is now defined more precisely in atomic terms.
 Under the International System of Units (via the International Committee for Weights and Measures, or CIPM), since 1967 the second has been defined as the duration of \\({9192631770}\\) periods of the radiation corresponding to the transition between the two hyperfine levels of the ground state of the caesium 133 atom.In 1997 CIPM added that the periods would be defined for a caesium atom at rest, and approaching the theoretical temperature of absolute zero, and in 1999, it included corrections from ambient radiation."""^^qudt:LatexString ;
-  qudt:siExactMatch si-unit:second ;
   qudt:applicableSystem sou:CGS ;
   qudt:applicableSystem sou:CGS-EMU ;
   qudt:applicableSystem sou:CGS-GAUSS ;
@@ -39829,6 +39806,7 @@ Under the International System of Units (via the International Committee for Wei
   qudt:iec61360Code "0112/2///62720#UAD722" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Second?oldid=495241006"^^xsd:anyURI ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/second-Time> ;
+  qudt:siExactMatch si-unit:second ;
   qudt:symbol "s" ;
   qudt:ucumCode "s"^^qudt:UCUMcs ;
   qudt:udunitsCode "s" ;
@@ -40214,7 +40192,6 @@ unit:SR
   a qudt:DerivedUnit ;
   a qudt:Unit ;
   dcterms:description "The steradian (symbol: sr) is the SI unit of solid angle. It is used to describe two-dimensional angular spans in three-dimensional space, analogous to the way in which the radian describes angles in a plane. The radian and steradian are special names for the number one that may be used to convey information about the quantity concerned. In practice the symbols rad and sr are used where appropriate, but the symbol for the derived unit one is generally omitted in specifying the values of dimensionless quantities."^^rdf:HTML ;
-  qudt:siExactMatch si-unit:steradian ;
   qudt:applicableSystem sou:CGS ;
   qudt:applicableSystem sou:CGS-EMU ;
   qudt:applicableSystem sou:CGS-GAUSS ;
@@ -40229,6 +40206,7 @@ unit:SR
   qudt:iec61360Code "0112/2///62720#UAA986" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Steradian?oldid=494317847"^^xsd:anyURI ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/steradian> ;
+  qudt:siExactMatch si-unit:steradian ;
   qudt:symbol "sr" ;
   qudt:ucumCode "sr"^^qudt:UCUMcs ;
   qudt:udunitsCode "sr" ;
@@ -40407,7 +40385,6 @@ unit:SV
   a qudt:DerivedUnit ;
   a qudt:Unit ;
   dcterms:description "Although the sievert has the same dimensions as the gray (i.e. joules per kilogram), it measures a different quantity. To avoid any risk of confusion between the absorbed dose and the equivalent dose, the corresponding special units, namely the gray instead of the joule per kilogram for absorbed dose and the sievert instead of the joule per kilogram for the dose equivalent, should be used."^^rdf:HTML ;
-  qudt:siExactMatch si-unit:sievert ;
   qudt:applicableSystem sou:CGS ;
   qudt:applicableSystem sou:CGS-EMU ;
   qudt:applicableSystem sou:CGS-GAUSS ;
@@ -40424,6 +40401,7 @@ unit:SV
   qudt:informativeReference "http://en.wikipedia.org/wiki/Sievert?oldid=495474333"^^xsd:anyURI ;
   qudt:informativeReference "http://www.oxfordreference.com/view/10.1093/acref/9780198605225.001.0001/acref-9780198605225-e-1284"^^xsd:anyURI ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/sievert> ;
+  qudt:siExactMatch si-unit:sievert ;
   qudt:siUnitsExpression "J/kg" ;
   qudt:symbol "Sv" ;
   qudt:ucumCode "Sv"^^qudt:UCUMcs ;
@@ -40580,7 +40558,6 @@ unit:T
   a qudt:DerivedUnit ;
   a qudt:Unit ;
   dcterms:description "The SI unit of flux density (or field intensity) for magnetic fields (also called the magnetic induction). The intensity of a magnetic field can be measured by placing a current-carrying conductor in the field. The magnetic field exerts a force on the conductor, a force which depends on the amount of the current and on the length of the conductor. One tesla is defined as the field intensity generating one newton of force per ampere of current per meter of conductor. Equivalently, one tesla represents a magnetic flux density of one weber per square meter of area. A field of one tesla is quite strong: the strongest fields available in laboratories are about 20 teslas, and the Earth's magnetic flux density, at its surface, is about 50 microteslas. The tesla, defined in 1958, honors the Serbian-American electrical engineer Nikola Tesla (1856-1943), whose work in electromagnetic induction led to the first practical generators and motors using alternating current. \\(T =  V\\cdot s \\cdot m^{-2} = N\\cdot A^{-1}\\cdot m^{-1} = Wb\\cdot m^{-1} = kg \\cdot  C^{-1}\\cdot s^{-1}\\cdot A^{-1} = kg \\cdot s^{-2}\\cdot A^{-1} = N \\cdot s \\cdot C^{-1}\\cdot m^{-1}\\) where, \\(\\\\\\) \\(A\\) = ampere, \\(C\\)=coulomb, \\(m\\) = meter,  \\(N\\) = newton, \\(s\\) = second, \\(T\\) = tesla, \\(Wb\\) = weber"^^qudt:LatexString ;
-  qudt:siExactMatch si-unit:tesla ;
   qudt:applicableSystem sou:CGS-EMU ;
   qudt:applicableSystem sou:CGS-GAUSS ;
   qudt:applicableSystem sou:SI ;
@@ -40597,6 +40574,7 @@ unit:T
   qudt:informativeReference "http://en.wikipedia.org/wiki/Tesla_(unit)"^^xsd:anyURI ;
   qudt:informativeReference "http://www.oxfordreference.com/view/10.1093/acref/9780198605225.001.0001/acref-9780198605225-e-1406?rskey=AzXBLd"^^xsd:anyURI ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/tesla> ;
+  qudt:siExactMatch si-unit:tesla ;
   qudt:siUnitsExpression "Wb/m^2" ;
   qudt:symbol "T" ;
   qudt:ucumCode "T"^^qudt:UCUMcs ;
@@ -40801,7 +40779,6 @@ unit:TON
 unit:TONNE
   a qudt:Unit ;
   dcterms:description "1,000-fold of the SI base unit kilogram"^^rdf:HTML ;
-  qudt:siExactMatch si-unit:tonne ;
   qudt:applicableSystem sou:CGS ;
   qudt:applicableSystem sou:CGS-EMU ;
   qudt:applicableSystem sou:CGS-GAUSS ;
@@ -40812,6 +40789,7 @@ unit:TONNE
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Mass ;
   qudt:plainTextDescription "1,000-fold of the SI base unit kilogram" ;
+  qudt:siExactMatch si-unit:tonne ;
   qudt:symbol "t" ;
   qudt:ucumCode "t"^^qudt:UCUMcs ;
   qudt:udunitsCode "t" ;
@@ -42386,7 +42364,6 @@ unit:UnitPole
 unit:V
   a qudt:Unit ;
   dcterms:description "\\(\\textit{Volt} is the SI unit of electric potential. Separating electric charges creates potential energy, which can be measured in energy units such as joules. Electric potential is defined as the amount of potential energy present per unit of charge. Electric potential is measured in volts, with one volt representing a potential of one joule per coulomb of charge. The name of the unit honors the Italian scientist Count Alessandro Volta (1745-1827), the inventor of the first battery.  The volt also may be expressed with a variety of other units. For example, a volt is also equal to one watt per ampere (W/A) and one joule per ampere per second (J/A/s).\\)"^^qudt:LatexString ;
-  qudt:siExactMatch si-unit:volt ;
   qudt:applicableSystem sou:CGS-EMU ;
   qudt:applicableSystem sou:CGS-GAUSS ;
   qudt:applicableSystem sou:PLANCK ;
@@ -42403,6 +42380,7 @@ unit:V
   qudt:informativeReference "http://en.wikipedia.org/wiki/Volt?oldid=494812083"^^xsd:anyURI ;
   qudt:latexDefinition "\\(\\text{V}\\ \\equiv\\ \\text{volt}\\ \\equiv\\ \\frac{\\text{J}}{\\text{C}}\\ \\equiv\\ \\frac{\\text{joule}}{\\text{coulomb}}\\ \\equiv\\ \\frac{\\text{W.s}}{\\text{C}}\\ \\equiv\\ \\frac{\\text{watt.second}}{\\text{coulomb}}\\ \\equiv\\ \\frac{\\text{W}}{\\text{A}}\\ \\equiv\\ \\frac{\\text{watt}}{\\text{amp}}\\)"^^qudt:LatexString ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/volt> ;
+  qudt:siExactMatch si-unit:volt ;
   qudt:siUnitsExpression "W/A" ;
   qudt:symbol "V" ;
   qudt:ucumCode "V"^^qudt:UCUMcs ;
@@ -42929,7 +42907,6 @@ unit:W
   a qudt:DerivedUnit ;
   a qudt:Unit ;
   dcterms:description "The SI unit of power. Power is the rate at which work is done, or (equivalently) the rate at which energy is expended. One watt is equal to a power rate of one joule of work per second of time. This unit is used both in mechanics and in electricity, so it links the mechanical and electrical units to one another. In mechanical terms, one watt equals about 0.001 341 02 horsepower (hp) or 0.737 562 foot-pound per second (lbf/s). In electrical terms, one watt is the power produced by a current of one ampere flowing through an electric potential of one volt. The name of the unit honors James Watt (1736-1819), the British engineer whose improvements to the steam engine are often credited with igniting the Industrial Revolution."^^rdf:HTML ;
-  qudt:siExactMatch si-unit:watt ;
   qudt:applicableSystem sou:CGS ;
   qudt:applicableSystem sou:CGS-EMU ;
   qudt:applicableSystem sou:CGS-GAUSS ;
@@ -42947,6 +42924,7 @@ unit:W
   qudt:informativeReference "http://en.wikipedia.org/wiki/Watt?oldid=494906356"^^xsd:anyURI ;
   qudt:latexDefinition "\\(\\text{W}\\ \\equiv\\ \\text{watt}\\ \\equiv\\ \\frac{\\text{J}}{\\text{s}}\\ \\equiv\\ \\frac{\\text{joule}}{\\text{second}}\\ \\equiv\\ \\frac{\\text{N.m}}{\\text{s}}\\ \\equiv\\ \\frac{\\text{newton.metre}}{\\text{second}}\\ \\equiv\\ \\text{V.A}\\ \\equiv\\ \\text{volt.amp}\\ \\equiv\\ \\Omega\\text{.A}^{2}\\ \\equiv\\ \\text{ohm.amp}^{2}\\)"^^qudt:LatexString ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/watt> ;
+  qudt:siExactMatch si-unit:watt ;
   qudt:symbol "W" ;
   qudt:ucumCode "W"^^qudt:UCUMcs ;
   qudt:udunitsCode "W" ;
@@ -43549,7 +43527,6 @@ unit:WB
   a qudt:DerivedUnit ;
   a qudt:Unit ;
   dcterms:description "The SI unit of magnetic flux. \"Flux\" is the rate (per unit of time) at which something crosses a surface perpendicular to the flow. The weber is a large unit, equal to \\(10^{8}\\) maxwells, and practical fluxes are usually fractions of one weber. The weber is the magnetic flux which, linking a circuit of one turn, would produce in it an electromotive force of 1 volt if it were reduced to zero at a uniform rate in 1 second. In SI base units, the dimensions of the weber are \\((kg \\cdot m^2)/(s^2 \\cdot A)\\). The weber is commonly expressed in terms of other derived units as the Tesla-square meter (\\(T \\cdot m^2\\)), volt-seconds (\\(V \\cdot s\\)), or joules per ampere (\\(J/A\\))."^^qudt:LatexString ;
-  qudt:siExactMatch si-unit:weber ;
   qudt:applicableSystem sou:CGS-EMU ;
   qudt:applicableSystem sou:CGS-GAUSS ;
   qudt:applicableSystem sou:SI ;
@@ -43563,6 +43540,7 @@ unit:WB
   qudt:iec61360Code "0112/2///62720#UAA317" ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Weber_(unit)"^^xsd:anyURI ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/weber> ;
+  qudt:siExactMatch si-unit:weber ;
   qudt:siUnitsExpression "V.s" ;
   qudt:symbol "Wb" ;
   qudt:ucumCode "Wb"^^qudt:UCUMcs ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -7145,8 +7145,7 @@ unit:DeciB-MilliW-PER-MegaHZ
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAD892" ;
-  qudt:symbol "dBm" ;
-  qudt:symbol "dBm/Mhz" ;
+  qudt:symbol "dB·mW/Mhz" ;
   qudt:ucumCode "dB.mW.MHz-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "DBM" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -7159,7 +7158,6 @@ unit:DeciB-PER-KiloM
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA410" ;
   qudt:symbol "dB/km" ;
-  qudt:symbol "db/km" ;
   qudt:ucumCode "dB.km-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H51" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -7172,7 +7170,6 @@ unit:DeciB-PER-M
   qudt:hasQuantityKind quantitykind:LinearLogarithmicRatio ;
   qudt:iec61360Code "0112/2///62720#UAA411" ;
   qudt:symbol "dB/m" ;
-  qudt:symbol "db/m" ;
   qudt:ucumCode "dB.m-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H52" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -7999,7 +7996,6 @@ unit:EUR-PER-KiloW
   qudt:hasDimensionVector qkdv:A0E0L-2I0M-1H0T3D0 ;
   qudt:hasQuantityKind quantitykind:CostPerUnitPower ;
   qudt:plainTextDescription "Unit for measuring the hardware cost of a power generation unit relative to the generated power" ;
-  qudt:symbol "€/W" ;
   qudt:symbol "€/kW" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Euro per kilowatt"@en ;
@@ -20978,8 +20974,6 @@ unit:LB_F-PER-IN2
   qudt:iec61360Code "0112/2///62720#UAA701" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Pounds_per_square_inch?oldid=485678341"^^xsd:anyURI ;
   qudt:symbol "lbf/in²" ;
-  qudt:symbol "psi" ;
-  qudt:symbol "psia" ;
   qudt:ucumCode "[lbf_av].[sin_i]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "PS" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -23706,7 +23700,6 @@ unit:MOL-PER-KiloGM-K
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA886" ;
   qudt:iec61360Code "0112/2///62720#UAD689" ;
-  qudt:symbol "(mol/kg)/K" ;
   qudt:symbol "mol/(kg·K)" ;
   qudt:ucumCode "mol.K-1.kg-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L24" ;
@@ -29734,6 +29727,7 @@ unit:MilliMOL-PER-L
   qudt:conversionMultiplier 1.0 ;
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:expression "\\(mmo/L\\)"^^qudt:LatexString ;
+  qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:AmountOfSubstanceConcentration ;
   qudt:hasQuantityKind quantitykind:AmountOfSubstancePerUnitVolume ;
   qudt:hasQuantityKind quantitykind:BloodGlucoseLevel ;
@@ -30934,7 +30928,6 @@ unit:N-M-PER-W0dot5
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA242" ;
-  qudt:symbol "N·m/W0.5" ;
   qudt:symbol "N·m/√W" ;
   qudt:uneceCommonCode "H41" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -32748,7 +32741,6 @@ unit:OCT
   qudt:hasQuantityKind quantitykind:LogarithmicFrequencyInterval ;
   qudt:iec61360Code "0112/2///62720#UAA914" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Octave_(electronics)"^^xsd:anyURI ;
-  qudt:symbol "oct" ;
   qudt:symbol "octave" ;
   qudt:uneceCommonCode "C59" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -33061,7 +33053,6 @@ unit:ONE
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA915" ;
-  qudt:symbol "1" ;
   qudt:symbol "one" ;
   qudt:uneceCommonCode "C62" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -34611,7 +34602,6 @@ unit:PER-DEG_F
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H-1T0D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA047" ;
-  qudt:symbol "F⁻¹" ;
   qudt:symbol "°F⁻¹" ;
   qudt:ucumCode "[degF]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J26" ;
@@ -35146,7 +35136,6 @@ unit:PER-M3
   qudt:hasQuantityKind quantitykind:NumberDensity ;
   qudt:iec61360Code "0112/2///62720#UAA740" ;
   qudt:iec61360Code "0112/2///62720#UAD524" ;
-  qudt:symbol "/m³" ;
   qudt:symbol "m⁻³" ;
   qudt:ucumCode "/m3"^^qudt:UCUMcs ;
   qudt:ucumCode "m-3"^^qudt:UCUMcs ;
@@ -35500,7 +35489,6 @@ unit:PER-PA
   qudt:iec61360Code "0112/2///62720#UAA269" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Pascal?oldid=492989202"^^xsd:anyURI ;
   qudt:siUnitsExpression "m^2/N" ;
-  qudt:symbol "/Pa" ;
   qudt:symbol "Pa⁻¹" ;
   qudt:ucumCode "Pa-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C96" ;
@@ -35649,8 +35637,7 @@ unit:PER-SEC-M2
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Flux ;
   qudt:iec61360Code "0112/2///62720#UAA974" ;
-  qudt:symbol "/s·m²" ;
-  qudt:symbol "s⁻¹/m²" ;
+  qudt:symbol "s⁻¹·m⁻²" ;
   qudt:ucumCode "/(s1.m2)"^^qudt:UCUMcs ;
   qudt:ucumCode "s-1.m-2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C99" ;
@@ -35687,8 +35674,7 @@ unit:PER-SEC-M3
   qudt:hasDimensionVector qkdv:A0E0L-3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Slowing-DownDensity ;
   qudt:iec61360Code "0112/2///62720#UAA975" ;
-  qudt:symbol "1/(s·m³)" ;
-  qudt:symbol "s⁻¹/m³" ;
+  qudt:symbol "s⁻¹·m⁻³" ;
   qudt:ucumCode "s-1.m-3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C98" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -35723,8 +35709,7 @@ unit:PER-SEC-SR-M2
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA977" ;
-  qudt:symbol "1/(s·sr·m²)" ;
-  qudt:symbol "s⁻¹/(sr·m²)" ;
+  qudt:symbol "s⁻¹·sr⁻¹·m⁻²" ;
   qudt:ucumCode "s-1.sr-1.m-2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D2" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -36863,7 +36848,6 @@ unit:PHON
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA937" ;
-  qudt:symbol "Phon" ;
   qudt:symbol "phon" ;
   qudt:uneceCommonCode "C69" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -38985,8 +38969,7 @@ unit:QT_US
   qudt:hasQuantityKind quantitykind:LiquidVolume ;
   qudt:hasQuantityKind quantitykind:Volume ;
   qudt:iec61360Code "0112/2///62720#UAA964" ;
-  qudt:symbol "qt (US liq.)" ;
-  qudt:symbol "qt" ;
+  qudt:symbol "qt{US liq}" ;
   qudt:ucumCode "[qt_us]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "QT" ;
   qudt:uneceCommonCode "QTL" ;
@@ -40667,6 +40650,7 @@ unit:THERM_US
 .
 unit:THM_EEC
   a qudt:Unit ;
+  qudt:exactMatch unit:THERM_EC ;
   qudt:expression "\\(therm-eec\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Energy ;
@@ -40682,6 +40666,7 @@ unit:THM_US
   qudt:applicableSystem sou:USCS ;
   qudt:conversionMultiplier 105480400.0 ;
   qudt:conversionMultiplierSN 1.054804E8 ;
+  qudt:exactMatch unit:THERM_US ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Energy ;
   qudt:hasQuantityKind quantitykind:ThermalEnergy ;


### PR DESCRIPTION
This includes the following tweaks:
- Reserializing using TBC to get a baseline file sorting
- Many additions/tweaks of values for `qudt:symbol`
- Add two `qudt:exactMatch` statements for new URIs for units that already existed
- Change one quantity kind and swap out a deprecated dimension vector
- Merge `unit:MilloMOL-PER-L` (which is misspelled) into `unit:MilliMOL-PER-L` (which already existed)
- Fix degree symbols with underline
- Standardize all multiplication symbols in `qudt:symbol`
- Fix SHACL Violations