### PR TITLE
Rh latex fixes cusp3

### DIFF
--- a/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
+++ b/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
@@ -360,7 +360,10 @@ quantitykind:AcceptorIonizationEnergy
 .
 quantitykind:Acidity
   a qudt:QuantityKind ;
-  dcterms:description "Chemicals or substances having a pH less than 7 are said to be acidic; lower pH means higher acidity."^^rdf:HTML ;
+  dcterms:description """
+  Chemicals or substances having a pH less than 7 are said to be acidic;
+   lower pH means higher acidity.
+  """^^qudt:LatexString ;
   qudt:applicableUnit unit:PH ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Acid"^^xsd:anyURI ;
@@ -473,7 +476,10 @@ quantitykind:ActiveEnergy
 .
 quantitykind:ActivePower
   a qudt:QuantityKind ;
-  dcterms:description "$Active Power$ is, under periodic conditions, the mean value, taken over one period $T$, of the instantaneous power $p$. In complex notation, $P = \\mathbf{Re} \\; \\underline{S}$, where $\\underline{S}$ is $\\textit{complex power}$\"."^^qudt:LatexString ;
+  dcterms:description """
+  An $Active Power$ is, under periodic conditions, the mean value, taken over one period $T$, of the instantaneous power $p$. 
+  In complex notation, $P = \\mathbf{Re} \\; \\underline{S}$, where $\\underline{S}$ is $\\textit{complex power}$.
+  """^^qudt:LatexString ;
   qudt:applicableUnit unit:ExaW ;
   qudt:applicableUnit unit:FT-LB_F-PER-HR ;
   qudt:applicableUnit unit:FT-LB_F-PER-MIN ;
@@ -2186,7 +2192,10 @@ quantitykind:BandwidthLengthProduct
 .
 quantitykind:Basicity
   a qudt:QuantityKind ;
-  dcterms:description "Chemicals or substances having a pH higher than 7 are said to be basic; higher pH means higher basicity."^^rdf:HTML ;
+  dcterms:description """
+  Chemicals or substances having a $pH$ higher than 7 are said to be basic;
+   higher $pH$ means higher basicity.
+  """^^qudt:LatexString ;
   qudt:applicableUnit unit:PH ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Base_(chemistry)"^^xsd:anyURI ;
@@ -17729,7 +17738,43 @@ quantitykind:OverRangeDistance
 .
 quantitykind:PH
   a qudt:QuantityKind ;
-  dcterms:description "Chemicals or substances having a pH less than 7 are said to be acidic; more than 7 means basic."^^rdf:HTML ;
+ dcterms:description """
+  The quantity kind $\\textit${pH}$ is the negative logarithm (base 10) of the concentration of
+   free protons (or hydronium ions).
+   This definition of $pH$ is based on the activity of hydrogen ions ($a_{H^+}$)
+   and expressed as:
+   
+  $$\\text{pH} = -\log_{10} [H^+]$$
+  
+  Where the activity is the product of the 
+   concentration $H^+$ and the activity coefficient $\\gamma_{H^+}$, with the definition:
+
+  $$a_{H^+} = \gamma_{H^+}[H^+]$$
+  
+  This definition is appropriate for concentrations equal to or less than $1\\ mol/l$, 
+   where $aH+ \\equiv [H+]$, that is, $1\\ mol/L\\ HCl$ has a $pH$ of 0.
+
+  For representing large concentrations of hydrogen ions ($H^+$), the symbol typically
+   used is $pOH$ which specifically represents the concentration of hydroxide ions 
+   ($OH^-$) in a solution and is related to $pH$ through the water dissociation constant.
+  However, $pH$ still remains valid and useful even in highly acidic conditions.
+ 
+  In solutions with very high ionic strengths, the activity coefficients of ions
+   (which affect the activity of hydrogen ions) deviate significantly from 1. 
+  This can affect the accuracy of $pH$ calculated simply from ion concentration.
+  For example: in highly concentrated salts or acids, such as $6\\ M\\ HCl$.
+  For these conditions, where the $pH$ is high (above 14), that high concentrations
+   of $[H^+]$ or $[OH^-]$, the definition is:
+
+  $$\\text{pOH} = -\\log_{10} [OH^-] \\quad (\\text{for very basic solutions})$$
+
+  While $pH$ is a universally recognized scale for expressing hydrogen ion activity,
+   its appropriateness and accuracy can diminish under conditions of extremely high
+   ionic strength, non-aqueous environments, high temperatures, or very high or
+  low $pH$ values. 
+  In such cases, alternative measurement strategies might be required to obtain
+   meaningful and accurate descriptions of acidity or basicity.
+  """^^qudt:LatexString ;
   qudt:applicableUnit unit:PH ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Acid"^^xsd:anyURI ;
@@ -17803,33 +17848,53 @@ quantitykind:PREDICTED-MASS
 .
 quantitykind:PRODUCT-OF-INERTIA
   a qudt:QuantityKind ;
-  dcterms:description "A measure of a body's dynamic (or coupled) imbalance resulting in a precession when rotating about an axis other than the body?s principal axis."^^rdf:HTML ;
+  dcterms:description """
+  The quantity kind $\\textit{Product of Inertia}$ is a measure of a body's dynamic
+   (or coupled) imbalance resulting in a precession when rotating about an axis 
+   other than the body's principal axis.
+  """^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T0D0 ;
-  qudt:plainTextDescription "A measure of a body's dynamic (or coupled) imbalance resulting in a precession when rotating about an axis other than the body?s principal axis." ;
+  qudt:plainTextDescription "A measure of a body's dynamic (or coupled) imbalance resulting in a precession when rotating about an axis other than the body's principal axis." ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
   rdfs:label "Product of Inertia"@en ;
 .
 quantitykind:PRODUCT-OF-INERTIA_X
   a qudt:QuantityKind ;
