### PR TITLE
Add UCUM code aliases

### DIFF
--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -145,6 +145,7 @@ unit:A-HR-PER-KiloGM
   qudt:iec61360Code "0112/2///62720#UAD884" ;
   qudt:symbol "A·h/kg" ;
   qudt:ucumCode "A.h.kg-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "A.h/kg"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "ampere hour per kilogram" ;
 .
@@ -261,6 +262,7 @@ unit:A-PER-CentiM
   qudt:plainTextDescription "SI base unit ampere divided by the 0.01-fold of the SI base unit metre" ;
   qudt:symbol "A/cm" ;
   qudt:ucumCode "A.cm-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "A/cm"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A2" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Ampere Per Centimeter"@en-us ;
@@ -316,6 +318,7 @@ unit:A-PER-GM
   qudt:hasQuantityKind quantitykind:SpecificElectricCurrent ;
   qudt:symbol "A/g" ;
   qudt:ucumCode "A.g-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "A/g"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Ampere per Gram"@en ;
 .
@@ -347,6 +350,7 @@ unit:A-PER-K
   qudt:iec61360Code "0112/2///62720#UAD896" ;
   qudt:symbol "A/K" ;
   qudt:ucumCode "A.K-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "A/K"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "ampere per kelvin" ;
 .
@@ -361,6 +365,7 @@ unit:A-PER-KiloGM
   qudt:iec61360Code "0112/2///62720#UAD543" ;
   qudt:symbol "A/kg" ;
   qudt:ucumCode "A.kg-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "A/kg"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H31" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "ampere per kilogram" ;
@@ -520,6 +525,7 @@ unit:A-PER-PA
   qudt:iec61360Code "0112/2///62720#UAB320" ;
   qudt:symbol "A/Pa" ;
   qudt:ucumCode "A.Pa-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "A/Pa"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "N93" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "ampere per pascal" ;
@@ -836,6 +842,7 @@ unit:ATM-M3-PER-MOL
   qudt:hasQuantityKind quantitykind:HenrysLawVolatilityConstant ;
   qudt:symbol "atm·m³/mol" ;
   qudt:ucumCode "atm.m3.mol-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "atm.m3/mol"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Atmosphere Cubic Meter per Mole"@en-us ;
   rdfs:label "Atmosphere Cubic Metre per Mole"@en ;
@@ -850,6 +857,7 @@ unit:ATM-PER-M
   qudt:iec61360Code "0112/2///62720#UAB423" ;
   qudt:symbol "Atm/m" ;
   qudt:ucumCode "atm.m-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "atm/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P83" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "standard atmosphere per metre" ;
@@ -883,6 +891,7 @@ unit:ATM_T-PER-M
   qudt:iec61360Code "0112/2///62720#UAB424" ;
   qudt:symbol "at/m" ;
   qudt:ucumCode "att.m-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "att/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P84" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "technical atmosphere per metre" ;
@@ -1188,6 +1197,7 @@ unit:B-PER-M
   qudt:iec61360Code "0112/2///62720#UAB480" ;
   qudt:symbol "B/m" ;
   qudt:ucumCode "B.m-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "B/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P43" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "bel per metre" ;
@@ -1297,6 +1307,7 @@ unit:BAR-PER-DEG_C
   qudt:iec61360Code "0112/2///62720#UAD921" ;
   qudt:symbol "bar/°C" ;
   qudt:ucumCode "bar.Cel-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "bar/Cel"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "bar per degree Celsius" ;
 .
@@ -1373,6 +1384,7 @@ unit:BARN-PER-SR
   qudt:iec61360Code "0112/2///62720#UAB128" ;
   qudt:symbol "b/sr" ;
   qudt:ucumCode "b.sr-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "b/sr"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A17" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "barn per steradian" ;
@@ -1710,6 +1722,7 @@ unit:BIT-PER-M
   qudt:iec61360Code "0112/2///62720#UAA340" ;
   qudt:symbol "bit/m" ;
   qudt:ucumCode "bit.m-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "bit/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E88" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "bit per metre" ;
@@ -1849,6 +1862,7 @@ unit:BQ-PER-L
   qudt:hasQuantityKind quantitykind:ActivityConcentration ;
   qudt:symbol "Bq/L" ;
   qudt:ucumCode "Bq.L-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "Bq/L"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Becquerels per litre"@en ;
 .
@@ -3239,6 +3253,7 @@ unit:BYTE-PER-SEC
   qudt:iec61360Code "0112/2///62720#UAB305" ;
   qudt:symbol "byte/s" ;
   qudt:ucumCode "By.s-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "By/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P93" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "byte per second" ;
@@ -3363,6 +3378,7 @@ unit:C-M2-PER-KiloGM
   qudt:iec61360Code "0112/2///62720#UAD912" ;
   qudt:symbol "C·m²/kg" ;
   qudt:ucumCode "C.m2.kg-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "C.m2/kg"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J53" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "coulomb square metre per kilogram" ;
@@ -4254,6 +4270,7 @@ unit:CD-PER-LM
   qudt:hasQuantityKind quantitykind:LuminousIntensityDistribution ;
   qudt:symbol "cd/lm" ;
   qudt:ucumCode "cd.lm-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "cd/lm"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Candela per Lumen"@en ;
 .
@@ -4695,6 +4712,7 @@ unit:CentiM-PER-BAR
   qudt:iec61360Code "0112/2///62720#UAA377" ;
   qudt:symbol "cm/bar" ;
   qudt:ucumCode "cm.bar-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "cm/bar"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G04" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "centimetre per bar" ;
@@ -4752,6 +4770,7 @@ unit:CentiM-PER-KiloYR
   qudt:hasQuantityKind quantitykind:Velocity ;
   qudt:symbol "cm/(1000 yr)" ;
   qudt:ucumCode "cm.ka-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "cm/ka"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Centimetres per thousand years"@en ;
 .
@@ -4847,6 +4866,7 @@ unit:CentiM-PER-YR
   qudt:hasQuantityKind quantitykind:Velocity ;
   qudt:symbol "cm/yr" ;
   qudt:ucumCode "cm.a-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "cm/a"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Centimetres per year"@en ;
 .
@@ -4937,6 +4957,7 @@ unit:CentiM2-PER-ERG
   qudt:iec61360Code "0112/2///62720#UAB168" ;
   qudt:symbol "cm²/erg" ;
   qudt:ucumCode "cm2.erg-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "cm2/erg"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D16" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "square centimetre per erg" ;
@@ -4952,6 +4973,7 @@ unit:CentiM2-PER-GM
   qudt:iec61360Code "0112/2///62720#UAB193" ;
   qudt:symbol "cm²/g" ;
   qudt:ucumCode "cm2.g-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "cm2/g"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H15" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Square centimeters per gram"@en-us ;
@@ -4971,6 +4993,7 @@ unit:CentiM2-PER-SEC
   qudt:iec61360Code "0112/2///62720#UAB408" ;
   qudt:symbol "cm²/s" ;
   qudt:ucumCode "cm2.s-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "cm2/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M81" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Square centimetres per second"@en ;
@@ -5043,6 +5066,7 @@ unit:CentiM3-PER-BAR
   qudt:iec61360Code "0112/2///62720#UAA387" ;
   qudt:symbol "cm³/bar" ;
   qudt:ucumCode "cm3.bar-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "cm3/bar"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G94" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "cubic centimetre per bar" ;
@@ -5609,6 +5633,7 @@ unit:CentiPOISE-PER-K
   qudt:iec61360Code "0112/2///62720#UAA357" ;
   qudt:symbol "cP/K" ;
   qudt:ucumCode "cP.K-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "cP/K"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J73" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "centipoise per kelvin" ;
@@ -5844,6 +5869,7 @@ unit:DEG-PER-M
   qudt:iec61360Code "0112/2///62720#UAA025" ;
   qudt:symbol "°/m" ;
   qudt:ucumCode "deg.m-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "deg/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H27" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Degrees per metre"@en ;
@@ -6162,6 +6188,7 @@ unit:DEG_C-PER-BAR
   qudt:iec61360Code "0112/2///62720#UAA035" ;
   qudt:symbol "°C/bar" ;
   qudt:ucumCode "Cel.bar-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "Cel/bar"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F60" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "degree Celsius per bar" ;
@@ -6211,6 +6238,7 @@ unit:DEG_C-PER-M
   qudt:hasQuantityKind quantitykind:TemperatureGradient ;
   qudt:symbol "°C/m" ;
   qudt:ucumCode "Cel.m-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "Cel/m"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Degrees Celsius per metre"@en ;
 .
@@ -6261,6 +6289,7 @@ unit:DEG_C-PER-YR
   qudt:hasQuantityKind quantitykind:TemperaturePerTime ;
   qudt:symbol "°C/yr" ;
   qudt:ucumCode "Cel.a-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "Cel/a"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Degrees Celsius per year"@en ;
 .
@@ -6288,6 +6317,7 @@ unit:DEG_C2-PER-SEC
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:symbol "°C²/s" ;
   qudt:ucumCode "K2.s-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "K2/s"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Square Degrees Celsius per second"@en ;
 .
@@ -6458,6 +6488,7 @@ unit:DEG_F-PER-BAR
   qudt:iec61360Code "0112/2///62720#UAA042" ;
   qudt:symbol "°F/bar" ;
   qudt:ucumCode "[degF].bar-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[degF]/bar"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J21" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "degree Fahrenheit per bar" ;
@@ -7147,6 +7178,7 @@ unit:DeciB-MilliW-PER-MegaHZ
   qudt:iec61360Code "0112/2///62720#UAD892" ;
   qudt:symbol "dB·mW/Mhz" ;
   qudt:ucumCode "dB.mW.MHz-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "dB.mW/MHz"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "DBM" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "decibel milliwatts per megahertz" ;
@@ -7159,6 +7191,7 @@ unit:DeciB-PER-KiloM
   qudt:iec61360Code "0112/2///62720#UAA410" ;
   qudt:symbol "dB/km" ;
   qudt:ucumCode "dB.km-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "dB/km"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H51" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "decibel per kilometre" ;
@@ -7171,6 +7204,7 @@ unit:DeciB-PER-M
   qudt:iec61360Code "0112/2///62720#UAA411" ;
   qudt:symbol "dB/m" ;
   qudt:ucumCode "dB.m-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "dB/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H52" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "decibel per metre" ;
@@ -7213,6 +7247,7 @@ unit:DeciBAR-PER-YR
   qudt:hasQuantityKind quantitykind:ForcePerAreaTime ;
   qudt:symbol "dbar/yr" ;
   qudt:ucumCode "dbar.a-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "dbar/a"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Decibars per year"@en ;
 .
@@ -7487,6 +7522,7 @@ unit:DeciM3-PER-KiloGM
   qudt:iec61360Code "0112/2///62720#UAB409" ;
   qudt:symbol "dm³/kg" ;
   qudt:ucumCode "dm3.kg-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "dm3/kg"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "N28" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "cubic decimetre per kilogram" ;
@@ -7794,6 +7830,7 @@ unit:ERG-CentiM2-PER-GM
   qudt:iec61360Code "0112/2///62720#UAB149" ;
   qudt:symbol "erg·cm²/g" ;
   qudt:ucumCode "erg.cm2.g-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "erg.cm2/g"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A67" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "erg square centimetre per gram" ;
@@ -8107,6 +8144,7 @@ unit:EV-M2-PER-KiloGM
   qudt:iec61360Code "0112/2///62720#UAA428" ;
   qudt:symbol "eV·m²/kg" ;
   qudt:ucumCode "eV.m2.kg-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "eV.m2/kg"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A56" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "electronvolt square metre per kilogram" ;
@@ -8353,6 +8391,7 @@ unit:ExaJ-PER-SEC
   qudt:iec61360Code "0112/2///62720#UAB515" ;
   qudt:symbol "EJ/s" ;
   qudt:ucumCode "EJ.s-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "EJ/s"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "exajoule per second" ;
 .
@@ -8619,6 +8658,7 @@ unit:FARAD_Ab-PER-CentiM
   qudt:hasQuantityKind quantitykind:Permittivity ;
   qudt:symbol "abF/cm" ;
   qudt:ucumCode "GF.cm-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "GF/cm"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Abfarad per Centimeter"@en-us ;
   rdfs:label "Abfarad per Centimetre"@en ;
@@ -9095,6 +9135,7 @@ unit:FT-PER-PSI
   qudt:iec61360Code "0112/2///62720#UAA447" ;
   qudt:symbol "ft/psi" ;
   qudt:ucumCode "[ft_i].[psi]-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[ft_i]/[psi]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K17" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "foot per psi" ;
