### PR TITLE
Srr same ucum match

### DIFF
--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -2373,7 +2373,6 @@ unit:BTU_IT-PER-FT2-HR-DEG_F
   qudt:conversionMultiplierSN 5.678263341113487328270053328717809E0 ;
   qudt:definedUnitOfSystem sou:IMPERIAL ;
   qudt:definedUnitOfSystem sou:USCS ;
-  qudt:exactMatch unit:BTU_TH-FT-PER-FT2-HR-DEG_F ;
   qudt:expression "$Btu/(hr-ft^{2}-degF)$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H-1T-3D0 ;
   qudt:hasQuantityKind quantitykind:CoefficientOfHeatTransfer ;
@@ -2888,15 +2887,14 @@ unit:BTU_TH-FT-PER-FT2-HR-DEG_F
   qudt:conversionMultiplierSN 1.729577206E0 ;
   qudt:definedUnitOfSystem sou:IMPERIAL ;
   qudt:definedUnitOfSystem sou:USCS ;
-  qudt:exactMatch unit:BTU_IT-PER-FT2-HR-DEG_F ;
   qudt:expression "$Btu(IT) ft/(hr ft^2 degF)$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H-1T-3D0 ;
   qudt:hasQuantityKind quantitykind:ThermalConductivity ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Thermal_conductivity"^^xsd:anyURI ;
   qudt:informativeReference "http://www.translatorscafe.com/cafe/EN/units-converter/thermal-conductivity/c/"^^xsd:anyURI ;
   qudt:symbol "Btu{th}·ft/(ft²·hr·°F)" ;
-  qudt:ucumCode "[Btu_IT].[ft_i]-2.h-1.[degF]-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[Btu_IT]/([ft_i]2.h.[degF])"^^qudt:UCUMcs ;
+  qudt:ucumCode "[Btu_th].[ft_i]-2.h-1.[degF]-1" ;
+  qudt:ucumCode "[Btu_th]/([ft_i]2.h.[degF])" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "BTU (TH) Foot per Square Foot Hour Degree Fahrenheit"@en ;
 .
@@ -5898,7 +5896,6 @@ unit:DAY
   qudt:conversionMultiplierSN 8.64E4 ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Day"^^xsd:anyURI ;
   qudt:definedUnitOfSystem sou:USCS ;
-  qudt:exactMatch unit:DAY_Sidereal ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:BiodegredationHalfLife ;
   qudt:hasQuantityKind quantitykind:FishBiotransformationHalfLife ;
@@ -5925,13 +5922,11 @@ unit:DAY_Sidereal
   qudt:applicableSystem sou:USCS ;
   qudt:conversionMultiplier 86164.099 ;
   qudt:conversionMultiplierSN 8.6164099E4 ;
-  qudt:exactMatch unit:DAY ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Time ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Sidereal_time"^^xsd:anyURI ;
   qudt:informativeReference "http://scienceworld.wolfram.com/astronomy/SiderealDay.html"^^xsd:anyURI ;
   qudt:symbol "day{sidereal}" ;
-  qudt:ucumCode "d"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Sidereal Day"@en ;
 .
@@ -13104,7 +13099,6 @@ unit:HR
   qudt:conversionMultiplierSN 3.6E3 ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Hour"^^xsd:anyURI ;
   qudt:definedUnitOfSystem sou:USCS ;
-  qudt:exactMatch unit:HR_Sidereal ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Time ;
   qudt:iec61360Code "0112/2///62720#UAA525" ;
@@ -13161,12 +13155,10 @@ unit:HR_Sidereal
   qudt:applicableSystem sou:USCS ;
   qudt:conversionMultiplier 3590.17 ;
   qudt:conversionMultiplierSN 3.59017E3 ;
-  qudt:exactMatch unit:HR ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Time ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Sidereal_time"^^xsd:anyURI ;
   qudt:symbol "hr{sidereal}" ;
-  qudt:ucumCode "h"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Sidereal Hour"@en ;
 .
@@ -18092,13 +18084,12 @@ unit:KiloLB_F-PER-FT
   qudt:applicableSystem sou:USCS ;
   qudt:conversionMultiplier 14593.904199475066 ;
   qudt:conversionMultiplierSN 1.4593904199475066E4 ;
-  qudt:exactMatch unit:LB_F-PER-FT ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerLength ;
   qudt:iec61360Code "0112/2///62720#UAB192" ;
   qudt:plainTextDescription "unit of the length-related force" ;
   qudt:symbol "klbf/ft" ;
-  qudt:ucumCode "[lbf_av].[ft_i]-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[klbf_av].[ft_i]-1" ;
   qudt:uneceCommonCode "F17" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Pound Force Per Foot"@en ;
@@ -21324,7 +21315,6 @@ unit:LB_F-PER-FT
   qudt:conversionMultiplierSN 1.45939042E1 ;
   qudt:definedUnitOfSystem sou:IMPERIAL ;
   qudt:definedUnitOfSystem sou:USCS ;
-  qudt:exactMatch unit:KiloLB_F-PER-FT ;
   qudt:expression "$lbf/ft$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerLength ;
@@ -23747,7 +23737,6 @@ unit:MIN
   qudt:conversionMultiplier 60.0 ;
   qudt:conversionMultiplierSN 6.0E1 ;
   qudt:definedUnitOfSystem sou:USCS ;
-  qudt:exactMatch unit:MIN_Sidereal ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Time ;
   qudt:iec61360Code "0112/2///62720#UAA842" ;