-  dcterms:description "A measure of a body's dynamic (or coupled) imbalance resulting in a precession when rotating about an axis other than the body?s principal axis."^^rdf:HTML ;
+  dcterms:description """
+  The quantity kind $\\textit{Product of Inertia in the X axis}$ is a measure of a body's
+   dynamic (or coupled) imbalance resulting in a precession when rotating about an
+  axis other than the body's principal axis.
+  """^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T0D0 ;
-  qudt:plainTextDescription "A measure of a body's dynamic (or coupled) imbalance resulting in a precession when rotating about an axis other than the body?s principal axis." ;
+  qudt:plainTextDescription "A measure of a body's dynamic (or coupled) imbalance resulting in a precession when rotating about an axis other than the body's principal axis." ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
   rdfs:label "Product of Inertia in the X axis"@en ;
   skos:broader quantitykind:PRODUCT-OF-INERTIA ;
 .
 quantitykind:PRODUCT-OF-INERTIA_Y
   a qudt:QuantityKind ;
-  dcterms:description "A measure of a body?s dynamic (or coupled) imbalance resulting in a precession when rotating about an axis other than the body's principal axis."^^rdf:HTML ;
+  dcterms:description """
+  The quantity kind $\\textit{Product of Inertia in the Y axis}$ is a measure of a body's
+   dynamic (or coupled) imbalance resulting in a precession when rotating about an axis
+   other than the body's principal axis.
+  """^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T0D0 ;
-  qudt:plainTextDescription "A measure of a body?s dynamic (or coupled) imbalance resulting in a precession when rotating about an axis other than the body's principal axis." ;
+  qudt:plainTextDescription """
+  The quantity kind 'Product of Inertia in the Y axis' is a measure of a body's 
+  dynamic (or coupled) imbalance resulting in a precession when rotating about an axis
+  other than the body's principal axis.
+  """ ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
   rdfs:label "Product of Inertia in the Y axis"@en ;
   skos:broader quantitykind:PRODUCT-OF-INERTIA ;
 .
 quantitykind:PRODUCT-OF-INERTIA_Z
   a qudt:QuantityKind ;
-  dcterms:description "A measure of a body's dynamic (or coupled) imbalance resulting in a precession when rotating about an axis other than the body's principal axis."^^rdf:HTML ;
+  dcterms:description """
+  The quantity kind $\\textit{Product of Inertia in the Z axis}$ is a measure of a body's
+   dynamic (or coupled) imbalance resulting in a precession when rotating about an axis
+  other than the body's principal axis.
+  """^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T0D0 ;
   qudt:plainTextDescription "A measure of a body's dynamic (or coupled) imbalance resulting in a precession when rotating about an axis other than the body's principal axis." ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
@@ -17851,7 +17916,10 @@ quantitykind:PackingFraction
 .
 quantitykind:PartialPressure
   a qudt:QuantityKind ;
-  dcterms:description "\"Partial Pressure\" is the pressure that the gas would have if it alone occupied the volume of the mixture at the same temperature."^^rdf:HTML ;
+  dcterms:description """
+  The quantity kind $\\textit{Partial Pressure}$ is the pressure that the gas would
+   have if it alone occupied the volume of the mixture at the same temperature.
+  """^^qudt:LatexString ;
   qudt:abbreviation "pa" ;
   qudt:applicableUnit unit:ATM ;
   qudt:applicableUnit unit:ATM_T ;
@@ -17928,7 +17996,10 @@ quantitykind:PartialPressure
 .
 quantitykind:ParticleCurrent
   a qudt:QuantityKind ;
-  dcterms:description "\"Particle Current\" can be used to describe the net number of particles passing through a surface in an infinitesimal time interval."^^rdf:HTML ;
+  dcterms:description """
+  The quantity kind $\\textit{Particle Current}$ can be used to describe the net number
+   of particles passing through a surface in an infinitesimal time interval.
+  """^^qudt:LatexString ;
   qudt:applicableUnit unit:GigaHZ ;
   qudt:applicableUnit unit:HZ ;
   qudt:applicableUnit unit:KiloHZ ;
@@ -17967,7 +18038,11 @@ quantitykind:ParticleCurrent
 .
 quantitykind:ParticleCurrentDensity
   a qudt:QuantityKind ;
-  dcterms:description "vector whose component is perpendicular to a surface equal to the net number of particles crossing that surface in the positive direction per unit area and per unit time"@en ;
+  dcterms:description """
+  The quantity kind $\\textit{Particle Current Density}$ is a vector whose component is
+   perpendicular to a surface equal to the net number of particles crossing that surface
+   in the positive direction per unit area and per unit time.
+  """^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T-1D0 ;
   qudt:iec61360Code "0112/2///62720#UAD132" ;
   qudt:plainTextDescription "Vektor, dessen Komponente senkrecht zu einer Fläche gleich der Nettoanzahl von Teilchen ist, die flächen- und zeitbezogen in positiver Richtung durch diese Fläche hindurchgehen"@de ;
@@ -17978,7 +18053,11 @@ quantitykind:ParticleCurrentDensity
 .
 quantitykind:ParticleFluence
   a qudt:QuantityKind ;
-  dcterms:description "\"Particle Fluence\" is the total number of particles that intersect a unit area in a specific time interval of interest, and has units of m–2 (number of particles per meter squared)."^^rdf:HTML ;
+  dcterms:description """
+  The quantity kind $\\textit{Particle Fluence}$ is the total number of particles that
+   intersect a unit area in a specific time interval of interest, and has units of $m^{-2}$
+    (number of particles per meter squared).
+  """^^qudt:LatexString ;
   qudt:applicableUnit unit:NUM-PER-HA ;
   qudt:applicableUnit unit:NUM-PER-KiloM2 ;
   qudt:applicableUnit unit:NUM-PER-M2 ;
@@ -17991,7 +18070,7 @@ quantitykind:ParticleFluence
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
   qudt:latexDefinition "$\\Phi = \\frac{dN}{dA}$, where $dN$ describes the number of particles incident on a small spherical domain at a given point in space, and $dA$ describes the cross-sectional area of that domain."^^qudt:LatexString ;
   qudt:latexSymbol "$\\Phi$"^^qudt:LatexString ;
