### PR TITLE
Replace quantitykind:Unknown with relevant quantity kinds for many units

### DIFF
--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -128,7 +128,8 @@ unit:A-HR-PER-DeciM3
   qudt:conversionMultiplier 3600000.0 ;
   qudt:conversionMultiplierSN 3.6E6 ;
   qudt:hasDimensionVector qkdv:A0E1L-3I0M0H0T1D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:ElectricChargeDensity ;
+  qudt:hasQuantityKind quantitykind:ElectricChargeVolumeDensity ;
   qudt:iec61360Code "0112/2///62720#UAD883" ;
   qudt:symbol "A·h/dm³" ;
   qudt:ucumCode "A.h.dm-3"^^qudt:UCUMcs ;
@@ -141,7 +142,7 @@ unit:A-HR-PER-KiloGM
   qudt:conversionMultiplier 3600.0 ;
   qudt:conversionMultiplierSN 3.6E3 ;
   qudt:hasDimensionVector qkdv:A0E1L0I0M-1H0T1D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:ElectricChargePerMass ;
   qudt:iec61360Code "0112/2///62720#UAD884" ;
   qudt:symbol "A·h/kg" ;
   qudt:ucumCode "A.h.kg-1"^^qudt:UCUMcs ;
@@ -154,7 +155,9 @@ unit:A-HR-PER-M2
   qudt:conversionMultiplier 3600.0 ;
   qudt:conversionMultiplierSN 3.6E3 ;
   qudt:hasDimensionVector qkdv:A0E1L-2I0M0H0T1D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:ElectricChargePerArea ;
+  qudt:hasQuantityKind quantitykind:ElectricChargeSurfaceDensity ;
+  qudt:hasQuantityKind quantitykind:ElectricPolarization ;
   qudt:iec61360Code "0112/2///62720#UAD885" ;
   qudt:symbol "A·h/m²" ;
   qudt:ucumCode "A.h.m-2"^^qudt:UCUMcs ;
@@ -167,7 +170,8 @@ unit:A-HR-PER-M3
   qudt:conversionMultiplier 3600.0 ;
   qudt:conversionMultiplierSN 3.6E3 ;
   qudt:hasDimensionVector qkdv:A0E1L-3I0M0H0T1D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:ElectricChargeDensity ;
+  qudt:hasQuantityKind quantitykind:ElectricChargeVolumeDensity ;
   qudt:iec61360Code "0112/2///62720#UAD882" ;
   qudt:symbol "A·h/m³" ;
   qudt:ucumCode "A.h.m-3"^^qudt:UCUMcs ;
@@ -343,7 +347,7 @@ unit:A-PER-K
   qudt:conversionMultiplier 1.0 ;
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E1L0I0M0H-1T0D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:ElectricCurrentPerUnitTemperature ;
   qudt:iec61360Code "0112/2///62720#UAD896" ;
   qudt:symbol "A/K" ;
   qudt:ucumCode "A.K-1"^^qudt:UCUMcs ;
@@ -640,7 +644,7 @@ unit:AC-FT_US
   qudt:conversionMultiplier 1233.48426566137344 ;
   qudt:conversionMultiplierSN 1.23348426566137344E3 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T0D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:Volume ;
   qudt:iec61360Code "0112/2///62720#UAB288" ;
   qudt:symbol "acre‑ft (US survey)" ;
   qudt:ucumCode "[acr_br].[ft_us]"^^qudt:UCUMcs ;
@@ -1023,7 +1027,13 @@ unit:AttoA
   qudt:conversionMultiplier 0.000000000000000001 ;
   qudt:conversionMultiplierSN 1.0E-18 ;
   qudt:hasDimensionVector qkdv:A0E1L0I0M0H0T0D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:CurrentLinkage ;
+  qudt:hasQuantityKind quantitykind:DisplacementCurrent ;
+  qudt:hasQuantityKind quantitykind:ElectricCurrent ;
+  qudt:hasQuantityKind quantitykind:ElectricCurrentPhasor ;
+  qudt:hasQuantityKind quantitykind:MagneticTension ;
+  qudt:hasQuantityKind quantitykind:MagnetomotiveForce ;
+  qudt:hasQuantityKind quantitykind:TotalCurrent ;
   qudt:iec61360Code "0112/2///62720#UAB637" ;
   qudt:symbol "aA" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -1293,7 +1303,7 @@ unit:BAR-PER-DEG_C
   qudt:conversionMultiplier 100000.0 ;
   qudt:conversionMultiplierSN 1.0E5 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H-1T-2D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:PressureCoefficient ;
   qudt:iec61360Code "0112/2///62720#UAD921" ;
   qudt:symbol "bar/°C" ;
   qudt:ucumCode "bar.Cel-1"^^qudt:UCUMcs ;
@@ -1706,7 +1716,7 @@ unit:BIT-PER-M
   qudt:conversionMultiplier 0.69314718055994530941723212145818 ;
   qudt:conversionMultiplierSN 6.9314718055994530941723212145818E-1 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T0D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:LinearBitDensity ;
   qudt:iec61360Code "0112/2///62720#UAA340" ;
   qudt:symbol "bit/m" ;
   qudt:ucumCode "bit.m-1"^^qudt:UCUMcs ;
@@ -1720,7 +1730,7 @@ unit:BIT-PER-M2
   qudt:conversionMultiplier 0.69314718055994530941723212145818 ;
   qudt:conversionMultiplierSN 6.9314718055994530941723212145818E-1 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T0D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:AreaBitDensity ;
   qudt:iec61360Code "0112/2///62720#UAA341" ;
   qudt:symbol "bit/m²" ;
   qudt:ucumCode "bit.m-2"^^qudt:UCUMcs ;
@@ -1734,7 +1744,7 @@ unit:BIT-PER-M3
   qudt:conversionMultiplier 0.69314718055994530941723212145818 ;
   qudt:conversionMultiplierSN 6.9314718055994530941723212145818E-1 ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M0H0T0D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:VolumetricBitDensity ;
   qudt:iec61360Code "0112/2///62720#UAA342" ;
   qudt:symbol "b/m³" ;
   qudt:ucumCode "bit.m-3"^^qudt:UCUMcs ;
@@ -1930,7 +1940,7 @@ unit:BTU_39DEG_F
   a qudt:Unit ;
   dcterms:description "unit of heat energy according to the Imperial system of units in a reference temperature of 39 °F" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:ThermalEnergy ;
   qudt:iec61360Code "0112/2///62720#UAB216" ;
   qudt:symbol "Btu (39 °F)" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -1940,7 +1950,7 @@ unit:BTU_59DEG_F
   a qudt:Unit ;
   dcterms:description "unit of heat energy according to the Imperial system of units in a reference temperature of 59 °F" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:ThermalEnergy ;
   qudt:iec61360Code "0112/2///62720#UAB217" ;
   qudt:symbol "Btu (59 °F)" ;
   qudt:uneceCommonCode "N67" ;
@@ -1951,7 +1961,7 @@ unit:BTU_60DEG_F
   a qudt:Unit ;
   dcterms:description "unit of head energy according to the Imperial system of units at a reference temperature of 60 °F" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:ThermalEnergy ;
   qudt:iec61360Code "0112/2///62720#UAB218" ;
   qudt:symbol "Btu (60 °F)" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -2189,8 +2199,9 @@ unit:BTU_IT-PER-FT2-HR
   dcterms:description "unit of the surface heat flux according to the Imperial system of units" ;
   qudt:conversionMultiplier 3.154590745063048768072844787664884 ;
   qudt:conversionMultiplierSN 3.154590745063048768072844787664884E0 ;
+  qudt:exactMatch unit:BTU_IT-PER-HR-FT2 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:PowerPerArea ;
   qudt:iec61360Code "0112/2///62720#UAB263" ;
   qudt:symbol "BtuIT/(ft²·h)" ;
   qudt:ucumCode "[Btu_IT].[ft_i]-2.h-1"^^qudt:UCUMcs ;
@@ -2222,8 +2233,9 @@ unit:BTU_IT-PER-FT2-SEC
   dcterms:description "unit of the surface heat flux according to the Imperial system of units" ;
   qudt:conversionMultiplier 11356.52668222697556506224123559358 ;
   qudt:conversionMultiplierSN 1.135652668222697556506224123559358E4 ;
+  qudt:exactMatch unit:BTU_IT-PER-SEC-FT2 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:PowerPerArea ;
   qudt:iec61360Code "0112/2///62720#UAB266" ;
   qudt:symbol "BtuIT/(ft²·s)" ;
   qudt:ucumCode "[Btu_IT].[ft_i]-2.s-1"^^qudt:UCUMcs ;
@@ -2305,6 +2317,7 @@ unit:BTU_IT-PER-HR-FT2
   qudt:conversionMultiplierSN 3.15459075E0 ;
   qudt:definedUnitOfSystem sou:IMPERIAL ;
   qudt:definedUnitOfSystem sou:USCS ;
+  qudt:exactMatch unit:BTU_IT-PER-FT2-HR ;
   qudt:expression "\\(Btu/(hr-ft^{2})\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:PowerPerArea ;
@@ -2320,7 +2333,7 @@ unit:BTU_IT-PER-HR-FT2-DEG_F
   qudt:conversionMultiplier 5.678263341113487328270053328717809 ;
   qudt:conversionMultiplierSN 5.678263341113487328270053328717809E0 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H-1T-3D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:CoefficientOfHeatTransfer ;
   qudt:iec61360Code "0112/2///62720#UAB276" ;
   qudt:symbol "BtuIT/(h·ft²·°F)" ;
   qudt:ucumCode "[Btu_IT].h-1.[ft_i]-2.[degF]-1"^^qudt:UCUMcs ;
@@ -2352,7 +2365,7 @@ unit:BTU_IT-PER-IN2-SEC
   qudt:conversionMultiplier 1635339.842240684481368962737925476 ;
   qudt:conversionMultiplierSN 1.635339842240684481368962737925476E6 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:PowerPerArea ;
   qudt:iec61360Code "0112/2///62720#UAB268" ;
   qudt:symbol "BtuIT/(in²·s)" ;
   qudt:ucumCode "[Btu_IT].[in_i]-2.s-1"^^qudt:UCUMcs ;
@@ -2614,6 +2627,7 @@ unit:BTU_IT-PER-SEC-FT2
   qudt:conversionMultiplierSN 1.13565267E4 ;
   qudt:definedUnitOfSystem sou:IMPERIAL ;
   qudt:definedUnitOfSystem sou:USCS ;
+  qudt:exactMatch unit:BTU_IT-PER-FT2-SEC ;
   qudt:expression "\\(Btu/(s-ft^{2})\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:PowerPerArea ;
@@ -2630,7 +2644,7 @@ unit:BTU_IT-PER-SEC-FT2-DEG_F
   qudt:conversionMultiplier 20441.74802800855438177219198338411 ;
   qudt:conversionMultiplierSN 2.044174802800855438177219198338411E4 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H-1T-3D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:CoefficientOfHeatTransfer ;
   qudt:iec61360Code "0112/2///62720#UAB278" ;
   qudt:symbol "BtuIT/(s·ft²·°F)" ;
   qudt:ucumCode "[Btu_IT].s-1.[ft_i]-2.[degF]-1"^^qudt:UCUMcs ;
@@ -2812,7 +2826,7 @@ unit:BTU_TH-PER-FT2
   qudt:conversionMultiplier 11348.93179491220093551298213707538 ;
   qudt:conversionMultiplierSN 1.134893179491220093551298213707538E4 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-2D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:EnergyPerArea ;
   qudt:iec61360Code "0112/2///62720#UAB284" ;
   qudt:symbol "Btuth/ft²" ;
   qudt:ucumCode "[Btu_th].[ft_i]-2"^^qudt:UCUMcs ;
@@ -2826,7 +2840,7 @@ unit:BTU_TH-PER-FT2-HR
   qudt:conversionMultiplier 3.152481054142278037642495038076495 ;
   qudt:conversionMultiplierSN 3.152481054142278037642495038076495E0 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:PowerPerArea ;
   qudt:iec61360Code "0112/2///62720#UAB264" ;
   qudt:symbol "Btuth/(ft²·h)" ;
   qudt:ucumCode "[Btu_th].[ft_i]-2.h-1"^^qudt:UCUMcs ;
@@ -2840,7 +2854,7 @@ unit:BTU_TH-PER-FT2-MIN
   qudt:conversionMultiplier 189.1488632485366822585497022845897 ;
   qudt:conversionMultiplierSN 1.891488632485366822585497022845897E2 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:PowerPerArea ;
   qudt:iec61360Code "0112/2///62720#UAB265" ;
   qudt:symbol "Btuth/(ft²·min)" ;
   qudt:ucumCode "[Btu_th].[ft_i]-2.min-1"^^qudt:UCUMcs ;
@@ -2853,7 +2867,7 @@ unit:BTU_TH-PER-FT2-SEC
   qudt:conversionMultiplier 11348.93179491220093551298213707538 ;
   qudt:conversionMultiplierSN 1.134893179491220093551298213707538E4 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:PowerPerArea ;
   qudt:iec61360Code "0112/2///62720#UAB267" ;
   qudt:symbol "Btuth/(ft²·s)" ;
   qudt:ucumCode "[Btu_th].[ft_i]-2.s-1"^^qudt:UCUMcs ;
@@ -2907,7 +2921,7 @@ unit:BTU_TH-PER-HR-FT2-DEG_F
   qudt:conversionMultiplier 5.674465897456100013799219272049695 ;
   qudt:conversionMultiplierSN 5.674465897456100013799219272049695E0 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H-1T-3D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:CoefficientOfHeatTransfer ;
   qudt:iec61360Code "0112/2///62720#UAB277" ;
   qudt:symbol "Btuth/(h·ft²·°F)" ;
   qudt:ucumCode "[Btu_th].h-1.[ft_i]-2.[degF]-1"^^qudt:UCUMcs ;
@@ -3010,7 +3024,7 @@ unit:BTU_TH-PER-SEC-FT2-DEG_F
   qudt:conversionMultiplier 20428.0772308419600496771893793789 ;
   qudt:conversionMultiplierSN 2.04280772308419600496771893793789E4 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H-1T-3D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:CoefficientOfHeatTransfer ;
   qudt:iec61360Code "0112/2///62720#UAB279" ;
   qudt:symbol "Btuth/(s·ft²·°F)" ;
   qudt:ucumCode "[Btu_th].s-1.[ft_i]-2.[degF]-1"^^qudt:UCUMcs ;