@@ -23794,12 +23783,10 @@ unit:MIN_Sidereal
   qudt:applicableSystem sou:USCS ;
   qudt:conversionMultiplier 59.83617 ;
   qudt:conversionMultiplierSN 5.983617E1 ;
-  qudt:exactMatch unit:MIN ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Time ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Sidereal_time"^^xsd:anyURI ;
   qudt:symbol "min{sidereal}" ;
-  qudt:ucumCode "min"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Sidereal Minute"@en ;
 .
@@ -27857,7 +27844,6 @@ unit:MilliARCSEC
   qudt:applicableSystem sou:USCS ;
   qudt:conversionMultiplier 0.00000000484813681 ;
   qudt:conversionMultiplierSN 4.84813681E-9 ;
-  qudt:exactMatch unit:RAD ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Angle ;
   qudt:hasQuantityKind quantitykind:PlaneAngle ;
@@ -32106,7 +32092,6 @@ unit:NUM
   qudt:applicableSystem sou:SI ;
   qudt:conversionMultiplier 1.0 ;
   qudt:conversionMultiplierSN 1.0E0 ;
-  qudt:exactMatch unit:REV ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:ChargeNumber ;
   qudt:hasQuantityKind quantitykind:Dimensionless ;
@@ -32178,7 +32163,6 @@ unit:NUM-PER-HR
   qudt:conversionMultiplier 0.000277777777777778 ;
   qudt:conversionMultiplierSN 2.77777777777778E-4 ;
   qudt:exactMatch unit:PER-HR ;
-  qudt:exactMatch unit:REV-PER-HR ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Frequency ;
   qudt:symbol "/hr" ;
@@ -32348,7 +32332,6 @@ unit:NUM-PER-SEC
   qudt:conversionMultiplier 1.0 ;
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:exactMatch unit:PER-SEC ;
-  qudt:exactMatch unit:REV-PER-SEC ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Frequency ;
   qudt:symbol "/s" ;
@@ -39940,7 +39923,6 @@ unit:RAD
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Radian"^^xsd:anyURI ;
   qudt:definedUnitOfSystem sou:SI ;
-  qudt:exactMatch unit:MilliARCSEC ;
   qudt:guidance "<p>See NIST section <a href=\"http://physics.nist.gov/Pubs/SP811/sec07.html#7.10\">SP811 section7.10</a></p>"^^rdf:HTML ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Angle ;
@@ -40239,7 +40221,6 @@ unit:REV
   qudt:conversionMultiplier 6.28318531 ;
   qudt:conversionMultiplierSN 6.28318531E0 ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Revolution"^^xsd:anyURI ;
-  qudt:exactMatch unit:NUM ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Angle ;
   qudt:hasQuantityKind quantitykind:PlaneAngle ;
@@ -40247,7 +40228,6 @@ unit:REV
   qudt:informativeReference "http://en.wikipedia.org/wiki/Revolution?oldid=494110330"^^xsd:anyURI ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/revolution> ;
   qudt:symbol "rev" ;
-  qudt:ucumCode "{#}"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M44" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Revolution"@en ;
@@ -40257,12 +40237,10 @@ unit:REV-PER-HR
   dcterms:description "\"Revolution per Hour\" is a unit for  'Angular Velocity' expressed as $rev/h$."^^qudt:LatexString ;
   qudt:conversionMultiplier 0.00174532925 ;
   qudt:conversionMultiplierSN 1.74532925E-3 ;
-  qudt:exactMatch unit:NUM-PER-HR ;
   qudt:expression "$rev/h$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:AngularVelocity ;
   qudt:symbol "rev/hr" ;
-  qudt:ucumCode "{#}.h-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Revolution per Hour"@en ;
 .
@@ -40288,12 +40266,10 @@ unit:REV-PER-SEC
   dcterms:description "\"Revolution per Second\" is a unit for  'Angular Velocity' expressed as $rev/s$."^^qudt:LatexString ;
   qudt:conversionMultiplier 6.28318531 ;
   qudt:conversionMultiplierSN 6.28318531E0 ;
-  qudt:exactMatch unit:NUM-PER-SEC ;
   qudt:expression "$rev/s$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:AngularVelocity ;
   qudt:symbol "rev/s" ;
-  qudt:ucumCode "{#}.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "RPS" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Revolution per Second"@en ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -1547,6 +1547,7 @@ unit:BBL
   qudt:applicableSystem sou:USCS ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Barrel"^^xsd:anyURI ;
   qudt:definedUnitOfSystem sou:USCS ;
+  qudt:exactMatch unit:BBL_US ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Volume ;
   qudt:iec61360Code "0112/2///62720#UAA334" ;
@@ -1642,6 +1643,7 @@ unit:BBL_US
   qudt:applicableSystem sou:USCS ;
   qudt:conversionMultiplier 0.1589873 ;
   qudt:conversionMultiplierSN 1.589873E-1 ;
+  qudt:exactMatch unit:BBL ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Volume ;
   qudt:iec61360Code "0112/2///62720#UAA334" ;
@@ -2371,6 +2373,7 @@ unit:BTU_IT-PER-FT2-HR-DEG_F
   qudt:conversionMultiplierSN 5.678263341113487328270053328717809E0 ;
   qudt:definedUnitOfSystem sou:IMPERIAL ;
   qudt:definedUnitOfSystem sou:USCS ;
+  qudt:exactMatch unit:BTU_TH-FT-PER-FT2-HR-DEG_F ;
   qudt:expression "$Btu/(hr-ft^{2}-degF)$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H-1T-3D0 ;
   qudt:hasQuantityKind quantitykind:CoefficientOfHeatTransfer ;