-  qudt:plainTextDescription "\"Particle Fluence\" is the total number of particles that intersect a unit area in a specific time interval of interest, and has units of m–2 (number of particles per meter squared)." ;
+  qudt:plainTextDescription "\"Particle Fluence\" is the total number of particles that intersect a unit area in a specific time interval of interest, and has units of /m2 (number of particles per meter squared)." ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
   rdfs:label "Particle Fluence"@en ;
 .

--- a/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
+++ b/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
@@ -368,10 +368,11 @@ quantitykind:Acidity
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Acid"^^xsd:anyURI ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/PH"^^xsd:anyURI ;
+  qudt:informativeReference "https://iupac.org/wp-content/uploads/2019/05/IUPAC-GB3-2012-2ndPrinting-PDFsearchable.pdf"^^xml:anyURI ;
   qudt:plainTextDescription "Chemicals or substances having a pH less than 7 are said to be acidic; lower pH means higher acidity." ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
   rdfs:label "Acidity"@en ;
-  skos:broader quantitykind:PH ;
+  rdfs:seeAlso quantitykind:Basicity ; 
 .
 quantitykind:AcousticImpedance
   a qudt:QuantityKind ;
@@ -2200,10 +2201,11 @@ quantitykind:Basicity
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Base_(chemistry)"^^xsd:anyURI ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/PH"^^xsd:anyURI ;
+  qudt:informativeReference "https://iupac.org/wp-content/uploads/2019/05/IUPAC-GB3-2012-2ndPrinting-PDFsearchable.pdf"^^xml:anyURI ;
   qudt:plainTextDescription "Chemicals or substances having a pH higher than 7 are said to be basic; higher pH means higher basicity." ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Acidity"@en ;
-  skos:broader quantitykind:PH ;
+  rdfs:label "Basicity"@en ;
+  rdfs:seeAlso quantitykind:Acidity ; 
 .
 quantitykind:BatteryCapacity
   a qudt:QuantityKind ;
@@ -17735,53 +17737,6 @@ quantitykind:OverRangeDistance
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
   rdfs:label "Over-range distance"@en ;
   skos:broader quantitykind:Length ;
-.
-quantitykind:PH
-  a qudt:QuantityKind ;
- dcterms:description """
-  The quantity kind $\\textit${pH}$ is the negative logarithm (base 10) of the concentration of
-   free protons (or hydronium ions).
-   This definition of $pH$ is based on the activity of hydrogen ions ($a_{H^+}$)
-   and expressed as:
-   
-  $$\\text{pH} = -\log_{10} [H^+]$$
-  
-  Where the activity is the product of the 
-   concentration $H^+$ and the activity coefficient $\\gamma_{H^+}$, with the definition:
-
-  $$a_{H^+} = \gamma_{H^+}[H^+]$$
-  
-  This definition is appropriate for concentrations equal to or less than $1\\ mol/l$, 
-   where $aH+ \\equiv [H+]$, that is, $1\\ mol/L\\ HCl$ has a $pH$ of 0.
-
-  For representing large concentrations of hydrogen ions ($H^+$), the symbol typically
-   used is $pOH$ which specifically represents the concentration of hydroxide ions 
-   ($OH^-$) in a solution and is related to $pH$ through the water dissociation constant.
-  However, $pH$ still remains valid and useful even in highly acidic conditions.
- 
-  In solutions with very high ionic strengths, the activity coefficients of ions
-   (which affect the activity of hydrogen ions) deviate significantly from 1. 
-  This can affect the accuracy of $pH$ calculated simply from ion concentration.
-  For example: in highly concentrated salts or acids, such as $6\\ M\\ HCl$.
-  For these conditions, where the $pH$ is high (above 14), that high concentrations
-   of $[H^+]$ or $[OH^-]$, the definition is:
-
-  $$\\text{pOH} = -\\log_{10} [OH^-] \\quad (\\text{for very basic solutions})$$
-
-  While $pH$ is a universally recognized scale for expressing hydrogen ion activity,
-   its appropriateness and accuracy can diminish under conditions of extremely high
-   ionic strength, non-aqueous environments, high temperatures, or very high or
-  low $pH$ values. 
-  In such cases, alternative measurement strategies might be required to obtain
-   meaningful and accurate descriptions of acidity or basicity.
-  """^^qudt:LatexString ;
-  qudt:applicableUnit unit:PH ;
-  qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
-  qudt:informativeReference "https://en.wikipedia.org/wiki/Acid"^^xsd:anyURI ;
-  qudt:informativeReference "https://en.wikipedia.org/wiki/PH"^^xsd:anyURI ;
-  qudt:plainTextDescription "Chemicals or substances having a pH less than 7 are said to be acidic; more than 7 means basic." ;
-  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "PH"@en ;
 .
 quantitykind:PREDICTED-MASS
   a qudt:QuantityKind ;

--- a/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
+++ b/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
@@ -368,7 +368,7 @@ quantitykind:Acidity
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Acid"^^xsd:anyURI ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/PH"^^xsd:anyURI ;
-  qudt:informativeReference "https://iupac.org/wp-content/uploads/2019/05/IUPAC-GB3-2012-2ndPrinting-PDFsearchable.pdf"^^xml:anyURI ;
+  qudt:informativeReference "https://iupac.org/wp-content/uploads/2019/05/IUPAC-GB3-2012-2ndPrinting-PDFsearchable.pdf"^^xsd:anyURI ;
   qudt:plainTextDescription "Chemicals or substances having a pH less than 7 are said to be acidic; lower pH means higher acidity." ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
   rdfs:label "Acidity"@en ;