@@ -3713,7 +3727,7 @@ unit:CAL_20DEG_C
   a qudt:Unit ;
   dcterms:description "unit for quantity of heat, which is to be required for 1 g air free water at a constant pressure from 101,325 kPa, to warm up the pressure of standard atmosphere at sea level, from 19.5 °C on 20.5 °C" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:ThermalEnergy ;
   qudt:iec61360Code "0112/2///62720#UAB219" ;
   qudt:symbol "cal₂₀" ;
   qudt:uneceCommonCode "N69" ;
@@ -3918,7 +3932,7 @@ unit:CAL_TH-PER-CentiM2
   qudt:conversionMultiplier 41840.0 ;
   qudt:conversionMultiplierSN 4.184E4 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-2D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:EnergyPerArea ;
   qudt:iec61360Code "0112/2///62720#UAB285" ;
   qudt:symbol "calth/cm²" ;
   qudt:ucumCode "cal_th.cm-2"^^qudt:UCUMcs ;
@@ -3932,7 +3946,7 @@ unit:CAL_TH-PER-CentiM2-MIN
   qudt:conversionMultiplier 697.3333333333333333333333333333335 ;
   qudt:conversionMultiplierSN 6.973333333333333333333333333333335E2 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:PowerPerArea ;
   qudt:iec61360Code "0112/2///62720#UAB269" ;
   qudt:symbol "calth/(cm²·min)" ;
   qudt:ucumCode "cal_th.cm-2.min-1"^^qudt:UCUMcs ;
@@ -3946,7 +3960,7 @@ unit:CAL_TH-PER-CentiM2-SEC
   qudt:conversionMultiplier 41840.0 ;
   qudt:conversionMultiplierSN 4.184E4 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:PowerPerArea ;
   qudt:iec61360Code "0112/2///62720#UAB270" ;
   qudt:symbol "calth/(cm²·s)" ;
   qudt:ucumCode "cal_th.cm-2.s-1"^^qudt:UCUMcs ;
@@ -4220,7 +4234,7 @@ unit:CD-PER-FT2
   qudt:conversionMultiplier 10.7639104167097223083335055559 ;
   qudt:conversionMultiplierSN 1.07639104167097223083335055559E1 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I1M0H0T0D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:Luminance ;
   qudt:iec61360Code "0112/2///62720#UAB441" ;
   qudt:symbol "cd/ft²" ;
   qudt:ucumCode "cd.[ft_i]-2"^^qudt:UCUMcs ;
@@ -4283,7 +4297,7 @@ unit:CD_IN
   a qudt:Unit ;
   dcterms:description "obsolete, non-legal unit of the power in Germany relating to DIN 1301-3:1979" ;
   qudt:hasDimensionVector qkdv:A0E0L0I1M0H0T0D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:LuminousIntensity ;
   qudt:iec61360Code "0112/2///62720#UAB440" ;
   qudt:symbol "international candle" ;
   qudt:uneceCommonCode "P36" ;
@@ -4338,7 +4352,7 @@ unit:CHAIN_US
   a qudt:Unit ;
   dcterms:description "unit of the length according the Anglo-American system of units" ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T0D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:Length ;
   qudt:iec61360Code "0112/2///62720#UAA372" ;
   qudt:symbol "ch (US survey)" ;
   qudt:uneceCommonCode "M49" ;
@@ -4349,7 +4363,8 @@ unit:CI-PER-KiloGM
   a qudt:Unit ;
   dcterms:description "1,000-fold of the unit curie divided by the SI base unit kilogram" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M-1H0T-1D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:MassicActivity ;
+  qudt:hasQuantityKind quantitykind:SpecificActivity ;
   qudt:iec61360Code "0112/2///62720#UAB091" ;
   qudt:symbol "Ci/kg" ;
   qudt:uneceCommonCode "A42" ;
@@ -4933,7 +4948,7 @@ unit:CentiM2-PER-ERG
   qudt:conversionMultiplier 1000.0 ;
   qudt:conversionMultiplierSN 1.0E3 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M-1H0T2D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:SpectralCrossSection ;
   qudt:iec61360Code "0112/2///62720#UAB168" ;
   qudt:symbol "cm²/erg" ;
   qudt:ucumCode "cm2.erg-1"^^qudt:UCUMcs ;
@@ -4981,7 +4996,7 @@ unit:CentiM2-PER-SR-ERG
   qudt:conversionMultiplier 1000.0 ;
   qudt:conversionMultiplierSN 1.0E3 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M-1H0T2D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:SpectralAngularCrossSection ;
   qudt:iec61360Code "0112/2///62720#UAB169" ;
   qudt:symbol "cm²/(sr·erg)" ;
   qudt:ucumCode "cm2.sr-1.erg-1"^^qudt:UCUMcs ;
@@ -5445,7 +5460,8 @@ unit:CentiM_H20_4DEG_C
   a qudt:Unit ;
   dcterms:description "non SI-conform unit of pressure, at which a value of 1 cmH₂O meets the static pressure, which is generated by a head of water at a temperature of 4 °C with a height of 1 centimetre" ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:ForcePerArea ;
+  qudt:hasQuantityKind quantitykind:VaporPressure ;
   qudt:iec61360Code "0112/2///62720#UAB236" ;
   qudt:symbol "cmH₂O (4 °C)" ;
   qudt:uneceCommonCode "N14" ;
@@ -5478,7 +5494,8 @@ unit:CentiM_H2O_4DEG_C
   a qudt:Unit ;
   dcterms:description "non SI-conform unit of pressure, at which a value of 1 cmH₂O meets the static pressure, which is generated by a head of water at a temperature of 4 °C with a height of 1 centimetre" ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:ForcePerArea ;
+  qudt:hasQuantityKind quantitykind:VaporPressure ;
   qudt:iec61360Code "0112/2///62720#UAB236" ;
   qudt:symbol "cmH₂0 (4 °C)" ;
   qudt:uneceCommonCode "N14" ;
@@ -5508,7 +5525,8 @@ unit:CentiM_HG_0DEG_C
   a qudt:Unit ;
   dcterms:description "non SI-conform unit of pressure, at which a value of 1 cmHg meets the static pressure, which is generated by a mercury at a temperature of 0 °C with a height of 1 centimetre" ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:ForcePerArea ;
+  qudt:hasQuantityKind quantitykind:VaporPressure ;
   qudt:iec61360Code "0112/2///62720#UAB235" ;
   qudt:symbol "cmHg (0 °C)" ;
   qudt:uneceCommonCode "N13" ;
@@ -5840,7 +5858,9 @@ unit:DEG-PER-M
   qudt:conversionMultiplier 0.0174532925199433 ;
   qudt:conversionMultiplierSN 1.74532925199433E-2 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T0D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:AngularWavenumber ;
+  qudt:hasQuantityKind quantitykind:DebyeAngularWavenumber ;
+  qudt:hasQuantityKind quantitykind:FermiAngularWavenumber ;
   qudt:iec61360Code "0112/2///62720#UAA025" ;
   qudt:symbol "°/m" ;
   qudt:ucumCode "deg.m-1"^^qudt:UCUMcs ;
@@ -6440,7 +6460,7 @@ unit:DEG_F-HR-PER-BTU_TH
   qudt:conversionMultiplier 1.896902829486604790432999412407318 ;
   qudt:conversionMultiplierSN 1.896902829486604790432999412407318E0 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M-1H1T3D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:ThermalResistance ;
   qudt:iec61360Code "0112/2///62720#UAB249" ;
   qudt:symbol "°F/(Btuth/h)" ;
   qudt:ucumCode "[degF].h.[Btu_th]-1"^^qudt:UCUMcs ;
@@ -6571,7 +6591,7 @@ unit:DEG_F-SEC-PER-BTU_IT
   qudt:conversionMultiplier 0.0005265650668407318199100859275227703 ;
   qudt:conversionMultiplierSN 5.265650668407318199100859275227703E-4 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M-1H1T3D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:ThermalResistance ;
   qudt:iec61360Code "0112/2///62720#UAB250" ;
   qudt:symbol "°F·s/Btu{IT}" ;
   qudt:ucumCode "[degF].s.[Btu_IT]-1"^^qudt:UCUMcs ;
@@ -6585,7 +6605,7 @@ unit:DEG_F-SEC-PER-BTU_TH
   qudt:conversionMultiplier 0.0005269174526351679973424998367798105 ;
   qudt:conversionMultiplierSN 5.269174526351679973424998367798105E-4 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M-1H1T3D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:ThermalResistance ;
   qudt:iec61360Code "0112/2///62720#UAB251" ;
   qudt:symbol "°F·s/Btu{th}" ;
   qudt:ucumCode "[degF].s.[Btu_th]-1"^^qudt:UCUMcs ;
@@ -6801,7 +6821,8 @@ unit:DYN-M
   qudt:conversionMultiplier 0.00001 ;
   qudt:conversionMultiplierSN 1.0E-5 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:MomentOfForce ;
+  qudt:hasQuantityKind quantitykind:Torque ;
   qudt:iec61360Code "0112/2///62720#UAB419" ;
   qudt:symbol "dyn·m" ;
   qudt:ucumCode "dyn.m"^^qudt:UCUMcs ;
@@ -7155,7 +7176,7 @@ unit:DeciB-PER-KiloM
   a qudt:Unit ;
   dcterms:description "0.1-fold of the unit bel divided by 1,000-fold of the SI base unit metre" ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T0D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:LinearLogarithmicRatio ;
   qudt:iec61360Code "0112/2///62720#UAA410" ;
   qudt:symbol "dB/km" ;
   qudt:ucumCode "dB.km-1"^^qudt:UCUMcs ;
@@ -7220,7 +7241,10 @@ unit:DeciB_A
   a qudt:Unit ;
   dcterms:description "unit of sound pressure level with frequency weighting A" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:SoundExposureLevel ;
+  qudt:hasQuantityKind quantitykind:SoundPowerLevel ;
+  qudt:hasQuantityKind quantitykind:SoundPressureLevel ;
+  qudt:hasQuantityKind quantitykind:SoundReductionIndex ;
   qudt:iec61360Code "0112/2///62720#UAD893" ;
   qudt:symbol "dB(A)" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -7248,7 +7272,10 @@ unit:DeciB_ISO
   a qudt:Unit ;
   dcterms:description "antenna gain of a transmitted or received signal" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:SoundExposureLevel ;
+  qudt:hasQuantityKind quantitykind:SoundPowerLevel ;
+  qudt:hasQuantityKind quantitykind:SoundPressureLevel ;
+  qudt:hasQuantityKind quantitykind:SoundReductionIndex ;
   qudt:iec61360Code "0112/2///62720#UAD889" ;
   qudt:symbol "dBi" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -7281,7 +7308,10 @@ unit:DeciB_Z
   a qudt:Unit ;
   dcterms:description "unit of sound pressure level with frequency weighting Z (ZERO or linear weighting)" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:SoundExposureLevel ;
+  qudt:hasQuantityKind quantitykind:SoundPowerLevel ;
+  qudt:hasQuantityKind quantitykind:SoundPressureLevel ;
+  qudt:hasQuantityKind quantitykind:SoundReductionIndex ;
   qudt:iec61360Code "0112/2///62720#UAD895" ;
   qudt:symbol "dB(Z)" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -7731,7 +7761,7 @@ unit:ENZ
   a qudt:Unit ;
   dcterms:description "unit to express the catalytic activity of a specified chemical redation" ;
   qudt:hasDimensionVector qkdv:A1E0L0I0M0H0T-1D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:CatalyticActivity ;
   qudt:iec61360Code "0112/2///62720#UAB600" ;
   qudt:symbol "U" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -7741,7 +7771,7 @@ unit:ENZ-PER-L
   a qudt:Unit ;
   dcterms:description "amount of enzyme units divided by litre" ;
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T-1D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:CatalyticActivityConcentration ;
   qudt:iec61360Code "0112/2///62720#UAB601" ;
   qudt:symbol "U/L" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -7790,7 +7820,7 @@ unit:ERG-CentiM2-PER-GM
   qudt:conversionMultiplier 0.00000001 ;
   qudt:conversionMultiplierSN 1.0E-8 ;
   qudt:hasDimensionVector qkdv:A0E0L4I0M0H0T-2D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:TotalMassStoppingPower ;
   qudt:iec61360Code "0112/2///62720#UAB149" ;
   qudt:symbol "erg·cm²/g" ;
   qudt:ucumCode "erg.cm2.g-1"^^qudt:UCUMcs ;
@@ -7982,7 +8012,7 @@ unit:EU-PER-L
   a qudt:Unit ;
   dcterms:description "amount of enzyme units divided by litre" ;
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T-1D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:CatalyticActivityConcentration ;
   qudt:iec61360Code "0112/2///62720#UAB601" ;
   qudt:symbol "U/L" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -8089,7 +8119,7 @@ unit:EV-M2
   qudt:conversionMultiplier 0.0000000000000000001602176487 ;
   qudt:conversionMultiplierSN 1.602176487E-19 ;
   qudt:hasDimensionVector qkdv:A0E0L4I0M1H0T-2D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:TotalAtomicStoppingPower ;
   qudt:iec61360Code "0112/2///62720#UAA427" ;
   qudt:symbol "eV·m²" ;
   qudt:ucumCode "eV.m2"^^qudt:UCUMcs ;
@@ -8386,7 +8416,7 @@ unit:ExbiBIT-PER-M
   qudt:conversionMultiplier 1152921504606846980.0 ;
   qudt:conversionMultiplierSN 1.15292150460684698E18 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T0D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:LinearBitDensity ;
   qudt:iec61360Code "0112/2///62720#UAA140" ;
   qudt:symbol "Eibit/m" ;
   qudt:uneceCommonCode "E65" ;
@@ -9441,7 +9471,8 @@ unit:FT3-PER-LB
   qudt:conversionMultiplier 0.06242796057614461195632545582722213 ;
   qudt:conversionMultiplierSN 6.242796057614461195632545582722213E-2 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M-1H0T0D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:SoilAdsorptionCoefficient ;
+  qudt:hasQuantityKind quantitykind:SpecificVolume ;
   qudt:iec61360Code "0112/2///62720#UAB410" ;
   qudt:symbol "ft³/lbm" ;
   qudt:ucumCode "[ft_i]3.[lb_av]-1"^^qudt:UCUMcs ;
@@ -9534,7 +9565,9 @@ unit:FT4
   qudt:conversionMultiplier 0.0086309748412416 ;
   qudt:conversionMultiplierSN 8.6309748412416E-3 ;
   qudt:hasDimensionVector qkdv:A0E0L4I0M0H0T0D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:SecondAxialMomentOfArea ;
