### PR TITLE
Change quantitykind for unit:M2-PER-SEC2

### DIFF
--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -22439,7 +22439,7 @@ unit:M2-PER-SEC2
   qudt:conversionMultiplier 1.0 ;
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-2D0 ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasQuantityKind quantitykind:SpecificModulus ;
   qudt:iec61360Code "0112/2///62720#UAD501" ;
   qudt:symbol "m²/s²" ;
   qudt:ucumCode "m2.s-2"^^qudt:UCUMcs ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -31804,9 +31804,9 @@ unit:NUM-PER-GM
   qudt:hasDimensionVector qkdv:A0E0L0I0M-1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:symbol "/g" ;
+  qudt:ucumCode "/g"^^qudt:UCUMcs ;
   qudt:ucumCode "{#}.g-1"^^qudt:UCUMcs ;
   qudt:ucumCode "{#}/g"^^qudt:UCUMcs ;
-  qudt:ucumCode "/g"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Number per gram"@en ;
 .
@@ -31818,9 +31818,9 @@ unit:NUM-PER-HA
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:ParticleFluence ;
   qudt:symbol "/ha" ;
+  qudt:ucumCode "/har"^^qudt:UCUMcs ;
   qudt:ucumCode "{#}.har-1"^^qudt:UCUMcs ;
   qudt:ucumCode "{#}/har"^^qudt:UCUMcs ;
-  qudt:ucumCode "/har"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Number per hectare"@en ;
 .
@@ -31831,9 +31831,9 @@ unit:NUM-PER-HR
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Frequency ;
   qudt:symbol "/hr" ;