@@ -2201,7 +2201,7 @@ quantitykind:Basicity
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Base_(chemistry)"^^xsd:anyURI ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/PH"^^xsd:anyURI ;
-  qudt:informativeReference "https://iupac.org/wp-content/uploads/2019/05/IUPAC-GB3-2012-2ndPrinting-PDFsearchable.pdf"^^xml:anyURI ;
+  qudt:informativeReference "https://iupac.org/wp-content/uploads/2019/05/IUPAC-GB3-2012-2ndPrinting-PDFsearchable.pdf"^^xsd:anyURI ;
   qudt:plainTextDescription "Chemicals or substances having a pH higher than 7 are said to be basic; higher pH means higher basicity." ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
   rdfs:label "Basicity"@en ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -37769,50 +37769,47 @@ unit:PFUND
 unit:PH
   a qudt:Unit ;
   dcterms:description """
-  The unit $\\textit${pH}$ is the negative logarithm (base 10) of the concentration of
+  In chemistry the unit $\\textit${pH}$, also referred to as $\\textit${acidity} or $\\textit${basicity}, is the negative logarithm (base 10) of the concentration of
    free protons (or hydronium ions).
-  $pH$ is defined in terms of the activity of hydrogen(1+) ions (hydrogen ions) in solution as:
-  
-  $$\\text{pH} = \\text{p}a_{H^+} = -\\log_{10}(a_{H^+})$$
+  The definition of $pH$ in terms of hydrogen ions in solution is:
 
-  where $a_{H^+}$ is the activity of the hydrogen(1+) (hydrogen ion) in solution.
+  $$\\[\\text{pH}=-\\log_{10}(a_{H^+})\\equiv-\\log_{10}\\left(\\left[H^+\\right]\\right)\\]$$
+
+  where $a_{H^+}$ is the equilibrium molar concentration of $H^+$ in the solution, the activity of
+   the hydrogen ion in the solution.
+
+  This definition is appropriate for concentrations equal to or less than $1\\ mol/l$, 
+   where $aH+ \\equiv [H+]$, that is, $1\\ mol/L\\ HCl$ has a $pH$ of 0.
   
-  In terms of standard molality ($b^\\circ$), the activity ($a_{H^+}$) of the hydrogen ions is the
-   product of their molality ($m_{H^+}$) and the activity coefficient ($\gamma_{H^+}$), 
-   where $m_{H^+}$ is expressed in $mol/kg$ and $b^\circ$ is typically taken as $\\ mol/kg$:
+  To relate this to standard molality ($b^\\circ$), consider the activity ($a_{H^+}$) of the hydrogen
+   ions is the product of their molality ($m_{H^+}$) and the activity coefficient ($\gamma_{H^+}$), 
+   where $m_{H^+}$ is expressed in $mol/kg$ and $b^\circ$ is typically taken as $1 \\ mol/kg$.
+  The activity can then be expressed as:
 
   $$a_{H^+} = \\gamma_{H^+} \\times m_{H^+}$$ 
 
-  and
+  The expansion of $pH$ then becomes:
 
-  $$\\text{pH} = -log_{10}\\left(m_{H&plus;}\\times\\gamma_{m,{H^&plus;}}/m^\\circ\\right)$$
+  $$\\text{pH} = -log_{10}\\left(m_{H+}\\times\\gamma_{H^+}\\right)$$
 
-The symbol p is interpreted
-as an operator (px = 􀀀lg x) with the unique exception of the symbol $pH$.
+  Or?
 
-The symbol $pH$ is also an exception to the rules for symbols and quantities. 
- 
-Since pH is defined in terms of a quantity that cannot be measured independently,
- the above equation can be only regarded as a notional definition.
+  $$\\text{pH} = -log_{10}\\left(m_{H+}\\times\\gamma_{m,{H^+}}/m^\\circ\\right)$$
 
-The establishment of primary pH standards requires the application of the concept of the
-"primary method of measurement", assuring full traceability of the results of all measurements
-  and their uncertainties. 
-Any limitation in the theory or determination of experimental variables must be included in the 
-estimated uncertainty of the method.
-
-   This definition of $pH$ is based on the activity of hydrogen ions ($a_{H^+}$)
-   and expressed as:
-   
-  $$\\text{pH} = -\log_{10} [H^+]$$
+  Where: 
   
-  Where the activity is the product of the 
-   concentration $H^+$ and the activity coefficient $\\gamma_{H^+}$, with the definition:
+  $m_{H+}$ is the molality of hydrogen ions in the solution relative to the standard 
+    molality $b^{\\circ}$
 
-  $$a_{H^+} = \\gamma_{H^+}[H^+]$$
-  
-  This definition is appropriate for concentrations equal to or less than $1\\ mol/l$, 
-   where $aH+ \\equiv [H+]$, that is, $1\\ mol/L\\ HCl$ has a $pH$ of 0.
+  $\\gamma_{H^+}$ is the activity coefficient, which adjusts the molality to account for
+   non-ideal behavior due to interactions between ions in the solution.
+
+This definition is particularly relevant in more concentrated solutions or when precise thermodynamic
+ calculations are required. 
+It reflects how the properties of the solution deviate from ideal behavior and provides a more accurate
+ understanding of the $pH$ under various conditions.
+
+TBD:
 
   For representing large concentrations of hydrogen ions ($H^+$), the symbol typically
    used is $pOH$ which specifically represents the concentration of hydroxide ions 
@@ -37831,7 +37828,8 @@ estimated uncertainty of the method.
   While $pH$ is a universally recognized scale for expressing hydrogen ion activity,
    its appropriateness and accuracy can diminish under conditions of extremely high
    ionic strength, non-aqueous environments, high temperatures, or very high or
-  low $pH$ values. 
+  low $pH$ values.
+
   In such cases, alternative measurement strategies might be required to obtain
    meaningful and accurate descriptions of acidity or basicity.
   """^^qudt:LatexString ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -37781,9 +37781,9 @@ unit:PH
   This definition is appropriate for concentrations equal to or less than $1\\ mol/l$, 
    where $aH+ \\equiv [H+]$, that is, $1\\ mol/L\\ HCl$ has a $pH$ of 0.
   