+  qudt:hasQuantityKind quantitykind:SecondMomentOfArea ;
+  qudt:hasQuantityKind quantitykind:SecondPolarMomentOfArea ;
   qudt:iec61360Code "0112/2///62720#UAB209" ;
   qudt:symbol "ft⁴" ;
   qudt:uneceCommonCode "N27" ;
@@ -9562,7 +9595,8 @@ unit:FT_H2O_39dot2DEG_F
   a qudt:Unit ;
   dcterms:description "non SI-conform unit of pressure according to the Anglo-American and Imperial system for units, whereas the value of 1 ftH₂O is equivalent to the static pressure, which is generated by a head of water at a temperature 39.2°F with a height of 1 foot" ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:ForcePerArea ;
+  qudt:hasQuantityKind quantitykind:VaporPressure ;
   qudt:iec61360Code "0112/2///62720#UAB237" ;
   qudt:symbol "ftH₂O (39.2 °F)" ;
   qudt:uneceCommonCode "N15" ;
@@ -10169,7 +10203,7 @@ unit:GA_Charriere
   a qudt:Unit ;
   dcterms:description "unit for the diameter of urological instruments and catheters for different purposes corresponding to: 1 Ch = 0,333 333 333 10 ⁻ ³ m" ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T0D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:Length ;
   qudt:iec61360Code "0112/2///62720#UAB382" ;
   qudt:symbol "Ch" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -10609,7 +10643,8 @@ unit:GM-PER-CentiM-SEC
   qudt:conversionMultiplier 0.1 ;
   qudt:conversionMultiplierSN 1.0E-1 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-1D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:DynamicViscosity ;
+  qudt:hasQuantityKind quantitykind:Viscosity ;
   qudt:iec61360Code "0112/2///62720#UAB433" ;
   qudt:symbol "g/(cm·s)" ;
   qudt:ucumCode "g.cm-1.s-1"^^qudt:UCUMcs ;
@@ -10682,7 +10717,7 @@ unit:GM-PER-CentiM3-BAR
   qudt:conversionMultiplier 0.01 ;
   qudt:conversionMultiplierSN 1.0E-2 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T2D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:MassPerEnergy ;
   qudt:iec61360Code "0112/2///62720#UAA471" ;
   qudt:symbol "g/(cm³·bar)" ;
   qudt:ucumCode "g.cm-3.bar-1"^^qudt:UCUMcs ;
@@ -10814,7 +10849,7 @@ unit:GM-PER-DeciM3-BAR
   qudt:conversionMultiplier 0.00001 ;
   qudt:conversionMultiplierSN 1.0E-5 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T2D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:MassPerEnergy ;
   qudt:iec61360Code "0112/2///62720#UAA477" ;
   qudt:symbol "g/(dm³·bar)" ;
   qudt:ucumCode "g.dm-3.bar-1"^^qudt:UCUMcs ;
@@ -10997,7 +11032,7 @@ unit:GM-PER-L-BAR
   qudt:conversionMultiplier 0.00001 ;
   qudt:conversionMultiplierSN 1.0E-5 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T2D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:MassPerEnergy ;
   qudt:iec61360Code "0112/2///62720#UAA484" ;
   qudt:symbol "g/(l·bar)" ;
   qudt:ucumCode "g.L-1.bar-1"^^qudt:UCUMcs ;
@@ -11159,7 +11194,7 @@ unit:GM-PER-M3-BAR
   qudt:conversionMultiplier 0.00000001 ;
   qudt:conversionMultiplierSN 1.0E-8 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T2D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:MassPerEnergy ;
   qudt:iec61360Code "0112/2///62720#UAA489" ;
   qudt:symbol "g/(m³·bar)" ;
   qudt:ucumCode "g.m-3.bar-1"^^qudt:UCUMcs ;
@@ -11323,7 +11358,7 @@ unit:GM-PER-MilliL-BAR
   qudt:conversionMultiplier 0.01 ;
   qudt:conversionMultiplierSN 1.0E-2 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T2D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:MassPerEnergy ;
   qudt:iec61360Code "0112/2///62720#UAA495" ;
   qudt:symbol "g/(ml·bar)" ;
   qudt:ucumCode "g.mL-1.bar-1"^^qudt:UCUMcs ;
@@ -11385,7 +11420,10 @@ unit:GM-PER-MilliM2
   qudt:conversionMultiplier 1000.0 ;
   qudt:conversionMultiplierSN 1.0E3 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M1H0T0D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:BodyMassIndex ;
+  qudt:hasQuantityKind quantitykind:MassPerArea ;
+  qudt:hasQuantityKind quantitykind:MeanMassRange ;
+  qudt:hasQuantityKind quantitykind:SurfaceDensity ;
   qudt:iec61360Code "0112/2///62720#UAB389" ;
   qudt:symbol "g/mm²" ;
   qudt:ucumCode "g.mm-2"^^qudt:UCUMcs ;
@@ -11784,7 +11822,9 @@ unit:GRAY-PER-HR
   qudt:conversionMultiplier 0.0002777777777777777777777777777777778 ;
   qudt:conversionMultiplierSN 2.777777777777777777777777777777778E-4 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:AbsorbedDoseRate ;
+  qudt:hasQuantityKind quantitykind:KermaRate ;
+  qudt:hasQuantityKind quantitykind:SpecificPower ;
   qudt:iec61360Code "0112/2///62720#UAB476" ;
   qudt:symbol "Gy/h" ;
   qudt:ucumCode "Gy.h-1"^^qudt:UCUMcs ;
@@ -11798,7 +11838,9 @@ unit:GRAY-PER-MIN
   qudt:conversionMultiplier 0.01666666666666666666666666666666667 ;
   qudt:conversionMultiplierSN 1.666666666666666666666666666666667E-2 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:AbsorbedDoseRate ;
+  qudt:hasQuantityKind quantitykind:KermaRate ;
+  qudt:hasQuantityKind quantitykind:SpecificPower ;
   qudt:iec61360Code "0112/2///62720#UAB472" ;
   qudt:symbol "Gy/min" ;
   qudt:ucumCode "Gy.min-1"^^qudt:UCUMcs ;
@@ -11983,7 +12025,7 @@ unit:GigaBIT-PER-M
   qudt:conversionMultiplier 693147180.55994530941723212145818 ;
   qudt:conversionMultiplierSN 6.9314718055994530941723212145818E8 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T0D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:LinearBitDensity ;
   qudt:iec61360Code "0112/2///62720#UAA159" ;
   qudt:symbol "Gibit/m" ;
   qudt:ucumCode "Gbit.m-1"^^qudt:UCUMcs ;
@@ -12662,7 +12704,7 @@ unit:HK
   a qudt:Unit ;
   dcterms:description "obsolete, non-legal unit of the power in Germany relating to DIN 1301-3:1979" ;
   qudt:hasDimensionVector qkdv:A0E0L0I1M0H0T0D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:LuminousIntensity ;
   qudt:iec61360Code "0112/2///62720#UAB439" ;
   qudt:symbol "HK" ;
   qudt:uneceCommonCode "P35" ;
@@ -13323,7 +13365,8 @@ unit:IN-PDL
   qudt:conversionMultiplier 0.0035116758411504 ;
   qudt:conversionMultiplierSN 3.5116758411504E-3 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:MomentOfForce ;
+  qudt:hasQuantityKind quantitykind:Torque ;
   qudt:iec61360Code "0112/2///62720#UAB437" ;
   qudt:symbol "in·pdl" ;
   qudt:ucumCode "[in_i].[lb_av].[ft_i].s-2"^^qudt:UCUMcs ;
@@ -13472,7 +13515,10 @@ unit:IN-PER-YR
   qudt:conversionMultiplier 0.0000000008048774304763353360204831799629884 ;
   qudt:conversionMultiplierSN 8.048774304763353360204831799629884E-10 ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T-1D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:ElectromagneticWavePhaseSpeed ;
+  qudt:hasQuantityKind quantitykind:LinearVelocity ;
+  qudt:hasQuantityKind quantitykind:Speed ;
+  qudt:hasQuantityKind quantitykind:Velocity ;
   qudt:iec61360Code "0112/2///62720#UAB370" ;
   qudt:symbol "in/y" ;
   qudt:ucumCode "[in_i].a-1"^^qudt:UCUMcs ;
@@ -13564,7 +13610,8 @@ unit:IN3-PER-LB
   qudt:conversionMultiplier 0.00003612729200008368747472537952964244 ;
   qudt:conversionMultiplierSN 3.612729200008368747472537952964244E-5 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M-1H0T0D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:SoilAdsorptionCoefficient ;
+  qudt:hasQuantityKind quantitykind:SpecificVolume ;
   qudt:iec61360Code "0112/2///62720#UAB411" ;
   qudt:symbol "in³/lbm" ;
   qudt:ucumCode "[in_i]3.[lb_av]-1"^^qudt:UCUMcs ;
@@ -13655,7 +13702,8 @@ unit:IN_H2O_39dot2DEG_F
   a qudt:Unit ;
   dcterms:description "non SI-conform unit of pressure according to the Anglo-American and Imperial system for units, whereas the value of 1 inH₂O meets the static pressure, which is generated by a head of water at a temperature of 39.2°F with a height of 1 inch" ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:ForcePerArea ;
+  qudt:hasQuantityKind quantitykind:VaporPressure ;
   qudt:iec61360Code "0112/2///62720#UAB240" ;
   qudt:symbol "inH₂O (39.2 °F)" ;
   qudt:uneceCommonCode "N18" ;
@@ -13666,7 +13714,8 @@ unit:IN_H2O_60DEG_F
   a qudt:Unit ;
   dcterms:description "non SI-conform unit of pressure according to the Anglo-American and Imperial system for units, whereas the value of 1 inH₂O meets the static pressure, which is generated by a head of water at a temperature of 60°F with a height of 1 inch" ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:ForcePerArea ;
+  qudt:hasQuantityKind quantitykind:VaporPressure ;
   qudt:iec61360Code "0112/2///62720#UAB241" ;
   qudt:symbol "inH₂O (60 °F)" ;
   qudt:uneceCommonCode "N19" ;
@@ -13697,7 +13746,8 @@ unit:IN_HG_32DEG_F
   a qudt:Unit ;
   dcterms:description "non SI-conform unit of pressure according to the Anglo-American and Imperial system for units, whereas the value of 1 inHg meets the static pressure, which is generated by a mercury at a temperature of 32°F with a height of 1 inch" ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:ForcePerArea ;
+  qudt:hasQuantityKind quantitykind:VaporPressure ;
   qudt:iec61360Code "0112/2///62720#UAB238" ;
   qudt:symbol "inHg (32 °F)" ;
   qudt:uneceCommonCode "N16" ;
@@ -13708,7 +13758,8 @@ unit:IN_HG_60DEG_F
   a qudt:Unit ;
   dcterms:description "non SI-conform unit of pressure according to the Anglo-American and Imperial system for units, whereas the value of 1 inHg meets the static pressure, which is generated by a mercury at a temperature of 60°F with a height of 1 inch" ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:ForcePerArea ;
+  qudt:hasQuantityKind quantitykind:VaporPressure ;
   qudt:iec61360Code "0112/2///62720#UAB239" ;
   qudt:symbol "inHg (60 °F)" ;
   qudt:uneceCommonCode "N17" ;
@@ -13945,7 +13996,7 @@ unit:J-PER-DAY
   qudt:conversionMultiplier 0.00001157407407407407407407407407407407 ;
   qudt:conversionMultiplierSN 1.157407407407407407407407407407407E-5 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAB446" ;
   qudt:symbol "J/d" ;
   qudt:ucumCode "J.d-1"^^qudt:UCUMcs ;
@@ -14303,7 +14354,7 @@ unit:J-PER-MIN
   qudt:conversionMultiplier 0.01666666666666666666666666666666667 ;
   qudt:conversionMultiplierSN 1.666666666666666666666666666666667E-2 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAB444" ;
   qudt:symbol "J/min" ;
   qudt:ucumCode "J.min-1"^^qudt:UCUMcs ;
@@ -14878,7 +14929,7 @@ unit:KAT-PER-M3
   qudt:conversionMultiplier 1.0 ;
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T-1D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:CatalyticActivityConcentration ;
   qudt:iec61360Code "0112/2///62720#UAB602" ;
   qudt:symbol "kat/m³" ;
   qudt:ucumCode "kat.m-3"^^qudt:UCUMcs ;
@@ -15226,7 +15277,7 @@ unit:KiloBD
   qudt:conversionMultiplier 1000.0 ;
   qudt:conversionMultiplierSN 1.0E3 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:DigitRate ;
   qudt:iec61360Code "0112/2///62720#UAA560" ;
   qudt:symbol "kBd" ;
   qudt:uneceCommonCode "K50" ;
@@ -16075,8 +16126,9 @@ unit:KiloGM-M-PER-SEC2
   dcterms:description "product of the SI base unit kilogram and the SI base unit metre divided by the power of the SI base unit second by exponent 2" ;
   qudt:conversionMultiplier 1.0 ;
   qudt:conversionMultiplierSN 1.0E0 ;
+  qudt:exactMatch unit:N ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H0T-2D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:Force ;
   qudt:iec61360Code "0112/2///62720#UAB355" ;
   qudt:symbol "kg·m/s²" ;
   qudt:ucumCode "kg.m.s-2"^^qudt:UCUMcs ;
@@ -16227,7 +16279,7 @@ unit:KiloGM-PER-CentiM3-BAR
   qudt:conversionMultiplier 10.0 ;
   qudt:conversionMultiplierSN 1.0E1 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T2D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:MassPerEnergy ;
   qudt:iec61360Code "0112/2///62720#UAA599" ;
   qudt:symbol "kg/(cm³·bar)" ;
   qudt:ucumCode "kg.cm-3.bar-1"^^qudt:UCUMcs ;
@@ -16323,7 +16375,7 @@ unit:KiloGM-PER-DeciM3-BAR
   qudt:conversionMultiplier 0.01 ;
   qudt:conversionMultiplierSN 1.0E-2 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T2D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:MassPerEnergy ;
   qudt:iec61360Code "0112/2///62720#UAA606" ;
   qudt:symbol "kg/(dm³·bar)" ;
   qudt:ucumCode "kg.dm-3.bar-1"^^qudt:UCUMcs ;
@@ -16579,7 +16631,7 @@ unit:KiloGM-PER-L-BAR
   qudt:conversionMultiplier 0.01 ;
   qudt:conversionMultiplierSN 1.0E-2 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T2D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:MassPerEnergy ;
   qudt:iec61360Code "0112/2///62720#UAA614" ;
   qudt:symbol "kg/(l·bar)" ;
   qudt:ucumCode "kg.L-1.bar-1"^^qudt:UCUMcs ;