+  qudt:ucumCode "/h"^^qudt:UCUMcs ;
   qudt:ucumCode "{#}.h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "{#}/h"^^qudt:UCUMcs ;
-  qudt:ucumCode "/h"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Number per hour"@en ;
 .
@@ -31845,9 +31845,9 @@ unit:NUM-PER-HectoGM
   qudt:hasDimensionVector qkdv:A0E0L0I0M-1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:symbol "/hg" ;
+  qudt:ucumCode "/hg"^^qudt:UCUMcs ;
   qudt:ucumCode "{#}.hg-1"^^qudt:UCUMcs ;
   qudt:ucumCode "{#}/hg"^^qudt:UCUMcs ;
-  qudt:ucumCode "/hg"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Number per 100 grams"@en ;
 .
@@ -31872,7 +31872,6 @@ unit:NUM-PER-L
   qudt:ucumCode "/L"^^qudt:UCUMcs ;
   qudt:ucumCode "{#}.L-1"^^qudt:UCUMcs ;
   qudt:ucumCode "{#}/L"^^qudt:UCUMcs ;
-  qudt:ucumCode "/L"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Number per litre"@en ;
 .
@@ -31994,9 +31993,9 @@ unit:NUM-PER-SEC
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Frequency ;
   qudt:symbol "/s" ;
+  qudt:ucumCode "/s"^^qudt:UCUMcs ;
   qudt:ucumCode "{#}.s-1"^^qudt:UCUMcs ;
   qudt:ucumCode "{#}/s"^^qudt:UCUMcs ;
-  qudt:ucumCode "/s"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Counts per second"@en ;
 .
@@ -32011,9 +32010,9 @@ unit:NUM-PER-YR
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Frequency ;
   qudt:symbol "#/yr" ;
+  qudt:ucumCode "/a"^^qudt:UCUMcs ;
   qudt:ucumCode "{#}.a-1"^^qudt:UCUMcs ;
   qudt:ucumCode "{#}/a"^^qudt:UCUMcs ;
-  qudt:ucumCode "/a"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Number per Year"@en ;
 .
@@ -34796,8 +34795,8 @@ unit:PER-ANGSTROM
   qudt:iec61360Code "0112/2///62720#UAB058" ;
   qudt:plainTextDescription "reciprocal of the unit angstrom" ;
   qudt:symbol "/Å" ;
-  qudt:ucumCode "Ao-1"^^qudt:UCUMcs ;
   qudt:ucumCode "/Ao"^^qudt:UCUMcs ;
+  qudt:ucumCode "Ao-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C85" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Reciprocal Angstrom"@en ;
@@ -34815,8 +34814,8 @@ unit:PER-BAR
   qudt:iec61360Code "0112/2///62720#UAA328" ;
   qudt:plainTextDescription "reciprocal of the metrical unit with the name bar" ;
   qudt:symbol "/bar" ;
-  qudt:ucumCode "bar-1"^^qudt:UCUMcs ;
   qudt:ucumCode "/bar"^^qudt:UCUMcs ;
+  qudt:ucumCode "bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F58" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Reciprocal Bar"@en ;
@@ -34912,8 +34911,8 @@ unit:PER-DEG_F
   qudt:hasQuantityKind quantitykind:ThermalExpansionCoefficient ;
   qudt:iec61360Code "0112/2///62720#UAA047" ;
   qudt:symbol "°F⁻¹" ;
-  qudt:ucumCode "[degF]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "/[degF]"^^qudt:UCUMcs ;
+  qudt:ucumCode "[degF]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J26" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "reciprocal degree Fahrenheit" ;
@@ -34961,8 +34960,8 @@ unit:PER-FT3
   qudt:iec61360Code "0112/2///62720#UAA453" ;
   qudt:plainTextDescription "reciprocal value of the power of the unit foot according to the Anglo-American and the Imperial system of units with the exponent 3" ;
   qudt:symbol "/ft³" ;
-  qudt:ucumCode "[cft_i]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "/[cft_i]"^^qudt:UCUMcs ;
+  qudt:ucumCode "[cft_i]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K20" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Reciprocal Cubic Foot"@en ;
@@ -34980,8 +34979,8 @@ unit:PER-GM
   qudt:hasQuantityKind quantitykind:InverseMass ;
   qudt:iec61360Code "0112/2///62720#UAC004" ;
   qudt:symbol "/g" ;
-  qudt:ucumCode "g-1"^^qudt:UCUMcs ;
   qudt:ucumCode "/g"^^qudt:UCUMcs ;
+  qudt:ucumCode "g-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Reciprocal gram"@en ;
 .
@@ -35014,8 +35013,8 @@ unit:PER-H
   qudt:hasQuantityKind quantitykind:Reluctance ;
   qudt:iec61360Code "0112/2///62720#UAA169" ;
   qudt:symbol "/H" ;
-  qudt:ucumCode "H-1"^^qudt:UCUMcs ;
   qudt:ucumCode "/H"^^qudt:UCUMcs ;
+  qudt:ucumCode "H-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C89" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Reciprocal Henry"@en ;
@@ -35052,8 +35051,8 @@ unit:PER-IN
   qudt:hasQuantityKind quantitykind:Repetency ;
   qudt:iec61360Code "0112/2///62720#UAB360" ;
   qudt:symbol "in⁻¹" ;
-  qudt:ucumCode "[in_i]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "/[in_i]"^^qudt:UCUMcs ;
+  qudt:ucumCode "[in_i]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "Q24" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "reciprocal inch" ;
@@ -35084,8 +35083,8 @@ unit:PER-IN3
   qudt:iec61360Code "0112/2///62720#UAA546" ;
   qudt:plainTextDescription "reciprocal value of the power of the unit inch according to the Anglo-American and the Imperial system of units with the exponent 3" ;
   qudt:symbol "/in³" ;
-  qudt:ucumCode "[cin_i]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "/[cin_i]"^^qudt:UCUMcs ;
+  qudt:ucumCode "[cin_i]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K49" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Reciprocal Cubic Inch"@en ;
@@ -35099,8 +35098,8 @@ unit:PER-J
   qudt:hasQuantityKind quantitykind:InverseEnergy ;
   qudt:iec61360Code "0112/2///62720#UAB324" ;
   qudt:symbol "J⁻¹" ;
-  qudt:ucumCode "J-1"^^qudt:UCUMcs ;
   qudt:ucumCode "/J"^^qudt:UCUMcs ;
+  qudt:ucumCode "J-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "N91" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "reciprocal joule" ;
@@ -35158,8 +35157,8 @@ unit:PER-K
   qudt:hasQuantityKind quantitykind:ThermalExpansionCoefficient ;
   qudt:iec61360Code "0112/2///62720#UAA193" ;
   qudt:symbol "/K" ;
-  qudt:ucumCode "K-1"^^qudt:UCUMcs ;
   qudt:ucumCode "/K"^^qudt:UCUMcs ;
+  qudt:ucumCode "K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C91" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Reciprocal Kelvin"@en ;
@@ -35173,8 +35172,8 @@ unit:PER-KiloGM
   qudt:hasQuantityKind quantitykind:InverseMass ;
   qudt:iec61360Code "0112/2///62720#UAC003" ;
   qudt:symbol "kg⁻¹" ;
-  qudt:ucumCode "kg-1"^^qudt:UCUMcs ;
   qudt:ucumCode "/kg"^^qudt:UCUMcs ;
+  qudt:ucumCode "kg-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "reciprocal kilogram" ;
 .
@@ -35279,8 +35278,8 @@ unit:PER-LB
   qudt:hasQuantityKind quantitykind:InverseMass ;
   qudt:iec61360Code "0112/2///62720#UAC008" ;
   qudt:symbol "lb⁻¹" ;
-  qudt:ucumCode "[lb_av]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "/[lb_av]"^^qudt:UCUMcs ;
+  qudt:ucumCode "[lb_av]-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "reciprocal pound (avoirdupois)" ;
 .
@@ -35560,8 +35559,8 @@ unit:PER-MO
   qudt:iec61360Code "0112/2///62720#UAA881" ;
   qudt:plainTextDescription "reciprocal of the unit month" ;
   qudt:symbol "/mo" ;
-  qudt:ucumCode "mo-1"^^qudt:UCUMcs ;
   qudt:ucumCode "/mo"^^qudt:UCUMcs ;
+  qudt:ucumCode "mo-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H11" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Reciprocal Month"@en ;
@@ -35615,8 +35614,8 @@ unit:PER-MegaPA
   qudt:hasQuantityKind quantitykind:StressOpticCoefficient ;
   qudt:iec61360Code "0112/2///62720#UAD929" ;
   qudt:symbol "1/MPa" ;
-  qudt:ucumCode "MPa-1"^^qudt:UCUMcs ;
   qudt:ucumCode "/MPa"^^qudt:UCUMcs ;
+  qudt:ucumCode "MPa-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "reciprocal megapascal" ;
 .
@@ -35669,8 +35668,8 @@ unit:PER-MilliGM
   qudt:hasQuantityKind quantitykind:InverseMass ;
   qudt:iec61360Code "0112/2///62720#UAC005" ;
   qudt:symbol "mg⁻¹" ;
-  qudt:ucumCode "mg-1"^^qudt:UCUMcs ;
   qudt:ucumCode "/mg"^^qudt:UCUMcs ;
+  qudt:ucumCode "mg-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "reciprocal milligram" ;
 .
@@ -35794,8 +35793,8 @@ unit:PER-OZ
   qudt:hasQuantityKind quantitykind:InverseMass ;
   qudt:iec61360Code "0112/2///62720#UAC007" ;
   qudt:symbol "oz⁻¹" ;
-  qudt:ucumCode "[oz_av]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "/[oz_av]"^^qudt:UCUMcs ;
+  qudt:ucumCode "[oz_av]-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "reciprocal ounce (avoirdupois)" ;
 .
@@ -35821,8 +35820,8 @@ unit:PER-PA
   qudt:informativeReference "http://en.wikipedia.org/wiki/Pascal?oldid=492989202"^^xsd:anyURI ;
   qudt:siUnitsExpression "m^2/N" ;
   qudt:symbol "Pa⁻¹" ;
-  qudt:ucumCode "Pa-1"^^qudt:UCUMcs ;
   qudt:ucumCode "/Pa"^^qudt:UCUMcs ;
+  qudt:ucumCode "Pa-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C96" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Reciprocal Pascal"@en ;
@@ -35926,8 +35925,8 @@ unit:PER-RAD
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAB327" ;
   qudt:symbol "rad⁻¹" ;
-  qudt:ucumCode "rad-1"^^qudt:UCUMcs ;
   qudt:ucumCode "/rad"^^qudt:UCUMcs ;
+  qudt:ucumCode "rad-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P97" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "reciprocal radian" ;
@@ -36076,8 +36075,8 @@ unit:PER-SR
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:symbol "/sr" ;
-  qudt:ucumCode "sr-1"^^qudt:UCUMcs ;
   qudt:ucumCode "/sr"^^qudt:UCUMcs ;
+  qudt:ucumCode "sr-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Reciprocal steradian"@en ;
 .
@@ -36137,8 +36136,8 @@ unit:PER-TONNE
   qudt:hasQuantityKind quantitykind:InverseMass ;
   qudt:iec61360Code "0112/2///62720#UAC006" ;
   qudt:symbol "t⁻¹" ;
-  qudt:ucumCode "t-1"^^qudt:UCUMcs ;
   qudt:ucumCode "/t"^^qudt:UCUMcs ;
+  qudt:ucumCode "t-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "reciprocal tonne" ;
 .
@@ -36151,8 +36150,8 @@ unit:PER-V
   qudt:hasQuantityKind quantitykind:ReciprocalVoltage ;
   qudt:iec61360Code "0112/2///62720#UAB326" ;
   qudt:symbol "V⁻¹" ;
-  qudt:ucumCode "V-1"^^qudt:UCUMcs ;
   qudt:ucumCode "/V"^^qudt:UCUMcs ;
+  qudt:ucumCode "V-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P96" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "reciprocal volt" ;
@@ -36184,8 +36183,8 @@ unit:PER-WB
   qudt:iec61360Code "0112/2///62720#UAB354" ;
   qudt:informativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
   qudt:symbol "/Wb" ;
-  qudt:ucumCode "Wb-1"^^qudt:UCUMcs ;
   qudt:ucumCode "/Wb"^^qudt:UCUMcs ;
+  qudt:ucumCode "Wb-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "Q23" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Reciprocal Weber"@en ;
@@ -36206,8 +36205,8 @@ unit:PER-WK
   qudt:iec61360Code "0112/2///62720#UAA099" ;
   qudt:plainTextDescription "reciprocal of the unit week" ;
   qudt:symbol "/wk" ;
-  qudt:ucumCode "wk-1"^^qudt:UCUMcs ;
   qudt:ucumCode "/wk"^^qudt:UCUMcs ;
+  qudt:ucumCode "wk-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H85" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Reciprocal Week"@en ;


### PR DESCRIPTION
All this does is change the Quantity Kind for `unit:M2-PER-SEC2`.

I'm not sure why TBC reserialized all the `qudt:ucumCode`s in different orders, I would expect it to be the same every time.