@@ -9731,6 +9772,7 @@ unit:FemtoGM-PER-L
   qudt:hasQuantityKind quantitykind:MassDensity ;
   qudt:symbol "fg/L" ;
   qudt:ucumCode "fg.L-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "fg/L"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Femtograms per litre"@en ;
 .
@@ -9817,6 +9859,7 @@ unit:FemtoMOL-PER-KiloGM
   qudt:hasQuantityKind quantitykind:AmountOfSubstancePerUnitMass ;
   qudt:symbol "fmol/kg" ;
   qudt:ucumCode "fmol.kg-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "fmol/kg"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Femtomoles per kilogram"@en ;
 .
@@ -9832,6 +9875,7 @@ unit:FemtoMOL-PER-L
   qudt:hasQuantityKind quantitykind:Solubility_Water ;
   qudt:symbol "fmol/L" ;
   qudt:ucumCode "fmol.L-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "fmol/L"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Femtomoles per litre"@en ;
 .
@@ -10074,6 +10118,7 @@ unit:GAL_US-PER-HR
   qudt:plainTextDescription "unit gallon (US, liq.) according to the Anglo-American system of units divided by the SI unit hour" ;
   qudt:symbol "gal{US}/hr" ;
   qudt:ucumCode "[gal_us].h-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[gal_us]/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G50" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Gallon (US) Per Hour"@en ;
@@ -10111,6 +10156,7 @@ unit:GAL_US-PER-SEC
   qudt:plainTextDescription "unit gallon (US, liq.) according to the Anglo-American system of units divided by the SI base unit second" ;
   qudt:symbol "gal{US}/s" ;
   qudt:ucumCode "[gal_us].s-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[gal_us]/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K30" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Gallon (US Liquid) Per Second"@en ;
@@ -10763,6 +10809,7 @@ unit:GM-PER-DEG_C
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:symbol "g/°C" ;
   qudt:ucumCode "d.Cel-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "d/Cel"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Gram Degree Celsius"@en ;
 .
@@ -10986,6 +11033,7 @@ unit:GM-PER-L
   qudt:plainTextDescription "0,001-fold of the SI base unit kilogram divided by the unit litre" ;
   qudt:symbol "g/L" ;
   qudt:ucumCode "g.L-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "g/L"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "GL" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Gram Per Liter"@en-us ;
@@ -11292,6 +11340,7 @@ unit:GM-PER-MOL
   qudt:plainTextDescription "0.01-fold of the SI base unit kilogram divided by the SI base unit mol" ;
   qudt:symbol "g/mol" ;
   qudt:ucumCode "g.mol-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "g/mol"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A94" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Gram Per Mole"@en ;
@@ -11312,6 +11361,7 @@ unit:GM-PER-MilliL
   qudt:plainTextDescription "0,001-fold of the SI base unit kilogram divided by the 0.001-fold of the unit litre" ;
   qudt:symbol "g/mL" ;
   qudt:ucumCode "g.mL-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "g/mL"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "GJ" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Gram Per Millilitre"@en ;
@@ -13857,6 +13907,7 @@ unit:J-M-PER-MOL
   qudt:hasQuantityKind quantitykind:LengthMolarEnergy ;
   qudt:symbol "J·m/mol" ;
   qudt:ucumCode "J.m.mol-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "J.m/mol"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Joule Meter per Mole"@en-us ;
   rdfs:label "Joule Metre per Mole"@en ;
@@ -14328,6 +14379,7 @@ unit:J-PER-MOL
   qudt:iec61360Code "0112/2///62720#UAA183" ;
   qudt:symbol "J/mol" ;
   qudt:ucumCode "J.mol-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "J/mol"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B15" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Joule je Mol"@de ;
@@ -14496,6 +14548,7 @@ unit:J-SEC-PER-MOL
   qudt:hasQuantityKind quantitykind:MolarAngularMomentum ;
   qudt:symbol "J·s/mol" ;
   qudt:ucumCode "J.s.mol-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "J.s/mol"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Joule Second per Mole"@en ;
 .
@@ -15593,6 +15646,7 @@ unit:KiloCAL-PER-GM
   qudt:hasQuantityKind quantitykind:SpecificEnergy ;
   qudt:symbol "kcal/g" ;
   qudt:ucumCode "kcal.g-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "kcal/g"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kilocalorie per Gram"@en ;
 .
@@ -15633,6 +15687,7 @@ unit:KiloCAL-PER-MIN
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:symbol "kcal/min" ;
   qudt:ucumCode "kcal.min-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "kcal/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K54" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kilocalorie Per Minute"@en ;
@@ -15651,6 +15706,7 @@ unit:KiloCAL-PER-MOL
   qudt:hasQuantityKind quantitykind:MolarEnergy ;
   qudt:symbol "kcal/mol" ;
   qudt:ucumCode "kcal.mol-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "kcal/mol"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kilocalorie per Mole"@en ;
 .
@@ -15687,6 +15743,7 @@ unit:KiloCAL-PER-SEC
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:symbol "kcal/s" ;
   qudt:ucumCode "kcal.s-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "kcal/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K55" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kilocalorie Per Second"@en ;
@@ -16264,6 +16321,7 @@ unit:KiloGM-PER-DAY
   qudt:plainTextDescription "SI base unit kilogram divided by the unit day" ;
   qudt:symbol "kg/day" ;
   qudt:ucumCode "kg.d-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "kg/d"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F30" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kilogram Per Day"@en ;
@@ -16547,6 +16605,7 @@ unit:KiloGM-PER-KiloMOL
   qudt:plainTextDescription "SI base unit kilogram divided by the 1 000-fold of the SI base unit mol" ;
   qudt:symbol "kg/kmol" ;
   qudt:ucumCode "kg.kmol-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "kg/kmol"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F24" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kilogram Per Kilomol"@en ;
@@ -17569,6 +17628,7 @@ unit:KiloJ-PER-MOL
   qudt:plainTextDescription "1 000-fold of the SI derived unit joule divided by the SI base unit mol" ;
   qudt:symbol "kJ/mol" ;
   qudt:ucumCode "kJ.mol-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "kJ/mol"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B44" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kilojoule Per Mole"@en ;
@@ -17623,6 +17683,7 @@ unit:KiloL-PER-HR
   qudt:plainTextDescription "unit of the volume kilolitres divided by the unit hour" ;
   qudt:symbol "kL/hr" ;
   qudt:ucumCode "kL.h-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "kL/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "4X" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kilolitre Per Hour"@en ;
@@ -18034,6 +18095,7 @@ unit:KiloMOL-PER-SEC
   qudt:plainTextDescription "1 000-fold of the SI base unit mol divided by the SI base unit second" ;
   qudt:symbol "kmol/s" ;
   qudt:ucumCode "kmol.s-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "kmol/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E94" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kilomole Per Second"@en ;
@@ -18899,6 +18961,7 @@ unit:L-PER-BAR
   qudt:iec61360Code "0112/2///62720#UAA651" ;
   qudt:symbol "l/bar" ;
   qudt:ucumCode "L.bar-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "L/bar"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G95" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "litre per bar" ;
@@ -19157,6 +19220,7 @@ unit:L-PER-MicroMOL
   qudt:hasQuantityKind quantitykind:MolarVolume ;
   qudt:symbol "L/µmol" ;
   qudt:ucumCode "L.umol-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "L/umol"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Litres per micromole"@en ;
 .
@@ -21221,6 +21285,7 @@ unit:LM-PER-W
   qudt:iec61360Code "0112/2///62720#UAA719" ;
   qudt:symbol "lm/W" ;
   qudt:ucumCode "lm.W-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "lm/W"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B61" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Lumen per Watt"@en ;
@@ -22187,6 +22252,7 @@ unit:M2-PER-MOL
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
   qudt:symbol "m²/mol" ;
   qudt:ucumCode "m2.mol-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "m2/mol"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D22" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Square Meter per Mole"@en-us ;
@@ -23651,6 +23717,7 @@ unit:MOL-PER-HR
   qudt:plainTextDescription "SI base unit mole divided by the unit for time hour" ;
   qudt:symbol "mol/hr" ;
   qudt:ucumCode "mol.h-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "mol/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L23" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Mole Per Hour"@en ;
@@ -23939,6 +24006,7 @@ unit:MOL-PER-MIN
   qudt:plainTextDescription "SI base unit mole divided by the unit for time minute" ;
   qudt:symbol "mol/min" ;
   qudt:ucumCode "mol.min-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "mol/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L30" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Mole Per Minute"@en ;
@@ -23955,6 +24023,7 @@ unit:MOL-PER-MOL
   qudt:qkdvNumerator qkdv:A1E0L0I0M0H0T0D0 ;
   qudt:symbol "mol/mol" ;
   qudt:ucumCode "mol.mol-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "mol/mol"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Moles per mole"@en ;
 .
@@ -25081,6 +25150,7 @@ unit:MegaPA-L-PER-SEC
   qudt:plainTextDescription "product out of the 1,000,000-fold of the SI derived unit pascal and the unit litre divided by the SI base unit second" ;
   qudt:symbol "MPa·L/s" ;
   qudt:ucumCode "MPa.L.s-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "MPa.L/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F97" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Megapascal Liter Per Second"@en-us ;
@@ -25575,6 +25645,7 @@ unit:MicroBQ-PER-L
   qudt:hasQuantityKind quantitykind:ActivityConcentration ;
   qudt:symbol "μBq/L" ;
   qudt:ucumCode "uBq.L-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "uBq/L"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Microbecquerels per litre"@en ;
 .
@@ -25756,6 +25827,7 @@ unit:MicroGAL-PER-M
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:symbol "µGal/m" ;
   qudt:ucumCode "uGal.m-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "uGal/m"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "MicroGals per metre"@en ;
 .
@@ -26488,6 +26560,7 @@ unit:MicroM3-PER-MilliL
   qudt:qkdvNumerator qkdv:A0E0L3I0M0H0T0D0 ;
   qudt:symbol "µm³/mL" ;
   qudt:ucumCode "um3.mL-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "um3/mL"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Cubic microns per millilitre"@en ;
 .
@@ -27407,6 +27480,7 @@ unit:MilliBAR-L-PER-SEC
   qudt:plainTextDescription "product out of the 0.001-fold of the unit bar and the unit litre divided by the SI base unit second" ;
   qudt:symbol "mbar·L/s" ;
   qudt:ucumCode "mbar.L.s-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "mbar.L/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F95" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Millibar Liter Per Second"@en-us ;
@@ -27523,6 +27597,7 @@ unit:MilliBQ-PER-L
   qudt:hasQuantityKind quantitykind:ActivityConcentration ;
   qudt:symbol "mBq/L" ;
   qudt:ucumCode "mBq.L-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "mBq/L"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Millibecquerels per litre"@en ;
 .
@@ -27756,6 +27831,7 @@ unit:MilliGAL-PER-MO
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:symbol "mgal/mo" ;
   qudt:ucumCode "mGal.mo-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "mGal/mo"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "MilliGals per month"@en ;
 .
@@ -28033,6 +28109,7 @@ unit:MilliGM-PER-DeciL
   qudt:hasQuantityKind quantitykind:MassDensity ;
   qudt:symbol "mg/dL" ;
   qudt:ucumCode "mg.dL-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "mg/dL"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "milligrams per decilitre"@en ;
   rdfs:label "milligrams per decilitre"@en-us ;
@@ -28074,6 +28151,7 @@ unit:MilliGM-PER-HA
   qudt:plainTextDescription "0.000001-fold of the SI base unit kilogram divided by the 10,000-fold of the power of the SI base unit metre with the exponent 2" ;
   qudt:symbol "mg/ha" ;
   qudt:ucumCode "mg.har-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "mg/har"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Milligram Per Hectare"@en ;
 .
@@ -28092,6 +28170,7 @@ unit:MilliGM-PER-HR
   qudt:plainTextDescription "0.000001-fold of the SI base unit kilogram divided by the unit hour" ;
   qudt:symbol "mg/hr" ;
   qudt:ucumCode "mg.h-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "mg/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "4M" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Milligram Per Hour"@en ;
@@ -28134,6 +28213,7 @@ unit:MilliGM-PER-K
   qudt:iec61360Code "0112/2///62720#UAA816" ;
   qudt:symbol "mg/K" ;
   qudt:ucumCode "mg.K-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "mg/K"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F16" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "milligram per kelvin" ;