@@ -16632,7 +16684,8 @@ unit:KiloGM-PER-M-DAY
   qudt:conversionMultiplier 0.00001157407407407407407407407407407407 ;
   qudt:conversionMultiplierSN 1.157407407407407407407407407407407E-5 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-1D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:DynamicViscosity ;
+  qudt:hasQuantityKind quantitykind:Viscosity ;
   qudt:iec61360Code "0112/2///62720#UAB431" ;
   qudt:symbol "kg/(m·d)" ;
   qudt:ucumCode "kg.m-1.d-1"^^qudt:UCUMcs ;
@@ -16665,7 +16718,8 @@ unit:KiloGM-PER-M-MIN
   qudt:conversionMultiplier 0.01666666666666666666666666666666667 ;
   qudt:conversionMultiplierSN 1.666666666666666666666666666666667E-2 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-1D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:DynamicViscosity ;
+  qudt:hasQuantityKind quantitykind:Viscosity ;
   qudt:iec61360Code "0112/2///62720#UAB430" ;
   qudt:symbol "kg/(m·min)" ;
   qudt:ucumCode "kg.m-1.min-1"^^qudt:UCUMcs ;
@@ -16849,7 +16903,7 @@ unit:KiloGM-PER-M3-BAR
   qudt:conversionMultiplier 0.00001 ;
   qudt:conversionMultiplierSN 1.0E-5 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T2D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:MassPerEnergy ;
   qudt:iec61360Code "0112/2///62720#UAA621" ;
   qudt:symbol "kg/(m³·bar)" ;
   qudt:ucumCode "kg.m-3.bar-1"^^qudt:UCUMcs ;
@@ -16878,7 +16932,7 @@ unit:KiloGM-PER-M3-PA
   qudt:conversionMultiplier 1.0 ;
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T2D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:MassPerEnergy ;
   qudt:iec61360Code "0112/2///62720#UAB310" ;
   qudt:symbol "kg/(m³·Pa)" ;
   qudt:ucumCode "kg.m-3.Pa-1"^^qudt:UCUMcs ;
@@ -17290,7 +17344,8 @@ unit:KiloGM_F-M-PER-SEC
   qudt:conversionMultiplier 9.80665 ;
   qudt:conversionMultiplierSN 9.80665E0 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:ActivePower ;
+  qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAB154" ;
   qudt:plainTextDescription "product of the SI base unit metre and the unit kilogram-force according to the Anglo-American and Imperial system of units divided by the SI base unit second" ;
   qudt:symbol "kgf·m/s" ;
@@ -17449,7 +17504,7 @@ unit:KiloJ-PER-DAY
   qudt:conversionMultiplier 0.01157407407407407407407407407407407 ;
   qudt:conversionMultiplierSN 1.157407407407407407407407407407407E-2 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAB450" ;
   qudt:symbol "kJ/d" ;
   qudt:ucumCode "kJ.d-1"^^qudt:UCUMcs ;
@@ -17536,7 +17591,7 @@ unit:KiloJ-PER-KiloV
   qudt:conversionMultiplier 1.0 ;
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E1L0I0M0H0T1D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:ElectricCharge ;
   qudt:iec61360Code "0112/2///62720#UAD920" ;
   qudt:symbol "kJ/kV" ;
   qudt:ucumCode "kJ.kV-1"^^qudt:UCUMcs ;
@@ -17549,7 +17604,7 @@ unit:KiloJ-PER-MIN
   qudt:conversionMultiplier 16.66666666666666666666666666666667 ;
   qudt:conversionMultiplierSN 1.666666666666666666666666666666667E1 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAB448" ;
   qudt:symbol "kJ/min" ;
   qudt:ucumCode "kJ.min-1"^^qudt:UCUMcs ;
@@ -18773,7 +18828,7 @@ unit:KiloW-PER-M-DEG_C
   qudt:conversionMultiplier 1000.0 ;
   qudt:conversionMultiplierSN 1.0E3 ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H-1T-3D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:ThermalConductivity ;
   qudt:iec61360Code "0112/2///62720#UAB459" ;
   qudt:symbol "kW/(m·°C)" ;
   qudt:ucumCode "kW.m-1.Cel-1"^^qudt:UCUMcs ;
@@ -19139,7 +19194,8 @@ unit:L-PER-MOL-SEC
   qudt:conversionMultiplier 0.001 ;
   qudt:conversionMultiplierSN 1.0E-3 ;
   qudt:hasDimensionVector qkdv:A-1E0L3I0M0H0T-1D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:AtmosphericHydroxylationRate ;
+  qudt:hasQuantityKind quantitykind:SecondOrderReactionRateConstant ;
   qudt:iec61360Code "0112/2///62720#UAD915" ;
   qudt:symbol "l/(mol·s)" ;
   qudt:ucumCode "L.mol-1.s-1"^^qudt:UCUMcs ;
@@ -19251,7 +19307,9 @@ unit:LANGLEY
   a qudt:Unit ;
   dcterms:description "[CGS] unit of the areal-related energy transmission (as a measure of the incendent quantity of heat of solar radiation on the earth's surface)" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-2D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:EnergyFluence ;
+  qudt:hasQuantityKind quantitykind:EnergyPerArea ;
+  qudt:hasQuantityKind quantitykind:RadiantFluence ;
   qudt:iec61360Code "0112/2///62720#UAB296" ;
   qudt:symbol "Ly" ;
   qudt:uneceCommonCode "P40" ;
@@ -20059,7 +20117,8 @@ unit:LB-PER-FT-DAY
   qudt:conversionMultiplier 0.00001722411971724020608535044230582288 ;
   qudt:conversionMultiplierSN 1.722411971724020608535044230582288E-5 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-1D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:DynamicViscosity ;
+  qudt:hasQuantityKind quantitykind:Viscosity ;
   qudt:iec61360Code "0112/2///62720#UAB436" ;
   qudt:symbol "lb/(ft·d)" ;
   qudt:ucumCode "[lb_av].[ft_i]-1.d-1"^^qudt:UCUMcs ;
@@ -20106,7 +20165,8 @@ unit:LB-PER-FT-MIN
   qudt:conversionMultiplier 0.02480273239282589676290463692038495 ;
   qudt:conversionMultiplierSN 2.480273239282589676290463692038495E-2 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-1D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:DynamicViscosity ;
+  qudt:hasQuantityKind quantitykind:Viscosity ;
   qudt:iec61360Code "0112/2///62720#UAB435" ;
   qudt:symbol "lb/(ft·min)" ;
   qudt:ucumCode "[lb_av].[ft_i]-1.min-1"^^qudt:UCUMcs ;
@@ -20191,7 +20251,7 @@ unit:LB-PER-FT3-PSI
   qudt:conversionMultiplier 0.002323281585433525342009905143512828 ;
   qudt:conversionMultiplierSN 2.323281585433525342009905143512828E-3 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T2D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:MassPerEnergy ;
   qudt:iec61360Code "0112/2///62720#UAA678" ;
   qudt:symbol "lb/(ft³·psi)" ;
   qudt:ucumCode "[lb_av].[ft_i]-3.[psi]-1"^^qudt:UCUMcs ;
@@ -20380,7 +20440,7 @@ unit:LB-PER-IN3-PSI
   qudt:conversionMultiplier 4.014630579629131790993116087990167 ;
   qudt:conversionMultiplierSN 4.014630579629131790993116087990167E0 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T2D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:MassPerEnergy ;
   qudt:iec61360Code "0112/2///62720#UAA687" ;
   qudt:symbol "lb/(in³·psi)" ;
   qudt:ucumCode "[lb_av].[in_i]-3.[psi]-1"^^qudt:UCUMcs ;
@@ -20394,7 +20454,7 @@ unit:LB-PER-LB
   qudt:conversionMultiplier 1.0 ;
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:MassRatio ;
   qudt:iec61360Code "0112/2///62720#UAB388" ;
   qudt:symbol "lb/lb" ;
   qudt:ucumCode "[lb_av].[lb_av]-1"^^qudt:UCUMcs ;
@@ -20547,7 +20607,10 @@ unit:LB-PER-YD2
   qudt:conversionMultiplier 0.5424919595981167270976517261676497 ;
   qudt:conversionMultiplierSN 5.424919595981167270976517261676497E-1 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M1H0T0D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:BodyMassIndex ;
+  qudt:hasQuantityKind quantitykind:MassPerArea ;
+  qudt:hasQuantityKind quantitykind:MeanMassRange ;
+  qudt:hasQuantityKind quantitykind:SurfaceDensity ;
   qudt:iec61360Code "0112/2///62720#UAB390" ;
   qudt:symbol "lb/yd²" ;
   qudt:ucumCode "[lb_av].[yd_i]-2"^^qudt:UCUMcs ;
@@ -21034,7 +21097,7 @@ unit:LB_F-PER-YD
   qudt:conversionMultiplier 4.864634530666166666666666666666666 ;
   qudt:conversionMultiplierSN 4.864634530666166666666666666666666E0 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-2D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:ForcePerLength ;
   qudt:iec61360Code "0112/2///62720#UAB454" ;
   qudt:symbol "lbf/yd" ;
   qudt:ucumCode "[lbf_av].[yd_i]-1"^^qudt:UCUMcs ;
@@ -21172,7 +21235,7 @@ unit:LM-HR
   qudt:conversionMultiplier 3600.0 ;
   qudt:conversionMultiplierSN 3.6E3 ;
   qudt:hasDimensionVector qkdv:A0E0L0I1M0H0T1D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:LuminousEnergy ;
   qudt:iec61360Code "0112/2///62720#UAA720" ;
   qudt:symbol "lm·h" ;
   qudt:ucumCode "lm.h"^^qudt:UCUMcs ;
@@ -21186,7 +21249,7 @@ unit:LM-PER-FT2
   qudt:conversionMultiplier 10.7639104167097223083335055559 ;
   qudt:conversionMultiplierSN 1.07639104167097223083335055559E1 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I1M0H0T0D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:Luminance ;
   qudt:iec61360Code "0112/2///62720#UAB254" ;
   qudt:symbol "lm/ft²" ;
   qudt:ucumCode "lm.[ft_i]-2"^^qudt:UCUMcs ;
@@ -21200,7 +21263,7 @@ unit:LM-PER-M2
   qudt:conversionMultiplier 1.0 ;
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I1M0H0T0D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:Luminance ;
   qudt:iec61360Code "0112/2///62720#UAA721" ;
   qudt:symbol "lm/m²" ;
   qudt:ucumCode "lm.m-2"^^qudt:UCUMcs ;
@@ -21469,7 +21532,7 @@ unit:M-PA-PER-SEC
   qudt:conversionMultiplier 1.0 ;
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:PowerPerArea ;
   qudt:iec61360Code "0112/2///62720#UAD914" ;
   qudt:symbol "m·Pa/s" ;
   qudt:ucumCode "m.Pa.s-1"^^qudt:UCUMcs ;
@@ -21496,7 +21559,8 @@ unit:M-PER-DEG_C-M
   qudt:conversionMultiplier 1.0 ;
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H-1T0D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:ExpansionRatio ;
+  qudt:hasQuantityKind quantitykind:ThermalExpansionCoefficient ;
   qudt:iec61360Code "0112/2///62720#UAB461" ;
   qudt:symbol "m/(°C·m)" ;
   qudt:ucumCode "m.Cel-1.m-1"^^qudt:UCUMcs ;
@@ -21745,7 +21809,7 @@ unit:M-PER-V-SEC
   qudt:conversionMultiplier 1.0 ;
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E1L-1I0M-1H0T2D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:MagneticReluctivity ;
   qudt:iec61360Code "0112/2///62720#UAD917" ;
   qudt:symbol "m/(V·s)" ;
   qudt:ucumCode "m.V-1.s-1"^^qudt:UCUMcs ;
@@ -23432,7 +23496,8 @@ unit:MI_UK3
   a qudt:Unit ;
   dcterms:description "unit of volume according to the Imperial system of units" ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T0D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:SectionModulus ;
+  qudt:hasQuantityKind quantitykind:Volume ;
   qudt:iec61360Code "0112/2///62720#UAB290" ;
   qudt:symbol "mi³" ;
   qudt:uneceCommonCode "M69" ;
@@ -23462,7 +23527,8 @@ unit:MI_US-PER-SEC2
   qudt:conversionMultiplier 1609.347 ;
   qudt:conversionMultiplierSN 1.609347E3 ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T-2D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:Acceleration ;
+  qudt:hasQuantityKind quantitykind:LinearAcceleration ;
   qudt:iec61360Code "0112/2///62720#UAB401" ;
   qudt:symbol "mi{US}/s²" ;
   qudt:ucumCode "[mi_us].s-2"^^qudt:UCUMcs ;
@@ -23683,7 +23749,7 @@ unit:MOL-PER-KiloGM-BAR
   qudt:conversionMultiplier 0.00001 ;
   qudt:conversionMultiplierSN 1.0E-5 ;
   qudt:hasDimensionVector qkdv:A1E0L1I0M-2H0T2D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:AmountOfSubstancePerUnitMassPressure ;
   qudt:iec61360Code "0112/2///62720#UAA887" ;
   qudt:symbol "mol/(kg·bar)" ;
   qudt:ucumCode "mol.kg-1.bar-1"^^qudt:UCUMcs ;
@@ -23791,7 +23857,7 @@ unit:MOL-PER-M2-DAY
   qudt:conversionMultiplier 0.0000115740740740741 ;
   qudt:conversionMultiplierSN 1.15740740740741E-5 ;
   qudt:hasDimensionVector qkdv:A1E0L-2I0M0H0T-1D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:PhotosyntheticPhotonFluxDensity ;
   qudt:symbol "mol/(m²·day)" ;
   qudt:ucumCode "mol.m-2.d-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -23805,7 +23871,7 @@ unit:MOL-PER-M2-SEC
   qudt:conversionMultiplier 1.0 ;
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A1E0L-2I0M0H0T-1D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:PhotosyntheticPhotonFluxDensity ;
   qudt:symbol "mol/(m²·s)" ;
   qudt:ucumCode "mol.m-2.s-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -23817,7 +23883,7 @@ unit:MOL-PER-M2-SEC-M
   qudt:conversionMultiplier 1.0 ;
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T-1D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:CatalyticActivityConcentration ;
   qudt:symbol "mol/(m²·s·m)" ;
   qudt:ucumCode "mol.m-2.s-1.m-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -23921,7 +23987,7 @@ unit:MOL-PER-M3-SEC
   qudt:conversionMultiplier 1.0 ;
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T-1D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:CatalyticActivityConcentration ;
   qudt:symbol "mol/(m³·s)" ;
   qudt:ucumCode "mol.m-3.s-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -24025,7 +24091,9 @@ unit:MOL_LB-PER-LB
   qudt:conversionMultiplier 999.9999999999999999999999999999998 ;
   qudt:conversionMultiplierSN 9.999999999999999999999999999999998E2 ;
   qudt:hasDimensionVector qkdv:A1E0L0I0M-1H0T0D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:AmountOfSubstancePerUnitMass ;