@@ -2885,6 +2888,7 @@ unit:BTU_TH-FT-PER-FT2-HR-DEG_F
   qudt:conversionMultiplierSN 1.729577206E0 ;
   qudt:definedUnitOfSystem sou:IMPERIAL ;
   qudt:definedUnitOfSystem sou:USCS ;
+  qudt:exactMatch unit:BTU_IT-PER-FT2-HR-DEG_F ;
   qudt:expression "$Btu(IT) ft/(hr ft^2 degF)$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H-1T-3D0 ;
   qudt:hasQuantityKind quantitykind:ThermalConductivity ;
@@ -4623,6 +4627,7 @@ unit:CUP
   qudt:conversionMultiplier 0.00023658825 ;
   qudt:conversionMultiplierSN 2.3658825E-4 ;
   qudt:definedUnitOfSystem sou:USCS ;
+  qudt:exactMatch unit:CUP_US ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:LiquidVolume ;
   qudt:symbol "cup" ;
@@ -4637,6 +4642,7 @@ unit:CUP_US
   qudt:applicableSystem sou:USCS ;
   qudt:conversionMultiplier 0.0002365882 ;
   qudt:conversionMultiplierSN 2.365882E-4 ;
+  qudt:exactMatch unit:CUP ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:LiquidVolume ;
   qudt:iec61360Code "0112/2///62720#UAA404" ;
@@ -5892,6 +5898,7 @@ unit:DAY
   qudt:conversionMultiplierSN 8.64E4 ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Day"^^xsd:anyURI ;
   qudt:definedUnitOfSystem sou:USCS ;
+  qudt:exactMatch unit:DAY_Sidereal ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:BiodegredationHalfLife ;
   qudt:hasQuantityKind quantitykind:FishBiotransformationHalfLife ;
@@ -5918,6 +5925,7 @@ unit:DAY_Sidereal
   qudt:applicableSystem sou:USCS ;
   qudt:conversionMultiplier 86164.099 ;
   qudt:conversionMultiplierSN 8.6164099E4 ;
+  qudt:exactMatch unit:DAY ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Time ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Sidereal_time"^^xsd:anyURI ;
@@ -6977,6 +6985,7 @@ unit:DWT
   qudt:conversionMultiplierSN 1.55517384E-3 ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Pennyweight"^^xsd:anyURI ;
   qudt:definedUnitOfSystem sou:USCS ;