@@ -28249,6 +28329,7 @@ unit:MilliGM-PER-M
   qudt:plainTextDescription "0.000001-fold of the SI base unit kilogram divided by the SI base unit metre" ;
   qudt:symbol "mg/m" ;
   qudt:ucumCode "mg.m-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "mg/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C12" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Milligram Per Meter"@en-us ;
@@ -28690,6 +28771,7 @@ unit:MilliGRAY-PER-HR
   qudt:iec61360Code "0112/2///62720#UAB477" ;
   qudt:symbol "mGy/h" ;
   qudt:ucumCode "mGy.h-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "mGy/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P62" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "milligray per hour" ;
@@ -28704,6 +28786,7 @@ unit:MilliGRAY-PER-MIN
   qudt:iec61360Code "0112/2///62720#UAB473" ;
   qudt:symbol "mGy/min" ;
   qudt:ucumCode "mGy.min-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "mGy/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P58" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "milligray per minute" ;
@@ -28720,6 +28803,7 @@ unit:MilliGRAY-PER-SEC
   qudt:iec61360Code "0112/2///62720#UAB298" ;
   qudt:symbol "mGy/s" ;
   qudt:ucumCode "mGy.s-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "mGy/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P54" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "milligray per second" ;
@@ -28757,6 +28841,7 @@ unit:MilliH-PER-KiloOHM
   qudt:plainTextDescription "0.001-fold of the SI derived unit henry divided by the 1 000-fold of the SI derived unit ohm" ;
   qudt:symbol "mH/kΩ" ;
   qudt:ucumCode "mH.kOhm-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "mH/kOhm"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H05" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Millihenry Per Kiloohm"@en ;
@@ -28775,6 +28860,7 @@ unit:MilliH-PER-OHM
   qudt:plainTextDescription "0.001-fold of the SI derived unit henry divided by the SI derived unit ohm" ;
   qudt:symbol "mH/Ω" ;
   qudt:ucumCode "mH.Ohm-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "mH/Ohm"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H06" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Millihenry Per Ohm"@en ;
@@ -28846,6 +28932,7 @@ unit:MilliJ-PER-GM
   qudt:plainTextDescription "The 0.001-fold of the SI base unit joule divided by the 0.001-fold of the SI base unit kilogram" ;
   qudt:symbol "mJ/g" ;
   qudt:ucumCode "mJ.g-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "mJ/g"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Millijoule Per Gram"@en ;
 .
@@ -28882,6 +28969,7 @@ unit:MilliJ-PER-SEC
   qudt:iec61360Code "0112/2///62720#UAB511" ;
   qudt:symbol "mJ/s" ;
   qudt:ucumCode "mJ.s-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "mJ/s"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "millijoule per second" ;
 .
@@ -28955,6 +29043,7 @@ unit:MilliL-PER-BAR
   qudt:iec61360Code "0112/2///62720#UAA846" ;
   qudt:symbol "ml/bar" ;
   qudt:ucumCode "mL.bar-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "mL/bar"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G97" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "millilitre per bar" ;
@@ -29015,6 +29104,7 @@ unit:MilliL-PER-DAY
   qudt:plainTextDescription "0.001-fold of the unit litre divided by the unit day" ;
   qudt:symbol "mL/day" ;
   qudt:ucumCode "mL.d-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "mL/d"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G54" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Millilitre Per Day"@en ;
@@ -29086,6 +29176,7 @@ unit:MilliL-PER-HR
   qudt:plainTextDescription "0.001-fold of the unit litre divided by the unit hour" ;
   qudt:symbol "mL/hr" ;
   qudt:ucumCode "mL.h-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "mL/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G55" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Millilitre Per Hour"@en ;
@@ -29131,6 +29222,7 @@ unit:MilliL-PER-K
   qudt:plainTextDescription "0.001-fold of the unit litre divided by the SI base unit kelvin" ;
   qudt:symbol "mL/K" ;
   qudt:ucumCode "mL.K-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "mL/K"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G30" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Millilitre Per Kelvin"@en ;
@@ -29280,6 +29372,7 @@ unit:MilliL-PER-SEC
   qudt:plainTextDescription "0.001-fold of the unit litre divided by the SI base unit second" ;
   qudt:symbol "mL/s" ;
   qudt:ucumCode "mL.s-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "mL/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "40" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Millilitre Per Second"@en ;
@@ -29348,6 +29441,7 @@ unit:MilliM-PER-BAR
   qudt:iec61360Code "0112/2///62720#UAA865" ;
   qudt:symbol "mm/bar" ;
   qudt:ucumCode "mm.bar-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "mm/bar"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G06" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "millimetre per bar" ;
@@ -29422,6 +29516,7 @@ unit:MilliM-PER-K
   qudt:plainTextDescription "0.001-fold of the SI base unit metre divided by the SI base unit kelvin" ;
   qudt:symbol "mm/K" ;
   qudt:ucumCode "mm.K-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "mm/K"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F53" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Millimeter Per Kelvin"@en-us ;
@@ -29437,6 +29532,7 @@ unit:MilliM-PER-M
   qudt:iec61360Code "0112/2///62720#UAC001" ;
   qudt:symbol "mm/m" ;
   qudt:ucumCode "mm.m-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "mm/m"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "millimetre per metre" ;
 .
@@ -29478,6 +29574,7 @@ unit:MilliM-PER-SEC
   qudt:plainTextDescription "0.001-fold of the SI base unit metre divided by the SI base unit second" ;
   qudt:symbol "mm/s" ;
   qudt:ucumCode "mm.s-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "mm/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C16" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Millimeter Per Second"@en-us ;
@@ -29557,6 +29654,7 @@ unit:MilliM2-PER-SEC
   qudt:plainTextDescription "0.000001-fold of the power of the SI base unit metre with the exponent 2 divided by the SI base unit second" ;
   qudt:symbol "mm²/s" ;
   qudt:ucumCode "mm2.s-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "mm2/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C17" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Square Millimeter Per Second"@en-us ;
@@ -29697,6 +29795,7 @@ unit:MilliMOL-PER-GM
   qudt:plainTextDescription "0.001-fold of the SI base unit mol divided by the 0.001-fold of the SI base unit kilogram" ;
   qudt:symbol "mmol/g" ;
   qudt:ucumCode "mmol.g-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "mmol/g"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H68" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Millimole Per Gram"@en ;
@@ -29819,6 +29918,7 @@ unit:MilliMOL-PER-MOL
   qudt:qkdvNumerator qkdv:A1E0L0I0M0H0T0D0 ;
   qudt:symbol "mmol/mol" ;
   qudt:ucumCode "mmol.mol-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "mmol/mol"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Millimoles per mole"@en ;
 .
@@ -29947,6 +30047,7 @@ unit:MilliN-PER-M
   qudt:plainTextDescription "0.001-fold of the SI derived unit newton divided by the SI base unit metre" ;
   qudt:symbol "mN/m" ;
   qudt:ucumCode "mN.m-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "mN/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C22" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Millinewton Per Meter"@en-us ;
@@ -29996,6 +30097,7 @@ unit:MilliOHM-PER-BAR
   qudt:iec61360Code "0112/2///62720#UAD878" ;
   qudt:symbol "mΩ/bar" ;
   qudt:ucumCode "mOhm.bar-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "mOhm/bar"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "milliohm per bar" ;
 .
@@ -30009,6 +30111,7 @@ unit:MilliOHM-PER-K
   qudt:iec61360Code "0112/2///62720#UAD874" ;
   qudt:symbol "mΩ/K" ;
   qudt:ucumCode "mOhm.K-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "mOhm/K"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "milliohm per kelvin" ;
 .
@@ -30022,6 +30125,7 @@ unit:MilliOHM-PER-M
   qudt:iec61360Code "0112/2///62720#UAA743" ;
   qudt:symbol "mΩ/m" ;
   qudt:ucumCode "mOhm.m-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "mOhm/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F54" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "milliohm per metre" ;
@@ -30059,6 +30163,7 @@ unit:MilliPA-PER-M
   qudt:iec61360Code "0112/2///62720#UAB420" ;
   qudt:symbol "mPa/m" ;
   qudt:ucumCode "mPa.m-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "mPa/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P80" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "millipascal per metre" ;
@@ -30095,6 +30200,7 @@ unit:MilliPA-SEC-PER-BAR
   qudt:plainTextDescription "0.001-fold of the product of the SI derived unit pascal and the SI base unit second divided by the unit of the pressure bar" ;
   qudt:symbol "mPa·s/bar" ;
   qudt:ucumCode "mPa.s.bar-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "mPa.s/bar"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L16" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Millipascal Second Per Bar"@en ;
@@ -30109,6 +30215,7 @@ unit:MilliPA-SEC-PER-K
   qudt:iec61360Code "0112/2///62720#UAA798" ;
   qudt:symbol "mPa·s/K" ;
   qudt:ucumCode "mPa.s.K-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "mPa.s/K"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L15" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "millipascal second per kelvin" ;
@@ -30176,6 +30283,7 @@ unit:MilliRAD_R-PER-HR
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:symbol "mrad/hr" ;
   qudt:ucumCode "mRAD.h-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "mRAD/h"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Millirads per hour"@en ;
 .
@@ -30249,6 +30357,7 @@ unit:MilliS-PER-M
   qudt:hasQuantityKind quantitykind:Conductivity ;
   qudt:symbol "mS/m" ;
   qudt:ucumCode "mS.m-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "mS/m"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "MilliSiemens per metre"@en ;
 .
@@ -30308,6 +30417,7 @@ unit:MilliSV-PER-HR
   qudt:iec61360Code "0112/2///62720#UAB465" ;
   qudt:symbol "mSv/h" ;
   qudt:ucumCode "mSv.h-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "mSv/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P71" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "millisievert per hour" ;
@@ -30322,6 +30432,7 @@ unit:MilliSV-PER-MIN
   qudt:iec61360Code "0112/2///62720#UAB469" ;
   qudt:symbol "mSv/min" ;
   qudt:ucumCode "mSv.min-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "mSv/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P75" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "millisievert per minute" ;
@@ -30336,6 +30447,7 @@ unit:MilliSV-PER-SEC
   qudt:iec61360Code "0112/2///62720#UAB302" ;
   qudt:symbol "mSv/s" ;
   qudt:ucumCode "mSv.s-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "mSv/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P66" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "millisievert per second" ;
@@ -30418,6 +30530,7 @@ unit:MilliV-A-PER-K
   qudt:iec61360Code "0112/2///62720#UAD906" ;
   qudt:symbol "mV·A/K" ;
   qudt:ucumCode "mV.A.K-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "mV.A/K"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "millivolt ampere per kelvin" ;
 .
@@ -30455,6 +30568,7 @@ unit:MilliV-PER-M
   qudt:plainTextDescription "0.000001-fold of the SI derived unit volt divided by the SI base unit metre" ;
   qudt:symbol "mV/m" ;
   qudt:ucumCode "mV.m-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "mV/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C30" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Millivolt Per Meter"@en-us ;
@@ -30474,6 +30588,7 @@ unit:MilliV-PER-MIN
   qudt:plainTextDescription "0.001-fold of the SI derived unit volt divided by the unit minute" ;
   qudt:symbol "mV/min" ;
   qudt:ucumCode "mV.min-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "mV/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H62" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Millivolt Per Minute"@en ;
@@ -30488,6 +30603,7 @@ unit:MilliV-PER-V
   qudt:iec61360Code "0112/2///62720#UAD863" ;
   qudt:symbol "mV/V" ;
   qudt:ucumCode "mV.V-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "mV/V"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "millivolt per volt" ;
 .
@@ -30753,6 +30869,7 @@ unit:N-M-PER-A
   qudt:plainTextDescription "product of the SI derived unit newton and the SI base unit metre divided by the SI base unit ampere" ;
   qudt:symbol "N·m/A" ;
   qudt:ucumCode "N.m.A-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "N.m/A"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F90" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Newton Meter Per Ampere"@en-us ;
@@ -30783,6 +30900,7 @@ unit:N-M-PER-DEG
   qudt:iec61360Code "0112/2///62720#UAB308" ;
   qudt:symbol "N·m/°" ;
   qudt:ucumCode "N.m.deg-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "N.m/deg"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F89" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "newton metre per degree" ;