+  qudt:hasQuantityKind quantitykind:IonicStrength ;
+  qudt:hasQuantityKind quantitykind:MolalityOfSolute ;
   qudt:iec61360Code "0112/2///62720#UAB405" ;
   qudt:symbol "lb-mol/lbm" ;
   qudt:ucumCode "[mol_lb].[lb_av]-1"^^qudt:UCUMcs ;
@@ -24039,7 +24107,7 @@ unit:MOL_LB-PER-MIN
   qudt:conversionMultiplier 7.559872833333333333333333333333335 ;
   qudt:conversionMultiplierSN 7.559872833333333333333333333333335E0 ;
   qudt:hasDimensionVector qkdv:A1E0L0I0M0H0T-1D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:CatalyticActivity ;
   qudt:iec61360Code "0112/2///62720#UAB452" ;
   qudt:symbol "lb-mol/min" ;
   qudt:ucumCode "[mol_lb].min-1"^^qudt:UCUMcs ;
@@ -24053,7 +24121,7 @@ unit:MOL_LB-PER-SEC
   qudt:conversionMultiplier 453.59237 ;
   qudt:conversionMultiplierSN 4.5359237E2 ;
   qudt:hasDimensionVector qkdv:A1E0L0I0M0H0T-1D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:CatalyticActivity ;
   qudt:iec61360Code "0112/2///62720#UAB451" ;
   qudt:symbol "lb-mol/s" ;
   qudt:ucumCode "[mol_lb].s-1"^^qudt:UCUMcs ;
@@ -24065,7 +24133,7 @@ unit:MOMME_Pearl
   a qudt:Unit ;
   dcterms:description "unit momme (pearl) specifically expresses the mass of cultured pearls" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T0D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:Mass ;
   qudt:iec61360Code "0112/2///62720#UAB598" ;
   qudt:symbol "momme (pearl)" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -24075,7 +24143,7 @@ unit:MOMME_Textile
   a qudt:Unit ;
   dcterms:description "unit momme (textile) specifically express the weight of one square metre of silk" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T0D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:Mass ;
   qudt:iec61360Code "0112/2///62720#UAB599" ;
   qudt:symbol "momme (textile)" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -24136,7 +24204,8 @@ unit:M_H2O
   a qudt:Unit ;
   dcterms:description "not SI-conform unit of pressure, whereas a value of 1 mH₂O is equivalent to the static pressure, which is produced by one metre high watercolumn" ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:ForcePerArea ;
+  qudt:hasQuantityKind quantitykind:VaporPressure ;
   qudt:iec61360Code "0112/2///62720#UAB362" ;
   qudt:symbol "mH₂0" ;
   qudt:uneceCommonCode "N23" ;
@@ -24176,7 +24245,7 @@ unit:MebiBIT-PER-M2
   qudt:conversionMultiplier 726817.49800282521276748358899013255168 ;
   qudt:conversionMultiplierSN 7.2681749800282521276748358899013255168E5 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T0D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:AreaBitDensity ;
   qudt:iec61360Code "0112/2///62720#UAA231" ;
   qudt:symbol "Mibit/m²" ;
   qudt:ucumCode "Mibit.m-2"^^qudt:UCUMcs ;
@@ -24190,7 +24259,7 @@ unit:MebiBIT-PER-M3
   qudt:conversionMultiplier 726817.49800282521276748358899013255168 ;
   qudt:conversionMultiplierSN 7.2681749800282521276748358899013255168E5 ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M0H0T0D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:VolumetricBitDensity ;
   qudt:iec61360Code "0112/2///62720#UAA232" ;
   qudt:symbol "Mibit/m³" ;
   qudt:ucumCode "Mibit.m-3"^^qudt:UCUMcs ;
@@ -24569,7 +24638,7 @@ unit:MegaFLOPS
   a qudt:Unit ;
   dcterms:description "1,000,000-fold of the unit floating point operations divided by the SI base unit second" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:FloatingPointCalculationCapability ;
   qudt:iec61360Code "0112/2///62720#UAB591" ;
   qudt:symbol "Mflops" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -24967,7 +25036,8 @@ unit:MegaOHM-KiloM
   qudt:conversionMultiplier 1000000000.0 ;
   qudt:conversionMultiplierSN 1.0E9 ;
   qudt:hasDimensionVector qkdv:A0E-2L3I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:ResidualResistivity ;
+  qudt:hasQuantityKind quantitykind:Resistivity ;
   qudt:iec61360Code "0112/2///62720#UAB406" ;
   qudt:symbol "MΩ·km" ;
   qudt:ucumCode "MOhm.km"^^qudt:UCUMcs ;
@@ -25021,7 +25091,7 @@ unit:MegaOHM-PER-KiloM
   qudt:conversionMultiplier 1000.0 ;
   qudt:conversionMultiplierSN 1.0E3 ;
   qudt:hasDimensionVector qkdv:A0E-2L1I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:LinearResistance ;
   qudt:iec61360Code "0112/2///62720#UAA199" ;
   qudt:symbol "MΩ/km" ;
   qudt:ucumCode "MOhm.km-1"^^qudt:UCUMcs ;
@@ -25488,7 +25558,7 @@ unit:MicroA-PER-K
   qudt:conversionMultiplier 0.000001 ;
   qudt:conversionMultiplierSN 1.0E-6 ;
   qudt:hasDimensionVector qkdv:A0E1L0I0M0H-1T0D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:ElectricCurrentPerUnitTemperature ;
   qudt:iec61360Code "0112/2///62720#UAD898" ;
   qudt:symbol "µA/K" ;
   qudt:ucumCode "uA.K-1"^^qudt:UCUMcs ;
@@ -25974,7 +26044,7 @@ unit:MicroGM-PER-M3-BAR
   qudt:conversionMultiplier 0.00000000000001 ;
   qudt:conversionMultiplierSN 1.0E-14 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T2D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:MassPerEnergy ;
   qudt:iec61360Code "0112/2///62720#UAA087" ;
   qudt:symbol "µg/(m³·bar)" ;
   qudt:ucumCode "ug.m-3.bar-1"^^qudt:UCUMcs ;
@@ -26060,7 +26130,9 @@ unit:MicroGRAY-PER-HR
   qudt:conversionMultiplier 0.0000000002777777777777777777777777777777778 ;
   qudt:conversionMultiplierSN 2.777777777777777777777777777777778E-10 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:AbsorbedDoseRate ;
+  qudt:hasQuantityKind quantitykind:KermaRate ;
+  qudt:hasQuantityKind quantitykind:SpecificPower ;
   qudt:iec61360Code "0112/2///62720#UAB478" ;
   qudt:symbol "µGy/h" ;
   qudt:ucumCode "uGy.h-1"^^qudt:UCUMcs ;
@@ -26074,7 +26146,9 @@ unit:MicroGRAY-PER-MIN
   qudt:conversionMultiplier 0.00000001666666666666666666666666666666667 ;
   qudt:conversionMultiplierSN 1.666666666666666666666666666666667E-8 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:AbsorbedDoseRate ;
+  qudt:hasQuantityKind quantitykind:KermaRate ;
+  qudt:hasQuantityKind quantitykind:SpecificPower ;
   qudt:iec61360Code "0112/2///62720#UAB474" ;
   qudt:symbol "µGy/min" ;
   qudt:ucumCode "uGy.min-1"^^qudt:UCUMcs ;
@@ -26339,7 +26413,8 @@ unit:MicroM-PER-L-DAY
   qudt:conversionMultiplier 0.0000000115740740740741 ;
   qudt:conversionMultiplierSN 1.15740740740741E-8 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T-1D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:Flux ;
+  qudt:hasQuantityKind quantitykind:ParticleFluenceRate ;
   qudt:symbol "µm/(L·day)" ;
   qudt:ucumCode "um.L-1.d-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -26603,7 +26678,7 @@ unit:MicroMOL-PER-L-HR
   qudt:conversionMultiplier 0.000000277777777777778 ;
   qudt:conversionMultiplierSN 2.77777777777778E-7 ;
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T-1D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:CatalyticActivityConcentration ;
   qudt:symbol "µmol/(L·hr)" ;
   qudt:ucumCode "umol.L-1.h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "umol/L/h"^^qudt:UCUMcs ;
@@ -26630,7 +26705,7 @@ unit:MicroMOL-PER-M2-DAY
   qudt:conversionMultiplier 0.0000000000115740740740741 ;
   qudt:conversionMultiplierSN 1.15740740740741E-11 ;
   qudt:hasDimensionVector qkdv:A1E0L-2I0M0H0T-1D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:PhotosyntheticPhotonFluxDensity ;
   qudt:symbol "µmol/(m²·day)" ;
   qudt:ucumCode "umol.m-2.d-1"^^qudt:UCUMcs ;
   qudt:ucumCode "umol/m2/d"^^qudt:UCUMcs ;
@@ -26643,7 +26718,7 @@ unit:MicroMOL-PER-M2-HR
   qudt:conversionMultiplier 0.000000000277777777777778 ;
   qudt:conversionMultiplierSN 2.77777777777778E-10 ;
   qudt:hasDimensionVector qkdv:A1E0L-2I0M0H0T-1D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:PhotosyntheticPhotonFluxDensity ;
   qudt:symbol "µmol/(m²·hr)" ;
   qudt:ucumCode "umol.m-2.h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "umol/m2/h"^^qudt:UCUMcs ;
@@ -26993,7 +27068,9 @@ unit:MicroSV-PER-MIN
   qudt:conversionMultiplier 0.00000001666666666666666666666666666666667 ;
   qudt:conversionMultiplierSN 1.666666666666666666666666666666667E-8 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:AbsorbedDoseRate ;
+  qudt:hasQuantityKind quantitykind:KermaRate ;
+  qudt:hasQuantityKind quantitykind:SpecificPower ;
   qudt:iec61360Code "0112/2///62720#UAB470" ;
   qudt:symbol "µSv/min" ;
   qudt:ucumCode "uSv.min-1"^^qudt:UCUMcs ;
@@ -27007,7 +27084,9 @@ unit:MicroSV-PER-SEC
   qudt:conversionMultiplier 0.000001 ;
   qudt:conversionMultiplierSN 1.0E-6 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:AbsorbedDoseRate ;
+  qudt:hasQuantityKind quantitykind:KermaRate ;
+  qudt:hasQuantityKind quantitykind:SpecificPower ;
   qudt:iec61360Code "0112/2///62720#UAB303" ;
   qudt:symbol "µSv/s" ;
   qudt:ucumCode "uSv.s-1"^^qudt:UCUMcs ;
@@ -27291,7 +27370,7 @@ unit:MilliA-PER-K
   qudt:conversionMultiplier 0.001 ;
   qudt:conversionMultiplierSN 1.0E-3 ;
   qudt:hasDimensionVector qkdv:A0E1L0I0M0H-1T0D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:ElectricCurrentPerUnitTemperature ;
   qudt:iec61360Code "0112/2///62720#UAD897" ;
   qudt:symbol "mA/K" ;
   qudt:ucumCode "mA.K-1"^^qudt:UCUMcs ;
@@ -28348,7 +28427,7 @@ unit:MilliGM-PER-M3-BAR
   qudt:conversionMultiplier 0.00000000001 ;
   qudt:conversionMultiplierSN 1.0E-11 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T2D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:MassPerEnergy ;
   qudt:iec61360Code "0112/2///62720#UAA832" ;
   qudt:symbol "mg/(m³·bar)" ;
   qudt:ucumCode "mg.m-3.bar-1"^^qudt:UCUMcs ;
@@ -28686,7 +28765,9 @@ unit:MilliGRAY-PER-HR
   qudt:conversionMultiplier 0.0000002777777777777777777777777777777778 ;
   qudt:conversionMultiplierSN 2.777777777777777777777777777777778E-7 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:AbsorbedDoseRate ;
+  qudt:hasQuantityKind quantitykind:KermaRate ;
+  qudt:hasQuantityKind quantitykind:SpecificPower ;
   qudt:iec61360Code "0112/2///62720#UAB477" ;
   qudt:symbol "mGy/h" ;
   qudt:ucumCode "mGy.h-1"^^qudt:UCUMcs ;
@@ -28700,7 +28781,9 @@ unit:MilliGRAY-PER-MIN
   qudt:conversionMultiplier 0.00001666666666666666666666666666666667 ;
   qudt:conversionMultiplierSN 1.666666666666666666666666666666667E-5 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:AbsorbedDoseRate ;
+  qudt:hasQuantityKind quantitykind:KermaRate ;
+  qudt:hasQuantityKind quantitykind:SpecificPower ;
   qudt:iec61360Code "0112/2///62720#UAB473" ;
   qudt:symbol "mGy/min" ;
   qudt:ucumCode "mGy.min-1"^^qudt:UCUMcs ;
@@ -29380,7 +29463,8 @@ unit:MilliM-PER-DEG_C-M
   qudt:conversionMultiplier 0.001 ;
   qudt:conversionMultiplierSN 1.0E-3 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H-1T0D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:ExpansionRatio ;
+  qudt:hasQuantityKind quantitykind:ThermalExpansionCoefficient ;
   qudt:iec61360Code "0112/2///62720#UAA863" ;
   qudt:symbol "mm/(°C·m)" ;
   qudt:ucumCode "mm.Cel-1.m-1"^^qudt:UCUMcs ;
@@ -29761,7 +29845,7 @@ unit:MilliMOL-PER-M2-DAY
   qudt:conversionMultiplier 0.0000000115740740740741 ;
   qudt:conversionMultiplierSN 1.15740740740741E-8 ;
   qudt:hasDimensionVector qkdv:A1E0L-2I0M0H0T-1D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:PhotosyntheticPhotonFluxDensity ;
   qudt:symbol "mmol/(m²·day)" ;
   qudt:ucumCode "mmol.m-2.d-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -29773,7 +29857,7 @@ unit:MilliMOL-PER-M2-SEC
   qudt:conversionMultiplier 0.001 ;
   qudt:conversionMultiplierSN 1.0E-3 ;
   qudt:hasDimensionVector qkdv:A1E0L-2I0M0H0T-1D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:PhotosyntheticPhotonFluxDensity ;
   qudt:symbol "mmol/(m²·s)" ;
   qudt:ucumCode "mmol.m-2.s-1"^^qudt:UCUMcs ;
   qudt:ucumCode "mmol/m2/s1"^^qudt:UCUMcs ;