-  To relate this to standard molality ($b^\\circ$), consider the activity ($a_{H^+}$) of the hydrogen
-   ions is the product of their molality ($m_{H^+}$) and the activity coefficient ($\gamma_{H^+}$), 
-   where $m_{H^+}$ is expressed in $mol/kg$ and $b^\circ$ is typically taken as $1 \\ mol/kg$.
+  To relate this to standard molality ($b^\\circ$), consideration is given to the activity ($a_{H^+}$) of the hydrogen
+   ions is the product of their molality ($m_{H^+}$), and the activity coefficient ($\gamma_{H^+}$). 
+  Where $m_{H^+}$ is expressed in $mol/kg$ and $b^\circ$ is typically taken as $1 \\ mol/kg$.
   The activity can then be expressed as:
 
   $$a_{H^+} = \\gamma_{H^+} \\times m_{H^+}$$ 
@@ -37809,28 +37809,11 @@ This definition is particularly relevant in more concentrated solutions or when 
 It reflects how the properties of the solution deviate from ideal behavior and provides a more accurate
  understanding of the $pH$ under various conditions.
 
-TBD:
-
-  For representing large concentrations of hydrogen ions ($H^+$), the symbol typically
-   used is $pOH$ which specifically represents the concentration of hydroxide ions 
-   ($OH^-$) in a solution and is related to $pH$ through the water dissociation constant.
-  However, $pH$ still remains valid and useful even in highly acidic conditions.
- 
-  In solutions with very high ionic strengths, the activity coefficients of ions
-   (which affect the activity of hydrogen ions) deviate significantly from 1. 
-  This can affect the accuracy of $pH$ calculated simply from ion concentration.
-  For example: in highly concentrated salts or acids, such as $6\\ M\\ HCl$.
-  For these conditions, where the $pH$ is high (above 14), that high concentrations
-   of $[H^+]$ or $[OH^-]$, the definition is:
-
-  $$\\text{pOH} = -\\log_{10} [OH^-] \\quad (\\text{for very basic solutions})$$
-
-  While $pH$ is a universally recognized scale for expressing hydrogen ion activity,
-   its appropriateness and accuracy can diminish under conditions of extremely high
-   ionic strength, non-aqueous environments, high temperatures, or very high or
+While $pH$ is a universally recognized scale for expressing hydrogen ion activity,
+  its appropriateness and accuracy can diminish under conditions of extremely high
+  ionic strength, non-aqueous environments, high temperatures, or very high or
   low $pH$ values.
-
-  In such cases, alternative measurement strategies might be required to obtain
+In such cases, alternative measurement strategies might be required to obtain
    meaningful and accurate descriptions of acidity or basicity.
   """^^qudt:LatexString ;
   qudt:applicableSystem sou:ASU ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -37769,8 +37769,8 @@ unit:PFUND
 unit:PH
   a qudt:Unit ;
   dcterms:description """
-  In chemistry the unit $\\textit${pH}$, also referred to as $\\textit${acidity} or $\\textit${basicity}, is the negative logarithm (base 10) of the concentration of
-   free protons (or hydronium ions).
+  In chemistry the unit $\\textit${pH}$, also referred to as $\\textit${acidity} or $\\textit${basicity},
+   is the negative logarithm (base 10) of the concentration of free protons (or hydronium ions).
   The definition of $pH$ in terms of hydrogen ions in solution is:
 
   $$\\[\\text{pH}=-\\log_{10}(a_{H^+})\\equiv-\\log_{10}\\left(\\left[H^+\\right]\\right)\\]$$
@@ -37781,8 +37781,8 @@ unit:PH
   This definition is appropriate for concentrations equal to or less than $1\\ mol/l$, 
    where $aH+ \\equiv [H+]$, that is, $1\\ mol/L\\ HCl$ has a $pH$ of 0.
   
-  To relate this to standard molality ($b^\\circ$), consideration is given to the activity ($a_{H^+}$) of the hydrogen
-   ions is the product of their molality ($m_{H^+}$), and the activity coefficient ($\\gamma_{H^+}$). 
+  To relate this to standard molality ($b^\\circ$), consideration is given to the activity ($a_{H^+}$)
+   of the hydrogen ions is the product of their molality ($m_{H^+}$), and the activity coefficient ($\\gamma_{H^+}$). 
   Where $m_{H^+}$ is expressed in $mol/kg$ and $b^\\circ$ is typically taken as $1 \\ mol/kg$.
   The activity can then be expressed as:
 
@@ -37815,7 +37815,7 @@ While $pH$ is a universally recognized scale for expressing hydrogen ion activit
   low $pH$ values.
 In such cases, alternative measurement strategies might be required to obtain
    meaningful and accurate descriptions of acidity or basicity.
-  """^^qudt:LatexString ;
+"""^^qudt:LatexString ;
   qudt:applicableSystem sou:ASU ;
   qudt:applicableSystem sou:CGS ;
   qudt:applicableSystem sou:CGS-EMU ;
@@ -37828,7 +37828,7 @@ In such cases, alternative measurement strategies might be required to obtain
   qudt:hasQuantityKind quantitykind:Acidity ;
   qudt:hasQuantityKind quantitykind:Basicity ;
   qudt:hasQuantityKind quantitykind:PH ;
-  qudt:informativeReference "https://iupac.org/wp-content/uploads/2019/05/IUPAC-GB3-2012-2ndPrinting-PDFsearchable.pdf"^^xml:anyURI ;
+  qudt:informativeReference "https://iupac.org/wp-content/uploads/2019/05/IUPAC-GB3-2012-2ndPrinting-PDFsearchable.pdf"^^xsd:anyURI ;
   qudt:symbol "pH" ;
   qudt:ucumCode "[pH]"^^qudt:UCUMcs ;
   rdfs:comment "Unsure about dimensionality of pH; conversion requires a log function not just a multiplier"@en ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -37779,7 +37779,7 @@ unit:PH
    the hydrogen ion in the solution.
 
   This definition is appropriate for concentrations equal to, or less than $1\\ mol/l$, 
