### PR TITLE
Add 4 new units

### DIFF
--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -4151,6 +4151,25 @@ unit:CAL_TH-PER-CentiM2-SEC
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "calorie (thermochemical) per square centimetre second" ;
 .
+unit:CAL_TH-PER-CentiM3-K
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "$\\textit{Thermochemical Calorie per Cubic Centimeter Kelvin}$ is a unit for 'Volumetric Heat Capacity' expressed as $cal_th/(cm^{3} K)$."^^qudt:LatexString ;
+  qudt:applicableSystem sou:SI ;
+  qudt:conversionMultiplier 4184000.0 ;
+  qudt:conversionMultiplierSN 4.184E6 ;
+  qudt:definedUnitOfSystem sou:SI ;
+  qudt:expression "$cal_th/(cm^{3} K)$"^^qudt:LatexString ;
+  qudt:hasDimensionVector qkdv:A0E0L-1I0M1H-1T-2D0 ;
+  qudt:hasQuantityKind quantitykind:VolumetricHeatCapacity ;
+  qudt:plainTextDescription "Thermochemical Calorie per Cubic Centimeter Kelvin is a unit for Volumetric Heat Capacity expressed as cal{th}/(cm³·K)." ;
+  qudt:symbol "cal{th}/(cm³·K)" ;
+  qudt:ucumCode "cal_th.cm-3.K-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "cal_th/(cm3.K)"^^qudt:UCUMcs ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Thermochemical Calorie per Cubic Centimeter Kelvin"@en-us ;
+  rdfs:label "Thermochemical Calorie per Cubic Centimetre Kelvin"@en ;
+.
 unit:CAL_TH-PER-G
   a qudt:Unit ;
   dcterms:description """
@@ -5203,6 +5222,24 @@ unit:CentiM2-PER-SR-ERG
   qudt:uneceCommonCode "D17" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "square centimetre per steradian erg" ;
+.
+unit:CentiM2-PER-V-SEC
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  qudt:applicableSystem sou:CGS-EMU ;
+  qudt:applicableSystem sou:CGS-GAUSS ;
+  qudt:applicableSystem sou:SI ;
+  qudt:conversionMultiplier 0.0001 ;
+  qudt:conversionMultiplierSN 1.0E-4 ;
+  qudt:expression "$cm^2/V-s$"^^qudt:LatexString ;
+  qudt:hasDimensionVector qkdv:A0E1L0I0M-1H0T2D0 ;
+  qudt:hasQuantityKind quantitykind:Mobility ;
+  qudt:symbol "cm²/(V·s)" ;
+  qudt:ucumCode "cm2.V-1.s-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "cm2/(V.s)"^^qudt:UCUMcs ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Square Centimeter per Volt Second"@en-us ;
+  rdfs:label "square centimetre per volt second"@en ;
 .
 unit:CentiM2-SEC
   a qudt:DerivedUnit ;
@@ -8115,6 +8152,24 @@ unit:ERG-PER-CentiM
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Erg Per Centimeter"@en-us ;
   rdfs:label "Erg Per Centimetre"@en ;
+.
+unit:ERG-PER-CentiM2
+  a qudt:Unit ;
+  dcterms:description "Derived CGS unit erg divided by the 0.0001-fold of the power of the SI base unit metre by exponent 2"^^rdf:HTML ;
+  qudt:applicableSystem sou:CGS ;
+  qudt:applicableSystem sou:CGS-EMU ;
+  qudt:applicableSystem sou:CGS-GAUSS ;
+  qudt:applicableSystem sou:SI ;
+  qudt:conversionMultiplier 0.001 ;
+  qudt:conversionMultiplierSN 1.0E-3 ;
+  qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-2D0 ;
+  qudt:hasQuantityKind quantitykind:EnergyPerArea ;
+  qudt:plainTextDescription "Derived CGS unit erg divided by the 0.0001-fold of the power of the SI base unit metre by exponent 2" ;
+  qudt:symbol "erg/cm²" ;
+  qudt:ucumCode "erg.cm-2"^^qudt:UCUMcs ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Erg Per Square Centimeter"@en-us ;
+  rdfs:label "Erg Per Square Centimetre"@en ;
 .
 unit:ERG-PER-CentiM2-SEC
   a qudt:Unit ;
@@ -14325,6 +14380,25 @@ unit:J-PER-CentiM2-DAY
   qudt:ucumCode "J.cm-2.d-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Joules per square centimetre day"@en ;
+.
+unit:J-PER-CentiM3-K
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "$\\textit{Joule per Cubic Centimeter Kelvin}$ is a unit for 'Volumetric Heat Capacity' expressed as $J/(cm^{3} K)$."^^qudt:LatexString ;
+  qudt:applicableSystem sou:SI ;
+  qudt:conversionMultiplier 1000000.0 ;
+  qudt:conversionMultiplierSN 1.0E6 ;
+  qudt:definedUnitOfSystem sou:SI ;
+  qudt:expression "$J/(cm^{3} K)$"^^qudt:LatexString ;
+  qudt:hasDimensionVector qkdv:A0E0L-1I0M1H-1T-2D0 ;
+  qudt:hasQuantityKind quantitykind:VolumetricHeatCapacity ;
+  qudt:plainTextDescription "Joule per Cubic Centimeter Kelvin is a unit for Volumetric Heat Capacity expressed as J/(cm³·K)" ;
+  qudt:symbol "J/(cm³·K)" ;
+  qudt:ucumCode "J.cm-3.K-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "J/(cm3.K)"^^qudt:UCUMcs ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Joule per Cubic Centimeter Kelvin"@en-us ;
+  rdfs:label "Joule per Cubic Centimetre Kelvin"@en ;
 .
 unit:J-PER-DAY
   a qudt:Unit ;


### PR DESCRIPTION
This adds:
- `unit:CAL_TH-PER-CentiM3-K`
- `unit:CentiM2-PER-V-SEC`
- `unit:ERG-PER-CentiM2`
- `unit:J-PER-CentiM3-K`

Also, this removes two lingering references to `quantitykind:CO2Equivalent` (which seems to no longer exist) to ensure SHACL validation passes.