@@ -29802,7 +29886,7 @@ unit:MilliMOL-PER-M3-DAY
   qudt:conversionMultiplier 0.0000000115740740740741 ;
   qudt:conversionMultiplierSN 1.15740740740741E-8 ;
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T-1D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:CatalyticActivityConcentration ;
   qudt:symbol "mmol/(m³·day)" ;
   qudt:ucumCode "mmol.m-3.d-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -30018,7 +30102,7 @@ unit:MilliOHM-PER-M
   qudt:conversionMultiplier 0.001 ;
   qudt:conversionMultiplierSN 1.0E-3 ;
   qudt:hasDimensionVector qkdv:A0E-2L1I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:LinearResistance ;
   qudt:iec61360Code "0112/2///62720#UAA743" ;
   qudt:symbol "mΩ/m" ;
   qudt:ucumCode "mOhm.m-1"^^qudt:UCUMcs ;
@@ -30173,7 +30257,9 @@ unit:MilliRAD_R-PER-HR
   qudt:conversionMultiplier 0.000000002777777777777777777777777777777778 ;
   qudt:conversionMultiplierSN 2.777777777777777777777777777777778E-9 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:AbsorbedDoseRate ;
+  qudt:hasQuantityKind quantitykind:KermaRate ;
+  qudt:hasQuantityKind quantitykind:SpecificPower ;
   qudt:symbol "mrad/hr" ;
   qudt:ucumCode "mRAD.h-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -30304,7 +30390,9 @@ unit:MilliSV-PER-HR
   qudt:conversionMultiplier 0.0000002777777777777777777777777777777778 ;
   qudt:conversionMultiplierSN 2.777777777777777777777777777777778E-7 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:AbsorbedDoseRate ;
+  qudt:hasQuantityKind quantitykind:KermaRate ;
+  qudt:hasQuantityKind quantitykind:SpecificPower ;
   qudt:iec61360Code "0112/2///62720#UAB465" ;
   qudt:symbol "mSv/h" ;
   qudt:ucumCode "mSv.h-1"^^qudt:UCUMcs ;
@@ -30318,7 +30406,9 @@ unit:MilliSV-PER-MIN
   qudt:conversionMultiplier 0.00001666666666666666666666666666666667 ;
   qudt:conversionMultiplierSN 1.666666666666666666666666666666667E-5 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:AbsorbedDoseRate ;
+  qudt:hasQuantityKind quantitykind:KermaRate ;
+  qudt:hasQuantityKind quantitykind:SpecificPower ;
   qudt:iec61360Code "0112/2///62720#UAB469" ;
   qudt:symbol "mSv/min" ;
   qudt:ucumCode "mSv.min-1"^^qudt:UCUMcs ;
@@ -30332,7 +30422,9 @@ unit:MilliSV-PER-SEC
   qudt:conversionMultiplier 0.001 ;
   qudt:conversionMultiplierSN 1.0E-3 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:AbsorbedDoseRate ;
+  qudt:hasQuantityKind quantitykind:KermaRate ;
+  qudt:hasQuantityKind quantitykind:SpecificPower ;
   qudt:iec61360Code "0112/2///62720#UAB302" ;
   qudt:symbol "mSv/s" ;
   qudt:ucumCode "mSv.s-1"^^qudt:UCUMcs ;
@@ -30555,7 +30647,7 @@ unit:MilliW-PER-M2-NanoM
   qudt:conversionMultiplier 1000000.0 ;
   qudt:conversionMultiplierSN 1.0E6 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:ForcePerAreaTime ;
   qudt:symbol "mW/(m²·nm)" ;
   qudt:ucumCode "mW.m-2.nm-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -30637,6 +30729,7 @@ unit:N
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Newton"^^xsd:anyURI ;
   qudt:derivedCoherentUnitOfSystem sou:SI ;
+  qudt:exactMatch unit:KiloGM-M-PER-SEC2 ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Force ;
   qudt:iec61360Code "0112/2///62720#UAA235" ;
@@ -31388,7 +31481,8 @@ unit:N-SEC-PER-M2
   qudt:conversionMultiplier 1.0 ;
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-1D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:DynamicViscosity ;
+  qudt:hasQuantityKind quantitykind:Viscosity ;
   qudt:iec61360Code "0112/2///62720#UAB428" ;
   qudt:symbol "N·s/m²" ;
   qudt:ucumCode "N.s.m-2"^^qudt:UCUMcs ;
@@ -32103,7 +32197,9 @@ unit:NanoGRAY-PER-HR
   a qudt:Unit ;
   dcterms:description "0.000000001-fold of the SI derived unit gray divided by the unit hour" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:AbsorbedDoseRate ;
+  qudt:hasQuantityKind quantitykind:KermaRate ;
+  qudt:hasQuantityKind quantitykind:SpecificPower ;
   qudt:iec61360Code "0112/2///62720#UAB479" ;
   qudt:symbol "nGy/h" ;
   qudt:uneceCommonCode "P64" ;
@@ -32114,7 +32210,9 @@ unit:NanoGRAY-PER-MIN
   a qudt:Unit ;
   dcterms:description "0.000000001-fold of the SI derived unit gray divided by the unit minute" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:AbsorbedDoseRate ;
+  qudt:hasQuantityKind quantitykind:KermaRate ;
+  qudt:hasQuantityKind quantitykind:SpecificPower ;
   qudt:iec61360Code "0112/2///62720#UAB475" ;
   qudt:symbol "nGy/min" ;
   qudt:uneceCommonCode "P60" ;
@@ -32357,7 +32455,7 @@ unit:NanoMOL-PER-CentiM3-HR
   qudt:conversionMultiplier 0.000000277777777777778 ;
   qudt:conversionMultiplierSN 2.77777777777778E-7 ;
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T-1D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:CatalyticActivityConcentration ;
   qudt:symbol "nmol/(cm³·hr)" ;
   qudt:ucumCode "nmol.cm-3.h-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -32409,7 +32507,7 @@ unit:NanoMOL-PER-L-DAY
   qudt:conversionMultiplier 0.0000000000115740740740741 ;
   qudt:conversionMultiplierSN 1.15740740740741E-11 ;
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T-1D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:CatalyticActivityConcentration ;
   qudt:symbol "nmol/(L·day)" ;
   qudt:ucumCode "nmol.L-1.d-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -32421,7 +32519,7 @@ unit:NanoMOL-PER-L-HR
   qudt:conversionMultiplier 0.000000000277777777777778 ;
   qudt:conversionMultiplierSN 2.77777777777778E-10 ;
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T-1D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:CatalyticActivityConcentration ;
   qudt:symbol "nmol/(L·hr)" ;
   qudt:ucumCode "nmol.L-1.h-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -32433,7 +32531,7 @@ unit:NanoMOL-PER-M2-DAY
   qudt:conversionMultiplier 0.0000000000000115740740740741 ;
   qudt:conversionMultiplierSN 1.15740740740741E-14 ;
   qudt:hasDimensionVector qkdv:A1E0L-2I0M0H0T-1D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:PhotosyntheticPhotonFluxDensity ;
   qudt:symbol "nmol/(m²·day)" ;
   qudt:ucumCode "nmol.m-2.d-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -32599,7 +32697,9 @@ unit:NanoSV-PER-HR
   a qudt:Unit ;
   dcterms:description "0.000000001-fold of the SI derived unit sievert divided by the unit hour" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:AbsorbedDoseRate ;
+  qudt:hasQuantityKind quantitykind:KermaRate ;
+  qudt:hasQuantityKind quantitykind:SpecificPower ;
   qudt:iec61360Code "0112/2///62720#UAB467" ;
   qudt:symbol "nSv/h" ;
   qudt:uneceCommonCode "P73" ;
@@ -32610,7 +32710,9 @@ unit:NanoSV-PER-MIN
   a qudt:Unit ;
   dcterms:description "0.000000001-fold of the SI derived unit sievert divided by the unit minute" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:AbsorbedDoseRate ;
+  qudt:hasQuantityKind quantitykind:KermaRate ;
+  qudt:hasQuantityKind quantitykind:SpecificPower ;
   qudt:iec61360Code "0112/2///62720#UAB471" ;
   qudt:symbol "nSv/min" ;
   qudt:uneceCommonCode "P77" ;
@@ -32621,7 +32723,9 @@ unit:NanoSV-PER-SEC
   a qudt:Unit ;
   dcterms:description "0.000000001-fold of the SI derived unit sievert devided by the SI base unit second" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:AbsorbedDoseRate ;
+  qudt:hasQuantityKind quantitykind:KermaRate ;
+  qudt:hasQuantityKind quantitykind:SpecificPower ;
   qudt:iec61360Code "0112/2///62720#UAB304" ;
   qudt:symbol "nSv/s" ;
   qudt:uneceCommonCode "P68" ;
@@ -32875,7 +32979,8 @@ unit:OHM-KiloM
   qudt:conversionMultiplier 1000.0 ;
   qudt:conversionMultiplierSN 1.0E3 ;
   qudt:hasDimensionVector qkdv:A0E-2L3I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:ResidualResistivity ;
+  qudt:hasQuantityKind quantitykind:Resistivity ;
   qudt:iec61360Code "0112/2///62720#UAA018" ;
   qudt:symbol "Ω·km" ;
   qudt:ucumCode "Ohm.km"^^qudt:UCUMcs ;
@@ -32964,7 +33069,7 @@ unit:OHM-PER-KiloM
   qudt:conversionMultiplier 0.001 ;
   qudt:conversionMultiplierSN 1.0E-3 ;
   qudt:hasDimensionVector qkdv:A0E-2L1I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:LinearResistance ;
   qudt:iec61360Code "0112/2///62720#UAA019" ;
   qudt:symbol "Ω/km" ;
   qudt:ucumCode "Ohm.km-1"^^qudt:UCUMcs ;
@@ -32978,7 +33083,7 @@ unit:OHM-PER-M
   qudt:conversionMultiplier 1.0 ;
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E-2L1I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:LinearResistance ;
   qudt:iec61360Code "0112/2///62720#UAA021" ;
   qudt:symbol "Ω/m" ;
   qudt:ucumCode "Ohm.m-1"^^qudt:UCUMcs ;
@@ -32992,7 +33097,7 @@ unit:OHM-PER-MI
   qudt:conversionMultiplier 0.0006213712 ;
   qudt:conversionMultiplierSN 6.213712E-4 ;
   qudt:hasDimensionVector qkdv:A0E-2L1I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:LinearResistance ;
   qudt:iec61360Code "0112/2///62720#UAA022" ;
   qudt:symbol "Ω/mi" ;
   qudt:ucumCode "Ohm.[mi_i]-1"^^qudt:UCUMcs ;
@@ -33022,7 +33127,7 @@ unit:OHM_CIRC-MIL-PER-FT
   a qudt:Unit ;
   dcterms:description "unit of resistivity" ;
   qudt:hasDimensionVector qkdv:A0E-2L3I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:Resistivity ;
   qudt:iec61360Code "0112/2///62720#UAB215" ;
   qudt:symbol "Ω·cmil/ft" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -33419,7 +33524,10 @@ unit:OZ-PER-IN2
   qudt:conversionMultiplier 43.94184872744745489490978981957964 ;
   qudt:conversionMultiplierSN 4.394184872744745489490978981957964E1 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M1H0T0D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:BodyMassIndex ;
+  qudt:hasQuantityKind quantitykind:MassPerArea ;
+  qudt:hasQuantityKind quantitykind:MeanMassRange ;
+  qudt:hasQuantityKind quantitykind:SurfaceDensity ;
   qudt:iec61360Code "0112/2///62720#UAB261" ;
   qudt:symbol "oz/in²" ;
   qudt:ucumCode "[oz_av].[in_i]-2"^^qudt:UCUMcs ;
@@ -33844,7 +33952,7 @@ unit:P
   qudt:conversionMultiplier 0.00980665 ;
   qudt:conversionMultiplierSN 9.80665E-3 ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H0T-2D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:Force ;
   qudt:iec61360Code "0112/2///62720#UAB412" ;
   qudt:symbol "p" ;
   qudt:uneceCommonCode "M78" ;
@@ -34265,7 +34373,7 @@ unit:PA-SEC-PER-M3
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:expression "\\(Pa-s/m3\\)"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L-4I0M1H0T-1D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:PressureInRelationToVolumeFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA263" ;
   qudt:informativeReference "http://www.efunda.com/glossary/units/units--acoustic_impedance--pascal_second_per_cubic_meter.cfm"^^xsd:anyURI ;
   qudt:siUnitsExpression "Pa.s/m3" ;
@@ -34386,7 +34494,8 @@ unit:PDL-FT
   qudt:conversionMultiplier 0.0421401100938048 ;
   qudt:conversionMultiplierSN 4.21401100938048E-2 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:MomentOfForce ;
+  qudt:hasQuantityKind quantitykind:Torque ;
   qudt:iec61360Code "0112/2///62720#UAB417" ;
   qudt:symbol "pdl·ft" ;
   qudt:ucumCode "[lb_av].[ft_i].s-2.[ft_i]"^^qudt:UCUMcs ;
@@ -34400,7 +34509,8 @@ unit:PDL-IN
   qudt:conversionMultiplier 0.0035116758411504 ;
   qudt:conversionMultiplierSN 3.5116758411504E-3 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:MomentOfForce ;
+  qudt:hasQuantityKind quantitykind:Torque ;
   qudt:iec61360Code "0112/2///62720#UAB418" ;
   qudt:symbol "pdl·in" ;
   qudt:ucumCode "[lb_av].[ft_i].s-2.[in_i]"^^qudt:UCUMcs ;
@@ -34435,7 +34545,7 @@ unit:PDL-PER-IN
   qudt:conversionMultiplier 5.44310844 ;
   qudt:conversionMultiplierSN 5.44310844E0 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-2D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:ForcePerLength ;
   qudt:iec61360Code "0112/2///62720#UAB453" ;
   qudt:symbol "pdl/in" ;
   qudt:ucumCode "[lb_av].[ft_i].s-2.[in_i]-1"^^qudt:UCUMcs ;
@@ -34449,7 +34559,9 @@ unit:PDL-PER-IN2
   qudt:conversionMultiplier 214.295607874015748031496062992126 ;
   qudt:conversionMultiplierSN 2.14295607874015748031496062992126E2 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:ForcePerArea ;