@@ -30815,6 +30933,7 @@ unit:N-M-PER-KiloGM
   qudt:plainTextDescription "product of the derived SI unit newton and the SI base unit metre divided by the SI base unit kilogram" ;
   qudt:symbol "N·m/kg" ;
   qudt:ucumCode "N.m.kg-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "N.m/kg"^^qudt:UCUMcs ;
   qudt:udunitsCode "gp" ;
   qudt:uneceCommonCode "G19" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -30838,6 +30957,7 @@ unit:N-M-PER-M
   qudt:plainTextDescription "This is the SI unit for the rolling resistance, which is equivalent to drag force in newton" ;
   qudt:symbol "N·m/m" ;
   qudt:ucumCode "N.m.m-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "N.m/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "Q27" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Newton meter per meter"@en-us ;
@@ -30914,6 +31034,7 @@ unit:N-M-PER-RAD
   qudt:plainTextDescription "Newton Meter per Radian is the SI unit for Torsion Constant" ;
   qudt:symbol "N·m/rad" ;
   qudt:ucumCode "N.m.rad-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "N.m/rad"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M93" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Newton meter per radian"@en-us ;
@@ -30991,6 +31112,7 @@ unit:N-M-SEC-PER-M
   qudt:plainTextDescription "Newton metre seconds measured per metre" ;
   qudt:symbol "N·m·s/m" ;
   qudt:ucumCode "N.m.s.m-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "N.m.s/m"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Newton meter seconds per meter"@en-us ;
   rdfs:label "Newton metre seconds per metre"@en ;
@@ -31012,6 +31134,7 @@ unit:N-M-SEC-PER-RAD
   qudt:plainTextDescription "Newton metre seconds measured per radian" ;
   qudt:symbol "N·m·s/rad" ;
   qudt:ucumCode "N.m.s.rad-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "N.m.s/rad"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Newton meter seconds per radian"@en-us ;
   rdfs:label "Newton metre seconds per radian"@en ;
@@ -31089,6 +31212,7 @@ unit:N-PER-A
   qudt:plainTextDescription "SI derived unit newton divided by the SI base unit ampere" ;
   qudt:symbol "N/A" ;
   qudt:ucumCode "N.A-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "N/A"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H40" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Newton Per Ampere"@en ;
@@ -31110,6 +31234,7 @@ unit:N-PER-C
   qudt:hasQuantityKind quantitykind:ForcePerElectricCharge ;
   qudt:symbol "N/C" ;
   qudt:ucumCode "N.C-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "N/C"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Newton per Coulomb"@en ;
 .
@@ -31128,6 +31253,7 @@ unit:N-PER-CentiM
   qudt:plainTextDescription "SI derived unit newton divided by the 0.01-fold of the SI base unit metre" ;
   qudt:symbol "N/cm" ;
   qudt:ucumCode "N.cm-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "N/cm"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M23" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Newton Per Centimeter"@en-us ;
@@ -31171,6 +31297,7 @@ unit:N-PER-KiloGM
   qudt:hasQuantityKind quantitykind:ThrustToMassRatio ;
   qudt:symbol "N/kg" ;
   qudt:ucumCode "N.kg-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "N/kg"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Newton per Kilogram"@en ;
 .
@@ -31273,6 +31400,7 @@ unit:N-PER-MilliM
   qudt:plainTextDescription "SI derived unit newton divided by the 0.001-fold of the SI base unit metre" ;
   qudt:symbol "N/mm" ;
   qudt:ucumCode "N.mm-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "N/mm"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F47" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Newton Per Millimeter"@en-us ;
@@ -31316,6 +31444,7 @@ unit:N-PER-RAD
   qudt:plainTextDescription "A one-newton force applied for one angle/torsional torque" ;
   qudt:symbol "N/rad" ;
   qudt:ucumCode "N.rad-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "N/rad"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Newton per radian"@en ;
   rdfs:label "Newton per radian"@en-us ;
@@ -31376,6 +31505,7 @@ unit:N-SEC-PER-M
   qudt:plainTextDescription "Newton second measured per metre" ;
   qudt:symbol "N·s/m" ;
   qudt:ucumCode "N.s.m-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "N.s/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C58" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Newton Second per Meter"@en-us ;
@@ -31433,6 +31563,7 @@ unit:N-SEC-PER-RAD
   qudt:plainTextDescription "Newton seconds measured per radian" ;
   qudt:symbol "N·s/rad" ;
   qudt:ucumCode "N.s.rad-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "N.s/rad"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Newton seconds per radian"@en ;
   rdfs:label "Newton seconds per radian"@en-us ;
@@ -31505,6 +31636,7 @@ unit:NP-PER-SEC
   qudt:iec61360Code "0112/2///62720#UAA254" ;
   qudt:symbol "Np/s" ;
   qudt:ucumCode "Np.s-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "Np/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C51" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "neper per second" ;