-   where $aH+ \\equiv [H+]$, that is, $1\\ mol/L\\ HCl$ has a $pH$ of 0.
+   where $aH+ \\equiv [H+]$, that is, $1\\ mol/L\\ HCl$ has a $pH$ of zero.
   
   To relate this to standard molality ($b^\\circ$), consideration is given to the activity ($a_{H^+}$)
    of the hydrogen ions is the product of their molality ($m_{H^+}$), and the activity coefficient ($\\gamma_{H^+}$),
@@ -37798,7 +37798,7 @@ unit:PH
   $$\\text{pH} = -log_{10}\\left(m_{H+}\\times\\gamma_{H^+}\\right)$$
 
   Where, $m_{H+}$ is the molality of hydrogen ions in the solution relative to the standard 
-    molality, which can also be expressed as $b^{\\circ}$;
+    molality, which can also be expressed as $b^{\\circ}$.
 
 This definition is relevant in more concentrated solutions or when precise thermodynamic
  calculations are required. 

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -37790,24 +37790,15 @@ unit:PH
 
   $$a_{H^+} = \\gamma_{H^+} \\times m_{H^+}$$ 
 
+  Where, $\\gamma_{H^+}$ is the activity coefficient, which adjusts the molality to account for
+   non-ideal behavior due to interactions between ions in the solution.
+
   The expansion of $pH$ then becomes:
 
   $$\\text{pH} = -log_{10}\\left(m_{H+}\\times\\gamma_{H^+}\\right)$$
 
-  Or?
-
-  $$\\text{pH} = -log_{10}\\left(m_{H+}\\times\\gamma_{m,{H^+}}/m^\\circ\\right)$$
-
-  Where: 
-  
-  $m_{H+}$ is the molality of hydrogen ions in the solution relative to the standard 
-    molality $b^{\\circ}$
-
-
-  $\\gamma_{H^+}$ is the activity coefficient, which adjusts the molality to account for
-   non-ideal behavior due to interactions between ions in the solution.
-
-
+  Where, $m_{H+}$ is the molality of hydrogen ions in the solution relative to the standard 
+    molality, which can also be expressed as $b^{\\circ}$;
 
 This definition is relevant in more concentrated solutions or when precise thermodynamic
  calculations are required. 

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -37771,6 +37771,36 @@ unit:PH
   dcterms:description """
   The unit $\\textit${pH}$ is the negative logarithm (base 10) of the concentration of
    free protons (or hydronium ions).
+  $pH$ is defined in terms of the activity of hydrogen(1+) ions (hydrogen ions) in solution as:
+  
+  $$\\text{pH} = \\text{p}a_{H^+} = -\\log_{10}(a_{H^+})$$
+
+  where $a_{H^+}$ is the activity of the hydrogen(1+) (hydrogen ion) in solution.
+  
+  In terms of standard molality ($b^\\circ$), the activity ($a_{H^+}$) of the hydrogen ions is the
+   product of their molality ($m_{H^+}$) and the activity coefficient ($\gamma_{H^+}$), 
+   where $m_{H^+}$ is expressed in $mol/kg$ and $b^\circ$ is typically taken as $\\ mol/kg$:
+
+  $$a_{H^+} = \\gamma_{H^+} \\times m_{H^+}$$ 
+
+  and
+
+  $$\\text{pH} = -log_{10}\\left(m_{H&plus;}\\times\\gamma_{m,{H^&plus;}}/m^\\circ\\right)$$
+
+The symbol p is interpreted
+as an operator (px = 􀀀lg x) with the unique exception of the symbol $pH$.
+
+The symbol $pH$ is also an exception to the rules for symbols and quantities. 
+ 
+Since pH is defined in terms of a quantity that cannot be measured independently,
+ the above equation can be only regarded as a notional definition.
+
+The establishment of primary pH standards requires the application of the concept of the
+"primary method of measurement", assuring full traceability of the results of all measurements
+  and their uncertainties. 
+Any limitation in the theory or determination of experimental variables must be included in the 
+estimated uncertainty of the method.
+
    This definition of $pH$ is based on the activity of hydrogen ions ($a_{H^+}$)
    and expressed as:
    
@@ -37779,7 +37809,7 @@ unit:PH
   Where the activity is the product of the 
    concentration $H^+$ and the activity coefficient $\\gamma_{H^+}$, with the definition:
 
-  $$a_{H^+} = \gamma_{H^+}[H^+]$$
+  $$a_{H^+} = \\gamma_{H^+}[H^+]$$
   
   This definition is appropriate for concentrations equal to or less than $1\\ mol/l$, 
    where $aH+ \\equiv [H+]$, that is, $1\\ mol/L\\ HCl$ has a $pH$ of 0.
@@ -37817,6 +37847,7 @@ unit:PH
   qudt:hasQuantityKind quantitykind:Acidity ;
   qudt:hasQuantityKind quantitykind:Basicity ;
   qudt:hasQuantityKind quantitykind:PH ;
+  qudt:informativeReference "https://iupac.org/wp-content/uploads/2019/05/IUPAC-GB3-2012-2ndPrinting-PDFsearchable.pdf"^^xml:anyURI ;
   qudt:symbol "pH" ;
   qudt:ucumCode "[pH]"^^qudt:UCUMcs ;
   rdfs:comment "Unsure about dimensionality of pH; conversion requires a log function not just a multiplier"@en ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -37782,8 +37782,8 @@ unit:PH
    where $aH+ \\equiv [H+]$, that is, $1\\ mol/L\\ HCl$ has a $pH$ of 0.
   
   To relate this to standard molality ($b^\\circ$), consideration is given to the activity ($a_{H^+}$) of the hydrogen
-   ions is the product of their molality ($m_{H^+}$), and the activity coefficient ($\gamma_{H^+}$). 
-  Where $m_{H^+}$ is expressed in $mol/kg$ and $b^\circ$ is typically taken as $1 \\ mol/kg$.
+   ions is the product of their molality ($m_{H^+}$), and the activity coefficient ($\\gamma_{H^+}$). 
+  Where $m_{H^+}$ is expressed in $mol/kg$ and $b^\\circ$ is typically taken as $1 \\ mol/kg$.
   The activity can then be expressed as:
 
   $$a_{H^+} = \\gamma_{H^+} \\times m_{H^+}$$ 

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -1297,7 +1297,7 @@ unit:B-PER-M
   a qudt:Unit ;
   dcterms:description """
   The $\\textit{Bel}$ is the unit $\\textit{Bel}$ divided by the SI base unit metre/