+  qudt:hasQuantityKind quantitykind:ModulusOfLinearSubgradeReaction ;
+  qudt:hasQuantityKind quantitykind:VaporPressure ;
   qudt:iec61360Code "0112/2///62720#UAB427" ;
   qudt:symbol "pdl/in²" ;
   qudt:ucumCode "[lb_av].[ft_i].s-2.[in_i]-2"^^qudt:UCUMcs ;
@@ -34463,7 +34575,8 @@ unit:PDL-SEC-PER-FT2
   qudt:conversionMultiplier 1.488163943569553805774278215223097 ;
   qudt:conversionMultiplierSN 1.488163943569553805774278215223097E0 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-1D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:DynamicViscosity ;
+  qudt:hasQuantityKind quantitykind:Viscosity ;
   qudt:iec61360Code "0112/2///62720#UAB227" ;
   qudt:symbol "pdl/ft²)·s" ;
   qudt:ucumCode "[lb_av].[ft_i].s-2.s.[ft_i]-2"^^qudt:UCUMcs ;
@@ -34476,7 +34589,8 @@ unit:PDL-SEC-PER-IN2
   qudt:conversionMultiplier 214.295607874015748031496062992126 ;
   qudt:conversionMultiplierSN 2.14295607874015748031496062992126E2 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-1D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:DynamicViscosity ;
+  qudt:hasQuantityKind quantitykind:Viscosity ;
   qudt:iec61360Code "0112/2///62720#UAB434" ;
   qudt:symbol "pdl·s/in²" ;
   qudt:ucumCode "[lb_av].[ft_i].s-2.s.[in_i]-2"^^qudt:UCUMcs ;
@@ -34600,7 +34714,11 @@ unit:PER-DEG_F
   qudt:conversionMultiplier 1.799999999999999856000000000000012 ;
   qudt:conversionMultiplierSN 1.799999999999999856000000000000012E0 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H-1T0D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:ExpansionRatio ;
+  qudt:hasQuantityKind quantitykind:InverseTemperature ;
+  qudt:hasQuantityKind quantitykind:LinearExpansionCoefficient ;
+  qudt:hasQuantityKind quantitykind:RelativePressureCoefficient ;
+  qudt:hasQuantityKind quantitykind:ThermalExpansionCoefficient ;
   qudt:iec61360Code "0112/2///62720#UAA047" ;
   qudt:symbol "°F⁻¹" ;
   qudt:ucumCode "[degF]-1"^^qudt:UCUMcs ;
@@ -34614,7 +34732,7 @@ unit:PER-EV-M3
   qudt:conversionMultiplier 6241509074460762607.776240980930446 ;
   qudt:conversionMultiplierSN 6.241509074460762607776240980930446E18 ;
   qudt:hasDimensionVector qkdv:A0E0L-5I0M-1H0T2D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:EnergyDensityOfStates ;
   qudt:iec61360Code "0112/2///62720#UAB164" ;
   qudt:symbol "1/(eV·m³)" ;
   qudt:ucumCode "eV-1.m-3"^^qudt:UCUMcs ;
@@ -34666,7 +34784,7 @@ unit:PER-GM
   qudt:conversionMultiplier 1000.0 ;
   qudt:conversionMultiplierSN 1.0E3 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M-1H0T0D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:InverseMass ;
   qudt:iec61360Code "0112/2///62720#UAC004" ;
   qudt:symbol "/g" ;
   qudt:ucumCode "g-1"^^qudt:UCUMcs ;
@@ -34750,7 +34868,7 @@ unit:PER-IN2
   qudt:conversionMultiplier 1550.0031000062000124000248000496 ;
   qudt:conversionMultiplierSN 1.5500031000062000124000248000496E3 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T0D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:ParticleFluence ;
   qudt:iec61360Code "0112/2///62720#UAB361" ;
   qudt:symbol "/in²" ;
   qudt:ucumCode "[in_i]-2"^^qudt:UCUMcs ;
@@ -34781,7 +34899,7 @@ unit:PER-J
   qudt:conversionMultiplier 1.0 ;
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M-1H0T2D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:InverseEnergy ;
   qudt:iec61360Code "0112/2///62720#UAB324" ;
   qudt:symbol "J⁻¹" ;
   qudt:ucumCode "J-1"^^qudt:UCUMcs ;
@@ -35021,7 +35139,7 @@ unit:PER-M-NanoM
   qudt:conversionMultiplier 1000000000.0 ;
   qudt:conversionMultiplierSN 1.0E9 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T0D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:ParticleFluence ;
   qudt:symbol "/(m·nm)" ;
   qudt:ucumCode "m-1.nm-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -35271,7 +35389,11 @@ unit:PER-MegaK
   a qudt:Unit ;
   dcterms:description "0.000001-fold of reciprocal of the SI base unit kelvin" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H-1T0D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:ExpansionRatio ;
+  qudt:hasQuantityKind quantitykind:InverseTemperature ;
+  qudt:hasQuantityKind quantitykind:LinearExpansionCoefficient ;
+  qudt:hasQuantityKind quantitykind:RelativePressureCoefficient ;
+  qudt:hasQuantityKind quantitykind:ThermalExpansionCoefficient ;
   qudt:iec61360Code "0112/2///62720#UAA100" ;
   qudt:symbol "1/MK" ;
   qudt:uneceCommonCode "M20" ;
@@ -35284,7 +35406,11 @@ unit:PER-MegaPA
   qudt:conversionMultiplier 0.000001 ;
   qudt:conversionMultiplierSN 1.0E-6 ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M-1H0T2D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:Compressibility ;
+  qudt:hasQuantityKind quantitykind:InversePressure ;
+  qudt:hasQuantityKind quantitykind:IsentropicCompressibility ;
+  qudt:hasQuantityKind quantitykind:IsothermalCompressibility ;
+  qudt:hasQuantityKind quantitykind:StressOpticCoefficient ;
   qudt:iec61360Code "0112/2///62720#UAD929" ;
   qudt:symbol "1/MPa" ;
   qudt:ucumCode "MPa-1"^^qudt:UCUMcs ;
@@ -35726,7 +35852,7 @@ unit:PER-SEC2
   qudt:conversionMultiplier 1.0 ;
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-2D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:InverseTime_Squared ;
   qudt:symbol "/s²" ;
   qudt:ucumCode "s-2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -35788,7 +35914,7 @@ unit:PER-TON
   qudt:conversionMultiplier 0.001102311310924387903614869006725135 ;
   qudt:conversionMultiplierSN 1.102311310924387903614869006725135E-3 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M-1H0T0D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:InverseMass ;
   qudt:symbol "st⁻¹" ;
   qudt:ucumCode "ston_av-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -35813,7 +35939,7 @@ unit:PER-V
   qudt:conversionMultiplier 1.0 ;
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E1L-2I0M-1H0T3D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:ReciprocalVoltage ;
   qudt:iec61360Code "0112/2///62720#UAB326" ;
   qudt:symbol "V⁻¹" ;
   qudt:ucumCode "V-1"^^qudt:UCUMcs ;
@@ -35827,7 +35953,7 @@ unit:PER-V-A-SEC
   qudt:conversionMultiplier 1.0 ;
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M-1H0T2D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:InverseEnergy ;
   qudt:iec61360Code "0112/2///62720#UAB498" ;
   qudt:symbol "1/VAs" ;
   qudt:ucumCode "V-1.A-1.s-1"^^qudt:UCUMcs ;
@@ -36766,7 +36892,7 @@ unit:PERM_Metric_0DEG_C
   a qudt:Unit ;
   dcterms:description "traditional unit for the ability of a material to allow the transition of the steam, defined at a temperature of 0 °C as steam transmittance, where the mass of one grain steam penetrates an area of one foot squared at a pressure from one inch mercury per hour" ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T1D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:VaporPermeability ;
   qudt:iec61360Code "0112/2///62720#UAB294" ;
   qudt:symbol "perm (0 °C)" ;
   qudt:uneceCommonCode "P91" ;
@@ -36777,7 +36903,7 @@ unit:PERM_Metric_23DEG_C
   a qudt:Unit ;
   dcterms:description "traditional unit for the ability of a material to allow the transition of the steam, defined at a temperature of 23 °C as steam transmittance at which the mass of one grain of steam penetrates an area of one square foot at a pressure of one inch mercury per hour" ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T1D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:VaporPermeability ;
   qudt:iec61360Code "0112/2///62720#UAB295" ;
   qudt:symbol "perm (23 °C)" ;
   qudt:uneceCommonCode "P92" ;
@@ -36801,7 +36927,8 @@ unit:PFERDESTAERKE
   a qudt:Unit ;
   dcterms:description "obsolete, non-legal unit of the power in Germany relating to DIN 1301-3:1979" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:ActivePower ;
+  qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAB438" ;
   qudt:symbol "PS" ;
   qudt:uneceCommonCode "N12" ;
@@ -36812,7 +36939,7 @@ unit:PFUND
   a qudt:Unit ;
   dcterms:description "outdated unit of the mass in Germany" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T0D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:Mass ;
   qudt:iec61360Code "0112/2///62720#UAB387" ;
   qudt:symbol "pfd" ;
   qudt:uneceCommonCode "M86" ;
@@ -36846,7 +36973,7 @@ unit:PHON
   qudt:conversionMultiplier 1.0 ;
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:SoundPressureLevel ;
   qudt:iec61360Code "0112/2///62720#UAA937" ;
   qudt:symbol "phon" ;
   qudt:uneceCommonCode "C69" ;
@@ -37316,7 +37443,7 @@ unit:POISE-PER-PA
   qudt:conversionMultiplier 0.1 ;
   qudt:conversionMultiplierSN 1.0E-1 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T1D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:Time ;
   qudt:iec61360Code "0112/2///62720#UAB311" ;
   qudt:symbol "P/Pa" ;
   qudt:ucumCode "P.Pa-1"^^qudt:UCUMcs ;
@@ -37330,7 +37457,7 @@ unit:POND
   qudt:conversionMultiplier 0.00980665 ;
   qudt:conversionMultiplierSN 9.80665E-3 ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H0T-2D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:Force ;
   qudt:iec61360Code "0112/2///62720#UAB412" ;
   qudt:symbol "p" ;
   qudt:uneceCommonCode "M78" ;
@@ -37471,7 +37598,7 @@ unit:PPTH-PER-HR
   qudt:conversionMultiplier 0.000000277777777777778 ;
   qudt:conversionMultiplierSN 2.77777777777778E-7 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:Frequency ;
   qudt:symbol "‰/hr" ;
   qudt:ucumCode "[ppth].h-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -37683,7 +37810,7 @@ unit:PSU
   qudt:applicableSystem sou:PLANCK ;
   qudt:applicableSystem sou:SI ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:DimensionlessRatio ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Salinity#PSU"^^xsd:anyURI ;
   qudt:symbol "PSU" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -37723,7 +37850,7 @@ unit:PebiBIT-PER-M
   qudt:conversionMultiplier 1125899906842624.0 ;
   qudt:conversionMultiplierSN 1.125899906842624E15 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T0D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:LinearBitDensity ;
   qudt:iec61360Code "0112/2///62720#UAA271" ;
   qudt:symbol "Pibit/m" ;
   qudt:uneceCommonCode "E80" ;
@@ -37736,7 +37863,7 @@ unit:PebiBIT-PER-M2
   qudt:conversionMultiplier 1125899906842620.0 ;
   qudt:conversionMultiplierSN 1.12589990684262E15 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T0D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:AreaBitDensity ;
   qudt:iec61360Code "0112/2///62720#UAA272" ;
   qudt:symbol "Pibit/m²" ;
   qudt:uneceCommonCode "E81" ;
@@ -37749,7 +37876,7 @@ unit:PebiBIT-PER-M3
   qudt:conversionMultiplier 1125899906842620.0 ;
   qudt:conversionMultiplierSN 1.12589990684262E15 ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M0H0T0D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:VolumetricBitDensity ;
   qudt:iec61360Code "0112/2///62720#UAA273" ;
   qudt:symbol "Pibit/m³" ;
   qudt:uneceCommonCode "E82" ;
@@ -38391,7 +38518,7 @@ unit:PicoMOL-PER-M3-SEC
   qudt:conversionMultiplier 0.000000000001 ;
   qudt:conversionMultiplierSN 1.0E-12 ;
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T-1D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:CatalyticActivityConcentration ;
   qudt:symbol "pmol/(m³·s)" ;
   qudt:ucumCode "pmol.m-3.s-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -39121,7 +39248,7 @@ unit:R-PER-SEC
   qudt:conversionMultiplier 0.000258 ;
   qudt:conversionMultiplierSN 2.58E-4 ;
   qudt:hasDimensionVector qkdv:A0E1L0I0M-1H0T0D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:ExposureRate ;
   qudt:iec61360Code "0112/2///62720#UAA276" ;
   qudt:symbol "R/s" ;
   qudt:ucumCode "R.s-1"^^qudt:UCUMcs ;
@@ -39411,7 +39538,9 @@ unit:REM-PER-SEC
   qudt:conversionMultiplier 0.01 ;
   qudt:conversionMultiplierSN 1.0E-2 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:AbsorbedDoseRate ;
+  qudt:hasQuantityKind quantitykind:KermaRate ;
+  qudt:hasQuantityKind quantitykind:SpecificPower ;
   qudt:iec61360Code "0112/2///62720#UAB442" ;
   qudt:symbol "rem/s" ;
   qudt:ucumCode "REM.s-1"^^qudt:UCUMcs ;
@@ -40386,7 +40515,9 @@ unit:SV-PER-HR
   qudt:conversionMultiplier 0.0002777777777777777777777777777777778 ;
   qudt:conversionMultiplierSN 2.777777777777777777777777777777778E-4 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:AbsorbedDoseRate ;
+  qudt:hasQuantityKind quantitykind:KermaRate ;
+  qudt:hasQuantityKind quantitykind:SpecificPower ;
   qudt:iec61360Code "0112/2///62720#UAB464" ;
   qudt:symbol "Sv/h" ;
   qudt:ucumCode "Sv.h-1"^^qudt:UCUMcs ;
@@ -40400,7 +40531,9 @@ unit:SV-PER-MIN
   qudt:conversionMultiplier 0.01666666666666666666666666666666667 ;
   qudt:conversionMultiplierSN 1.666666666666666666666666666666667E-2 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:AbsorbedDoseRate ;