@@ -31579,6 +31711,8 @@ unit:NUM-PER-GM
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:symbol "/g" ;
   qudt:ucumCode "{#}.g-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "{#}/g"^^qudt:UCUMcs ;
+  qudt:ucumCode "/g"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Number per gram"@en ;
 .
@@ -31591,6 +31725,8 @@ unit:NUM-PER-HA
   qudt:hasQuantityKind quantitykind:ParticleFluence ;
   qudt:symbol "/ha" ;
   qudt:ucumCode "{#}.har-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "{#}/har"^^qudt:UCUMcs ;
+  qudt:ucumCode "/har"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Number per hectare"@en ;
 .
@@ -31602,6 +31738,8 @@ unit:NUM-PER-HR
   qudt:hasQuantityKind quantitykind:Frequency ;
   qudt:symbol "/hr" ;
   qudt:ucumCode "{#}.h-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "{#}/h"^^qudt:UCUMcs ;
+  qudt:ucumCode "/h"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Number per hour"@en ;
 .
@@ -31614,6 +31752,8 @@ unit:NUM-PER-HectoGM
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:symbol "/hg" ;
   qudt:ucumCode "{#}.hg-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "{#}/hg"^^qudt:UCUMcs ;
+  qudt:ucumCode "/hg"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Number per 100 grams"@en ;
 .
@@ -31637,6 +31777,8 @@ unit:NUM-PER-L
   qudt:symbol "/L" ;
   qudt:ucumCode "/L"^^qudt:UCUMcs ;
   qudt:ucumCode "{#}.L-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "{#}/L"^^qudt:UCUMcs ;
+  qudt:ucumCode "/L"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Number per litre"@en ;
 .
@@ -31650,6 +31792,7 @@ unit:NUM-PER-M
   qudt:symbol "/m" ;
   qudt:ucumCode "/m"^^qudt:UCUMcs ;
   qudt:ucumCode "{#}.m-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "{#}/m"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Number per metre"@en ;
 .
@@ -31758,6 +31901,8 @@ unit:NUM-PER-SEC
   qudt:hasQuantityKind quantitykind:Frequency ;
   qudt:symbol "/s" ;
   qudt:ucumCode "{#}.s-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "{#}/s"^^qudt:UCUMcs ;
+  qudt:ucumCode "/s"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Counts per second"@en ;
 .
@@ -31773,6 +31918,8 @@ unit:NUM-PER-YR
   qudt:hasQuantityKind quantitykind:Frequency ;
   qudt:symbol "#/yr" ;
   qudt:ucumCode "{#}.a-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "{#}/a"^^qudt:UCUMcs ;
+  qudt:ucumCode "/a"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Number per Year"@en ;
 .
@@ -31800,6 +31947,7 @@ unit:NanoA-PER-K
   qudt:iec61360Code "0112/2///62720#UAD899" ;
   qudt:symbol "nA/K" ;
   qudt:ucumCode "nA.K-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "nA/K"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "nanoampere per kelvin" ;
 .
@@ -31831,6 +31979,7 @@ unit:NanoBQ-PER-L
   qudt:hasQuantityKind quantitykind:ActivityConcentration ;
   qudt:symbol "nBq/L" ;
   qudt:ucumCode "nBq.L-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "nBq/L"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Nanobecquerels per litre"@en ;
 .
@@ -31895,6 +32044,7 @@ unit:NanoFARAD-PER-M
   qudt:plainTextDescription "0.000000001-fold of the SI derived unit farad divided by the SI base unit metre" ;
   qudt:symbol "nF/m" ;
   qudt:ucumCode "nF.m-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "nF/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C42" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Nanofarad Per Meter"@en-us ;
@@ -31966,6 +32116,7 @@ unit:NanoGM-PER-DAY
   qudt:hasQuantityKind quantitykind:MassPerTime ;
   qudt:symbol "ng/day" ;
   qudt:ucumCode "ng.d-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "ng/d"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Nanograms per day"@en ;
 .
@@ -32025,6 +32176,7 @@ unit:NanoGM-PER-L
   qudt:hasQuantityKind quantitykind:MassDensity ;
   qudt:symbol "ng/L" ;
   qudt:ucumCode "ng.L-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "ng/L"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Nanograms per litre"@en ;
 .
@@ -32096,6 +32248,7 @@ unit:NanoGM-PER-MilliL
   qudt:hasQuantityKind quantitykind:MassDensity ;
   qudt:symbol "ng/mL" ;
   qudt:ucumCode "ng.mL-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "ng/mL"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Nanograms per millilitre"@en ;
 .
@@ -32169,6 +32322,7 @@ unit:NanoH-PER-M
   qudt:plainTextDescription "0.000000001-fold of the SI derived unit henry divided by the SI base unit metre" ;
   qudt:symbol "nH/m" ;
   qudt:ucumCode "nH.m-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "nH/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C44" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Nanohenry Per Meter"@en-us ;
@@ -32201,6 +32355,7 @@ unit:NanoJ-PER-SEC
   qudt:iec61360Code "0112/2///62720#UAB509" ;
   qudt:symbol "nJ/s" ;
   qudt:ucumCode "nJ.s-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "nJ/s"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "nanojoule per second" ;
 .
@@ -32547,6 +32702,7 @@ unit:NanoS-PER-CentiM
   qudt:plainTextDescription "0.000000001-fold of the SI derived unit Siemens by the 0.01 fol of the SI base unit metre" ;
   qudt:symbol "nS/cm" ;
   qudt:ucumCode "nS.cm-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "nS/cm"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G44" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Nanosiemens Per Centimeter"@en-us ;
@@ -32566,6 +32722,7 @@ unit:NanoS-PER-M
   qudt:plainTextDescription "0.000000001-fold of the SI derived unit Siemens divided by the SI base unit metre" ;
   qudt:symbol "nS/m" ;
   qudt:ucumCode "nS.m-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "nS/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G45" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Nanosiemens Per Meter"@en-us ;
@@ -32942,6 +33099,7 @@ unit:OHM-PER-BAR
   qudt:iec61360Code "0112/2///62720#UAD879" ;
   qudt:symbol "Ω/bar" ;
   qudt:ucumCode "Ohm.bar-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "Ohm/bar"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "ohm per bar" ;
 .
@@ -32955,6 +33113,7 @@ unit:OHM-PER-K
   qudt:iec61360Code "0112/2///62720#UAD875" ;
   qudt:symbol "Ω/K" ;
   qudt:ucumCode "Ohm.K-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "Ohm/K"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "ohm per kelvin" ;
 .
@@ -32968,6 +33127,7 @@ unit:OHM-PER-KiloM
   qudt:iec61360Code "0112/2///62720#UAA019" ;
   qudt:symbol "Ω/km" ;
   qudt:ucumCode "Ohm.km-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "Ohm/km"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F56" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "ohm per kilometre" ;
@@ -32982,6 +33142,7 @@ unit:OHM-PER-M
   qudt:iec61360Code "0112/2///62720#UAA021" ;
   qudt:symbol "Ω/m" ;
   qudt:ucumCode "Ohm.m-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "Ohm/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H26" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "ohm per metre" ;
@@ -32996,6 +33157,7 @@ unit:OHM-PER-MI
   qudt:iec61360Code "0112/2///62720#UAA022" ;
   qudt:symbol "Ω/mi" ;
   qudt:ucumCode "Ohm.[mi_i]-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "Ohm/[mi_i]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F55" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "ohm per mile" ;
@@ -33319,6 +33481,7 @@ unit:OZ-PER-DAY
   qudt:plainTextDescription "traditional unit of the mass avoirdupois ounce according to the avoirdupois system of units divided by the unit for time day" ;
   qudt:symbol "oz/day" ;
   qudt:ucumCode "[oz_av].d-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[oz_av]/d"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L33" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Ounce (avoirdupois) Per Day"@en ;
@@ -33409,6 +33572,7 @@ unit:OZ-PER-HR
   qudt:plainTextDescription "traditional unit of the mass avoirdupois ounce according to the avoirdupois system of units divided by the unit for time hour" ;
   qudt:symbol "oz/hr" ;
   qudt:ucumCode "[oz_av].h-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[oz_av]/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L34" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Ounce (avoirdupois) Per Hour"@en ;
@@ -33442,6 +33606,7 @@ unit:OZ-PER-IN3
   qudt:hasQuantityKind quantitykind:MassDensity ;
   qudt:symbol "oz/in³" ;
   qudt:ucumCode "[oz_av].[cin_i]-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[oz_av]/[cin_i]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L39" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Imperial Mass Ounce per Cubic Inch"@en ;
@@ -33459,6 +33624,7 @@ unit:OZ-PER-MIN
   qudt:plainTextDescription "traditional unit of the mass avoirdupois ounce according to the avoirdupois system of units divided by the unit for time minute" ;
   qudt:symbol "oz/min" ;
   qudt:ucumCode "[oz_av].min-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[oz_av]/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L35" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Ounce (avoirdupois) Per Minute"@en ;
@@ -33476,6 +33642,7 @@ unit:OZ-PER-SEC
   qudt:plainTextDescription "traditional unit of the mass avoirdupois ounce according to the avoirdupois system of units divided by the SI base unit second" ;
   qudt:symbol "oz/s" ;
   qudt:ucumCode "[oz_av].s-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[oz_av]/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L36" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Ounce (avoirdupois) Per Second"@en ;
@@ -33495,6 +33662,7 @@ unit:OZ-PER-YD2
   qudt:iec61360Code "0112/2///62720#UAB104" ;
   qudt:symbol "oz/yd³{US}" ;
   qudt:ucumCode "[oz_av].[syd_i]-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[oz_av]/[syd_i]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "ON" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Imperial Mass Ounce per Square Yard"@en ;
@@ -33513,6 +33681,7 @@ unit:OZ-PER-YD3
   qudt:plainTextDescription "unit ounce  according to the avoirdupois system of units divided by the power of the unit yard according to the Anglo-American and the Imperial system of units with the exponent 3" ;
   qudt:symbol "oz/yd³" ;
   qudt:ucumCode "[oz_av].[cyd_i]-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[oz_av]/[cyd_i]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G32" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Ounce (avoirdupois) Per Cubic Yard"@en ;
@@ -33698,6 +33867,7 @@ unit:OZ_VOL_UK-PER-DAY
   qudt:plainTextDescription "unit of the volume fluid ounce (UK) for fluids according to the Imperial system of units divided by the unit for time day" ;
   qudt:symbol "oz{UK}/day" ;
   qudt:ucumCode "[foz_br].d-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[foz_br]/d"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J95" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Ounce (UK Fluid) Per Day"@en ;
@@ -33715,6 +33885,7 @@ unit:OZ_VOL_UK-PER-HR
   qudt:plainTextDescription "unit of the volume fluid ounce (UK) for fluids according to the Imperial system of units divided by the unit for time hour" ;
   qudt:symbol "oz{UK}/hr" ;
   qudt:ucumCode "[foz_br].h-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[foz_br]/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J96" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Ounce (UK Fluid) Per Hour"@en ;
@@ -33732,6 +33903,7 @@ unit:OZ_VOL_UK-PER-MIN
   qudt:plainTextDescription "unit of the volume fluid ounce (UK) for fluids according to the Imperial system of units divided by the unit for time minute" ;
   qudt:symbol "oz{UK}/min" ;
   qudt:ucumCode "[foz_br].min-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[foz_br]/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J97" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Ounce (UK Fluid) Per Minute"@en ;
@@ -33749,6 +33921,7 @@ unit:OZ_VOL_UK-PER-SEC
   qudt:plainTextDescription "unit of the volume fluid ounce (UK) for fluids according to the Imperial system of units divided by the SI base unit second" ;
   qudt:symbol "oz{UK}/s" ;
   qudt:ucumCode "[foz_br].s-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[foz_br]/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J98" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Ounce (UK Fluid) Per Second"@en ;
@@ -33783,6 +33956,7 @@ unit:OZ_VOL_US-PER-DAY
   qudt:plainTextDescription "unit of the volume fluid ounce (US) for fluids according to the Anglo-American system of units divided by unit for time day" ;
   qudt:symbol "fl oz{US}/day" ;
   qudt:ucumCode "[foz_us].d-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[foz_us]/d"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J99" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Ounce (US Fluid) Per Day"@en ;
@@ -33800,6 +33974,7 @@ unit:OZ_VOL_US-PER-HR
   qudt:plainTextDescription "unit of the volume fluid ounce (US) for fluids according to the Anglo-American system of units divided by the unit for time hour" ;
   qudt:symbol "fl oz{US}/hr" ;
   qudt:ucumCode "[foz_us].h-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[foz_us]/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K10" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Ounce (US Fluid) Per Hour"@en ;
@@ -33817,6 +33992,7 @@ unit:OZ_VOL_US-PER-MIN
   qudt:plainTextDescription "unit of the volume fluid ounce (US) for fluids according to the Anglo-American system of units divided by the unit for time minute" ;
   qudt:symbol "fl oz{US}/min" ;
   qudt:ucumCode "[foz_us].min-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[foz_us]/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K11" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Ounce (US Fluid) Per Minute"@en ;
@@ -33834,6 +34010,7 @@ unit:OZ_VOL_US-PER-SEC
   qudt:plainTextDescription "unit of the volume fluid ounce (US) for fluids according to the Anglo-American system of units divided by the SI base unit second" ;
   qudt:symbol "fl oz{US}/s" ;
   qudt:ucumCode "[foz_us].s-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[foz_us]/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K12" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Ounce (US Fluid) Per Second"@en ;
@@ -33920,6 +34097,7 @@ unit:PA-L-PER-SEC
   qudt:plainTextDescription "product out of the SI derived unit pascal and the unit litre divided by the SI base unit second" ;
   qudt:symbol "Pa·L/s" ;
   qudt:ucumCode "Pa.L.s-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "Pa.L/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F99" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Pascal Liter Per Second"@en-us ;
@@ -33952,6 +34130,7 @@ unit:PA-M-PER-SEC
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:symbol "Pa·m/s" ;
   qudt:ucumCode "Pa.m.s-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "Pa.m/s"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Pascal metres per second"@en ;
 .
@@ -34035,6 +34214,7 @@ unit:PA-M3-PER-SEC
   qudt:plainTextDescription "product out of the SI derived unit pascal and the power of the SI base unit metre with the exponent 3 divided by the SI base unit second" ;
   qudt:symbol "Pa·m³/s" ;
   qudt:ucumCode "Pa.m3.s-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "Pa.m3/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G01" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Pascal Cubic Meter Per Second"@en-us ;
@@ -34052,6 +34232,7 @@ unit:PA-PER-BAR
   qudt:plainTextDescription "SI derived unit pascal divided by the unit bar" ;
   qudt:symbol "Pa/bar" ;
   qudt:ucumCode "Pa.bar-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "Pa/bar"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F07" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Pascal Per Bar"@en ;
@@ -34070,6 +34251,7 @@ unit:PA-PER-HR
   qudt:hasQuantityKind quantitykind:ForcePerAreaTime ;
   qudt:symbol "Pa/hr" ;
   qudt:ucumCode "Pa.h-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "Pa/h"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Pascal per Hour"@en ;
 .
@@ -34084,6 +34266,7 @@ unit:PA-PER-K
   qudt:iec61360Code "0112/2///62720#UAA259" ;
   qudt:symbol "Pa/K" ;
   qudt:ucumCode "Pa.K-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "Pa/K"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C64" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Pascal per Kelvin"@en ;
@@ -34123,6 +34306,7 @@ unit:PA-PER-MIN
   qudt:hasQuantityKind quantitykind:ForcePerAreaTime ;
   qudt:symbol "Pa/min" ;
   qudt:ucumCode "Pa.min-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "Pa/min"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Pascal per Minute"@en ;
 .
@@ -34198,6 +34382,7 @@ unit:PA-SEC-PER-BAR
   qudt:plainTextDescription "product out of the SI derived unit pascal and the SI base unit second divided by the unit bar" ;
   qudt:symbol "Pa·s/bar" ;
   qudt:ucumCode "Pa.s.bar-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "Pa.s/bar"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H07" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Pascal Second Per Bar"@en ;
@@ -34212,6 +34397,7 @@ unit:PA-SEC-PER-K
   qudt:iec61360Code "0112/2///62720#UAA266" ;
   qudt:symbol "Pa·s/K" ;
   qudt:ucumCode "Pa.s.K-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "Pa.s/K"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F77" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "pascal second per kelvin" ;
@@ -34226,6 +34412,7 @@ unit:PA-SEC-PER-L
   qudt:iec61360Code "0112/2///62720#UAB499" ;
   qudt:symbol "Pa·s/l" ;
   qudt:ucumCode "Pa.s.L-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "Pa.s/L"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M32" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "pascal second per litre" ;
@@ -34248,6 +34435,7 @@ unit:PA-SEC-PER-M
   qudt:siUnitsExpression "Pa.s/m" ;
   qudt:symbol "Pa·s/m" ;
   qudt:ucumCode "Pa.s.m-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "Pa.s/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C67" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Pascal Second Per Meter"@en-us ;
@@ -34495,6 +34683,7 @@ unit:PER-ANGSTROM
   qudt:plainTextDescription "reciprocal of the unit angstrom" ;
   qudt:symbol "/Å" ;
   qudt:ucumCode "Ao-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "/Ao"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C85" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Reciprocal Angstrom"@en ;
@@ -34513,6 +34702,7 @@ unit:PER-BAR
   qudt:plainTextDescription "reciprocal of the metrical unit with the name bar" ;
   qudt:symbol "/bar" ;
   qudt:ucumCode "bar-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "/bar"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F58" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Reciprocal Bar"@en ;
@@ -34591,6 +34781,7 @@ unit:PER-DEG_C
   qudt:plainTextDescription "Unit for expressing the change of some quantity relative to a unit change in temperature." ;
   qudt:symbol "/°C" ;
   qudt:ucumCode ".Cel-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "/Cel"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "reciprocal degree Celsius"@en ;
 .
@@ -34604,6 +34795,7 @@ unit:PER-DEG_F
   qudt:iec61360Code "0112/2///62720#UAA047" ;
   qudt:symbol "°F⁻¹" ;
   qudt:ucumCode "[degF]-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "/[degF]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J26" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "reciprocal degree Fahrenheit" ;
@@ -34652,6 +34844,7 @@ unit:PER-FT3
   qudt:plainTextDescription "reciprocal value of the power of the unit foot according to the Anglo-American and the Imperial system of units with the exponent 3" ;
   qudt:symbol "/ft³" ;
   qudt:ucumCode "[cft_i]-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "/[cft_i]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K20" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Reciprocal Cubic Foot"@en ;
@@ -34670,6 +34863,7 @@ unit:PER-GM
   qudt:iec61360Code "0112/2///62720#UAC004" ;
   qudt:symbol "/g" ;
   qudt:ucumCode "g-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "/g"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Reciprocal gram"@en ;
 .
@@ -34703,6 +34897,7 @@ unit:PER-H
   qudt:iec61360Code "0112/2///62720#UAA169" ;
   qudt:symbol "/H" ;
   qudt:ucumCode "H-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "/H"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C89" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Reciprocal Henry"@en ;
@@ -34740,6 +34935,7 @@ unit:PER-IN
   qudt:iec61360Code "0112/2///62720#UAB360" ;
   qudt:symbol "in⁻¹" ;
   qudt:ucumCode "[in_i]-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "/[in_i]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "Q24" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "reciprocal inch" ;
@@ -34771,6 +34967,7 @@ unit:PER-IN3
   qudt:plainTextDescription "reciprocal value of the power of the unit inch according to the Anglo-American and the Imperial system of units with the exponent 3" ;
   qudt:symbol "/in³" ;
   qudt:ucumCode "[cin_i]-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "/[cin_i]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K49" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Reciprocal Cubic Inch"@en ;
@@ -34785,6 +34982,7 @@ unit:PER-J
   qudt:iec61360Code "0112/2///62720#UAB324" ;
   qudt:symbol "J⁻¹" ;
   qudt:ucumCode "J-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "/J"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "N91" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "reciprocal joule" ;
@@ -34843,6 +35041,7 @@ unit:PER-K
   qudt:iec61360Code "0112/2///62720#UAA193" ;
   qudt:symbol "/K" ;
   qudt:ucumCode "K-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "/K"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C91" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Reciprocal Kelvin"@en ;
@@ -34857,6 +35056,7 @@ unit:PER-KiloGM
   qudt:iec61360Code "0112/2///62720#UAC003" ;
   qudt:symbol "kg⁻¹" ;
   qudt:ucumCode "kg-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "/kg"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "reciprocal kilogram" ;
 .
@@ -34962,6 +35162,7 @@ unit:PER-LB
   qudt:iec61360Code "0112/2///62720#UAC008" ;
   qudt:symbol "lb⁻¹" ;
   qudt:ucumCode "[lb_av]-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "/[lb_av]"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "reciprocal pound (avoirdupois)" ;
 .
@@ -35242,6 +35443,7 @@ unit:PER-MO
   qudt:plainTextDescription "reciprocal of the unit month" ;
   qudt:symbol "/mo" ;
   qudt:ucumCode "mo-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "/mo"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H11" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Reciprocal Month"@en ;
@@ -35288,6 +35490,7 @@ unit:PER-MegaPA
   qudt:iec61360Code "0112/2///62720#UAD929" ;
   qudt:symbol "1/MPa" ;
   qudt:ucumCode "MPa-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "/MPa"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "reciprocal megapascal" ;
 .
@@ -35341,6 +35544,7 @@ unit:PER-MilliGM
   qudt:iec61360Code "0112/2///62720#UAC005" ;
   qudt:symbol "mg⁻¹" ;
   qudt:ucumCode "mg-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "/mg"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "reciprocal milligram" ;
 .
@@ -35465,6 +35669,7 @@ unit:PER-OZ
   qudt:iec61360Code "0112/2///62720#UAC007" ;
   qudt:symbol "oz⁻¹" ;
   qudt:ucumCode "[oz_av]-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "/[oz_av]"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "reciprocal ounce (avoirdupois)" ;
 .
@@ -35491,6 +35696,7 @@ unit:PER-PA
   qudt:siUnitsExpression "m^2/N" ;
   qudt:symbol "Pa⁻¹" ;
   qudt:ucumCode "Pa-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "/Pa"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C96" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Reciprocal Pascal"@en ;
@@ -35595,6 +35801,7 @@ unit:PER-RAD
   qudt:iec61360Code "0112/2///62720#UAB327" ;
   qudt:symbol "rad⁻¹" ;
   qudt:ucumCode "rad-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "/rad"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P97" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "reciprocal radian" ;
@@ -35744,6 +35951,7 @@ unit:PER-SR
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:symbol "/sr" ;
   qudt:ucumCode "sr-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "/sr"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Reciprocal steradian"@en ;
 .
@@ -35804,6 +36012,7 @@ unit:PER-TONNE
   qudt:iec61360Code "0112/2///62720#UAC006" ;
   qudt:symbol "t⁻¹" ;
   qudt:ucumCode "t-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "/t"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "reciprocal tonne" ;
 .
@@ -35817,6 +36026,7 @@ unit:PER-V
   qudt:iec61360Code "0112/2///62720#UAB326" ;
   qudt:symbol "V⁻¹" ;
   qudt:ucumCode "V-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "/V"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P96" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "reciprocal volt" ;
@@ -35849,6 +36059,7 @@ unit:PER-WB
   qudt:informativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
   qudt:symbol "/Wb" ;
   qudt:ucumCode "Wb-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "/Wb"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "Q23" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Reciprocal Weber"@en ;
@@ -35870,6 +36081,7 @@ unit:PER-WK
   qudt:plainTextDescription "reciprocal of the unit week" ;
   qudt:symbol "/wk" ;
   qudt:ucumCode "wk-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "/wk"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H85" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Reciprocal Week"@en ;
@@ -36063,6 +36275,7 @@ unit:PERCENT-HR-PER-L
   qudt:iec61360Code "0112/2///62720#UAC782" ;
   qudt:symbol "%/(l/h)" ;
   qudt:ucumCode "h.%.L-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "h.%/L"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "percent hour per litre" ;
 .
@@ -36247,6 +36460,7 @@ unit:PERCENT-PER-CentiPOISE
   qudt:iec61360Code "0112/2///62720#UAC807" ;
   qudt:symbol "%/cP" ;
   qudt:ucumCode "%.cP-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "%/cP"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "percent per centipoise" ;
 .
@@ -36258,6 +36472,7 @@ unit:PERCENT-PER-DAY
   qudt:hasQuantityKind quantitykind:Frequency ;
   qudt:symbol "%/day" ;
   qudt:ucumCode "%.d-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "%/d"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Percent per day"@en ;
 .
@@ -36271,6 +36486,7 @@ unit:PERCENT-PER-DEG
   qudt:iec61360Code "0112/2///62720#UAA002" ;
   qudt:symbol "%/°" ;
   qudt:ucumCode "%.deg-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "%/deg"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H90" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "percent per degree" ;
@@ -36296,6 +36512,7 @@ unit:PERCENT-PER-DEG_C
   qudt:iec61360Code "0112/2///62720#UAA003" ;
   qudt:symbol "%/°C" ;
   qudt:ucumCode "%.Cel-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "%/Cel"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M25" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "percent per degree Celsius" ;
@@ -36360,6 +36577,7 @@ unit:PERCENT-PER-HR
   qudt:hasQuantityKind quantitykind:Frequency ;
   qudt:symbol "%/day" ;
   qudt:ucumCode "%.h-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "%/h"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Percent per hour"@en ;
 .
@@ -36373,6 +36591,7 @@ unit:PERCENT-PER-HectoBAR
   qudt:iec61360Code "0112/2///62720#UAB373" ;
   qudt:symbol "%/hbar" ;
   qudt:ucumCode "%.hbar-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "%/hbar"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H72" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "percent per hectobar" ;
@@ -36401,6 +36620,7 @@ unit:PERCENT-PER-K
   qudt:iec61360Code "0112/2///62720#UAA008" ;
   qudt:symbol "%/K" ;
   qudt:ucumCode "%.K-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "%/K"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H25" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "percent per kelvin" ;
@@ -36428,6 +36648,7 @@ unit:PERCENT-PER-M
   qudt:iec61360Code "0112/2///62720#UAA013" ;
   qudt:symbol "%/m" ;
   qudt:ucumCode "%.m-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "%/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H99" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Percent per metre"@en ;
@@ -36442,6 +36663,7 @@ unit:PERCENT-PER-MO
   qudt:iec61360Code "0112/2///62720#UAB372" ;
   qudt:symbol "%/mo" ;
   qudt:ucumCode "%.mo-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "%/mo"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H71" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "percent per month" ;
@@ -36456,6 +36678,7 @@ unit:PERCENT-PER-MilliM
   qudt:iec61360Code "0112/2///62720#UAA014" ;
   qudt:symbol "%/mm" ;
   qudt:ucumCode "%.mm-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "%/mm"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J10" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "percent per millimetre" ;
@@ -36483,6 +36706,7 @@ unit:PERCENT-PER-OHM
   qudt:iec61360Code "0112/2///62720#UAA001" ;
   qudt:symbol "%/Ω" ;
   qudt:ucumCode "%.Ohm-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "%/Ohm"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H89" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "percent per ohm" ;
@@ -36510,6 +36734,7 @@ unit:PERCENT-PER-PERCENT
   qudt:iec61360Code "0112/2///62720#UAD871" ;
   qudt:symbol "%/%" ;
   qudt:ucumCode "%.%-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "%/%"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "percent per percent" ;
 .
@@ -36523,6 +36748,7 @@ unit:PERCENT-PER-POISE
   qudt:iec61360Code "0112/2///62720#UAC806" ;
   qudt:symbol "%/P" ;
   qudt:ucumCode "%.P-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "%/P"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "percent per poise" ;
 .
@@ -36536,6 +36762,7 @@ unit:PERCENT-PER-V
   qudt:iec61360Code "0112/2///62720#UAA009" ;
   qudt:symbol "%/V" ;
   qudt:ucumCode "%.V-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "%/V"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H95" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "percent per volt" ;
@@ -36549,6 +36776,7 @@ unit:PERCENT-PER-WK
   qudt:hasQuantityKind quantitykind:Frequency ;
   qudt:symbol "%/wk" ;
   qudt:ucumCode "%.wk-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "%/wk"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Percent per week"@en ;
 .
@@ -36627,6 +36855,7 @@ unit:PERCENT-SEC-PER-L
   qudt:iec61360Code "0112/2///62720#UAC798" ;
   qudt:symbol "%/(l/s)" ;
   qudt:ucumCode "%.s.L-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "%.s/L"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "percent second per litre" ;
 .
@@ -36934,6 +37163,7 @@ unit:PINT_UK-PER-HR
   qudt:plainTextDescription "unit of the volume pint (UK) (both for fluids and for dry measures) according to the Imperial system of units divided by the unit for time hour" ;
   qudt:symbol "pt{UK}/hr" ;
   qudt:ucumCode "[pt_br].h-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[pt_br]/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L54" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Pint (UK) Per Hour"@en ;
@@ -36951,6 +37181,7 @@ unit:PINT_UK-PER-MIN
   qudt:plainTextDescription "unit of the volume pint (UK) (both for fluids and for dry measures) according to the Imperial system of units divided by the unit for time minute" ;
   qudt:symbol "pt{UK}/min" ;
   qudt:ucumCode "[pt_br].min-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[pt_br]/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L55" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Pint (UK) Per Minute"@en ;
@@ -36968,6 +37199,7 @@ unit:PINT_UK-PER-SEC
   qudt:plainTextDescription "unit of the volume pint (UK) (both for fluids and for dry measures) according to the Imperial system of units divided by the SI base unit second" ;
   qudt:symbol "pt{UK}/s" ;
   qudt:ucumCode "[pt_br].s-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[pt_br]/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L56" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Pint (UK) Per Second"@en ;
@@ -37003,6 +37235,7 @@ unit:PINT_US-PER-DAY
   qudt:plainTextDescription "unit of the volume pint (US liquid) according to the Anglo-American system of units divided by the unit for time day" ;
   qudt:symbol "pt{US}/day" ;
   qudt:ucumCode "[pt_us].d-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[pt_us]/d"^^qudt:UCUMcs ;
   qudt:udunitsCode "kg" ;
   qudt:uneceCommonCode "L57" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -37021,6 +37254,7 @@ unit:PINT_US-PER-HR
   qudt:plainTextDescription "unit of the volume pint (US liquid) according to the Anglo-American system of units divided by the unit for time hour" ;
   qudt:symbol "pt{US}/hr" ;
   qudt:ucumCode "[pt_us].h-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[pt_us]/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L58" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Pint (US Liquid) Per Hour"@en ;
@@ -37038,6 +37272,7 @@ unit:PINT_US-PER-MIN
   qudt:plainTextDescription "unit of the volume pint (US liquid) according to the Anglo-American system of units divided by the unit for time minute" ;
   qudt:symbol "pt{US}/min" ;
   qudt:ucumCode "[pt_us].min-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[pt_us]/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L59" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Pint (US Liquid) Per Minute"@en ;
@@ -37055,6 +37290,7 @@ unit:PINT_US-PER-SEC
   qudt:plainTextDescription "unit of the volume pint (US liquid) according to the Anglo-American system of units divided by the SI base unit second" ;
   qudt:symbol "pt{US}/s" ;
   qudt:ucumCode "[pt_us].s-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[pt_us]/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L60" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Pint (US Liquid) Per Second"@en ;
@@ -37116,6 +37352,7 @@ unit:PK_UK-PER-DAY
   qudt:plainTextDescription "unit of the volume peck (UK) according to the Imperial system of units divided by the unit for time day" ;
   qudt:symbol "peck{UK}/day" ;
   qudt:ucumCode "[pk_br].d-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[pk_br]/d"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L44" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Peck (UK) Per Day"@en ;
@@ -37133,6 +37370,7 @@ unit:PK_UK-PER-HR
   qudt:plainTextDescription "unit of the volume peck (UK) according to the Imperial system of units divided by the unit for time hour" ;
   qudt:symbol "peck{UK}/hr" ;
   qudt:ucumCode "[pk_br].h-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[pk_br]/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L45" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Peck (UK) Per Hour"@en ;
@@ -37150,6 +37388,7 @@ unit:PK_UK-PER-MIN
   qudt:plainTextDescription "unit of the volume peck (UK) according to the Imperial system of units divided by the unit for time minute" ;
   qudt:symbol "peck{UK}/min" ;
   qudt:ucumCode "[pk_br].min-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[pk_br]/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L46" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Peck (UK) Per Minute"@en ;
@@ -37167,6 +37406,7 @@ unit:PK_UK-PER-SEC
   qudt:plainTextDescription "unit of the volume peck (UK) according to the Imperial system of units divided by the SI base unit second" ;
   qudt:symbol "peck{UK}/s" ;
   qudt:ucumCode "[pk_br].s-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[pk_br]/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L47" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Peck (UK) Per Second"@en ;
@@ -37202,6 +37442,7 @@ unit:PK_US_DRY-PER-DAY
   qudt:plainTextDescription "unit of the volume peck (US dry) as dry measure according to the Anglo-American system of units divided by the unit for time day" ;
   qudt:symbol "peck{US Dry}/day" ;
   qudt:ucumCode "[pk_us].d-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[pk_us]/d"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L48" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Peck (US Dry) Per Day"@en ;
@@ -37219,6 +37460,7 @@ unit:PK_US_DRY-PER-HR
   qudt:plainTextDescription "unit of the volume peck (US dry) as dry measure according to the Anglo-American system of units divided by the unit for time hour" ;
   qudt:symbol "peck{US Dry}/hr" ;
   qudt:ucumCode "[pk_us].h-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[pk_us]/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L49" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Peck (US Dry) Per Hour"@en ;
@@ -37236,6 +37478,7 @@ unit:PK_US_DRY-PER-MIN
   qudt:plainTextDescription "unit of the volume peck (US dry) as dry measure according to the Anglo-American system of units divided by the unit for time minute" ;
   qudt:symbol "peck{US Dry}/min" ;
   qudt:ucumCode "[pk_us].min-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[pk_us]/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L50" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Peck (US Dry) Per Minute"@en ;
@@ -37253,6 +37496,7 @@ unit:PK_US_DRY-PER-SEC
   qudt:plainTextDescription "unit of the volume peck (US dry) as dry measure according to the Anglo-American system of units divided by the SI base unit second" ;
   qudt:symbol "peck{US Dry}/s" ;
   qudt:ucumCode "[pk_us].s-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[pk_us]/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L51" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Peck (US Dry) Per Second"@en ;
@@ -37292,6 +37536,7 @@ unit:POISE-PER-BAR
   qudt:plainTextDescription "CGS unit poise divided by the unit bar" ;
   qudt:symbol "P/bar" ;
   qudt:ucumCode "P.bar-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "P/bar"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F06" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Poise Per Bar"@en ;
@@ -37306,6 +37551,7 @@ unit:POISE-PER-K
   qudt:iec61360Code "0112/2///62720#UAA256" ;
   qudt:symbol "P/K" ;
   qudt:ucumCode "P.K-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "P/K"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F86" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "poise per kelvin" ;
@@ -37320,6 +37566,7 @@ unit:POISE-PER-PA
   qudt:iec61360Code "0112/2///62720#UAB311" ;
   qudt:symbol "P/Pa" ;
   qudt:ucumCode "P.Pa-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "P/Pa"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "N35" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "poise per pascal" ;
@@ -37395,6 +37642,7 @@ unit:PPM-PER-K
   qudt:hasQuantityKind quantitykind:ThermalExpansionCoefficient ;
   qudt:symbol "PPM/K" ;
   qudt:ucumCode "ppm.K-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "ppm/K"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Parts-Per-Million per Kelvin"@en ;
 .
@@ -37474,6 +37722,7 @@ unit:PPTH-PER-HR
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:symbol "‰/hr" ;
   qudt:ucumCode "[ppth].h-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[ppth]/h"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Parts-per-thousand per hour"@en ;
 .
@@ -37617,6 +37866,7 @@ unit:PSI-M3-PER-SEC
   qudt:plainTextDescription "product of the composed unit for pressure (pound-force per square inch) and the composed unit for volume flow (cubic metre per second)" ;
   qudt:symbol "psi·m³/s" ;
   qudt:ucumCode "[psi].m3.s-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[psi].m3/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K89" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "PSI Cubic Meter Per Second"@en-us ;
@@ -37837,6 +38087,7 @@ unit:PetaBIT-PER-SEC
   qudt:iec61360Code "0112/2///62720#UAA270" ;
   qudt:symbol "Pbit/s" ;
   qudt:ucumCode "Pbit.s-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "Pbit/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E79" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "petabit per second" ;
@@ -37952,6 +38203,7 @@ unit:PetaJ-PER-SEC
   qudt:iec61360Code "0112/2///62720#UAB514" ;
   qudt:symbol "PJ/s" ;
   qudt:ucumCode "PJ.s-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "PJ/s"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "petajoule per second" ;
 .
@@ -38007,6 +38259,7 @@ unit:PicoA-PER-HectoPA
   qudt:iec61360Code "0112/2///62720#UAD930" ;
   qudt:symbol "pA/hPa" ;
   qudt:ucumCode "pA.hPa-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "pA/hPa"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "picoampere per hectopascal" ;
 .
@@ -38083,6 +38336,7 @@ unit:PicoFARAD-PER-M
   qudt:plainTextDescription "0.000000000001-fold of the SI derived unit farad divided by the SI base unit metre" ;
   qudt:symbol "pF/m" ;
   qudt:ucumCode "pF.m-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "pF/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C72" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Picofarad Per Meter"@en-us ;
@@ -38121,6 +38375,7 @@ unit:PicoGM-PER-GM
   qudt:qkdvNumerator qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:symbol "pg/g" ;
   qudt:ucumCode "pg.g-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "pg/g"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Picograms per gram"@en ;
 .
@@ -38139,6 +38394,7 @@ unit:PicoGM-PER-KiloGM
   qudt:qkdvNumerator qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:symbol "pg/kg" ;
   qudt:ucumCode "pg.kg-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "pg/kg"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Picograms per kilogram"@en ;
 .
@@ -38156,6 +38412,7 @@ unit:PicoGM-PER-L
   qudt:hasQuantityKind quantitykind:MassDensity ;
   qudt:symbol "pg/L" ;
   qudt:ucumCode "pg.L-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "pg/L"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Picograms per litre"@en ;
 .
@@ -38223,6 +38480,7 @@ unit:PicoJ-PER-SEC
   qudt:iec61360Code "0112/2///62720#UAB508" ;
   qudt:symbol "pJ/s" ;
   qudt:ucumCode "pJ.s-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "pJ/s"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "picojoule per second" ;
 .
@@ -38304,6 +38562,7 @@ unit:PicoMOL-PER-KiloGM
   qudt:hasQuantityKind quantitykind:AmountOfSubstancePerUnitMass ;
   qudt:symbol "pmol/kg" ;
   qudt:ucumCode "pmol.kg-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "pmol/kg"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Picomoles per kilogram"@en ;
 .
@@ -38318,6 +38577,7 @@ unit:PicoMOL-PER-L
   qudt:hasQuantityKind quantitykind:Solubility_Water ;
   qudt:symbol "pmol/L" ;
   qudt:ucumCode "pmol.L-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "pmol/L"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Picomoles per litre"@en ;
 .
@@ -38431,6 +38691,7 @@ unit:PicoPA-PER-KiloM
   qudt:plainTextDescription "0.000000000001-fold of the SI derived unit pascal divided by the 1 000-fold of the SI base unit metre" ;
   qudt:symbol "pPa/km" ;
   qudt:ucumCode "pPa.km-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "pPa/km"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H69" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Picopascal Per Kilometer"@en-us ;
@@ -38469,6 +38730,7 @@ unit:PicoS-PER-M
   qudt:plainTextDescription "0.000000000001-fold of the SI derived unit Siemens divided by the SI base unit metre" ;
   qudt:symbol "pS/m" ;
   qudt:ucumCode "pS.m-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "pS/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L42" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Picosiemens Per Meter"@en-us ;
@@ -38989,6 +39251,7 @@ unit:QT_US-PER-DAY
   qudt:plainTextDescription "unit fo the volume quart (US liquid) for fluids according to the Anglo-American system of units divided by the unit for time day" ;
   qudt:symbol "qt/day" ;
   qudt:ucumCode "[qt_us].d-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[qt_us]/d"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K98" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Quart (US Liquid) Per Day"@en ;
@@ -39006,6 +39269,7 @@ unit:QT_US-PER-HR
   qudt:plainTextDescription "unit fo the volume quart (US liquid) for fluids according to the Anglo-American system of units divided by the unit for time hour" ;
   qudt:symbol "qt/hr" ;
   qudt:ucumCode "[qt_us].h-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[qt_us]/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K99" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Quart (US Liquid) Per Hour"@en ;
@@ -39023,6 +39287,7 @@ unit:QT_US-PER-MIN
   qudt:plainTextDescription "unit fo the volume quart (US liquid) for fluids according to the Anglo-American system of units divided by the unit for time minute" ;
   qudt:symbol "qt/min" ;
   qudt:ucumCode "[qt_us].min-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[qt_us]/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L10" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Quart (US Liquid) Per Minute"@en ;
@@ -39040,6 +39305,7 @@ unit:QT_US-PER-SEC
   qudt:plainTextDescription "unit fo the volume quart (US liquid) for fluids according to the Anglo-American system of units divided by the SI base unit second" ;
   qudt:symbol "qt/s" ;
   qudt:ucumCode "[qt_us].s-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[qt_us]/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L11" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Quart (US Liquid) Per Second"@en ;
@@ -39125,6 +39391,7 @@ unit:R-PER-SEC
   qudt:iec61360Code "0112/2///62720#UAA276" ;
   qudt:symbol "R/s" ;
   qudt:ucumCode "R.s-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "R/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D6" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "roentgen per second" ;
@@ -39195,6 +39462,7 @@ unit:RAD-M2-PER-KiloGM
   qudt:iec61360Code "0112/2///62720#UAB162" ;
   qudt:symbol "rad·m²/kg" ;
   qudt:ucumCode "rad.m2.kg-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "rad.m2/kg"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C83" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Radian Square Meter per Kilogram"@en-us ;
@@ -39211,6 +39479,7 @@ unit:RAD-M2-PER-MOL
   qudt:iec61360Code "0112/2///62720#UAB161" ;
   qudt:symbol "rad·m²/mol" ;
   qudt:ucumCode "rad.m2.mol-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "rad.m2/mol"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C82" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Radian Square Meter per Mole"@en-us ;
@@ -39253,6 +39522,7 @@ unit:RAD-PER-M
   qudt:informativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
   qudt:symbol "rad/m" ;
   qudt:ucumCode "rad.m-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "rad/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C84" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Radian per Meter"@en-us ;
@@ -39415,6 +39685,7 @@ unit:REM-PER-SEC
   qudt:iec61360Code "0112/2///62720#UAB442" ;
   qudt:symbol "rem/s" ;
   qudt:ucumCode "REM.s-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "REM/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P69" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "rem per second" ;
@@ -39655,6 +39926,7 @@ unit:S-M2-PER-MOL
   qudt:iec61360Code "0112/2///62720#UAA280" ;
   qudt:symbol "S·m²/mol" ;
   qudt:ucumCode "S.m2.mol-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "S.m2/mol"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D12" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Siemens Square meter per mole"@en-us ;
@@ -39674,6 +39946,7 @@ unit:S-PER-CentiM
   qudt:plainTextDescription "SI derived unit Siemens divided by the 0.01-fold of the SI base unit metre" ;
   qudt:symbol "S/cm" ;
   qudt:ucumCode "S.cm-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "S/cm"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H43" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Siemens Per Centimeter"@en-us ;
@@ -39825,6 +40098,7 @@ unit:SEC-PER-KiloGM
   qudt:iec61360Code "0112/2///62720#UAD530" ;
   qudt:symbol "s/kg" ;
   qudt:ucumCode "s.kg-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "s/kg"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "Q20" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "second per kilogram" ;
@@ -39842,6 +40116,7 @@ unit:SEC-PER-M
   qudt:iec61360Code "0112/2///62720#UAD709" ;
   qudt:symbol "s/m" ;
   qudt:ucumCode "s.m-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "s/m"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Seconds per metre"@en ;
 .
@@ -40217,6 +40492,7 @@ unit:ST-PER-BAR
   qudt:iec61360Code "0112/2///62720#UAA283" ;
   qudt:symbol "St/bar" ;
   qudt:ucumCode "St.bar-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "St/bar"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G46" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "stokes per bar" ;
@@ -40231,6 +40507,7 @@ unit:ST-PER-K
   qudt:iec61360Code "0112/2///62720#UAA282" ;
   qudt:symbol "St/K" ;
   qudt:ucumCode "St.K-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "St/K"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G10" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "stokes per kelvin" ;
@@ -40245,6 +40522,7 @@ unit:ST-PER-PA
   qudt:iec61360Code "0112/2///62720#UAB314" ;
   qudt:symbol "St/Pa" ;
   qudt:ucumCode "St.Pa-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "St/Pa"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M80" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "stokes per pascal" ;
@@ -40390,6 +40668,7 @@ unit:SV-PER-HR
   qudt:iec61360Code "0112/2///62720#UAB464" ;
   qudt:symbol "Sv/h" ;
   qudt:ucumCode "Sv.h-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "Sv/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P70" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "sievert per hour" ;
@@ -40404,6 +40683,7 @@ unit:SV-PER-MIN
   qudt:iec61360Code "0112/2///62720#UAB468" ;
   qudt:symbol "Sv/min" ;
   qudt:ucumCode "Sv.min-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "Sv/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P74" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "sievert per minute" ;
@@ -40418,6 +40698,7 @@ unit:SV-PER-SEC
   qudt:iec61360Code "0112/2///62720#UAB301" ;
   qudt:symbol "Sv/s" ;
   qudt:ucumCode "Sv.s-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "Sv/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P65" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "sievert per second" ;
@@ -40761,6 +41042,7 @@ unit:TONNE-PER-BAR
   qudt:iec61360Code "0112/2///62720#UAA990" ;
   qudt:symbol "t/bar" ;
   qudt:ucumCode "t.bar-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "t/bar"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L70" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "tonne per bar" ;
@@ -40781,6 +41063,7 @@ unit:TONNE-PER-DAY
   qudt:plainTextDescription "metric unit tonne divided by the unit for time day" ;
   qudt:symbol "t/day" ;
   qudt:ucumCode "t.d-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "t/d"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L71" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Tonne Per Day"@en ;
@@ -40830,6 +41113,7 @@ unit:TONNE-PER-HA
   qudt:plainTextDescription "A measure of density equivalent to 1000kg per hectare or one Megagram per hectare, typically used to express a volume of biomass or crop yield." ;
   qudt:symbol "t/ha" ;
   qudt:ucumCode "t.har-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "t/har"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "tonne per hectare"@en ;
 .
@@ -40867,6 +41151,7 @@ unit:TONNE-PER-HR
   qudt:plainTextDescription "unit tonne divided by the unit for time hour" ;
   qudt:symbol "t/hr" ;
   qudt:ucumCode "t.h-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "t/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E18" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Tonne Per Hour"@en ;
@@ -40909,6 +41194,7 @@ unit:TONNE-PER-K
   qudt:iec61360Code "0112/2///62720#UAA989" ;
   qudt:symbol "t/K" ;
   qudt:ucumCode "t.K-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "t/K"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L69" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "tonne per kelvin" ;
@@ -40979,6 +41265,7 @@ unit:TONNE-PER-MIN
   qudt:plainTextDescription "unit tonne divided by the unit for time minute" ;
   qudt:symbol "t/min" ;
   qudt:ucumCode "t.min-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "t/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L78" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Tonne Per Minute"@en ;
@@ -41021,6 +41308,7 @@ unit:TONNE-PER-MO
   qudt:iec61360Code "0112/2///62720#UAB366" ;
   qudt:symbol "t/mo" ;
   qudt:ucumCode "t.mo-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "t/mo"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M88" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "tonne per month" ;
@@ -41041,6 +41329,7 @@ unit:TONNE-PER-SEC
   qudt:plainTextDescription "unit tonne divided by the SI base unit second" ;
   qudt:symbol "t/s" ;
   qudt:ucumCode "t.s-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "t/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L81" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Tonne Per Second"@en ;
@@ -41087,6 +41376,7 @@ unit:TONNE-PER-YR
   qudt:iec61360Code "0112/2///62720#UAB367" ;
   qudt:symbol "t/y" ;
   qudt:ucumCode "t.a-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "t/a"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M89" ;
   rdfs:isDefinedBy <http://qudt.org/vocab/unit> ;
   rdfs:label "Ton Per Jaar"@nl ;
@@ -41226,6 +41516,7 @@ unit:TON_Metric-PER-BAR
   qudt:iec61360Code "0112/2///62720#UAA990" ;
   qudt:symbol "t/bar" ;
   qudt:ucumCode "t.bar-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "t/bar"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L70" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "tonne per bar" ;
@@ -41246,6 +41537,7 @@ unit:TON_Metric-PER-DAY
   qudt:plainTextDescription "metric unit ton divided by the unit for time day" ;
   qudt:symbol "t/day" ;
   qudt:ucumCode "t.d-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "t/d"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L71" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Tonne Per Day"@en ;
@@ -41295,6 +41587,7 @@ unit:TON_Metric-PER-HA
   qudt:plainTextDescription "A measure of density equivalent to 1000kg per hectare or one Megagram per hectare, typically used to express a volume of biomass or crop yield." ;
   qudt:symbol "t/ha" ;
   qudt:ucumCode "t.har-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "t/har"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "metric tonne per hectare"@en ;
 .
@@ -41314,6 +41607,7 @@ unit:TON_Metric-PER-HR
   qudt:plainTextDescription "unit tonne divided by the unit for time hour" ;
   qudt:symbol "t/hr" ;
   qudt:ucumCode "t.h-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "t/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E18" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Tonne Per Hour"@en ;
@@ -41356,6 +41650,7 @@ unit:TON_Metric-PER-K
   qudt:iec61360Code "0112/2///62720#UAA989" ;
   qudt:symbol "t/K" ;
   qudt:ucumCode "t.K-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "t/K"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L69" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "tonne per kelvin" ;
@@ -41412,6 +41707,7 @@ unit:TON_Metric-PER-MIN
   qudt:plainTextDescription "unit ton divided by the unit for time minute" ;
   qudt:symbol "t/min" ;
   qudt:ucumCode "t.min-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "t/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L78" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Tonne Per Minute"@en ;
@@ -41460,6 +41756,7 @@ unit:TON_Metric-PER-SEC
   qudt:plainTextDescription "unit ton divided by the SI base unit second" ;
   qudt:symbol "t/s" ;
   qudt:ucumCode "t.s-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "t/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L81" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Tonne Per Second (metric Ton)"@en ;
@@ -41674,6 +41971,7 @@ unit:TON_UK-PER-DAY
   qudt:plainTextDescription "unit British ton according to the Imperial system of units divided by the unit day" ;
   qudt:symbol "ton{UK}/day" ;
   qudt:ucumCode "[lton_av].d-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[lton_av]/d"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L85" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Long Ton (uk) Per Day"@en ;
@@ -41725,6 +42023,7 @@ unit:TON_US-PER-DAY
   qudt:plainTextDescription "unit American ton according to the Anglo-American system of units divided by the unit day" ;
   qudt:symbol "ton{US}/day" ;
   qudt:ucumCode "[ston_av].d-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[ston_av]/d"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L88" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Short Ton (us) Per Day"@en ;
@@ -41743,6 +42042,7 @@ unit:TON_US-PER-HR
   qudt:plainTextDescription "unit ton divided by the unit for time hour" ;
   qudt:symbol "ton{US}/hr" ;
   qudt:ucumCode "[ston_av].h-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[ston_av]/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "4W" ;
   qudt:uneceCommonCode "E18" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -41934,6 +42234,7 @@ unit:TeraBIT-PER-SEC
   qudt:iec61360Code "0112/2///62720#UAA291" ;
   qudt:symbol "Tbit/s" ;
   qudt:ucumCode "Tbit.s-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "Tbit/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E84" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "terabit per second" ;
@@ -42059,6 +42360,7 @@ unit:TeraJ-PER-SEC
   qudt:iec61360Code "0112/2///62720#UAB513" ;
   qudt:symbol "TJ/s" ;
   qudt:ucumCode "TJ.s-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "TJ/s"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "terajoule per second" ;
 .
@@ -42422,6 +42724,7 @@ unit:V-A-PER-K
   qudt:iec61360Code "0112/2///62720#UAD905" ;
   qudt:symbol "V·A/K" ;
   qudt:ucumCode "V.A.K-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "V.A/K"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "volt ampere per kelvin" ;
 .
@@ -42501,6 +42804,7 @@ unit:V-PER-BAR
   qudt:iec61360Code "0112/2///62720#UAA299" ;
   qudt:symbol "V/bar" ;
   qudt:ucumCode "V.bar-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "V/bar"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G60" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "volt per bar" ;
@@ -42519,6 +42823,7 @@ unit:V-PER-CentiM
   qudt:plainTextDescription "derived SI unit volt divided by the 0.01-fold of the SI base unit metre" ;
   qudt:symbol "V/cm" ;
   qudt:ucumCode "V.cm-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "V/cm"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D47" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Volt Per Centimeter"@en-us ;
@@ -42552,6 +42857,7 @@ unit:V-PER-K
   qudt:informativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
   qudt:symbol "V/K" ;
   qudt:ucumCode "V.K-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "V/K"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D48" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Volt per Kelvin"@en ;
@@ -42589,6 +42895,7 @@ unit:V-PER-M
   qudt:informativeReference "http://www.efunda.com/glossary/units/units--electric_field_strength--volt_per_meter.cfm"^^xsd:anyURI ;
   qudt:symbol "V/m" ;
   qudt:ucumCode "V.m-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "V/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D50" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Volt je Meter"@de ;
@@ -42644,6 +42951,7 @@ unit:V-PER-MicroSEC
   qudt:plainTextDescription "SI derived unit volt divided by the 0.000001-fold of the SI base unit second" ;
   qudt:symbol "V/µs" ;
   qudt:ucumCode "V.us-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "V/us"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H24" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Volt Per Microsecond"@en ;
@@ -42662,6 +42970,7 @@ unit:V-PER-MilliM
   qudt:plainTextDescription "SI derived unit volt divided by the 0.001-fold of the SI base unit metre" ;
   qudt:symbol "V/mm" ;
   qudt:ucumCode "V.mm-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "V/mm"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D51" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Volt Per Millimeter"@en-us ;
@@ -42677,6 +42986,7 @@ unit:V-PER-PA
   qudt:iec61360Code "0112/2///62720#UAB312" ;
   qudt:symbol "V/Pa" ;
   qudt:ucumCode "V.Pa-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "V/Pa"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "N98" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "volt per pascal" ;
@@ -42698,6 +43008,7 @@ unit:V-PER-SEC
   qudt:informativeReference "http://www.thefreedictionary.com/Webers"^^xsd:anyURI ;
   qudt:symbol "V/s" ;
   qudt:ucumCode "V.s-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "V/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H46" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Volt per second"@en ;
@@ -42712,6 +43023,7 @@ unit:V-PER-V
   qudt:iec61360Code "0112/2///62720#UAD862" ;
   qudt:symbol "V/V" ;
   qudt:ucumCode "V.V-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "V/V"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "volt per volt" ;
 .
@@ -42731,6 +43043,7 @@ unit:V-SEC-PER-M
   qudt:plainTextDescription "product of the SI derived unit volt and the SI base unit second divided by the SI base unit metre" ;
   qudt:symbol "V·s/m" ;
   qudt:ucumCode "V.s.m-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "V.s/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H45" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Volt Second Per Meter"@en-us ;
@@ -42789,6 +43102,7 @@ unit:V_Ab-PER-CentiM
   qudt:informativeReference "http://www.endmemo.com/convert/electric%20field%20strength.php"^^xsd:anyURI ;
   qudt:symbol "abV/cm" ;
   qudt:ucumCode "10.nV.cm-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "10.nV/cm"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Abvolt per centimeter"@en-us ;
   rdfs:label "Abvolt per centimetre"@en ;
@@ -42939,6 +43253,7 @@ unit:W-HR-PER-KiloGM
   qudt:iec61360Code "0112/2///62720#UAD888" ;
   qudt:symbol "W·h/kg" ;
   qudt:ucumCode "W.h.kg-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "W.h/kg"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "watt hour per kilogram" ;
 .
@@ -42952,6 +43267,7 @@ unit:W-HR-PER-L
   qudt:iec61360Code "0112/2///62720#UAD887" ;
   qudt:symbol "W·h/l" ;
   qudt:ucumCode "W.h.L-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "W.h/L"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "watt hour per litre" ;
 .


### PR DESCRIPTION
for UCUM codes in the form `a.b-1` or `a.b.c-1`, we add the corresponding UCUM alias `a/b` or `a.b/c` which are also valid UCUM code for those units. These are useful for symbol lookups

more complex expressions aliases are not added in this PR