-  """^qudt:LatexString ;
+  """^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:LinearLogarithmicRatio ;
   qudt:iec61360Code "0112/2///62720#UAB480" ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -37773,7 +37773,7 @@ unit:PH
    is the negative logarithm (base 10) of the concentration of free protons (or hydronium ions).
   The definition of $pH$ in terms of hydrogen ions in solution is:
 
-  $$\\[\\text{pH}=-\\log_{10}(a_{H^+})\\equiv-\\log_{10}\\left(\\left[H^+\\right]\\right)\\]$$
+  $$\\text{pH}=-\\log_{10}(a_{H^+})\\equiv-\\log_{10}\\left(\\left[H^+\\right]\\right)$$
 
   where $a_{H^+}$ is the equilibrium molar concentration of $H^+$ in the solution, the activity of
    the hydrogen ion in the solution.

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -37769,21 +37769,23 @@ unit:PFUND
 unit:PH
   a qudt:Unit ;
   dcterms:description """
-  In chemistry the unit $\\textit{pH}$, also referred to as $\\textit{acidity} or $\\textit{basicity},
+  In chemistry the unit $\\textit{pH}$, also referred to as $\\textit{acidity}$ or $\\textit{basicity}$,
    is the negative logarithm (base 10) of the concentration of free protons (or hydronium ions).
   The definition of $pH$ in terms of hydrogen ions in solution is:
 
   $$\\text{pH}=-\\log_{10}(a_{H^+})\\equiv-\\log_{10}\\left(\\left[H^+\\right]\\right)$$
 
-  where $a_{H^+}$ is the equilibrium molar concentration of $H^+$ in the solution, the activity of
+  Where $a_{H^+}$ is the equilibrium molar concentration of $H^+$ in the solution, the activity of
    the hydrogen ion in the solution.
 
-  This definition is appropriate for concentrations equal to or less than $1\\ mol/l$, 
+  This definition is appropriate for concentrations equal to, or less than $1\\ mol/l$, 
    where $aH+ \\equiv [H+]$, that is, $1\\ mol/L\\ HCl$ has a $pH$ of 0.
   
   To relate this to standard molality ($b^\\circ$), consideration is given to the activity ($a_{H^+}$)
-   of the hydrogen ions is the product of their molality ($m_{H^+}$), and the activity coefficient ($\\gamma_{H^+}$). 
-  Where $m_{H^+}$ is expressed in $mol/kg$ and $b^\\circ$ is typically taken as $1 \\ mol/kg$.
+   of the hydrogen ions is the product of their molality ($m_{H^+}$), and the activity coefficient ($\\gamma_{H^+}$),
+   where $m_{H^+}$ is expressed in $mol/kg$, and $b^\\circ$ is typically taken as $1 \\ mol/kg$.
+  
+  
   The activity can then be expressed as:
 
   $$a_{H^+} = \\gamma_{H^+} \\times m_{H^+}$$ 
@@ -37801,10 +37803,13 @@ unit:PH
   $m_{H+}$ is the molality of hydrogen ions in the solution relative to the standard 
     molality $b^{\\circ}$
 
+
   $\\gamma_{H^+}$ is the activity coefficient, which adjusts the molality to account for
    non-ideal behavior due to interactions between ions in the solution.
 
-This definition is particularly relevant in more concentrated solutions or when precise thermodynamic
+
+
+This definition is relevant in more concentrated solutions or when precise thermodynamic
  calculations are required. 
 It reflects how the properties of the solution deviate from ideal behavior and provides a more accurate
  understanding of the $pH$ under various conditions.

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -37769,7 +37769,7 @@ unit:PFUND
 unit:PH
   a qudt:Unit ;
   dcterms:description """
-  In chemistry the unit $\\textit${pH}$, also referred to as $\\textit${acidity} or $\\textit${basicity},
+  In chemistry the unit $\\textit{pH}$, also referred to as $\\textit{acidity} or $\\textit{basicity},
    is the negative logarithm (base 10) of the concentration of free protons (or hydronium ions).
   The definition of $pH$ in terms of hydrogen ions in solution is:
 

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -1245,7 +1245,10 @@ unit:B
   a qudt:DimensionlessUnit ;
   a qudt:LogarithmicUnit ;
   a qudt:Unit ;
-  dcterms:description "A logarithmic unit of sound pressure equal to 10 decibels (dB),  It is defined as: $1 B = (1/2) \\log_{10}(Np)$"^^qudt:LatexString ;
+  dcterms:description """
+  The $\\textit{Bel}$ is a logarithmic unit of sound pressure equal to 10 decibels (dB). 
+  It is defined as: $1 B = (1/2) \\log_{10}(Np)$
+  """^^qudt:LatexString ;
   qudt:applicableSystem sou:ASU ;
   qudt:applicableSystem sou:CGS ;
   qudt:applicableSystem sou:CGS-EMU ;
@@ -1292,7 +1295,9 @@ unit:B
 .
 unit:B-PER-M
   a qudt:Unit ;
-  dcterms:description "unit bel divided by the SI base unit metre" ;
+  dcterms:description """
+  The $\\textit{Bel}$ is the unit $\\textit{Bel}$ divided by the SI base unit metre/
+  """^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:LinearLogarithmicRatio ;
   qudt:iec61360Code "0112/2///62720#UAB480" ;
@@ -1305,7 +1310,12 @@ unit:B-PER-M
 .
 unit:BAN
   a qudt:Unit ;