+  qudt:hasQuantityKind quantitykind:KermaRate ;
+  qudt:hasQuantityKind quantitykind:SpecificPower ;
   qudt:iec61360Code "0112/2///62720#UAB468" ;
   qudt:symbol "Sv/min" ;
   qudt:ucumCode "Sv.min-1"^^qudt:UCUMcs ;
@@ -40414,7 +40547,9 @@ unit:SV-PER-SEC
   qudt:conversionMultiplier 1.0 ;
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:AbsorbedDoseRate ;
+  qudt:hasQuantityKind quantitykind:KermaRate ;
+  qudt:hasQuantityKind quantitykind:SpecificPower ;
   qudt:iec61360Code "0112/2///62720#UAB301" ;
   qudt:symbol "Sv/s" ;
   qudt:ucumCode "Sv.s-1"^^qudt:UCUMcs ;
@@ -40629,7 +40764,8 @@ unit:THERM_EC
   dcterms:description "unit of heat energy in commercial use, within the EU defined: 1 thm (EC) = 100 000 BtuIT" ;
   qudt:exactMatch unit:THM_EEC ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:Energy ;
+  qudt:hasQuantityKind quantitykind:ThermalEnergy ;
   qudt:iec61360Code "0112/2///62720#UAB222" ;
   qudt:symbol "thm{EC}" ;
   qudt:uneceCommonCode "N71" ;
@@ -40641,7 +40777,8 @@ unit:THERM_US
   dcterms:description "unit of heat energy in commercial use" ;
   qudt:exactMatch unit:THM_US ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:Energy ;
+  qudt:hasQuantityKind quantitykind:ThermalEnergy ;
   qudt:iec61360Code "0112/2///62720#UAB223" ;
   qudt:symbol "thm{US}" ;
   qudt:uneceCommonCode "N72" ;
@@ -40941,7 +41078,7 @@ unit:TONNE-PER-M3-BAR
   qudt:conversionMultiplier 0.01 ;
   qudt:conversionMultiplierSN 1.0E-2 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T2D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:MassPerEnergy ;
   qudt:iec61360Code "0112/2///62720#UAA999" ;
   qudt:symbol "t/(m³·bar)" ;
   qudt:ucumCode "t.m-3.bar-1"^^qudt:UCUMcs ;
@@ -41017,7 +41154,8 @@ unit:TONNE-PER-MO
   qudt:conversionMultiplier 0.0003919350772901616281311709002114104 ;
   qudt:conversionMultiplierSN 3.919350772901616281311709002114104E-4 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-1D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:MassFlowRate ;
+  qudt:hasQuantityKind quantitykind:MassPerTime ;
   qudt:iec61360Code "0112/2///62720#UAB366" ;
   qudt:symbol "t/mo" ;
   qudt:ucumCode "t.mo-1"^^qudt:UCUMcs ;
@@ -41083,7 +41221,8 @@ unit:TONNE-PER-YR
   qudt:conversionMultiplier 0.00003168808781 ;
   qudt:conversionMultiplierSN 3.168808781E-5 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-1D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:MassFlowRate ;
+  qudt:hasQuantityKind quantitykind:MassPerTime ;
   qudt:iec61360Code "0112/2///62720#UAB367" ;
   qudt:symbol "t/y" ;
   qudt:ucumCode "t.a-1"^^qudt:UCUMcs ;
@@ -41496,7 +41635,8 @@ unit:TON_Register
   a qudt:Unit ;
   dcterms:description "traditional unit of the cargo capacity" ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T0D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:SectionModulus ;
+  qudt:hasQuantityKind quantitykind:Volume ;
   qudt:iec61360Code "0112/2///62720#UAB291" ;
   qudt:symbol "RT" ;
   qudt:uneceCommonCode "M70" ;
@@ -41841,7 +41981,7 @@ unit:TebiBIT-PER-M
   qudt:conversionMultiplier 1099511627776.0 ;
   qudt:conversionMultiplierSN 1.099511627776E12 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T0D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:LinearBitDensity ;
   qudt:iec61360Code "0112/2///62720#UAA292" ;
   qudt:symbol "Tibit/m" ;
   qudt:uneceCommonCode "E85" ;
@@ -41854,7 +41994,7 @@ unit:TebiBIT-PER-M2
   qudt:conversionMultiplier 1099511627776.0 ;
   qudt:conversionMultiplierSN 1.099511627776E12 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T0D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:AreaBitDensity ;
   qudt:iec61360Code "0112/2///62720#UAA293" ;
   qudt:symbol "Tibit/m²" ;
   qudt:uneceCommonCode "E87" ;
@@ -41867,7 +42007,7 @@ unit:TebiBIT-PER-M3
   qudt:conversionMultiplier 1099511627776.0 ;
   qudt:conversionMultiplierSN 1.099511627776E12 ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M0H0T0D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:VolumetricBitDensity ;
   qudt:iec61360Code "0112/2///62720#UAA294" ;
   qudt:symbol "Tibit/m³" ;
   qudt:uneceCommonCode "E86" ;
@@ -41905,7 +42045,13 @@ unit:TeraA
   qudt:conversionMultiplier 1000000000000.0 ;
   qudt:conversionMultiplierSN 1.0E12 ;
   qudt:hasDimensionVector qkdv:A0E1L0I0M0H0T0D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:CurrentLinkage ;
+  qudt:hasQuantityKind quantitykind:DisplacementCurrent ;
+  qudt:hasQuantityKind quantitykind:ElectricCurrent ;
+  qudt:hasQuantityKind quantitykind:ElectricCurrentPhasor ;
+  qudt:hasQuantityKind quantitykind:MagneticTension ;
+  qudt:hasQuantityKind quantitykind:MagnetomotiveForce ;
+  qudt:hasQuantityKind quantitykind:TotalCurrent ;
   qudt:iec61360Code "0112/2///62720#UAB640" ;
   qudt:symbol "TA" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -41930,7 +42076,7 @@ unit:TeraBIT-PER-SEC
   qudt:conversionMultiplier 693147180559.94530941723212145818 ;
   qudt:conversionMultiplierSN 6.9314718055994530941723212145818E11 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:DataRate ;
   qudt:iec61360Code "0112/2///62720#UAA291" ;
   qudt:symbol "Tbit/s" ;
   qudt:ucumCode "Tbit.s-1"^^qudt:UCUMcs ;
@@ -41944,7 +42090,7 @@ unit:TeraBQ
   qudt:conversionMultiplier 1000000000000.0 ;
   qudt:conversionMultiplierSN 1.0E12 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:Activity ;
   qudt:iec61360Code "0112/2///62720#UAB589" ;
   qudt:symbol "TBq" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -42055,7 +42201,8 @@ unit:TeraJ-PER-SEC
   qudt:conversionMultiplier 1000000000000.0 ;
   qudt:conversionMultiplierSN 1.0E12 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:ActivePower ;
+  qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAB513" ;
   qudt:symbol "TJ/s" ;
   qudt:ucumCode "TJ.s-1"^^qudt:UCUMcs ;
@@ -42088,7 +42235,10 @@ unit:TeraV
   qudt:conversionMultiplier 1000000000000.0 ;
   qudt:conversionMultiplierSN 1.0E12 ;
   qudt:hasDimensionVector qkdv:A0E-1L2I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:ElectricPotential ;
+  qudt:hasQuantityKind quantitykind:ElectricPotentialDifference ;
+  qudt:hasQuantityKind quantitykind:EnergyPerElectricCharge ;
+  qudt:hasQuantityKind quantitykind:Voltage ;
   qudt:iec61360Code "0112/2///62720#UAC773" ;
   qudt:symbol "TV" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -42100,7 +42250,8 @@ unit:TeraV-A
   qudt:conversionMultiplier 1000000000000.0 ;
   qudt:conversionMultiplierSN 1.0E12 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:ComplexPower ;
+  qudt:hasQuantityKind quantitykind:NonActivePower ;
   qudt:iec61360Code "0112/2///62720#UAB535" ;
   qudt:symbol "TV·A" ;
   qudt:ucumCode "TV.A"^^qudt:UCUMcs ;
@@ -42111,7 +42262,7 @@ unit:TeraV-A_Reactive
   a qudt:Unit ;
   dcterms:description "0.000000000001 of the unit volt ampere reactive" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:ReactivePower ;
   qudt:iec61360Code "0112/2///62720#UAC509" ;
   qudt:symbol "TV·A{Reactive}" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -42469,7 +42620,7 @@ unit:V-IN2-PER-LB_F
   qudt:conversionMultiplier 0.0001450377312227268702148557236386593 ;
   qudt:conversionMultiplierSN 1.450377312227268702148557236386593E-4 ;
   qudt:hasDimensionVector qkdv:A0E-1L3I0M0H0T-1D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:HallCoefficient ;
   qudt:iec61360Code "0112/2///62720#UAA305" ;
   qudt:symbol "V/psi" ;
   qudt:ucumCode "V.[in_i]2.[lbf_av]-1"^^qudt:UCUMcs ;
@@ -42497,7 +42648,7 @@ unit:V-PER-BAR
   qudt:conversionMultiplier 0.00001 ;
   qudt:conversionMultiplierSN 1.0E-5 ;
   qudt:hasDimensionVector qkdv:A0E-1L3I0M0H0T-1D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:HallCoefficient ;
   qudt:iec61360Code "0112/2///62720#UAA299" ;
   qudt:symbol "V/bar" ;
   qudt:ucumCode "V.bar-1"^^qudt:UCUMcs ;
@@ -42673,7 +42824,7 @@ unit:V-PER-PA
   qudt:conversionMultiplier 1.0 ;
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E-1L3I0M0H0T-1D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:HallCoefficient ;
   qudt:iec61360Code "0112/2///62720#UAB312" ;
   qudt:symbol "V/Pa" ;
   qudt:ucumCode "V.Pa-1"^^qudt:UCUMcs ;
@@ -42935,7 +43086,11 @@ unit:W-HR-PER-KiloGM
   qudt:conversionMultiplier 3600.0 ;
   qudt:conversionMultiplierSN 3.6E3 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-2D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:SpecificEnergy ;
+  qudt:hasQuantityKind quantitykind:SpecificEnthalpy ;
+  qudt:hasQuantityKind quantitykind:SpecificGibbsEnergy ;
+  qudt:hasQuantityKind quantitykind:SpecificHelmholtzEnergy ;
+  qudt:hasQuantityKind quantitykind:SpecificInternalEnergy ;
   qudt:iec61360Code "0112/2///62720#UAD888" ;
   qudt:symbol "W·h/kg" ;
   qudt:ucumCode "W.h.kg-1"^^qudt:UCUMcs ;
@@ -43158,7 +43313,7 @@ unit:W-PER-M
   qudt:conversionMultiplier 1.0 ;
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:LineicPower ;
   qudt:iec61360Code "0112/2///62720#UAB374" ;
   qudt:symbol "W/m" ;
   qudt:ucumCode "W.m-1"^^qudt:UCUMcs ;
@@ -43172,7 +43327,7 @@ unit:W-PER-M-DEG_C
   qudt:conversionMultiplier 1.0 ;
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H-1T-3D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:ThermalConductivity ;
   qudt:iec61360Code "0112/2///62720#UAB457" ;
   qudt:symbol "W/(m·°C)" ;
   qudt:ucumCode "W.m-1.Cel-1"^^qudt:UCUMcs ;
@@ -43669,7 +43824,10 @@ unit:YD-PER-HR
   qudt:conversionMultiplier 0.000254 ;
   qudt:conversionMultiplierSN 2.54E-4 ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T-1D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:ElectromagneticWavePhaseSpeed ;
+  qudt:hasQuantityKind quantitykind:LinearVelocity ;
+  qudt:hasQuantityKind quantitykind:Speed ;
+  qudt:hasQuantityKind quantitykind:Velocity ;
   qudt:iec61360Code "0112/2///62720#UAB396" ;
   qudt:symbol "yd/h" ;
   qudt:ucumCode "[yd_i].h-1"^^qudt:UCUMcs ;
@@ -43683,7 +43841,10 @@ unit:YD-PER-MIN
   qudt:conversionMultiplier 0.01524 ;
   qudt:conversionMultiplierSN 1.524E-2 ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T-1D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:ElectromagneticWavePhaseSpeed ;
+  qudt:hasQuantityKind quantitykind:LinearVelocity ;
+  qudt:hasQuantityKind quantitykind:Speed ;
+  qudt:hasQuantityKind quantitykind:Velocity ;
   qudt:iec61360Code "0112/2///62720#UAB395" ;
   qudt:symbol "yd/min" ;
   qudt:ucumCode "[yd_i].min-1"^^qudt:UCUMcs ;
@@ -43711,7 +43872,10 @@ unit:YD-PER-SEC
   qudt:conversionMultiplier 0.9144 ;
   qudt:conversionMultiplierSN 9.144E-1 ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T-1D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:ElectromagneticWavePhaseSpeed ;
+  qudt:hasQuantityKind quantitykind:LinearVelocity ;
+  qudt:hasQuantityKind quantitykind:Speed ;
+  qudt:hasQuantityKind quantitykind:Velocity ;
   qudt:iec61360Code "0112/2///62720#UAB394" ;
   qudt:symbol "yd/s" ;
   qudt:ucumCode "[yd_i].s-1"^^qudt:UCUMcs ;
@@ -43725,7 +43889,8 @@ unit:YD-PER-SEC2
   qudt:conversionMultiplier 0.9144 ;
   qudt:conversionMultiplierSN 9.144E-1 ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T-2D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:Acceleration ;
+  qudt:hasQuantityKind quantitykind:LinearAcceleration ;
   qudt:iec61360Code "0112/2///62720#UAB399" ;
   qudt:symbol "yd/s²" ;
   qudt:ucumCode "[yd_i].s-2"^^qudt:UCUMcs ;
@@ -43925,7 +44090,7 @@ unit:YR_Metrology
   a qudt:Unit ;
   dcterms:description "31,557,600-fold of the SI base unit second according to one year with 365.25 days as physical quantity in the metrology" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T1D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:Time ;
   qudt:iec61360Code "0112/2///62720#UAD922" ;
   qudt:symbol "y (metrology)" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -44030,7 +44195,7 @@ unit:ZOLL
   a qudt:Unit ;
   dcterms:description "length measure corresponding to the imperial unit \"inch\"" ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T0D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:Length ;
   qudt:iec61360Code "0112/2///62720#UAB837" ;
   qudt:symbol "“" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;


### PR DESCRIPTION
This replaces `quantitykind:Unknown` with relevant quantity kind(s) for ~230 units where possible based on similarity with other units. For example, the quantity kinds specified for `unit:A` were applied to `unit:AttoA`.

Additionally, a few `qudt:exactMatch` statements were added. SHACL validation passed.
























































