### PR TITLE
remove plural from label

### DIFF
--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -22335,7 +22335,7 @@ unit:M-PER-YR
   qudt:symbol "m/a" ;
   qudt:ucumCode "m.a-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
-  rdfs:label "Metres per year"@en ;
+  rdfs:label "Metre per year"@en ;
 .
 unit:M-SEC
   a qudt:Unit ;


### PR DESCRIPTION
remove plural from label for Metres per year to make it consistent with the naming scheme