-  dcterms:description "A ban is a logarithmic unit which measures information or entropy, based on base 10 logarithms and powers of 10, rather than the powers of 2 and base 2 logarithms which define the bit. One ban is approximately $3.32 (log_2 10) bits$."^^qudt:LatexString ;
+  dcterms:description """
+  A $\\textit{ban}$ is a logarithmic unit which measures information or entropy,
+   based on base 10 logarithms and powers of 10, rather than the powers of 2
+   and base 2 logarithms which define the bit. 
+  One \\textit{ban} is approximately $3.32 (log_2 10) bits$.
+  """^^qudt:LatexString ;
   qudt:applicableSystem sou:ASU ;
   qudt:applicableSystem sou:CGS ;
   qudt:applicableSystem sou:CGS-EMU ;
@@ -1327,7 +1337,16 @@ unit:BAN
 .
 unit:BAR
   a qudt:Unit ;
-  dcterms:description "The bar is a non-SI unit of pressure, defined by the IUPAC as exactly equal to $100,000\\,Pa$. It is about equal to the atmospheric pressure on Earth at sea level, and since 1982 the IUPAC has recommended that the standard for atmospheric pressure should be harmonized to $100,000\\,Pa = 1 \\,bar \\approx 750.0616827\\, Torr$. Units derived from the bar are the megabar (symbol: Mbar), kilobar (symbol: kbar), decibar (symbol: dbar), centibar (symbol: cbar), and millibar (symbol: mbar or mb). They are not SI or cgs units, but they are accepted for use with the SI."^^qudt:LatexString ;
+  dcterms:description """
+  The \\textit{bar} is a non-SI unit of pressure, defined by the IUPAC as exactly equal
+   to $100,000\\,Pa$. 
+  It is about equal to the atmospheric pressure on Earth at sea level, and since 1982
+   the IUPAC has recommended that the standard for atmospheric pressure should be
+   harmonized to $100,000\\,Pa = 1 \\,bar \\approx 750.0616827\\, Torr$. 
+  Units derived from the bar are the megabar (symbol: Mbar), kilobar (symbol: kbar),
+   decibar (symbol: dbar), centibar (symbol: cbar), and millibar (symbol: mbar or mb). 
+  They are not SI or cgs units, but they are accepted for use with the SI.
+  """^^qudt:LatexString ;
   qudt:applicableSystem sou:CGS ;
   qudt:conversionMultiplier 100000.0 ;
   qudt:conversionMultiplierSN 1.0E5 ;
@@ -1347,14 +1366,17 @@ unit:BAR
 .
 unit:BAR-L-PER-SEC
   a qudt:Unit ;
-  dcterms:description "product of the unit bar and the unit litre divided by the SI base unit second"^^rdf:HTML ;
+  dcterms:description """
+  The unit \\textit{Bar Litre Per Second}$ is the product of the unit $bar$ and
+   the unit $litre$ divided by the SI base unit for second.
+  """^^qudt:LatexString ;
   qudt:applicableSystem sou:CGS ;
   qudt:conversionMultiplier 100.0 ;
   qudt:conversionMultiplierSN 1.0E2 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAA326" ;
-  qudt:plainTextDescription "product of the unit bar and the unit litre divided by the SI base unit second" ;
+  qudt:plainTextDescription "The unit 'Bar Litre Per Second' is the product of the unit bar and the unit litre divided by the SI base unit second" ;
   qudt:symbol "bar·L/s" ;
   qudt:ucumCode "bar.L.s-1"^^qudt:UCUMcs ;
   qudt:ucumCode "bar.L/s"^^qudt:UCUMcs ;
@@ -37746,7 +37768,43 @@ unit:PFUND
 .
 unit:PH
   a qudt:Unit ;
-  dcterms:description "the negative decadic logarithmus of the concentration of free protons (or hydronium ions) expressed in 1 mol/l."@en ;
+  dcterms:description """
+  The unit $\\textit${pH}$ is the negative logarithm (base 10) of the concentration of
+   free protons (or hydronium ions).
+   This definition of $pH$ is based on the activity of hydrogen ions ($a_{H^+}$)
+   and expressed as:
+   
+  $$\\text{pH} = -\log_{10} [H^+]$$
+  
+  Where the activity is the product of the 
+   concentration $H^+$ and the activity coefficient $\\gamma_{H^+}$, with the definition:
+
+  $$a_{H^+} = \gamma_{H^+}[H^+]$$
+  
+  This definition is appropriate for concentrations equal to or less than $1\\ mol/l$, 
+   where $aH+ \\equiv [H+]$, that is, $1\\ mol/L\\ HCl$ has a $pH$ of 0.
+
+  For representing large concentrations of hydrogen ions ($H^+$), the symbol typically
+   used is $pOH$ which specifically represents the concentration of hydroxide ions 
+   ($OH^-$) in a solution and is related to $pH$ through the water dissociation constant.
+  However, $pH$ still remains valid and useful even in highly acidic conditions.
+ 
+  In solutions with very high ionic strengths, the activity coefficients of ions
+   (which affect the activity of hydrogen ions) deviate significantly from 1. 
+  This can affect the accuracy of $pH$ calculated simply from ion concentration.
+  For example: in highly concentrated salts or acids, such as $6\\ M\\ HCl$.
+  For these conditions, where the $pH$ is high (above 14), that high concentrations
+   of $[H^+]$ or $[OH^-]$, the definition is:
+
+  $$\\text{pOH} = -\\log_{10} [OH^-] \\quad (\\text{for very basic solutions})$$
+
+  While $pH$ is a universally recognized scale for expressing hydrogen ion activity,
+   its appropriateness and accuracy can diminish under conditions of extremely high
+   ionic strength, non-aqueous environments, high temperatures, or very high or
+  low $pH$ values. 
+  In such cases, alternative measurement strategies might be required to obtain
+   meaningful and accurate descriptions of acidity or basicity.
+  """^^qudt:LatexString ;
   qudt:applicableSystem sou:ASU ;
   qudt:applicableSystem sou:CGS ;
   qudt:applicableSystem sou:CGS-EMU ;


### PR DESCRIPTION
Definition of pH and some corrections to other LaTeX definitions. Also removed pH as a QK - we have 'Acidity' and 'Basicity'.