### PR TITLE
Removed "kg" as udunit for PINT_US-PER-DAY

### DIFF
--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -37799,7 +37799,6 @@ unit:PINT_US-PER-DAY
   qudt:symbol "pt{US}/day" ;
   qudt:ucumCode "[pt_us].d-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[pt_us]/d"^^qudt:UCUMcs ;
-  qudt:udunitsCode "kg" ;
   qudt:uneceCommonCode "L57" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Pint (US Liquid) Per Day"@en ;


### PR DESCRIPTION
- I think this is a copy-paste error - I can't find this unit anywhere in the upstream and kg only matches KiloGM