+  qudt:exactMatch unit:Pennyweight ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Mass ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Pennyweight?oldid=486693644"^^xsd:anyURI ;
@@ -7977,6 +7986,7 @@ unit:E
   """^^qudt:LatexString ;
   qudt:conversionMultiplier 0.0000000000000000001602176634 ;
   qudt:conversionMultiplierSN 1.602176634E-19 ;
+  qudt:exactMatch unit:ElementaryCharge ;
   qudt:hasDimensionVector qkdv:A0E1L0I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:ElectricCharge ;
   qudt:symbol "e" ;
@@ -8509,6 +8519,7 @@ unit:ElementaryCharge
   qudt:applicableSystem sou:SI ;
   qudt:conversionMultiplier 0.0000000000000000001602176634 ;
   qudt:conversionMultiplierSN 1.602176634E-19 ;
+  qudt:exactMatch unit:E ;
   qudt:hasDimensionVector qkdv:A0E1L0I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:ElectricCharge ;
   qudt:symbol "e" ;
@@ -10214,6 +10225,7 @@ unit:GAL_IMP
   qudt:conversionMultiplier 0.00454609 ;
   qudt:conversionMultiplierSN 4.54609E-3 ;
   qudt:definedUnitOfSystem sou:IMPERIAL ;
+  qudt:exactMatch unit:GAL_UK ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:LiquidVolume ;
   qudt:symbol "gal{Imp}" ;
@@ -10228,6 +10240,7 @@ unit:GAL_UK
   qudt:applicableSystem sou:IMPERIAL ;
   qudt:conversionMultiplier 0.00454609 ;
   qudt:conversionMultiplierSN 4.54609E-3 ;
+  qudt:exactMatch unit:GAL_IMP ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:LiquidVolume ;
   qudt:iec61360Code "0112/2///62720#UAA500" ;
@@ -13091,6 +13104,7 @@ unit:HR
   qudt:conversionMultiplierSN 3.6E3 ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Hour"^^xsd:anyURI ;
   qudt:definedUnitOfSystem sou:USCS ;
+  qudt:exactMatch unit:HR_Sidereal ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Time ;
   qudt:iec61360Code "0112/2///62720#UAA525" ;
@@ -13147,6 +13161,7 @@ unit:HR_Sidereal
   qudt:applicableSystem sou:USCS ;
   qudt:conversionMultiplier 3590.17 ;
   qudt:conversionMultiplierSN 3.59017E3 ;
+  qudt:exactMatch unit:HR ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Time ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Sidereal_time"^^xsd:anyURI ;
@@ -13305,6 +13320,7 @@ unit:H_Ab
   qudt:conversionMultiplierSN 1.0E-9 ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Abhenry"^^xsd:anyURI ;
   qudt:derivedUnitOfSystem sou:CGS-EMU ;
+  qudt:exactMatch unit:NanoH ;
   qudt:hasDimensionVector qkdv:A0E-2L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Inductance ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Abhenry?oldid=477198643"^^xsd:anyURI ;
@@ -17618,6 +17634,7 @@ unit:KiloGM_F
   qudt:conversionMultiplier 9.80665 ;
   qudt:conversionMultiplierSN 9.80665E0 ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Kilogram-force"^^xsd:anyURI ;
+  qudt:exactMatch unit:KiloP ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Force ;
   qudt:iec61360Code "0112/2///62720#UAA632" ;
@@ -18075,6 +18092,7 @@ unit:KiloLB_F-PER-FT
   qudt:applicableSystem sou:USCS ;
   qudt:conversionMultiplier 14593.904199475066 ;
   qudt:conversionMultiplierSN 1.4593904199475066E4 ;
+  qudt:exactMatch unit:LB_F-PER-FT ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerLength ;
   qudt:iec61360Code "0112/2///62720#UAB192" ;
@@ -18653,6 +18671,7 @@ unit:KiloP
   qudt:applicableSystem sou:CGS ;
   qudt:conversionMultiplier 9.80665 ;
   qudt:conversionMultiplierSN 9.80665E0 ;
+  qudt:exactMatch unit:KiloGM_F ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Force ;
   qudt:iec61360Code "0112/2///62720#UAB059" ;
@@ -20601,6 +20620,7 @@ unit:LB-PER-GAL
   qudt:conversionMultiplierSN 9.97763727E1 ;
   qudt:definedUnitOfSystem sou:IMPERIAL ;
   qudt:definedUnitOfSystem sou:USCS ;
+  qudt:exactMatch unit:LB-PER-GAL_UK ;
   qudt:expression "$lb/gal$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Density ;
@@ -20616,6 +20636,7 @@ unit:LB-PER-GAL_UK
   qudt:applicableSystem sou:IMPERIAL ;
   qudt:conversionMultiplier 99.77637 ;
   qudt:conversionMultiplierSN 9.977637E1 ;
+  qudt:exactMatch unit:LB-PER-GAL ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Density ;
   qudt:hasQuantityKind quantitykind:MassDensity ;
@@ -21303,6 +21324,7 @@ unit:LB_F-PER-FT
   qudt:conversionMultiplierSN 1.45939042E1 ;
   qudt:definedUnitOfSystem sou:IMPERIAL ;
   qudt:definedUnitOfSystem sou:USCS ;
+  qudt:exactMatch unit:KiloLB_F-PER-FT ;
   qudt:expression "$lbf/ft$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerLength ;
@@ -23643,6 +23665,7 @@ unit:MI2
   qudt:conversionMultiplierSN 2.58998811E6 ;
   qudt:definedUnitOfSystem sou:IMPERIAL ;
   qudt:definedUnitOfSystem sou:USCS ;
+  qudt:exactMatch unit:MI_US2 ;
   qudt:expression "$square-mile$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Area ;
@@ -23724,6 +23747,7 @@ unit:MIN
   qudt:conversionMultiplier 60.0 ;
   qudt:conversionMultiplierSN 6.0E1 ;
   qudt:definedUnitOfSystem sou:USCS ;
+  qudt:exactMatch unit:MIN_Sidereal ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Time ;
   qudt:iec61360Code "0112/2///62720#UAA842" ;
@@ -23770,6 +23794,7 @@ unit:MIN_Sidereal
   qudt:applicableSystem sou:USCS ;
   qudt:conversionMultiplier 59.83617 ;
   qudt:conversionMultiplierSN 5.983617E1 ;
+  qudt:exactMatch unit:MIN ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Time ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Sidereal_time"^^xsd:anyURI ;
@@ -23878,6 +23903,7 @@ unit:MI_US2
   qudt:conversionMultiplierSN 2.589997766409E6 ;
   qudt:definedUnitOfSystem sou:IMPERIAL ;
   qudt:definedUnitOfSystem sou:USCS ;
+  qudt:exactMatch unit:MI2 ;
   qudt:expression "$square-mile$" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Area ;
@@ -31292,6 +31318,7 @@ unit:N-M-PER-ARCMIN
   dcterms:description "product of the SI derived unit newton and the SI base unit metre divided by the unit minute [unit of angle]" ;
   qudt:conversionMultiplier 3437.746766834402696604316471280553 ;
   qudt:conversionMultiplierSN 3.437746766834402696604316471280553E3 ;
+  qudt:exactMatch unit:N-M-PER-MIN_Angle ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:TorquePerAngle ;
   qudt:hasQuantityKind quantitykind:TorsionalSpringConstant ;
@@ -31419,6 +31446,7 @@ unit:N-M-PER-MIN_Angle
   dcterms:description "product of the SI derived unit newton and the SI base unit metre divided by the unit minute [unit of angle]" ;
   qudt:conversionMultiplier 3437.746873197331483367149303409351 ;
   qudt:conversionMultiplierSN 3.437746873197331483367149303409351E3 ;
+  qudt:exactMatch unit:N-M-PER-ARCMIN ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:TorquePerAngle ;
   qudt:hasQuantityKind quantitykind:TorsionalSpringConstant ;
@@ -32078,6 +32106,7 @@ unit:NUM
   qudt:applicableSystem sou:SI ;
   qudt:conversionMultiplier 1.0 ;
   qudt:conversionMultiplierSN 1.0E0 ;
+  qudt:exactMatch unit:REV ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:ChargeNumber ;
   qudt:hasQuantityKind quantitykind:Dimensionless ;
@@ -32120,6 +32149,7 @@ unit:NUM-PER-GM
   a qudt:Unit ;
   qudt:conversionMultiplier 1000.0 ;
   qudt:conversionMultiplierSN 1.0E3 ;
+  qudt:exactMatch unit:PER-GM ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M-1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:symbol "/g" ;
@@ -32147,6 +32177,8 @@ unit:NUM-PER-HR
   a qudt:Unit ;
   qudt:conversionMultiplier 0.000277777777777778 ;
   qudt:conversionMultiplierSN 2.77777777777778E-4 ;
+  qudt:exactMatch unit:PER-HR ;
+  qudt:exactMatch unit:REV-PER-HR ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Frequency ;
   qudt:symbol "/hr" ;
@@ -32185,6 +32217,7 @@ unit:NUM-PER-L
   a qudt:Unit ;
   qudt:conversionMultiplier 1000.0 ;
   qudt:conversionMultiplierSN 1.0E3 ;
+  qudt:exactMatch unit:PER-L ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:NumberDensity ;
   qudt:symbol "/L" ;
@@ -32199,6 +32232,7 @@ unit:NUM-PER-M
   dcterms:description "Unavailable."@en ;
   qudt:conversionMultiplier 1.0 ;
   qudt:conversionMultiplierSN 1.0E0 ;
+  qudt:exactMatch unit:PER-M ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:InverseLength ;
   qudt:symbol "/m" ;
@@ -32212,6 +32246,7 @@ unit:NUM-PER-M2
   a qudt:Unit ;
   qudt:conversionMultiplier 1.0 ;
   qudt:conversionMultiplierSN 1.0E0 ;
+  qudt:exactMatch unit:PER-M2 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:ParticleFluence ;
   qudt:symbol "/m²" ;
@@ -32235,6 +32270,7 @@ unit:NUM-PER-M3
   a qudt:Unit ;
   qudt:conversionMultiplier 1.0 ;
   qudt:conversionMultiplierSN 1.0E0 ;
+  qudt:exactMatch unit:PER-M3 ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:NumberDensity ;
   qudt:symbol "/m³" ;
@@ -32260,6 +32296,7 @@ unit:NUM-PER-MilliGM
   dcterms:description "Count of an entity or phenomenon occurrence in one millionth of the SI unit of mass (kilogram)."@en ;
   qudt:conversionMultiplier 1000000.0 ;
   qudt:conversionMultiplierSN 1.0E6 ;
+  qudt:exactMatch unit:PER-MilliGM ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M-1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:symbol "/mg" ;
@@ -32272,6 +32309,7 @@ unit:NUM-PER-MilliM3
   a qudt:Unit ;
   qudt:conversionMultiplier 1000000000.0 ;
   qudt:conversionMultiplierSN 1.0E9 ;
+  qudt:exactMatch unit:PER-MilliM3 ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:NumberDensity ;
   qudt:symbol "/mm³" ;
@@ -32309,6 +32347,8 @@ unit:NUM-PER-SEC
   a qudt:Unit ;
   qudt:conversionMultiplier 1.0 ;
   qudt:conversionMultiplierSN 1.0E0 ;
+  qudt:exactMatch unit:PER-SEC ;
+  qudt:exactMatch unit:REV-PER-SEC ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Frequency ;
   qudt:symbol "/s" ;
@@ -32325,6 +32365,7 @@ unit:NUM-PER-YR
   qudt:applicableSystem sou:CGS ;
   qudt:conversionMultiplier 0.00000003168808781402895023702689684893655 ;
   qudt:conversionMultiplierSN 3.168808781402895023702689684893655E-8 ;
+  qudt:exactMatch unit:PER-YR ;
   qudt:expression "$\\#/yr$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Frequency ;
@@ -32711,6 +32752,7 @@ unit:NanoH
   qudt:applicableSystem sou:SI ;
   qudt:conversionMultiplier 0.000000001 ;
   qudt:conversionMultiplierSN 1.0E-9 ;
+  qudt:exactMatch unit:H_Ab ;
   qudt:hasDimensionVector qkdv:A0E-2L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Inductance ;
   qudt:hasQuantityKind quantitykind:Permeance ;
@@ -33943,6 +33985,7 @@ unit:OZ-PER-GAL
   qudt:applicableSystem sou:IMPERIAL ;
   qudt:conversionMultiplier 6.23602329 ;
   qudt:conversionMultiplierSN 6.23602329E0 ;
+  qudt:exactMatch unit:OZ-PER-GAL_UK ;
   qudt:expression "oz/gal" ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Density ;
@@ -33958,6 +34001,7 @@ unit:OZ-PER-GAL_UK
   qudt:applicableSystem sou:IMPERIAL ;
   qudt:conversionMultiplier 6.236 ;
   qudt:conversionMultiplierSN 6.236E0 ;
+  qudt:exactMatch unit:OZ-PER-GAL ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Density ;
   qudt:hasQuantityKind quantitykind:MassDensity ;
@@ -35302,6 +35346,7 @@ unit:PER-GM
   qudt:applicableSystem sou:SI ;
   qudt:conversionMultiplier 1000.0 ;
   qudt:conversionMultiplierSN 1.0E3 ;
+  qudt:exactMatch unit:NUM-PER-GM ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M-1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:InverseMass ;
   qudt:iec61360Code "0112/2///62720#UAC004" ;
@@ -35358,6 +35403,7 @@ unit:PER-HR
   qudt:applicableSystem sou:USCS ;
   qudt:conversionMultiplier 0.0002777777777777777777777777777777778 ;
   qudt:conversionMultiplierSN 2.777777777777777777777777777777778E-4 ;
+  qudt:exactMatch unit:NUM-PER-HR ;
   qudt:expression "$m^{-1}$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Frequency ;
@@ -35584,6 +35630,7 @@ unit:PER-L
   qudt:applicableSystem sou:SI ;
   qudt:conversionMultiplier 1000.0 ;
   qudt:conversionMultiplierSN 1.0E3 ;
+  qudt:exactMatch unit:NUM-PER-L ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:InverseVolume ;
   qudt:iec61360Code "0112/2///62720#UAA667" ;
@@ -35620,6 +35667,7 @@ unit:PER-M
   qudt:conversionMultiplier 1.0 ;
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:derivedCoherentUnitOfSystem sou:SI ;
+  qudt:exactMatch unit:NUM-PER-M ;
   qudt:expression "$per-meter$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:AngularReciprocalLatticeVector ;
@@ -35728,6 +35776,7 @@ unit:PER-M2
   qudt:conversionMultiplier 1.0 ;
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Steradian"^^xsd:anyURI ;
+  qudt:exactMatch unit:NUM-PER-M2 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:ParticleFluence ;
   qudt:iec61360Code "0112/2///62720#UAA739" ;
@@ -35775,6 +35824,7 @@ unit:PER-M3
   qudt:conversionMultiplier 1.0 ;
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:derivedCoherentUnitOfSystem sou:SI ;
+  qudt:exactMatch unit:NUM-PER-M3 ;
   qudt:expression "$/m^3$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:InverseVolume ;
@@ -35991,6 +36041,7 @@ unit:PER-MilliGM
   dcterms:description "reciprocal of the 0.000001-fold of the SI base unit kilogram" ;
   qudt:conversionMultiplier 1000000.0 ;
   qudt:conversionMultiplierSN 1.0E6 ;
+  qudt:exactMatch unit:NUM-PER-MilliGM ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M-1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:InverseMass ;
   qudt:iec61360Code "0112/2///62720#UAC005" ;
@@ -36055,6 +36106,7 @@ unit:PER-MilliM3
   qudt:applicableSystem sou:SI ;
   qudt:conversionMultiplier 1000000000.0 ;
   qudt:conversionMultiplierSN 1.0E9 ;
+  qudt:exactMatch unit:NUM-PER-MilliM3 ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:InverseVolume ;
   qudt:iec61360Code "0112/2///62720#UAA870" ;
@@ -36273,6 +36325,8 @@ unit:PER-SEC
   qudt:definedUnitOfSystem sou:SI ;
   qudt:derivedCoherentUnitOfSystem sou:SI ;
   qudt:exactMatch unit:HZ ;
+  qudt:exactMatch unit:NUM-PER-SEC ;
+  qudt:exactMatch unit:SAMPLE-PER-SEC ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Frequency ;
   qudt:iec61360Code "0112/2///62720#UAD544" ;
@@ -36566,6 +36620,7 @@ unit:PER-YR
   qudt:applicableSystem sou:USCS ;
   qudt:conversionMultiplier 0.000000031709792 ;
   qudt:conversionMultiplierSN 3.1709792E-8 ;
+  qudt:exactMatch unit:NUM-PER-YR ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Frequency ;
   qudt:iec61360Code "0112/2///62720#UAB027" ;
@@ -37562,6 +37617,7 @@ unit:PINT
   qudt:conversionMultiplier 0.00056826125 ;
   qudt:conversionMultiplierSN 5.6826125E-4 ;
   qudt:definedUnitOfSystem sou:IMPERIAL ;
+  qudt:exactMatch unit:PINT_UK ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Volume ;
   qudt:symbol "pt" ;
@@ -37576,6 +37632,7 @@ unit:PINT_UK
   qudt:applicableSystem sou:IMPERIAL ;
   qudt:conversionMultiplier 0.0005682613 ;
   qudt:conversionMultiplierSN 5.682613E-4 ;
+  qudt:exactMatch unit:PINT ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Volume ;
   qudt:iec61360Code "0112/2///62720#UAA952" ;
@@ -38489,6 +38546,7 @@ unit:Pennyweight
   dcterms:description "non SI-conforming unit of mass which comes from the Anglo-American Troy or Apothecaries' Weight System of units according to NIST of 1 pwt = 1.555174 10^3 kg"^^rdf:HTML ;
   qudt:conversionMultiplier 0.001555174 ;
   qudt:conversionMultiplierSN 1.555174E-3 ;
+  qudt:exactMatch unit:DWT ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Mass ;
   qudt:iec61360Code "0112/2///62720#UAB182" ;
@@ -40138,6 +40196,7 @@ unit:REM
   qudt:applicableSystem sou:CGS ;
   qudt:conversionMultiplier 0.01 ;
   qudt:conversionMultiplierSN 1.0E-2 ;
+  qudt:exactMatch unit:R_man ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:DoseEquivalent ;
   qudt:iec61360Code "0112/2///62720#UAA971" ;
@@ -40180,6 +40239,7 @@ unit:REV
   qudt:conversionMultiplier 6.28318531 ;
   qudt:conversionMultiplierSN 6.28318531E0 ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Revolution"^^xsd:anyURI ;
+  qudt:exactMatch unit:NUM ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Angle ;
   qudt:hasQuantityKind quantitykind:PlaneAngle ;
@@ -40197,6 +40257,7 @@ unit:REV-PER-HR
   dcterms:description "\"Revolution per Hour\" is a unit for  'Angular Velocity' expressed as $rev/h$."^^qudt:LatexString ;
   qudt:conversionMultiplier 0.00174532925 ;
   qudt:conversionMultiplierSN 1.74532925E-3 ;
+  qudt:exactMatch unit:NUM-PER-HR ;
   qudt:expression "$rev/h$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:AngularVelocity ;
@@ -40227,6 +40288,7 @@ unit:REV-PER-SEC
   dcterms:description "\"Revolution per Second\" is a unit for  'Angular Velocity' expressed as $rev/s$."^^qudt:LatexString ;
   qudt:conversionMultiplier 6.28318531 ;
   qudt:conversionMultiplierSN 6.28318531E0 ;
+  qudt:exactMatch unit:NUM-PER-SEC ;
   qudt:expression "$rev/s$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:AngularVelocity ;
@@ -40321,6 +40383,7 @@ unit:R_man
   a qudt:Unit ;
   qudt:conversionMultiplier 0.01 ;
   qudt:conversionMultiplierSN 1.0E-2 ;
+  qudt:exactMatch unit:REM ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:DoseEquivalent ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Roentgen_equivalent_man"^^xsd:anyURI ;
@@ -40480,6 +40543,7 @@ unit:SAMPLE-PER-SEC
   dcterms:description "The number of discrete samples of some thing per second."^^rdf:HTML ;
   qudt:conversionMultiplier 1.0 ;
   qudt:conversionMultiplierSN 1.0E0 ;
+  qudt:exactMatch unit:PER-SEC ;
   qudt:expression "$sample-per-sec$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Frequency ;
@@ -41542,6 +41606,7 @@ unit:TONNE-PER-BAR
   dcterms:description "unit ton divided by the unit bar" ;
   qudt:conversionMultiplier 0.01 ;
   qudt:conversionMultiplierSN 1.0E-2 ;
+  qudt:exactMatch unit:TON_Metric-PER-BAR ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T2D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA990" ;
@@ -41578,6 +41643,7 @@ unit:TONNE-PER-DAY-BAR
   dcterms:description "unit ton divided by the product of the unit day and the unit bar" ;
   qudt:conversionMultiplier 0.0000001157407407407407407407407407407407 ;
   qudt:conversionMultiplierSN 1.157407407407407407407407407407407E-7 ;
+  qudt:exactMatch unit:TON_Metric-PER-DAY-BAR ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA993" ;
@@ -41592,6 +41658,7 @@ unit:TONNE-PER-DAY-K
   dcterms:description "unit ton divided by the product of the unit day and the SI base unit Kelvin" ;
   qudt:conversionMultiplier 0.01157407407407407407407407407407407 ;
   qudt:conversionMultiplierSN 1.157407407407407407407407407407407E-2 ;
+  qudt:exactMatch unit:TON_Metric-PER-DAY-K ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA992" ;
@@ -41666,6 +41733,7 @@ unit:TONNE-PER-HR-BAR
   dcterms:description "unit ton divided by the product of the unit hour and the unit bar" ;
   qudt:conversionMultiplier 0.000002777777777777777777777777777777778 ;
   qudt:conversionMultiplierSN 2.777777777777777777777777777777778E-6 ;
+  qudt:exactMatch unit:TON_Metric-PER-HR-BAR ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA996" ;
@@ -41680,6 +41748,7 @@ unit:TONNE-PER-HR-K
   dcterms:description "unit ton divided by the product of the unit hour and the SI base unit Kelvin" ;
   qudt:conversionMultiplier 0.2777777777777777777777777777777778 ;
   qudt:conversionMultiplierSN 2.777777777777777777777777777777778E-1 ;
+  qudt:exactMatch unit:TON_Metric-PER-HR-K ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA995" ;
@@ -41694,6 +41763,7 @@ unit:TONNE-PER-K
   dcterms:description "unit ton divided by the SI base unit Kelvin" ;
   qudt:conversionMultiplier 1000.0 ;
   qudt:conversionMultiplierSN 1.0E3 ;
+  qudt:exactMatch unit:TON_Metric-PER-K ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H-1T0D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA989" ;
@@ -41745,6 +41815,7 @@ unit:TONNE-PER-M3-K
   dcterms:description "1,000-fold of the SI base unit kilogram divided by the product of the power of the SI base unit metre with the exponent 3 and the SI base unit Kelvin" ;
   qudt:conversionMultiplier 1000.0 ;
   qudt:conversionMultiplierSN 1.0E3 ;
+  qudt:exactMatch unit:TON_Metric-PER-M3-K ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H-1T0D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA998" ;
@@ -41780,6 +41851,7 @@ unit:TONNE-PER-MIN-BAR
   dcterms:description "unit ton divided by the product of the unit minute and the unit bar" ;
   qudt:conversionMultiplier 0.0001666666666666666666666666666666667 ;
   qudt:conversionMultiplierSN 1.666666666666666666666666666666667E-4 ;
+  qudt:exactMatch unit:TON_Metric-PER-MIN-BAR ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAB002" ;
@@ -41794,6 +41866,7 @@ unit:TONNE-PER-MIN-K
   dcterms:description "unit ton divided by the product of the unit minute and the SI base unit Kelvin" ;
   qudt:conversionMultiplier 16.66666666666666666666666666666667 ;
   qudt:conversionMultiplierSN 1.666666666666666666666666666666667E1 ;
+  qudt:exactMatch unit:TON_Metric-PER-MIN-K ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAB001" ;
@@ -41845,6 +41918,7 @@ unit:TONNE-PER-SEC-BAR
   dcterms:description "unit ton divided by the product of the SI base unit second and the unit bar" ;
   qudt:conversionMultiplier 0.01 ;
   qudt:conversionMultiplierSN 1.0E-2 ;
+  qudt:exactMatch unit:TON_Metric-PER-SEC-BAR ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAB005" ;
@@ -41859,6 +41933,7 @@ unit:TONNE-PER-SEC-K
   dcterms:description "unit ton divided by the product of the SI base unit second and the SI base unit Kelvin" ;
   qudt:conversionMultiplier 1000.0 ;
   qudt:conversionMultiplierSN 1.0E3 ;
+  qudt:exactMatch unit:TON_Metric-PER-SEC-K ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAB004" ;
@@ -42018,6 +42093,7 @@ unit:TON_Metric-PER-BAR
   dcterms:description "unit ton divided by the unit bar" ;
   qudt:conversionMultiplier 0.01 ;
   qudt:conversionMultiplierSN 1.0E-2 ;
+  qudt:exactMatch unit:TONNE-PER-BAR ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T2D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA990" ;
@@ -42054,6 +42130,7 @@ unit:TON_Metric-PER-DAY-BAR
   dcterms:description "unit ton divided by the product of the unit day and the unit bar" ;
   qudt:conversionMultiplier 0.0000001157407407407407407407407407407407 ;
   qudt:conversionMultiplierSN 1.157407407407407407407407407407407E-7 ;
+  qudt:exactMatch unit:TONNE-PER-DAY-BAR ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA993" ;
@@ -42068,6 +42145,7 @@ unit:TON_Metric-PER-DAY-K
   dcterms:description "unit ton divided by the product of the unit day and the SI base unit Kelvin" ;
   qudt:conversionMultiplier 0.01157407407407407407407407407407407 ;
   qudt:conversionMultiplierSN 1.157407407407407407407407407407407E-2 ;
+  qudt:exactMatch unit:TONNE-PER-DAY-K ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA992" ;
@@ -42124,6 +42202,7 @@ unit:TON_Metric-PER-HR-BAR
   dcterms:description "unit ton divided by the product of the unit hour and the unit bar" ;
   qudt:conversionMultiplier 0.000002777777777777777777777777777777778 ;
   qudt:conversionMultiplierSN 2.777777777777777777777777777777778E-6 ;
+  qudt:exactMatch unit:TONNE-PER-HR-BAR ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA996" ;
@@ -42138,6 +42217,7 @@ unit:TON_Metric-PER-HR-K
   dcterms:description "unit ton divided by the product of the unit hour and the SI base unit Kelvin" ;
   qudt:conversionMultiplier 0.2777777777777777777777777777777778 ;
   qudt:conversionMultiplierSN 2.777777777777777777777777777777778E-1 ;
+  qudt:exactMatch unit:TONNE-PER-HR-K ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA995" ;
@@ -42152,6 +42232,7 @@ unit:TON_Metric-PER-K
   dcterms:description "unit ton divided by the SI base unit Kelvin" ;
   qudt:conversionMultiplier 1000.0 ;
   qudt:conversionMultiplierSN 1.0E3 ;
+  qudt:exactMatch unit:TONNE-PER-K ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H-1T0D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA989" ;
@@ -42189,6 +42270,7 @@ unit:TON_Metric-PER-M3-K
   dcterms:description "1,000-fold of the SI base unit kilogram divided by the product of the power of the SI base unit metre with the exponent 3 and the SI base unit Kelvin" ;
   qudt:conversionMultiplier 1000.0 ;
   qudt:conversionMultiplierSN 1.0E3 ;
+  qudt:exactMatch unit:TONNE-PER-M3-K ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H-1T0D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA998" ;
@@ -42224,6 +42306,7 @@ unit:TON_Metric-PER-MIN-BAR
   dcterms:description "unit ton divided by the product of the unit minute and the unit bar" ;
   qudt:conversionMultiplier 0.0001666666666666666666666666666666667 ;
   qudt:conversionMultiplierSN 1.666666666666666666666666666666667E-4 ;
+  qudt:exactMatch unit:TONNE-PER-MIN-BAR ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAB002" ;
@@ -42238,6 +42321,7 @@ unit:TON_Metric-PER-MIN-K
   dcterms:description "unit ton divided by the product of the unit minute and the SI base unit Kelvin" ;
   qudt:conversionMultiplier 16.66666666666666666666666666666667 ;
   qudt:conversionMultiplierSN 1.666666666666666666666666666666667E1 ;
+  qudt:exactMatch unit:TONNE-PER-MIN-K ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAB001" ;
@@ -42273,6 +42357,7 @@ unit:TON_Metric-PER-SEC-BAR
   dcterms:description "unit ton divided by the product of the SI base unit second and the unit bar" ;
   qudt:conversionMultiplier 0.01 ;
   qudt:conversionMultiplierSN 1.0E-2 ;
+  qudt:exactMatch unit:TONNE-PER-SEC-BAR ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAB005" ;
@@ -42287,6 +42372,7 @@ unit:TON_Metric-PER-SEC-K
   dcterms:description "unit ton divided by the product of the SI base unit second and the SI base unit Kelvin" ;
   qudt:conversionMultiplier 1000.0 ;
   qudt:conversionMultiplierSN 1.0E3 ;
+  qudt:exactMatch unit:TONNE-PER-SEC-K ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAB004" ;


### PR DESCRIPTION
Compared units with the same UCUM code. Sometimes they are qudt:exactMatch, sometimes they should not share the same UCUM code.