### PR TITLE
Srr cost per naming

### DIFF
--- a/collections/COLLECTION_QUDT_QA_TESTS_ALL-v2.1.ttl
+++ b/collections/COLLECTION_QUDT_QA_TESTS_ALL-v2.1.ttl
@@ -63,6 +63,11 @@
     ] ;
   sh:declare [
       a sh:PrefixDeclaration ;
+      sh:namespace "http://www.w3.org/2001/XMLSchema#"^^xsd:anyURI ;
+      sh:prefix "xsd" ;
+    ] ;
+  sh:declare [
+      a sh:PrefixDeclaration ;
       sh:namespace "http://www.w3.org/2002/07/owl#"^^xsd:anyURI ;
       sh:prefix "owl" ;
     ] ;
@@ -76,12 +81,7 @@
       sh:namespace "http://www.w3.org/ns/shacl#"^^xsd:anyURI ;
       sh:prefix "sh" ;
     ] ;
-  sh:declare [
-      a sh:PrefixDeclaration ;
-      sh:namespace "http://www.w3.org/2001/XMLSchema#"^^xsd:anyURI ;
-      sh:prefix "xsd" ;
-    ]
-  .
+.
 qudt:ClosedWorldShape
   a sh:NodeShape ;
   rdfs:isDefinedBy <http://qudt.org/2.1/collection/qa/all> ;
@@ -149,6 +149,7 @@ qudt:ExactMatchGoesBothWaysConstraint
 SELECT $this ?t
 WHERE {
 $this qudt:exactMatch ?t .
+FILTER NOT EXISTS {?t qudt:deprecated true}
 FILTER NOT EXISTS {?t qudt:exactMatch $this }
 }
 """ ;
@@ -355,33 +356,31 @@ FILTER (?udv != ?qdv) .
     ] ;
   sh:targetClass qudt:Unit ;
 .
-
 qudt:conversionMultiplierSnShape
-  sh:targetClass qudt:Unit;
-    rdfs:comment "qudt:conversionMultiplier must match qudt:conversionMultiplierSN if present" ;
-    sh:sparql [
-        a sh:SPARQLConstraint ;
-        sh:minCount 1;
-        sh:message """{$this} qudt:conversionMultiplier is {?valueDecimalNoTrailingZeros}, which does not match the value of qudt:conversionMultiplierSN, {?valueSN}, converted to decimal notation, {?valueSNStringValue} .  """ ;
-        sh:prefixes <http://qudt.org/2.1/collection/qa/all> ;
-        sh:select """
+  rdfs:comment "qudt:conversionMultiplier must match qudt:conversionMultiplierSN if present" ;
+  sh:sparql [
+      a sh:SPARQLConstraint ;
+      sh:message "{$this} qudt:conversionMultiplier is {?valueDecimalNoTrailingZeros}, which does not match the value of qudt:conversionMultiplierSN, {?valueSN}, converted to decimal notation, {?valueSNStringValue} .  " ;
+      sh:minCount 1 ;
+      sh:prefixes <http://qudt.org/2.1/collection/qa/all> ;
+      sh:select """
             SELECT $this ?valueDecimal ?valueDecimalNoTrailingZeros ?valueSN ?m ?e ?exponent ?mNoDot ?mDigitCount ?valueSNStringValue ?onePos ?lastMantissaDigit ?leftStart ?leftEnd ?rightStart ?rightEnd ?result
                         WHERE {
                             # select both values
                             $this
                                 qudt:conversionMultiplier ?valueDecimal ;
                                 qudt:conversionMultiplierSN ?valueSN .
-                            BIND(REPLACE(STR(?valueDecimal), "(\\\\.\\\\d)(\\\\d*[1-9])?0*$", "$1$2") as ?valueDecimalNoTrailingZeros)      # remove trailing zeros from valueDecimal (string)
-                            BIND(REPLACE(STR(?valueSN), "[eE]-?\\\\d+$", "") as ?m)                                           # extract the mantissa (string)
-                            BIND(REPLACE(STR(?valueSN), "^\\\\d(\\\\.\\\\d+)?[eE]", "") as ?e)                                    # extract the exponent (string)
-                            BIND(REPLACE(STR(?m),"(\\\\.|0+$)","") AS ?mNoDot)                                                # remove the comma and trailing zeros from the mantissa
+                            BIND(REPLACE(STR(?valueDecimal), \"(\\\\.\\\\d)(\\\\d*[1-9])?0*$\", \"$1$2\") as ?valueDecimalNoTrailingZeros)      # remove trailing zeros from valueDecimal (string)
+                            BIND(REPLACE(STR(?valueSN), \"[eE]-?\\\\d+$\", \"\") as ?m)                                           # extract the mantissa (string)
+                            BIND(REPLACE(STR(?valueSN), \"^\\\\d(\\\\.\\\\d+)?[eE]\", \"\") as ?e)                                    # extract the exponent (string)
+                            BIND(REPLACE(STR(?m),\"(\\\\.|0+$)\",\"\") AS ?mNoDot)                                                # remove the comma and trailing zeros from the mantissa
                             BIND(STRLEN(?mNoDot) as ?mDigitCount)                                                           # count the mantissa's characters
                             BIND(xsd:integer(?e) as  ?exponent)                                                             # cast e to an integer, called exponent
                             # prepare a string with 200 zeros padding left and right, mantissa in the middle
                             BIND(CONCAT(
-                                                "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                                                \"00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\",
                                                 ?mNoDot,
-                                                "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000") as ?baseStr)
+                                                \"00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\") as ?baseStr)
                             # first char has index 1 !!!
                             BIND(201 + ?exponent as ?onePos)
                             BIND(200 + ?mDigitCount  as ?lastMantissaDigit)
@@ -390,41 +389,41 @@ qudt:conversionMultiplierSnShape
                             BIND(?onePos+1 as ?rightStart)
                             BIND(IF(?lastMantissaDigit+1 > ?onePos+2, ?lastMantissaDigit+1, ?onePos+2)  as ?rightEnd)
                             # determine the expected string
-                            BIND(CONCAT(SUBSTR(?baseStr, ?leftStart, ?leftEnd-?leftStart), ".", SUBSTR(?baseStr, ?rightStart, ?rightEnd - ?rightStart)) as  ?valueSNStringValue)
+                            BIND(CONCAT(SUBSTR(?baseStr, ?leftStart, ?leftEnd-?leftStart), \".\", SUBSTR(?baseStr, ?rightStart, ?rightEnd - ?rightStart)) as  ?valueSNStringValue)
                             # compare with actual decimal value
-                            BIND(IF(?valueSNStringValue = STR(?valueDecimalNoTrailingZeros), "match!", "no match!") as ?result)
+                            BIND(IF(?valueSNStringValue = STR(?valueDecimalNoTrailingZeros), \"match!\", \"no match!\") as ?result)
                             # only generate message if no match (useful during development)
-                            FILTER(?result != "match!")
+                            FILTER(?result != \"match!\")
                         }
         """ ;
-      ] .
-      
+    ] ;
+  sh:targetClass qudt:Unit ;
+.
 qudt:conversionOffsetSnShape
-  sh:targetClass qudt:Unit;
-    rdfs:comment "qudt:conversionOffset must match qudt:conversionOffsetSN if present" ;
-    sh:sparql [
-        a sh:SPARQLConstraint ;
-        sh:minCount 1;
-        sh:message """{$this} qudt:conversionOffset is {?valueDecimalNoTrailingZeros}, which does not match the value of qudt:conversionOffsetSN, {?valueSN}, converted to decimal notation, {?valueSNStringValue} .  """ ;
-        sh:prefixes <http://qudt.org/2.1/collection/qa/all> ;
-        sh:select """
+  rdfs:comment "qudt:conversionOffset must match qudt:conversionOffsetSN if present" ;
+  sh:sparql [
+      a sh:SPARQLConstraint ;
+      sh:message "{$this} qudt:conversionOffset is {?valueDecimalNoTrailingZeros}, which does not match the value of qudt:conversionOffsetSN, {?valueSN}, converted to decimal notation, {?valueSNStringValue} .  " ;
+      sh:minCount 1 ;
+      sh:prefixes <http://qudt.org/2.1/collection/qa/all> ;
+      sh:select """
             SELECT $this ?valueDecimal ?valueDecimalNoTrailingZeros ?valueSN ?m ?e ?exponent ?mNoDot ?mDigitCount ?valueSNStringValue ?onePos ?lastMantissaDigit ?leftStart ?leftEnd ?rightStart ?rightEnd ?result
                         WHERE {
                             # select both values
                             $this
                                 qudt:conversionOffset ?valueDecimal ;
                                 qudt:conversionOffsetSN ?valueSN .
-                            BIND(REPLACE(STR(?valueDecimal), "(\\\\.\\\\d)(\\\\d*[1-9])?0*$", "$1$2") as ?valueDecimalNoTrailingZeros)      # remove trailing zeros from valueDecimal (string)
-                            BIND(REPLACE(STR(?valueSN), "[eE]-?\\\\d+$", "") as ?m)                                           # extract the mantissa (string)
-                            BIND(REPLACE(STR(?valueSN), "^\\\\d(\\\\.\\\\d+)?[eE]", "") as ?e)                                    # extract the exponent (string)
-                            BIND(REPLACE(STR(?m),"(\\\\.|0+$)","") AS ?mNoDot)                                                # remove the comma and trailing zeros from the mantissa
+                            BIND(REPLACE(STR(?valueDecimal), \"(\\\\.\\\\d)(\\\\d*[1-9])?0*$\", \"$1$2\") as ?valueDecimalNoTrailingZeros)      # remove trailing zeros from valueDecimal (string)
+                            BIND(REPLACE(STR(?valueSN), \"[eE]-?\\\\d+$\", \"\") as ?m)                                           # extract the mantissa (string)
+                            BIND(REPLACE(STR(?valueSN), \"^\\\\d(\\\\.\\\\d+)?[eE]\", \"\") as ?e)                                    # extract the exponent (string)
+                            BIND(REPLACE(STR(?m),\"(\\\\.|0+$)\",\"\") AS ?mNoDot)                                                # remove the comma and trailing zeros from the mantissa
                             BIND(STRLEN(?mNoDot) as ?mDigitCount)                                                           # count the mantissa's characters
                             BIND(xsd:integer(?e) as  ?exponent)                                                             # cast e to an integer, called exponent
                             # prepare a string with 200 zeros padding left and right, mantissa in the middle
                             BIND(CONCAT(
-                                                "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                                                \"00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\",
                                                 ?mNoDot,
-                                                "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000") as ?baseStr)
+                                                \"00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\") as ?baseStr)
                             # first char has index 1 !!!
                             BIND(201 + ?exponent as ?onePos)
                             BIND(200 + ?mDigitCount  as ?lastMantissaDigit)
@@ -433,41 +432,41 @@ qudt:conversionOffsetSnShape
                             BIND(?onePos+1 as ?rightStart)
                             BIND(IF(?lastMantissaDigit+1 > ?onePos+2, ?lastMantissaDigit+1, ?onePos+2)  as ?rightEnd)
                             # determine the expected string
-                            BIND(CONCAT(SUBSTR(?baseStr, ?leftStart, ?leftEnd-?leftStart), ".", SUBSTR(?baseStr, ?rightStart, ?rightEnd - ?rightStart)) as  ?valueSNStringValue)
+                            BIND(CONCAT(SUBSTR(?baseStr, ?leftStart, ?leftEnd-?leftStart), \".\", SUBSTR(?baseStr, ?rightStart, ?rightEnd - ?rightStart)) as  ?valueSNStringValue)
                             # compare with actual decimal value
-                            BIND(IF(?valueSNStringValue = STR(?valueDecimalNoTrailingZeros), "match!", "no match!") as ?result)
+                            BIND(IF(?valueSNStringValue = STR(?valueDecimalNoTrailingZeros), \"match!\", \"no match!\") as ?result)
                             # only generate message if no match (useful during development)
-                            FILTER(?result != "match!")
+                            FILTER(?result != \"match!\")
                         }
         """ ;
-      ] .
-
+    ] ;
+  sh:targetClass qudt:Unit ;
+.
 qudt:standardUncertaintySnShape
-  sh:targetClass qudt:ConstantValue;
-    rdfs:comment "qudt:standardUncertainty must match qudt:standardUncertaintySN if present" ;
-    sh:sparql [
-        a sh:SPARQLConstraint ;
-        sh:minCount 1;
-        sh:message """{$this} qudt:standardUncertainty is {?valueDecimalNoTrailingZeros}, which does not match the value of qudt:standardUncertaintySN, {?valueSN}, converted to decimal notation, {?valueSNStringValue} .  """ ;
-        sh:prefixes <http://qudt.org/2.1/collection/qa/all> ;
-        sh:select """
+  rdfs:comment "qudt:standardUncertainty must match qudt:standardUncertaintySN if present" ;
+  sh:sparql [
+      a sh:SPARQLConstraint ;
+      sh:message "{$this} qudt:standardUncertainty is {?valueDecimalNoTrailingZeros}, which does not match the value of qudt:standardUncertaintySN, {?valueSN}, converted to decimal notation, {?valueSNStringValue} .  " ;
+      sh:minCount 1 ;
+      sh:prefixes <http://qudt.org/2.1/collection/qa/all> ;
+      sh:select """
             SELECT $this ?valueDecimal ?valueDecimalNoTrailingZeros ?valueSN ?m ?e ?exponent ?mNoDot ?mDigitCount ?valueSNStringValue ?onePos ?lastMantissaDigit ?leftStart ?leftEnd ?rightStart ?rightEnd ?result
                         WHERE {
                             # select both values
                             $this
                                 qudt:standardUncertainty ?valueDecimal ;
                                 qudt:standardUncertaintySN ?valueSN .
-                            BIND(REPLACE(STR(?valueDecimal), "(\\\\.\\\\d)(\\\\d*[1-9])?0*$", "$1$2") as ?valueDecimalNoTrailingZeros)      # remove trailing zeros from valueDecimal (string)
-                            BIND(REPLACE(STR(?valueSN), "[eE]-?\\\\d+$", "") as ?m)                                           # extract the mantissa (string)
-                            BIND(REPLACE(STR(?valueSN), "^\\\\d(\\\\.\\\\d+)?[eE]", "") as ?e)                                    # extract the exponent (string)
-                            BIND(REPLACE(STR(?m),"(\\\\.|0+$)","") AS ?mNoDot)                                                # remove the comma and trailing zeros from the mantissa
+                            BIND(REPLACE(STR(?valueDecimal), \"(\\\\.\\\\d)(\\\\d*[1-9])?0*$\", \"$1$2\") as ?valueDecimalNoTrailingZeros)      # remove trailing zeros from valueDecimal (string)
+                            BIND(REPLACE(STR(?valueSN), \"[eE]-?\\\\d+$\", \"\") as ?m)                                           # extract the mantissa (string)
+                            BIND(REPLACE(STR(?valueSN), \"^\\\\d(\\\\.\\\\d+)?[eE]\", \"\") as ?e)                                    # extract the exponent (string)
+                            BIND(REPLACE(STR(?m),\"(\\\\.|0+$)\",\"\") AS ?mNoDot)                                                # remove the comma and trailing zeros from the mantissa
                             BIND(STRLEN(?mNoDot) as ?mDigitCount)                                                           # count the mantissa's characters
                             BIND(xsd:integer(?e) as  ?exponent)                                                             # cast e to an integer, called exponent
                             # prepare a string with 200 zeros padding left and right, mantissa in the middle
                             BIND(CONCAT(
-                                                "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                                                \"00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\",
                                                 ?mNoDot,
-                                                "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000") as ?baseStr)
+                                                \"00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\") as ?baseStr)
                             # first char has index 1 !!!
                             BIND(201 + ?exponent as ?onePos)
                             BIND(200 + ?mDigitCount  as ?lastMantissaDigit)
@@ -476,41 +475,41 @@ qudt:standardUncertaintySnShape
                             BIND(?onePos+1 as ?rightStart)
                             BIND(IF(?lastMantissaDigit+1 > ?onePos+2, ?lastMantissaDigit+1, ?onePos+2)  as ?rightEnd)
                             # determine the expected string
-                            BIND(CONCAT(SUBSTR(?baseStr, ?leftStart, ?leftEnd-?leftStart), ".", SUBSTR(?baseStr, ?rightStart, ?rightEnd - ?rightStart)) as  ?valueSNStringValue)
+                            BIND(CONCAT(SUBSTR(?baseStr, ?leftStart, ?leftEnd-?leftStart), \".\", SUBSTR(?baseStr, ?rightStart, ?rightEnd - ?rightStart)) as  ?valueSNStringValue)
                             # compare with actual decimal value
-                            BIND(IF(?valueSNStringValue = STR(?valueDecimalNoTrailingZeros), "match!", "no match!") as ?result)
+                            BIND(IF(?valueSNStringValue = STR(?valueDecimalNoTrailingZeros), \"match!\", \"no match!\") as ?result)
                             # only generate message if no match (useful during development)
-                            FILTER(?result != "match!")
+                            FILTER(?result != \"match!\")
                         }
         """ ;
-      ] .
-
+    ] ;
+  sh:targetClass qudt:ConstantValue ;
+.
 qudt:valueSnShape
-  sh:targetClass qudt:ConstantValue;
-    rdfs:comment "qudt:value must match qudt:valueSN if present" ;
-    sh:sparql [
-        a sh:SPARQLConstraint ;
-        sh:minCount 1;
-        sh:message """{$this} qudt:value is {?valueDecimalNoTrailingZeros}, which does not match the value of qudt:valueSN, {?valueSN}, converted to decimal notation, {?valueSNStringValue} .  """ ;
-        sh:prefixes <http://qudt.org/2.1/collection/qa/all> ;
-        sh:select """
+  rdfs:comment "qudt:value must match qudt:valueSN if present" ;
+  sh:sparql [
+      a sh:SPARQLConstraint ;
+      sh:message "{$this} qudt:value is {?valueDecimalNoTrailingZeros}, which does not match the value of qudt:valueSN, {?valueSN}, converted to decimal notation, {?valueSNStringValue} .  " ;
+      sh:minCount 1 ;
+      sh:prefixes <http://qudt.org/2.1/collection/qa/all> ;
+      sh:select """
             SELECT $this ?valueDecimal ?valueDecimalNoTrailingZeros ?valueSN ?m ?e ?exponent ?mNoDot ?mDigitCount ?valueSNStringValue ?onePos ?lastMantissaDigit ?leftStart ?leftEnd ?rightStart ?rightEnd ?result
                         WHERE {
                             # select both values
                             $this
                                 qudt:value ?valueDecimal ;
                                 qudt:valueSN ?valueSN .
-                            BIND(REPLACE(STR(?valueDecimal), "(\\\\.\\\\d)(\\\\d*[1-9])?0*$", "$1$2") as ?valueDecimalNoTrailingZeros)     # remove trailing zeros from valueDecimal (string)
-                            BIND(REPLACE(STR(?valueSN), "[eE]-?\\\\d+$", "") as ?m)                                           # extract the mantissa (string)
-                            BIND(REPLACE(STR(?valueSN), "^\\\\d(\\\\.\\\\d+)?[eE]", "") as ?e)                                    # extract the exponent (string)
-                            BIND(REPLACE(STR(?m),"(\\\\.|0+$)","") AS ?mNoDot)                                                # remove the comma and trailing zeros from the mantissa
+                            BIND(REPLACE(STR(?valueDecimal), \"(\\\\.\\\\d)(\\\\d*[1-9])?0*$\", \"$1$2\") as ?valueDecimalNoTrailingZeros)     # remove trailing zeros from valueDecimal (string)
+                            BIND(REPLACE(STR(?valueSN), \"[eE]-?\\\\d+$\", \"\") as ?m)                                           # extract the mantissa (string)
+                            BIND(REPLACE(STR(?valueSN), \"^\\\\d(\\\\.\\\\d+)?[eE]\", \"\") as ?e)                                    # extract the exponent (string)
+                            BIND(REPLACE(STR(?m),\"(\\\\.|0+$)\",\"\") AS ?mNoDot)                                                # remove the comma and trailing zeros from the mantissa
                             BIND(STRLEN(?mNoDot) as ?mDigitCount)                                                           # count the mantissa's characters
                             BIND(xsd:integer(?e) as  ?exponent)                                                             # cast e to an integer, called exponent
                             # prepare a string with 200 zeros padding left and right, mantissa in the middle
                             BIND(CONCAT(
-                                                "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                                                \"00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\",
                                                 ?mNoDot,
-                                                "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000") as ?baseStr)
+                                                \"00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\") as ?baseStr)
                             # first char has index 1 !!!
                             BIND(201 + ?exponent as ?onePos)
                             BIND(200 + ?mDigitCount  as ?lastMantissaDigit)
@@ -519,11 +518,13 @@ qudt:valueSnShape
                             BIND(?onePos+1 as ?rightStart)
                             BIND(IF(?lastMantissaDigit+1 > ?onePos+2, ?lastMantissaDigit+1, ?onePos+2)  as ?rightEnd)
                             # determine the expected string
-                            BIND(CONCAT(SUBSTR(?baseStr, ?leftStart, ?leftEnd-?leftStart), ".", SUBSTR(?baseStr, ?rightStart, ?rightEnd - ?rightStart)) as  ?valueSNStringValue)
+                            BIND(CONCAT(SUBSTR(?baseStr, ?leftStart, ?leftEnd-?leftStart), \".\", SUBSTR(?baseStr, ?rightStart, ?rightEnd - ?rightStart)) as  ?valueSNStringValue)
                             # compare with actual decimal value
-                            BIND(IF(?valueSNStringValue = STR(?valueDecimalNoTrailingZeros), "match!", "no match!") as ?result)
+                            BIND(IF(?valueSNStringValue = STR(?valueDecimalNoTrailingZeros), \"match!\", \"no match!\") as ?result)
                             # only generate message if no match (useful during development)
-                            FILTER(?result != "match!")
+                            FILTER(?result != \"match!\")
                         }
         """ ;
-      ] .
+    ] ;
+  sh:targetClass qudt:ConstantValue ;
+.

--- a/collections/COLLECTION_QUDT_QA_TESTS_ALL-v2.1.ttl
+++ b/collections/COLLECTION_QUDT_QA_TESTS_ALL-v2.1.ttl
@@ -95,6 +95,7 @@ qudt:ClosedWorldShape
 SELECT $this ?p ?o
 WHERE {
 $this a/rdfs:subClassOf* qudt:Concept .
+FILTER NOT EXISTS {$this qudt:deprecated true}
 $this ?p ?o .
 FILTER(STRSTARTS (str(?p), 'http://qudt.org/schema/qudt'))
 FILTER NOT EXISTS {$this a sh:NodeShape}
@@ -149,8 +150,8 @@ qudt:ExactMatchGoesBothWaysConstraint
 SELECT $this ?t
 WHERE {
 $this qudt:exactMatch ?t .
-FILTER NOT EXISTS {?t qudt:deprecated true}
-FILTER NOT EXISTS {?t qudt:exactMatch $this }
+FILTER NOT EXISTS {$this qudt:deprecated true} .
+FILTER NOT EXISTS {?t qudt:exactMatch $this } .
 }
 """ ;
     ] ;
@@ -168,6 +169,7 @@ qudt:InconsistentDimensionVectorInSKOSHierarchyConstraint
       sh:select """
 SELECT $this ?udv ?qk ?qdv
 WHERE {
+FILTER NOT EXISTS {$this qudt:deprecated true} .
 $this qudt:hasDimensionVector  ?udv .
 $this skos:broader* ?qk .
 ?qk qudt:hasDimensionVector ?qdv .
@@ -214,6 +216,7 @@ qudt:MultipleDescriptionsConstraint
       sh:select """
             SELECT $this (COUNT(?label) AS ?count) ?langTag
             WHERE {
+                FILTER NOT EXISTS {$this qudt:deprecated true} .
                 $this dcterms:description ?label .
                 FILTER(langMatches(lang(?label), ?langTag))
                 BIND(lang(?label) AS ?langTag)
@@ -237,6 +240,7 @@ qudt:MultipleLabelsConstraint
       sh:select """
             SELECT $this (COUNT(?label) AS ?count) ?langTag
             WHERE {
+                FILTER NOT EXISTS {$this qudt:deprecated true} .
                 $this rdfs:label ?label .
                 FILTER(langMatches(lang(?label), ?langTag))
                 BIND(lang(?label) AS ?langTag)
@@ -259,6 +263,7 @@ qudt:QuantityKindShape
           sh:select """
                 SELECT DISTINCT $this ?qk
                 WHERE {
+                FILTER NOT EXISTS {$this qudt:deprecated true} .
                 $this
                     skos:broader ?qk ;
                     qudt:exactMatch ?qk .
@@ -276,6 +281,7 @@ qudt:QuantityKindShape
           sh:select """
                 SELECT $this ?qk
                 WHERE {
+                FILTER NOT EXISTS {$this qudt:deprecated true} .
                 $this qudt:hasDimensionVector  ?udv .
                 $this skos:broader* ?qk .
                 ?qk qudt:hasDimensionVector ?qdv .
@@ -303,6 +309,7 @@ WHERE {{
      ?another qudt:symbol ?symbol .
     FILTER (?another != $this)
    }
+   FILTER NOT EXISTS {$this qudt:deprecated true} .
     $this a ?myType .
     ?myType <http://www.w3.org/2000/01/rdf-schema#subClassOf>+ qudt:Concept .
     ?another a ?anotherType .
@@ -324,6 +331,7 @@ qudt:UnitPointsToAllExactMatchQuantityKindsConstraint
       sh:select """
 SELECT $this ?qk ?qk2
 WHERE {
+FILTER NOT EXISTS {$this qudt:deprecated true} .
 $this qudt:hasQuantityKind ?qk .
 ?qk qudt:exactMatch ?qk2 .
 FILTER NOT EXISTS {$this qudt:hasQuantityKind ?qk2}
@@ -366,6 +374,7 @@ qudt:conversionMultiplierSnShape
       sh:select """
             SELECT $this ?valueDecimal ?valueDecimalNoTrailingZeros ?valueSN ?m ?e ?exponent ?mNoDot ?mDigitCount ?valueSNStringValue ?onePos ?lastMantissaDigit ?leftStart ?leftEnd ?rightStart ?rightEnd ?result
                         WHERE {
+                        FILTER NOT EXISTS {$this qudt:deprecated true} .
                             # select both values
                             $this
                                 qudt:conversionMultiplier ?valueDecimal ;
@@ -409,6 +418,7 @@ qudt:conversionOffsetSnShape
       sh:select """
             SELECT $this ?valueDecimal ?valueDecimalNoTrailingZeros ?valueSN ?m ?e ?exponent ?mNoDot ?mDigitCount ?valueSNStringValue ?onePos ?lastMantissaDigit ?leftStart ?leftEnd ?rightStart ?rightEnd ?result
                         WHERE {
+                        FILTER NOT EXISTS {$this qudt:deprecated true} .
                             # select both values
                             $this
                                 qudt:conversionOffset ?valueDecimal ;
@@ -452,6 +462,7 @@ qudt:standardUncertaintySnShape
       sh:select """
             SELECT $this ?valueDecimal ?valueDecimalNoTrailingZeros ?valueSN ?m ?e ?exponent ?mNoDot ?mDigitCount ?valueSNStringValue ?onePos ?lastMantissaDigit ?leftStart ?leftEnd ?rightStart ?rightEnd ?result
                         WHERE {
+                        FILTER NOT EXISTS {$this qudt:deprecated true} .
                             # select both values
                             $this
                                 qudt:standardUncertainty ?valueDecimal ;
@@ -495,6 +506,7 @@ qudt:valueSnShape
       sh:select """
             SELECT $this ?valueDecimal ?valueDecimalNoTrailingZeros ?valueSN ?m ?e ?exponent ?mNoDot ?mDigitCount ?valueSNStringValue ?onePos ?lastMantissaDigit ?leftStart ?leftEnd ?rightStart ?rightEnd ?result
                         WHERE {
+                        FILTER NOT EXISTS {$this qudt:deprecated true} .
                             # select both values
                             $this
                                 qudt:value ?valueDecimal ;

--- a/vocab/dimensionvectors/VOCAB_QUDT-DIMENSION-VECTORS-v2.1.ttl
+++ b/vocab/dimensionvectors/VOCAB_QUDT-DIMENSION-VECTORS-v2.1.ttl
@@ -1016,6 +1016,22 @@ qkdv:A0E0L-1I0M1H1T-3D0
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/dimensionvector> ;
   rdfs:label "A0E0L-1I0M1H1T-3D0" ;
 .
+qkdv:A0E0L-1I0M2H0T-2D0
+  a qudt:QuantityKindDimensionVector_CGS ;
+  a qudt:QuantityKindDimensionVector_ISO ;
+  a qudt:QuantityKindDimensionVector_Imperial ;
+  a qudt:QuantityKindDimensionVector_SI ;
+  qudt:dimensionExponentForAmountOfSubstance 0 ;
+  qudt:dimensionExponentForElectricCurrent 0 ;
+  qudt:dimensionExponentForLength -1 ;
+  qudt:dimensionExponentForLuminousIntensity 0 ;
+  qudt:dimensionExponentForMass 2 ;
+  qudt:dimensionExponentForThermodynamicTemperature 0 ;
+  qudt:dimensionExponentForTime -2 ;
+  qudt:dimensionlessExponent 0 ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/dimensionvector> ;
+  rdfs:label "A0E0L-1I0M2H0T-2D0" ;
+.
 qkdv:A0E0L-1dot5I0M0dot5H0T-1D0
   a qudt:QuantityKindDimensionVector_CGS ;
   qudt:dimensionExponentForAmountOfSubstance 0 ;

--- a/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
+++ b/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
@@ -880,7 +880,7 @@ quantitykind:AmountOfSubstanceConcentration
   qudt:applicableUnit unit:NanoMOL-PER-L ;
   qudt:applicableUnit unit:PicoMOL-PER-L ;
   qudt:applicableUnit unit:PicoMOL-PER-M3 ;
-  qudt:exactMatch quantitykind:AmountOfSubstancePerUnitVolume ;
+  qudt:exactMatch quantitykind:AmountOfSubstancePerVolume ;
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T0D0 ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Amount_of_substance_concentration"^^xsd:anyURI ;
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
@@ -934,7 +934,7 @@ quantitykind:AmountOfSubstanceFractionOfB
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
   rdfs:label "Amount of Substance of Fraction of B"@en ;
 .
-quantitykind:AmountOfSubstancePerUnitMass
+quantitykind:AmountOfSubstancePerMass
   a qudt:QuantityKind ;
   qudt:applicableUnit unit:CentiMOL-PER-KiloGM ;
   qudt:applicableUnit unit:FemtoMOL-PER-KiloGM ;
@@ -950,15 +950,51 @@ quantitykind:AmountOfSubstancePerUnitMass
   qudt:applicableUnit unit:NanoMOL-PER-KiloGM ;
   qudt:applicableUnit unit:PicoMOL-PER-KiloGM ;
   qudt:hasDimensionVector qkdv:A1E0L0I0M-1H0T0D0 ;
-  vaem:todo "fix the numerator and denominator dimensions" ;
+  qudt:qkdvDenominator qkdv:A0E0L0I0M1H0T0D0 ;
+  qudt:qkdvNumerator qkdv:A1E0L0I0M0H0T0D0 ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Amount of Substance per Mass"@en ;
+.
+quantitykind:AmountOfSubstancePerMassPressure
+  a qudt:QuantityKind ;
+  dcterms:description "The \"Variation of Molar Mass\" of a gas as a function of pressure."^^rdf:HTML ;
+  qudt:applicableUnit unit:MOL-PER-KiloGM-BAR ;
+  qudt:applicableUnit unit:MOL-PER-KiloGM-PA ;
+  qudt:hasDimensionVector qkdv:A1E0L1I0M-2H0T2D0 ;
+  qudt:plainTextDescription "The \"Variation of Molar Mass\" of a gas as a function of pressure." ;
+  qudt:qkdvDenominator qkdv:A0E0L-1I0M2H0T-2D0 ;
+  qudt:qkdvNumerator qkdv:A1E0L0I0M0H0T0D0 ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Molar Mass variation due to Pressure"@en ;
+.
+quantitykind:AmountOfSubstancePerUnitMass
+  a qudt:QuantityKind ;
+  dcterms:isReplacedBy quantitykind:AmountOfSubstancePerMass ;
+  qudt:applicableUnit unit:CentiMOL-PER-KiloGM ;
+  qudt:applicableUnit unit:FemtoMOL-PER-KiloGM ;
+  qudt:applicableUnit unit:IU-PER-MilliGM ;
+  qudt:applicableUnit unit:KiloMOL-PER-KiloGM ;
+  qudt:applicableUnit unit:MOL-PER-KiloGM ;
+  qudt:applicableUnit unit:MOL-PER-TONNE ;
+  qudt:applicableUnit unit:MOL_LB-PER-LB ;
+  qudt:applicableUnit unit:MicroMOL-PER-GM ;
+  qudt:applicableUnit unit:MicroMOL-PER-KiloGM ;
+  qudt:applicableUnit unit:MilliMOL-PER-GM ;
+  qudt:applicableUnit unit:MilliMOL-PER-KiloGM ;
+  qudt:applicableUnit unit:NanoMOL-PER-KiloGM ;
+  qudt:applicableUnit unit:PicoMOL-PER-KiloGM ;
+  qudt:deprecated true ;
+  qudt:hasDimensionVector qkdv:A1E0L0I0M-1H0T0D0 ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
   rdfs:label "Amount of Substance per Unit Mass"@en ;
 .
 quantitykind:AmountOfSubstancePerUnitMassPressure
   a qudt:QuantityKind ;
   dcterms:description "The \"Variation of Molar Mass\" of a gas as a function of pressure."^^rdf:HTML ;
+  dcterms:isReplacedBy quantitykind:AmountOfSubstancePerMassPressure ;
   qudt:applicableUnit unit:MOL-PER-KiloGM-BAR ;
   qudt:applicableUnit unit:MOL-PER-KiloGM-PA ;
+  qudt:deprecated true ;
   qudt:hasDimensionVector qkdv:A1E0L1I0M-2H0T2D0 ;
   qudt:plainTextDescription "The \"Variation of Molar Mass\" of a gas as a function of pressure." ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
@@ -967,6 +1003,32 @@ quantitykind:AmountOfSubstancePerUnitMassPressure
 quantitykind:AmountOfSubstancePerUnitVolume
   a qudt:QuantityKind ;
   dcterms:description "The amount of substance per unit volume is called the molar density. Molar density is an intensive property of a substance and depends on the temperature and pressure."^^rdf:HTML ;
+  dcterms:isReplacedBy quantitykind:AmountOfSubstancePerVolume ;
+  qudt:applicableUnit unit:CentiMOL-PER-L ;
+  qudt:applicableUnit unit:FemtoMOL-PER-L ;
+  qudt:applicableUnit unit:KiloMOL-PER-M3 ;
+  qudt:applicableUnit unit:MOL-PER-DeciM3 ;
+  qudt:applicableUnit unit:MOL-PER-L ;
+  qudt:applicableUnit unit:MOL-PER-M3 ;
+  qudt:applicableUnit unit:MicroMOL-PER-L ;
+  qudt:applicableUnit unit:MilliMOL-PER-L ;
+  qudt:applicableUnit unit:MilliMOL-PER-M3 ;
+  qudt:applicableUnit unit:NanoMOL-PER-L ;
+  qudt:applicableUnit unit:PicoMOL-PER-L ;
+  qudt:applicableUnit unit:PicoMOL-PER-M3 ;
+  qudt:deprecated true ;
+  qudt:exactMatch quantitykind:AmountOfSubstanceConcentration ;
+  qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T0D0 ;
+  qudt:informativeReference "http://www.ask.com/answers/72367781/what-is-defined-as-the-amount-of-substance-per-unit-of-volume"^^xsd:anyURI ;
+  qudt:informativeReference "https://en.wikipedia.org/wiki/Molar_concentration"^^xsd:anyURI ;
+  qudt:plainTextDescription "The amount of substance per unit volume is called the molar density. Molar density is an intensive property of a substance and depends on the temperature and pressure." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Amount of Substance per Unit Volume"@en ;
+  skos:broader quantitykind:Concentration ;
+.
+quantitykind:AmountOfSubstancePerVolume
+  a qudt:QuantityKind ;
+  dcterms:description "The amount of substance per volume is called the molar density. Molar density is an intensive property of a substance and depends on the temperature and pressure."^^rdf:HTML ;
   qudt:applicableUnit unit:CentiMOL-PER-L ;
   qudt:applicableUnit unit:FemtoMOL-PER-L ;
   qudt:applicableUnit unit:KiloMOL-PER-M3 ;
@@ -984,8 +1046,10 @@ quantitykind:AmountOfSubstancePerUnitVolume
   qudt:informativeReference "http://www.ask.com/answers/72367781/what-is-defined-as-the-amount-of-substance-per-unit-of-volume"^^xsd:anyURI ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Molar_concentration"^^xsd:anyURI ;
   qudt:plainTextDescription "The amount of substance per unit volume is called the molar density. Molar density is an intensive property of a substance and depends on the temperature and pressure." ;
+  qudt:qkdvDenominator qkdv:A0E0L3I0M0H0T0D0 ;
+  qudt:qkdvNumerator qkdv:A1E0L0I0M0H0T0D0 ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Amount of Substance per Unit Volume"@en ;
+  rdfs:label "Amount of Substance per Volume"@en ;
   skos:broader quantitykind:Concentration ;
 .
 quantitykind:Angle
@@ -1067,8 +1131,6 @@ quantitykind:AngularAcceleration
   qudt:dbpediaMatch "http://dbpedia.org/resource/Angular_acceleration"^^xsd:anyURI ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-2D0 ;
   qudt:iec61360Code "0112/2///62720#UAD006" ;
-  qudt:qkdvDenominator qkdv:A0E0L1I0M0H0T2D0 ;
-  qudt:qkdvNumerator qkdv:A0E0L1I0M0H0T0D0 ;
   qudt:siExactMatch si-quantity:ACCA ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
   rdfs:label "Accelerație unghiulară"@ro ;
@@ -4123,16 +4185,7 @@ quantitykind:CostPerArea
   rdfs:label "Kosten pro Fläche"@de ;
   rdfs:label "cost per area"@en ;
 .
-quantitykind:CostPerMass
-  a qudt:QuantityKind ;
-  qudt:applicableUnit unit:CHF-PER-KiloGM ;
-  qudt:hasDimensionVector qkdv:A0E0L0I0M-1H0T0D0 ;
-  qudt:plainTextDescription "Represents the cost associated with a unit mass of a substance or material. It is typically used in economic and engineering contexts to evaluate the expense incurred per kilogram, gram, or other units of mass. This measure helps in comparing the economic efficiency of different materials or substances based on their mass." ;
-  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Kosten pro Masse"@de ;
-  rdfs:label "cost per mass"@en ;
-.
-quantitykind:CostPerUnitEnergy
+quantitykind:CostPerEnergy
   a qudt:QuantityKind ;
   qudt:applicableUnit unit:EUR-PER-KiloW-HR ;
   qudt:applicableUnit unit:EUR-PER-W-HR ;
@@ -4144,10 +4197,46 @@ quantitykind:CostPerUnitEnergy
   rdfs:label "Energiekosten"@de ;
   rdfs:label "energy cost"@en ;
 .
-quantitykind:CostPerUnitPower
+quantitykind:CostPerMass
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:CHF-PER-KiloGM ;
+  qudt:hasDimensionVector qkdv:A0E0L0I0M-1H0T0D0 ;
+  qudt:plainTextDescription "Represents the cost associated with a unit mass of a substance or material. It is typically used in economic and engineering contexts to evaluate the expense incurred per kilogram, gram, or other units of mass. This measure helps in comparing the economic efficiency of different materials or substances based on their mass." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Kosten pro Masse"@de ;
+  rdfs:label "cost per mass"@en ;
+.
+quantitykind:CostPerPower
   a qudt:QuantityKind ;
   qudt:applicableUnit unit:EUR-PER-KiloW ;
   qudt:applicableUnit unit:EUR-PER-W ;
+  qudt:hasDimensionVector qkdv:A0E0L-2I0M-1H0T3D0 ;
+  qudt:informativeReference "https://en.wikipedia.org/wiki/Photovoltaics"^^xsd:anyURI ;
+  qudt:plainTextDescription "In photovoltaics, cost per power of electricity produced measures the cost of installing the hardware relative to the power produced." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Anschaffungskosten pro Watt"@de ;
+  rdfs:label "cost per power"@en ;
+.
+quantitykind:CostPerUnitEnergy
+  a qudt:QuantityKind ;
+  dcterms:isReplacedBy quantitykind:CostPerEnergy ;
+  qudt:applicableUnit unit:EUR-PER-KiloW-HR ;
+  qudt:applicableUnit unit:EUR-PER-W-HR ;
+  qudt:applicableUnit unit:EUR-PER-W-SEC ;
+  qudt:deprecated true ;
+  qudt:hasDimensionVector qkdv:A0E0L-2I0M-1H0T2D0 ;
+  qudt:informativeReference "https://en.wikipedia.org/wiki/Cost_of_electricity_by_source"^^xsd:anyURI ;
+  qudt:plainTextDescription "The monetary cost of a unit of energy" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Energiekosten"@de ;
+  rdfs:label "energy cost"@en ;
+.
+quantitykind:CostPerUnitPower
+  a qudt:QuantityKind ;
+  dcterms:isReplacedBy quantitykind:CostPerPower ;
+  qudt:applicableUnit unit:EUR-PER-KiloW ;
+  qudt:applicableUnit unit:EUR-PER-W ;
+  qudt:deprecated true ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M-1H0T3D0 ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Photovoltaics"^^xsd:anyURI ;
   qudt:plainTextDescription "In photovoltaics, cost per power of electricity produced measures the cost of installing the hardware relative to the power produced." ;
@@ -6318,20 +6407,24 @@ quantitykind:ElectricCurrentPerAngle
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
   rdfs:label "Electric Current per Angle"@en ;
 .
-quantitykind:ElectricCurrentPerUnitEnergy
+quantitykind:ElectricCurrentPerEnergy
   a qudt:QuantityKind ;
   qudt:applicableUnit unit:A-PER-J ;
   qudt:hasDimensionVector qkdv:A0E1L-2I0M-1H0T2D0 ;
+  qudt:qkdvDenominator qkdv:A0E0L2I0M1H0T-2D0 ;
+  qudt:qkdvNumerator qkdv:A0E1L0I0M0H0T0D0 ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Electric Current per Unit Energy"@en ;
+  rdfs:label "Electric Current per Energy"@en ;
 .
-quantitykind:ElectricCurrentPerUnitLength
+quantitykind:ElectricCurrentPerLength
   a qudt:QuantityKind ;
   qudt:hasDimensionVector qkdv:A0E1L-1I0M0H0T0D0 ;
+  qudt:qkdvDenominator qkdv:A0E0L1I0M0H0T0D0 ;
+  qudt:qkdvNumerator qkdv:A0E1L0I0M0H0T0D0 ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
-  rdfs:label "Electric Current per Unit Length"@en ;
+  rdfs:label "Electric Current per Length"@en ;
 .
-quantitykind:ElectricCurrentPerUnitTemperature
+quantitykind:ElectricCurrentPerTemperature
   a qudt:QuantityKind ;
   dcterms:description "\"Electric Current per Unit Temperature\" is used to express how a current is subject to temperature. Originally used in Wien's Law to describe phenomena related to filaments. One use today is to express how a current generator derates with temperature."^^rdf:HTML ;
   qudt:applicableUnit unit:A-PER-DEG_C ;
@@ -6340,6 +6433,41 @@ quantitykind:ElectricCurrentPerUnitTemperature
   qudt:applicableUnit unit:MicroA-PER-K ;
   qudt:applicableUnit unit:MilliA-PER-K ;
   qudt:applicableUnit unit:NanoA-PER-K ;
+  qudt:hasDimensionVector qkdv:A0E1L0I0M0H-1T0D0 ;
+  qudt:plainTextDescription "\"Electric Current per Temperature\" is used to express how a current is subject to temperature. Originally used in Wien's Law to describe phenomena related to filaments. One use today is to express how a current generator derates with temperature." ;
+  qudt:qkdvDenominator qkdv:A0E0L0I0M0H1T0D0 ;
+  qudt:qkdvNumerator qkdv:A0E1L0I0M0H0T0D0 ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Electric Current per Temperature"@en ;
+.
+quantitykind:ElectricCurrentPerUnitEnergy
+  a qudt:QuantityKind ;
+  dcterms:isReplacedBy quantitykind:ElectricCurrentPerEnergy ;
+  qudt:applicableUnit unit:A-PER-J ;
+  qudt:deprecated true ;
+  qudt:hasDimensionVector qkdv:A0E1L-2I0M-1H0T2D0 ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Electric Current per Unit Energy"@en ;
+.
+quantitykind:ElectricCurrentPerUnitLength
+  a qudt:QuantityKind ;
+  dcterms:isReplacedBy quantitykind:ElectricCurrentPerLength ;
+  qudt:deprecated true ;
+  qudt:hasDimensionVector qkdv:A0E1L-1I0M0H0T0D0 ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Electric Current per Unit Length"@en ;
+.
+quantitykind:ElectricCurrentPerUnitTemperature
+  a qudt:QuantityKind ;
+  dcterms:description "\"Electric Current per Unit Temperature\" is used to express how a current is subject to temperature. Originally used in Wien's Law to describe phenomena related to filaments. One use today is to express how a current generator derates with temperature."^^rdf:HTML ;
+  dcterms:isReplacedBy quantitykind:ElectricCurrentPerTemperature ;
+  qudt:applicableUnit unit:A-PER-DEG_C ;
+  qudt:applicableUnit unit:A-PER-K ;
+  qudt:applicableUnit unit:KiloA-PER-K ;
+  qudt:applicableUnit unit:MicroA-PER-K ;
+  qudt:applicableUnit unit:MilliA-PER-K ;
+  qudt:applicableUnit unit:NanoA-PER-K ;
+  qudt:deprecated true ;
   qudt:hasDimensionVector qkdv:A0E1L0I0M0H-1T0D0 ;
   qudt:plainTextDescription "\"Electric Current per Unit Temperature\" is used to express how a current is subject to temperature. Originally used in Wien's Law to describe phenomena related to filaments. One use today is to express how a current generator derates with temperature." ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
@@ -10475,9 +10603,9 @@ quantitykind:HeatFlowRate
   rdfs:label "Heat Flow Rate"@en ;
   skos:broader quantitykind:Power ;
 .
-quantitykind:HeatFlowRatePerUnitArea
+quantitykind:HeatFlowRatePerArea
   a qudt:QuantityKind ;
-  dcterms:description "$\\textit{Heat Flux}$ is the heat rate per unit area. In SI units, heat flux is measured in $W/m^2$. Heat rate is a scalar quantity, while heat flux is a vectorial quantity. To define the heat flux at a certain point in space, one takes the limiting case where the size of the surface becomes infinitesimally small."^^qudt:LatexString ;
+  dcterms:description "$\\textit{Heat Flux}$ is the heat rate per area. In SI units, heat flux is measured in $W/m^2$. Heat rate is a scalar quantity, while heat flux is a vectorial quantity. To define the heat flux at a certain point in space, one takes the limiting case where the size of the surface becomes infinitesimally small."^^qudt:LatexString ;
   qudt:applicableUnit unit:BTU_IT-PER-FT2-HR ;
   qudt:applicableUnit unit:BTU_IT-PER-FT2-SEC ;
   qudt:applicableUnit unit:BTU_IT-PER-HR-FT2 ;
@@ -10502,6 +10630,44 @@ quantitykind:HeatFlowRatePerUnitArea
   qudt:applicableUnit unit:W-PER-FT2 ;
   qudt:applicableUnit unit:W-PER-IN2 ;
   qudt:applicableUnit unit:W-PER-M2 ;
+  qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-3D0 ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Heat_flux"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI ;
+  qudt:qkdvDenominator qkdv:A0E0L2I0M0H0T0D0 ;
+  qudt:qkdvNumerator qkdv:A0E0L2I0M1H0T-3D0 ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Heat Flow Rate per Unit Area"@en ;
+  skos:broader quantitykind:PowerPerArea ;
+.
+quantitykind:HeatFlowRatePerUnitArea
+  a qudt:QuantityKind ;
+  dcterms:description "$\\textit{Heat Flux}$ is the heat rate per unit area. In SI units, heat flux is measured in $W/m^2$. Heat rate is a scalar quantity, while heat flux is a vectorial quantity. To define the heat flux at a certain point in space, one takes the limiting case where the size of the surface becomes infinitesimally small."^^qudt:LatexString ;
+  dcterms:isReplacedBy quantitykind:HeatFlowRatePerArea ;
+  qudt:applicableUnit unit:BTU_IT-PER-FT2-HR ;
+  qudt:applicableUnit unit:BTU_IT-PER-FT2-SEC ;
+  qudt:applicableUnit unit:BTU_IT-PER-HR-FT2 ;
+  qudt:applicableUnit unit:BTU_IT-PER-IN2-SEC ;
+  qudt:applicableUnit unit:BTU_IT-PER-SEC-FT2 ;
+  qudt:applicableUnit unit:BTU_TH-PER-FT2-HR ;
+  qudt:applicableUnit unit:BTU_TH-PER-FT2-MIN ;
+  qudt:applicableUnit unit:BTU_TH-PER-FT2-SEC ;
+  qudt:applicableUnit unit:CAL_TH-PER-CentiM2-MIN ;
+  qudt:applicableUnit unit:CAL_TH-PER-CentiM2-SEC ;
+  qudt:applicableUnit unit:ERG-PER-CentiM2-SEC ;
+  qudt:applicableUnit unit:FT-LB_F-PER-FT2-SEC ;
+  qudt:applicableUnit unit:J-PER-CentiM2-DAY ;
+  qudt:applicableUnit unit:KiloCAL-PER-CentiM2-MIN ;
+  qudt:applicableUnit unit:KiloCAL-PER-CentiM2-SEC ;
+  qudt:applicableUnit unit:M-PA-PER-SEC ;
+  qudt:applicableUnit unit:MicroW-PER-M2 ;
+  qudt:applicableUnit unit:MilliW-PER-M2 ;
+  qudt:applicableUnit unit:NanoW-PER-M2 ;
+  qudt:applicableUnit unit:PicoW-PER-M2 ;
+  qudt:applicableUnit unit:W-PER-CentiM2 ;
+  qudt:applicableUnit unit:W-PER-FT2 ;
+  qudt:applicableUnit unit:W-PER-IN2 ;
+  qudt:applicableUnit unit:W-PER-M2 ;
+  qudt:deprecated true ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-3D0 ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Heat_flux"^^xsd:anyURI ;
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI ;
@@ -12511,8 +12677,18 @@ quantitykind:LengthMolarEnergy
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
   rdfs:label "Length Molar Energy"@en ;
 .
+quantitykind:LengthPerElectricCurrent
+  a qudt:QuantityKind ;
+  qudt:hasDimensionVector qkdv:A0E-1L1I0M0H0T0D0 ;
+  qudt:qkdvDenominator qkdv:A0E1L0I0M0H0T0D0 ;
+  qudt:qkdvNumerator qkdv:A0E0L1I0M0H0T0D0 ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Length per Electric Current"@en ;
+.
 quantitykind:LengthPerUnitElectricCurrent
   a qudt:QuantityKind ;
+  dcterms:isReplacedBy quantitykind:LengthPerElectricCurrent ;
+  qudt:deprecated true ;
   qudt:hasDimensionVector qkdv:A0E-1L1I0M0H0T0D0 ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
   rdfs:label "Length per Unit Electric Current"@en ;
@@ -14139,7 +14315,7 @@ quantitykind:MagneticFieldStrength_H
   rdfs:label "شدت میدان مغناطیسی"@fa ;
   rdfs:label "磁場"@ja ;
   rdfs:label "磁場"@zh ;
-  skos:broader quantitykind:ElectricCurrentPerUnitLength ;
+  skos:broader quantitykind:ElectricCurrentPerLength ;
 .
 quantitykind:MagneticFlux
   a qudt:QuantityKind ;
@@ -14241,12 +14417,27 @@ quantitykind:MagneticFluxDensityOrMagneticPolarization
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
   rdfs:label "magnetic flux density or magnetic polarization"@en-US ;
 .
-quantitykind:MagneticFluxPerUnitLength
+quantitykind:MagneticFluxPerLength
   a qudt:QuantityKind ;
-  dcterms:description "\"Magnetic Flux per Unit Length\" is a quantity in the SI and C.G.S. Systems of Quantities."^^rdf:HTML ;
+  dcterms:description "\"Magnetic Flux per Length\" is a quantity in the SI and C.G.S. Systems of Quantities."^^rdf:HTML ;
   qudt:applicableUnit unit:N-PER-A ;
   qudt:applicableUnit unit:T-M ;
   qudt:applicableUnit unit:V-SEC-PER-M ;
+  qudt:hasDimensionVector qkdv:A0E-1L1I0M1H0T-2D0 ;
+  qudt:plainTextDescription "\"Magnetic Flux per Length\" is a quantity in the SI and C.G.S. Systems of Quantities." ;
+  qudt:qkdvDenominator qkdv:A0E0L1I0M0H0T0D0 ;
+  qudt:qkdvNumerator qkdv:A0E-1L2I0M1H0T-2D0 ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Magnetic flux per length"@en ;
+.
+quantitykind:MagneticFluxPerUnitLength
+  a qudt:QuantityKind ;
+  dcterms:description "\"Magnetic Flux per Unit Length\" is a quantity in the SI and C.G.S. Systems of Quantities."^^rdf:HTML ;
+  dcterms:isReplacedBy quantitykind:MagneticFluxPerLength ;
+  qudt:applicableUnit unit:N-PER-A ;
+  qudt:applicableUnit unit:T-M ;
+  qudt:applicableUnit unit:V-SEC-PER-M ;
+  qudt:deprecated true ;
   qudt:hasDimensionVector qkdv:A0E-1L1I0M1H0T-2D0 ;
   qudt:plainTextDescription "\"Magnetic Flux per Unit Length\" is a quantity in the SI and C.G.S. Systems of Quantities." ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
@@ -14438,7 +14629,7 @@ quantitykind:MagnetizationField
   qudt:symbol "M" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
   rdfs:label "Magnetization Field"@en ;
-  skos:broader quantitykind:ElectricCurrentPerUnitLength ;
+  skos:broader quantitykind:ElectricCurrentPerLength ;
 .
 quantitykind:MagnetomotiveForce
   a qudt:QuantityKind ;
@@ -16468,7 +16659,7 @@ quantitykind:MolalityOfSolute
   qudt:symbol "b_B" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
   rdfs:label "Molality of Solute"@en ;
-  skos:broader quantitykind:AmountOfSubstancePerUnitMass ;
+  skos:broader quantitykind:AmountOfSubstancePerMass ;
 .
 quantitykind:MolarAbsorptionCoefficient
   a qudt:QuantityKind ;
@@ -17737,9 +17928,22 @@ quantitykind:OlfactoryThreshold
   rdfs:label "Olfactory Threshold"@en ;
   skos:broader quantitykind:Concentration ;
 .
+quantitykind:OrbitalAngularMomentumPerMass
+  a qudt:QuantityKind ;
+  dcterms:description "Angular momentum of the orbit per mass of the vehicle"^^rdf:HTML ;
+  qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-1D0 ;
+  qudt:plainTextDescription "Angular momentum of the orbit per mass of the vehicle" ;
+  qudt:qkdvDenominator qkdv:A0E0L0I0M1H0T0D0 ;
+  qudt:qkdvNumerator qkdv:A0E0L2I0M1H0T-1D0 ;
+  qudt:symbol "h" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Orbital Angular Momentum per Mass"@en ;
+.
 quantitykind:OrbitalAngularMomentumPerUnitMass
   a qudt:QuantityKind ;
   dcterms:description "Angular momentum of the orbit per unit mass of the vehicle"^^rdf:HTML ;
+  dcterms:isReplacedBy quantitykind:OrbitalAngularMomentumPerMass ;
+  qudt:deprecated true ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-1D0 ;
   qudt:plainTextDescription "Angular momentum of the orbit per unit mass of the vehicle" ;
   qudt:symbol "h" ;
@@ -22041,7 +22245,7 @@ quantitykind:SerumOrPlasmaLevel
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T0D0 ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
   rdfs:label "Serum or Plasma Level"@en ;
-  skos:broader quantitykind:AmountOfSubstancePerUnitVolume ;
+  skos:broader quantitykind:AmountOfSubstancePerVolume ;
 .
 quantitykind:ShannonDiversityIndex
   a qudt:QuantityKind ;
@@ -22481,7 +22685,7 @@ quantitykind:Solubility_Water
   qudt:plainTextDescription "An amount of substance per unit volume that is the concentration of a saturated solution expressed as the ratio of the solute concentration over the volume of water.  A substance's solubility fundamentally depends on several physical and chemical properties of the solution as well as the environment it is in." ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
   rdfs:label "Water Solubility"@en ;
-  skos:broader quantitykind:AmountOfSubstancePerUnitVolume ;
+  skos:broader quantitykind:AmountOfSubstancePerVolume ;
 .
 quantitykind:SoundEnergyDensity
   a qudt:QuantityKind ;
@@ -27608,7 +27812,7 @@ quantitykind:VolumeFlowRate
   qudt:applicableUnit unit:YD3-PER-HR ;
   qudt:applicableUnit unit:YD3-PER-MIN ;
   qudt:applicableUnit unit:YD3-PER-SEC ;
-  qudt:exactMatch quantitykind:VolumePerUnitTime ;
+  qudt:exactMatch quantitykind:VolumePerTime ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:iec61360Code "0112/2///62720#UAD239" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Volumetric_flow_rate"^^xsd:anyURI ;
@@ -27671,7 +27875,7 @@ quantitykind:VolumePerArea
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
   rdfs:label "Volume per Unit Area"@en ;
 .
-quantitykind:VolumePerUnitTime
+quantitykind:VolumePerTime
   a qudt:QuantityKind ;
   qudt:applicableUnit unit:BBL_UK_PET-PER-DAY ;
   qudt:applicableUnit unit:BBL_UK_PET-PER-HR ;
@@ -27770,6 +27974,114 @@ quantitykind:VolumePerUnitTime
   qudt:applicableUnit unit:YD3-PER-HR ;
   qudt:applicableUnit unit:YD3-PER-MIN ;
   qudt:applicableUnit unit:YD3-PER-SEC ;
+  qudt:exactMatch quantitykind:VolumeFlowRate ;
+  qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
+  qudt:qkdvDenominator qkdv:A0E0L0I0M0H0T1D0 ;
+  qudt:qkdvNumerator qkdv:A0E0L3I0M0H0T0D0 ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Volume per Time"@en ;
+.
+quantitykind:VolumePerUnitTime
+  a qudt:QuantityKind ;
+  dcterms:isReplacedBy quantitykind:VolumePerTime ;
+  qudt:applicableUnit unit:BBL_UK_PET-PER-DAY ;
+  qudt:applicableUnit unit:BBL_UK_PET-PER-HR ;
+  qudt:applicableUnit unit:BBL_UK_PET-PER-MIN ;
+  qudt:applicableUnit unit:BBL_UK_PET-PER-SEC ;
+  qudt:applicableUnit unit:BBL_US-PER-DAY ;
+  qudt:applicableUnit unit:BBL_US-PER-MIN ;
+  qudt:applicableUnit unit:BBL_US_PET-PER-HR ;
+  qudt:applicableUnit unit:BBL_US_PET-PER-SEC ;
+  qudt:applicableUnit unit:BU_UK-PER-DAY ;
+  qudt:applicableUnit unit:BU_UK-PER-HR ;
+  qudt:applicableUnit unit:BU_UK-PER-MIN ;
+  qudt:applicableUnit unit:BU_UK-PER-SEC ;
+  qudt:applicableUnit unit:BU_US_DRY-PER-DAY ;
+  qudt:applicableUnit unit:BU_US_DRY-PER-HR ;
+  qudt:applicableUnit unit:BU_US_DRY-PER-MIN ;
+  qudt:applicableUnit unit:BU_US_DRY-PER-SEC ;
+  qudt:applicableUnit unit:CentiM3-PER-DAY ;
+  qudt:applicableUnit unit:CentiM3-PER-HR ;
+  qudt:applicableUnit unit:CentiM3-PER-MIN ;
+  qudt:applicableUnit unit:CentiM3-PER-SEC ;
+  qudt:applicableUnit unit:DeciM3-PER-DAY ;
+  qudt:applicableUnit unit:DeciM3-PER-HR ;
+  qudt:applicableUnit unit:DeciM3-PER-MIN ;
+  qudt:applicableUnit unit:DeciM3-PER-SEC ;
+  qudt:applicableUnit unit:FT3-PER-DAY ;
+  qudt:applicableUnit unit:FT3-PER-HR ;
+  qudt:applicableUnit unit:FT3-PER-MIN ;
+  qudt:applicableUnit unit:FT3-PER-SEC ;
+  qudt:applicableUnit unit:GAL_UK-PER-DAY ;
+  qudt:applicableUnit unit:GAL_UK-PER-HR ;
+  qudt:applicableUnit unit:GAL_UK-PER-MIN ;
+  qudt:applicableUnit unit:GAL_UK-PER-SEC ;
+  qudt:applicableUnit unit:GAL_US-PER-DAY ;
+  qudt:applicableUnit unit:GAL_US-PER-HR ;
+  qudt:applicableUnit unit:GAL_US-PER-MIN ;
+  qudt:applicableUnit unit:GAL_US-PER-SEC ;
+  qudt:applicableUnit unit:GI_UK-PER-DAY ;
+  qudt:applicableUnit unit:GI_UK-PER-HR ;
+  qudt:applicableUnit unit:GI_UK-PER-MIN ;
+  qudt:applicableUnit unit:GI_UK-PER-SEC ;
+  qudt:applicableUnit unit:GI_US-PER-DAY ;
+  qudt:applicableUnit unit:GI_US-PER-HR ;
+  qudt:applicableUnit unit:GI_US-PER-MIN ;
+  qudt:applicableUnit unit:GI_US-PER-SEC ;
+  qudt:applicableUnit unit:IN3-PER-HR ;
+  qudt:applicableUnit unit:IN3-PER-MIN ;
+  qudt:applicableUnit unit:IN3-PER-SEC ;
+  qudt:applicableUnit unit:KiloL-PER-HR ;
+  qudt:applicableUnit unit:L-PER-DAY ;
+  qudt:applicableUnit unit:L-PER-HR ;
+  qudt:applicableUnit unit:L-PER-MIN ;
+  qudt:applicableUnit unit:L-PER-SEC ;
+  qudt:applicableUnit unit:M3-PER-DAY ;
+  qudt:applicableUnit unit:M3-PER-HR ;
+  qudt:applicableUnit unit:M3-PER-MIN ;
+  qudt:applicableUnit unit:M3-PER-SEC ;
+  qudt:applicableUnit unit:M3-PER-YR ;
+  qudt:applicableUnit unit:MilliL-PER-DAY ;
+  qudt:applicableUnit unit:MilliL-PER-HR ;
+  qudt:applicableUnit unit:MilliL-PER-MIN ;
+  qudt:applicableUnit unit:MilliL-PER-SEC ;
+  qudt:applicableUnit unit:OZ_VOL_UK-PER-DAY ;
+  qudt:applicableUnit unit:OZ_VOL_UK-PER-HR ;
+  qudt:applicableUnit unit:OZ_VOL_UK-PER-MIN ;
+  qudt:applicableUnit unit:OZ_VOL_UK-PER-SEC ;
+  qudt:applicableUnit unit:OZ_VOL_US-PER-DAY ;
+  qudt:applicableUnit unit:OZ_VOL_US-PER-HR ;
+  qudt:applicableUnit unit:OZ_VOL_US-PER-MIN ;
+  qudt:applicableUnit unit:OZ_VOL_US-PER-SEC ;
+  qudt:applicableUnit unit:PINT_UK-PER-DAY ;
+  qudt:applicableUnit unit:PINT_UK-PER-HR ;
+  qudt:applicableUnit unit:PINT_UK-PER-MIN ;
+  qudt:applicableUnit unit:PINT_UK-PER-SEC ;
+  qudt:applicableUnit unit:PINT_US-PER-DAY ;
+  qudt:applicableUnit unit:PINT_US-PER-HR ;
+  qudt:applicableUnit unit:PINT_US-PER-MIN ;
+  qudt:applicableUnit unit:PINT_US-PER-SEC ;
+  qudt:applicableUnit unit:PK_UK-PER-DAY ;
+  qudt:applicableUnit unit:PK_UK-PER-HR ;
+  qudt:applicableUnit unit:PK_UK-PER-MIN ;
+  qudt:applicableUnit unit:PK_UK-PER-SEC ;
+  qudt:applicableUnit unit:PK_US_DRY-PER-DAY ;
+  qudt:applicableUnit unit:PK_US_DRY-PER-HR ;
+  qudt:applicableUnit unit:PK_US_DRY-PER-MIN ;
+  qudt:applicableUnit unit:PK_US_DRY-PER-SEC ;
+  qudt:applicableUnit unit:QT_UK-PER-DAY ;
+  qudt:applicableUnit unit:QT_UK-PER-HR ;
+  qudt:applicableUnit unit:QT_UK-PER-MIN ;
+  qudt:applicableUnit unit:QT_UK-PER-SEC ;
+  qudt:applicableUnit unit:QT_US-PER-DAY ;
+  qudt:applicableUnit unit:QT_US-PER-HR ;
+  qudt:applicableUnit unit:QT_US-PER-MIN ;
+  qudt:applicableUnit unit:QT_US-PER-SEC ;
+  qudt:applicableUnit unit:YD3-PER-DAY ;
+  qudt:applicableUnit unit:YD3-PER-HR ;
+  qudt:applicableUnit unit:YD3-PER-MIN ;
+  qudt:applicableUnit unit:YD3-PER-SEC ;
+  qudt:deprecated true ;
   qudt:exactMatch quantitykind:VolumeFlowRate ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;

--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -322,7 +322,7 @@ unit:A-PER-DEG_C
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:expression "$A/degC$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E1L0I0M0H-1T0D0 ;
-  qudt:hasQuantityKind quantitykind:ElectricCurrentPerUnitTemperature ;
+  qudt:hasQuantityKind quantitykind:ElectricCurrentPerTemperature ;
   qudt:informativeReference "http://books.google.com/books?id=zkErAAAAYAAJ&pg=PA60&lpg=PA60&dq=ampere+per+degree"^^xsd:anyURI ;
   qudt:informativeReference "http://web.mit.edu/course/21/21.guide/use-tab.htm"^^xsd:anyURI ;
   qudt:symbol "A/°C" ;
@@ -362,7 +362,7 @@ unit:A-PER-J
   qudt:derivedCoherentUnitOfSystem sou:SI ;
   qudt:expression "$A/J$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E1L-2I0M-1H0T2D0 ;
-  qudt:hasQuantityKind quantitykind:ElectricCurrentPerUnitEnergy ;
+  qudt:hasQuantityKind quantitykind:ElectricCurrentPerEnergy ;
   qudt:symbol "A/J" ;
   qudt:ucumCode "A.J-1"^^qudt:UCUMcs ;
   qudt:ucumCode "A/J"^^qudt:UCUMcs ;
@@ -375,7 +375,7 @@ unit:A-PER-K
   qudt:conversionMultiplier 1.0 ;
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E1L0I0M0H-1T0D0 ;
-  qudt:hasQuantityKind quantitykind:ElectricCurrentPerUnitTemperature ;
+  qudt:hasQuantityKind quantitykind:ElectricCurrentPerTemperature ;
   qudt:iec61360Code "0112/2///62720#UAD896" ;
   qudt:symbol "A/K" ;
   qudt:ucumCode "A.K-1"^^qudt:UCUMcs ;
@@ -1602,7 +1602,7 @@ unit:BBL_UK_PET-PER-DAY
   qudt:conversionMultiplierSN 1.841587E-6 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA331" ;
   qudt:plainTextDescription "unit of the volume barrel (UK petroleum) for crude oil according to the Imperial system of units divided by the unit day" ;
   qudt:symbol "bbl{UK petroleum}/day" ;
@@ -1618,7 +1618,7 @@ unit:BBL_UK_PET-PER-HR
   qudt:conversionMultiplierSN 4.41981E-5 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA332" ;
   qudt:plainTextDescription "unit of the volume barrel (UK petroleum) for crude oil according to the Imperial system of units divided by the unit hour" ;
   qudt:symbol "bbl{UK petroleum}/hr" ;
@@ -1634,7 +1634,7 @@ unit:BBL_UK_PET-PER-MIN
   qudt:conversionMultiplierSN 2.651886E-3 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA330" ;
   qudt:plainTextDescription "unit of the volume barrel (UK petroleum) for crude oil according to the Imperial system of units divided by the unit minute" ;
   qudt:symbol "bbl{UK petroleum}/min" ;
@@ -1650,7 +1650,7 @@ unit:BBL_UK_PET-PER-SEC
   qudt:conversionMultiplierSN 1.591132E-1 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA333" ;
   qudt:plainTextDescription "unit of the volume barrel (UK petroleum) for crude oil according to the Imperial system of units divided by the SI base unit second" ;
   qudt:symbol "bbl{UK petroleum}/s" ;
@@ -1684,7 +1684,7 @@ unit:BBL_US-PER-DAY
   qudt:conversionMultiplierSN 1.84E-6 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA335" ;
   qudt:plainTextDescription "unit of the volume barrel (US petroleum) for crude oil according to the Anglo-American system of units divided by the unit day" ;
   qudt:symbol "bbl{US petroleum}/day" ;
@@ -1702,7 +1702,7 @@ unit:BBL_US-PER-MIN
   qudt:conversionMultiplierSN 2.6498E-3 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA337" ;
   qudt:plainTextDescription "unit of the volume barrel (US petroleum) for crude oil according to the Anglo-American system of units divided by the unit minute" ;
   qudt:symbol "bbl{US petroleum}/min" ;
@@ -1735,7 +1735,7 @@ unit:BBL_US_PET-PER-HR
   qudt:conversionMultiplierSN 4.4163E-5 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA336" ;
   qudt:plainTextDescription "unit of the volume barrel (US petroleum) for crude oil according to the Anglo-American system of units divided by the unit hour" ;
   qudt:symbol "bbl{UK petroleum}/hr" ;
@@ -1753,7 +1753,7 @@ unit:BBL_US_PET-PER-SEC
   qudt:conversionMultiplierSN 1.589873E-1 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA338" ;
   qudt:plainTextDescription "unit of the volume barrel (US petroleum) for crude oil according to the Anglo-American system of units divided by the SI base unit second" ;
   qudt:symbol "bbl{UK petroleum}/s" ;
@@ -3254,7 +3254,7 @@ unit:BU_UK-PER-DAY
   qudt:conversionMultiplierSN 4.209343E-7 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA345" ;
   qudt:plainTextDescription "unit of the volume bushel (UK) (for fluids and for dry measures) according to the Imperial system of units divided by the unit for time day" ;
   qudt:symbol "bsh{UK}/day" ;
@@ -3273,7 +3273,7 @@ unit:BU_UK-PER-HR
   qudt:conversionMultiplierSN 1.010242E-5 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA346" ;
   qudt:plainTextDescription "unit of the volume bushel (UK) (for fluids and for dry measures) according to the Imperial system of units divided by the unit for time hour" ;
   qudt:symbol "bsh{UK}/hr" ;
@@ -3291,7 +3291,7 @@ unit:BU_UK-PER-MIN
   qudt:conversionMultiplierSN 6.061453E-4 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA347" ;
   qudt:plainTextDescription "unit of the volume bushel (UK) (for fluids and for dry measures) according to the Imperial system of units divided by the unit for time minute" ;
   qudt:symbol "bsh{UK}/min" ;
@@ -3310,7 +3310,7 @@ unit:BU_UK-PER-SEC
   qudt:conversionMultiplierSN 3.636872E-2 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA348" ;
   qudt:plainTextDescription "unit of the volume bushel (UK) (for fluids and for dry measures) according to the Imperial system of units divided by the SI base unit second" ;
   qudt:symbol "bsh{UK}/s" ;
@@ -3348,7 +3348,7 @@ unit:BU_US_DRY-PER-DAY
   qudt:conversionMultiplierSN 4.0786E-7 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA349" ;
   qudt:plainTextDescription "unit of the volume bushel (US dry) for dry measure according to the Anglo-American system of units divided by the unit for time day" ;
   qudt:symbol "bsh{US}/day" ;
@@ -3366,7 +3366,7 @@ unit:BU_US_DRY-PER-HR
   qudt:conversionMultiplierSN 9.789E-6 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA350" ;
   qudt:plainTextDescription "unit of the volume bushel (US dry) for dry measure according to the Anglo-American system of units divided by the unit for time hour" ;
   qudt:symbol "bsh{US}/hr" ;
@@ -3384,7 +3384,7 @@ unit:BU_US_DRY-PER-MIN
   qudt:conversionMultiplierSN 5.8732E-4 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA351" ;
   qudt:plainTextDescription "unit of the volume bushel (US dry) for dry measure according to the Anglo-American system of units divided by the unit for time minute" ;
   qudt:symbol "bsh{US}/min" ;
@@ -3402,7 +3402,7 @@ unit:BU_US_DRY-PER-SEC
   qudt:conversionMultiplierSN 3.523907E-2 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA352" ;
   qudt:plainTextDescription "unit of the volume bushel (US dry) for dry measure according to the Anglo-American system of units divided by the SI base unit second" ;
   qudt:symbol "bsh{US}/s" ;
@@ -5351,7 +5351,7 @@ unit:CentiM3-PER-DAY
   qudt:conversionMultiplierSN 1.157407E-11 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA388" ;
   qudt:plainTextDescription "0.000001-fold of the power of the SI base unit metre with the exponent 3 divided by the unit day" ;
   qudt:symbol "cm³/day" ;
@@ -5424,7 +5424,7 @@ unit:CentiM3-PER-HR
   qudt:conversionMultiplierSN 2.777778E-10 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA391" ;
   qudt:plainTextDescription "0.000001-fold of the power of the SI base unit metre with the exponent 3 divided by the unit hour" ;
   qudt:symbol "cm³/hr" ;
@@ -5513,7 +5513,7 @@ unit:CentiM3-PER-MIN
   qudt:conversionMultiplierSN 1.666667E-8 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA395" ;
   qudt:plainTextDescription "0,000 001-fold of the power of the SI base unit metre with the exponent 3 divided by the unit minute" ;
   qudt:symbol "cm³/min" ;
@@ -5598,7 +5598,7 @@ unit:CentiM3-PER-SEC
   qudt:conversionMultiplierSN 1.0E-6 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA399" ;
   qudt:plainTextDescription "0,000 001-fold of the power of the SI base unit metre with the exponent 3 divided by the SI base unit second" ;
   qudt:symbol "cm³/s" ;
@@ -5690,7 +5690,7 @@ unit:CentiMOL-PER-KiloGM
   qudt:conversionMultiplier 0.01 ;
   qudt:conversionMultiplierSN 1.0E-2 ;
   qudt:hasDimensionVector qkdv:A1E0L0I0M-1H0T0D0 ;
-  qudt:hasQuantityKind quantitykind:AmountOfSubstancePerUnitMass ;
+  qudt:hasQuantityKind quantitykind:AmountOfSubstancePerMass ;
   qudt:hasQuantityKind quantitykind:IonicStrength ;
   qudt:hasQuantityKind quantitykind:MolalityOfSolute ;
   qudt:plainTextDescription "1/100 of SI unit of amount of substance per kilogram" ;
@@ -7790,7 +7790,7 @@ unit:DeciM3-PER-DAY
   qudt:conversionMultiplierSN 1.157407407E-8 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA415" ;
   qudt:plainTextDescription "0,001-fold of the power of the SI base unit metre with the exponent 3 divided by the unit for time day" ;
   qudt:symbol "dm³/day" ;
@@ -7812,7 +7812,7 @@ unit:DeciM3-PER-HR
   qudt:conversionMultiplierSN 2.777778E-7 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA416" ;
   qudt:plainTextDescription "0,001-fold of the power of the SI base unit metre with the exponent 3 divided by the unit hour" ;
   qudt:symbol "dm³/hr" ;
@@ -7871,7 +7871,7 @@ unit:DeciM3-PER-MIN
   qudt:conversionMultiplierSN 1.666667E-5 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA418" ;
   qudt:plainTextDescription "0,001-fold of the power of the SI base unit metre with the exponent 3 divided by the unit for time minute" ;
   qudt:symbol "dm³/min" ;
@@ -7912,7 +7912,7 @@ unit:DeciM3-PER-SEC
   qudt:conversionMultiplierSN 1.0E-3 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA420" ;
   qudt:plainTextDescription "0,001-fold of the power of the SI base unit metre with the exponent 3 divided by the unit for time second" ;
   qudt:symbol "dm³/s" ;
@@ -8381,7 +8381,7 @@ unit:EUR-PER-KiloW
   qudt:conversionMultiplier 0.001 ;
   qudt:conversionMultiplierSN 1.0E-3 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M-1H0T3D0 ;
-  qudt:hasQuantityKind quantitykind:CostPerUnitPower ;
+  qudt:hasQuantityKind quantitykind:CostPerPower ;
   qudt:plainTextDescription "Unit for measuring the hardware cost of a power generation unit relative to the generated power" ;
   qudt:symbol "€/kW" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -8393,7 +8393,7 @@ unit:EUR-PER-KiloW-HR
   qudt:conversionMultiplier 0.0000002777777777777777777777777777777778 ;
   qudt:conversionMultiplierSN 2.777777777777777777777777777777778E-7 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M-1H0T2D0 ;
-  qudt:hasQuantityKind quantitykind:CostPerUnitEnergy ;
+  qudt:hasQuantityKind quantitykind:CostPerEnergy ;
   qudt:plainTextDescription "Unit for measuring the cost of electricity." ;
   qudt:symbol "€/(kW·hr)" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -8417,7 +8417,7 @@ unit:EUR-PER-W
   qudt:conversionMultiplier 1.0 ;
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M-1H0T3D0 ;
-  qudt:hasQuantityKind quantitykind:CostPerUnitPower ;
+  qudt:hasQuantityKind quantitykind:CostPerPower ;
   qudt:plainTextDescription "Unit for measuring the hardware cost of a power generation unit relative to the generated power" ;
   qudt:symbol "€/W" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -8429,7 +8429,7 @@ unit:EUR-PER-W-HR
   qudt:conversionMultiplier 0.0002777777777777777777777777777777778 ;
   qudt:conversionMultiplierSN 2.777777777777777777777777777777778E-4 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M-1H0T2D0 ;
-  qudt:hasQuantityKind quantitykind:CostPerUnitEnergy ;
+  qudt:hasQuantityKind quantitykind:CostPerEnergy ;
   qudt:plainTextDescription "Unit for measuring the cost of electricity." ;
   qudt:symbol "€/(W·hr)" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -8441,7 +8441,7 @@ unit:EUR-PER-W-SEC
   qudt:conversionMultiplier 1.0 ;
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M-1H0T2D0 ;
-  qudt:hasQuantityKind quantitykind:CostPerUnitEnergy ;
+  qudt:hasQuantityKind quantitykind:CostPerEnergy ;
   qudt:plainTextDescription "Unit for measuring the cost of electricity." ;
   qudt:symbol "€/(W·s)" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -9795,7 +9795,7 @@ unit:FT3-PER-DAY
   qudt:conversionMultiplierSN 3.277413E-7 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA458" ;
   qudt:plainTextDescription "power of the unit foot according to the Anglo-American and the Imperial system of units with the exponent 3 divided by the unit for time day" ;
   qudt:symbol "ft³/day" ;
@@ -9830,7 +9830,7 @@ unit:FT3-PER-HR
   qudt:conversionMultiplierSN 7.865792E-6 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA459" ;
   qudt:plainTextDescription "power of the unit foot according to the Anglo-American and the Imperial system of units with the exponent 3 divided by the unit hour" ;
   qudt:symbol "ft³/hr" ;
@@ -9867,7 +9867,7 @@ unit:FT3-PER-MIN
   qudt:expression "$ft^{3}/min$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA461" ;
   qudt:symbol "ft³/min" ;
   qudt:ucumCode "[cft_i].min-1"^^qudt:UCUMcs ;
@@ -9922,7 +9922,7 @@ unit:FT3-PER-SEC
   qudt:expression "$ft^{3}/s$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA462" ;
   qudt:symbol "ft³/s" ;
   qudt:ucumCode "[cft_i].s-1"^^qudt:UCUMcs ;
@@ -10223,7 +10223,7 @@ unit:FemtoMOL-PER-KiloGM
   qudt:conversionMultiplier 0.000000000000001 ;
   qudt:conversionMultiplierSN 1.0E-15 ;
   qudt:hasDimensionVector qkdv:A1E0L0I0M-1H0T0D0 ;
-  qudt:hasQuantityKind quantitykind:AmountOfSubstancePerUnitMass ;
+  qudt:hasQuantityKind quantitykind:AmountOfSubstancePerMass ;
   qudt:symbol "fmol/kg" ;
   qudt:ucumCode "fmol.kg-1"^^qudt:UCUMcs ;
   qudt:ucumCode "fmol/kg"^^qudt:UCUMcs ;
@@ -10376,7 +10376,7 @@ unit:GAL_UK-PER-DAY
   qudt:conversionMultiplierSN 5.261678E-8 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA501" ;
   qudt:plainTextDescription "unit gallon (UK dry or liq.) according to the Imperial system of units divided by the SI unit day" ;
   qudt:symbol "gal{UK}/day" ;
@@ -10393,7 +10393,7 @@ unit:GAL_UK-PER-HR
   qudt:conversionMultiplierSN 1.262803E-6 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA502" ;
   qudt:plainTextDescription "unit gallon (UK dry or Liq.) according to the Imperial system of units divided by the SI unit hour" ;
   qudt:symbol "gal{UK}/hr" ;
@@ -10410,7 +10410,7 @@ unit:GAL_UK-PER-MIN
   qudt:conversionMultiplierSN 7.576817E-5 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA503" ;
   qudt:plainTextDescription "unit gallon (UK dry or liq.) according to the Imperial system of units divided by the SI unit minute" ;
   qudt:symbol "gal{UK}/min" ;
@@ -10427,7 +10427,7 @@ unit:GAL_UK-PER-SEC
   qudt:conversionMultiplierSN 4.54609E-3 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA504" ;
   qudt:plainTextDescription "unit gallon (UK dry or liq.) according to the Imperial system of units divided by the SI base unit second" ;
   qudt:symbol "gal{UK}/s" ;
@@ -10464,7 +10464,7 @@ unit:GAL_US-PER-DAY
   qudt:expression "$gal/d$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA506" ;
   qudt:symbol "gal{US}/day" ;
   qudt:ucumCode "[gal_us].d-1"^^qudt:UCUMcs ;
@@ -10481,7 +10481,7 @@ unit:GAL_US-PER-HR
   qudt:conversionMultiplierSN 1.051503E-6 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA507" ;
   qudt:plainTextDescription "unit gallon (US, liq.) according to the Anglo-American system of units divided by the SI unit hour" ;
   qudt:symbol "gal{US}/hr" ;
@@ -10502,7 +10502,7 @@ unit:GAL_US-PER-MIN
   qudt:expression "$gal/min$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA508" ;
   qudt:symbol "gal{US}/min" ;
   qudt:ucumCode "[gal_us].min-1"^^qudt:UCUMcs ;
@@ -10519,7 +10519,7 @@ unit:GAL_US-PER-SEC
   qudt:conversionMultiplierSN 3.785412E-3 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA509" ;
   qudt:plainTextDescription "unit gallon (US, liq.) according to the Anglo-American system of units divided by the SI base unit second" ;
   qudt:symbol "gal{US}/s" ;
@@ -10633,7 +10633,7 @@ unit:GI_UK-PER-DAY
   qudt:conversionMultiplierSN 1.644274E-9 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA512" ;
   qudt:plainTextDescription "unit of the volume gill (UK) for fluids according to the Imperial system of units divided by the unit for time day" ;
   qudt:symbol "gill{UK}/day" ;
@@ -10650,7 +10650,7 @@ unit:GI_UK-PER-HR
   qudt:conversionMultiplierSN 3.946258E-8 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA513" ;
   qudt:plainTextDescription "unit of the volume gill (UK) for fluids according to the Imperial system of units divided by the unit for time hour" ;
   qudt:symbol "gill{UK}/hr" ;
@@ -10667,7 +10667,7 @@ unit:GI_UK-PER-MIN
   qudt:conversionMultiplierSN 2.367755E-6 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA514" ;
   qudt:plainTextDescription "unit of the volume gill (UK) for fluids according to the Imperial system of units divided by the unit for time minute" ;
   qudt:symbol "gill{UK}/min" ;
@@ -10684,7 +10684,7 @@ unit:GI_UK-PER-SEC
   qudt:conversionMultiplierSN 1.420653E-4 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA515" ;
   qudt:plainTextDescription "unit of the volume gill (UK) for fluids according to the Imperial system of units divided by the SI base unit second" ;
   qudt:symbol "gill{UK}/s" ;
@@ -10717,7 +10717,7 @@ unit:GI_US-PER-DAY
   qudt:conversionMultiplierSN 1.369145E-9 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA517" ;
   qudt:plainTextDescription "unit of the volume gill (US) for fluids according to the Anglo-American system of units divided by the unit for time day" ;
   qudt:symbol "gill{US}/day" ;
@@ -10734,7 +10734,7 @@ unit:GI_US-PER-HR
   qudt:conversionMultiplierSN 3.285947E-8 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA518" ;
   qudt:plainTextDescription "unit of the volume gill (US) for fluids according to the Anglo-American system of units divided by the unit for time hour" ;
   qudt:symbol "gill{US}/hr" ;
@@ -10751,7 +10751,7 @@ unit:GI_US-PER-MIN
   qudt:conversionMultiplierSN 1.971568E-6 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA519" ;
   qudt:plainTextDescription "unit of the volume gill (US) for fluids according to the Anglo-American system of units divided by the unit for time minute" ;
   qudt:symbol "gill{US}/min" ;
@@ -10768,7 +10768,7 @@ unit:GI_US-PER-SEC
   qudt:conversionMultiplierSN 1.182941E-4 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA520" ;
   qudt:plainTextDescription "unit of the volume gill (US) for fluids according to the Anglo-American system of units divided by the SI base unit second" ;
   qudt:symbol "gill{US}/s" ;
@@ -14036,7 +14036,7 @@ unit:IN3-PER-HR
   qudt:conversionMultiplierSN 4.551961E-9 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA550" ;
   qudt:plainTextDescription "power of the unit inch according to the Anglo-American and the Imperial system of units with the exponent 3 divided by the unit hour" ;
   qudt:symbol "in³/hr" ;
@@ -14073,7 +14073,7 @@ unit:IN3-PER-MIN
   qudt:expression "$in^{3}/min$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA551" ;
   qudt:symbol "in³/min" ;
   qudt:ucumCode "[cin_i].min-1"^^qudt:UCUMcs ;
@@ -14093,7 +14093,7 @@ unit:IN3-PER-SEC
   qudt:conversionMultiplierSN 1.638706E-5 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA552" ;
   qudt:plainTextDescription "power of the unit inch according to the Anglo-American and the Imperial system of units with the exponent 3 divided by the SI base unit second" ;
   qudt:symbol "in³/s" ;
@@ -14256,7 +14256,7 @@ The magnitude of one $IU/L$ depends on the material, so there is no single conve
   qudt:conversionOffset 0.0 ;
   qudt:conversionOffsetSN 0.0E0 ;
   qudt:hasDimensionVector qkdv:A1E0L0I0M-1H0T0D0 ;
-  qudt:hasQuantityKind quantitykind:AmountOfSubstancePerUnitMass ;
+  qudt:hasQuantityKind quantitykind:AmountOfSubstancePerMass ;
   qudt:plainTextDescription "International Units per milligramme." ;
   qudt:symbol "IU/mg" ;
   qudt:ucumCode "[IU].mg-1"^^qudt:UCUMcs ;
@@ -15673,7 +15673,7 @@ unit:KiloA-PER-K
   qudt:conversionMultiplier 1000.0 ;
   qudt:conversionMultiplierSN 1.0E3 ;
   qudt:hasDimensionVector qkdv:A0E1L0I0M0H-1T0D0 ;
-  qudt:hasQuantityKind quantitykind:ElectricCurrentPerUnitTemperature ;
+  qudt:hasQuantityKind quantitykind:ElectricCurrentPerTemperature ;
   qudt:iec61360Code "0112/2///62720#UAD900" ;
   qudt:symbol "kA/K" ;
   qudt:ucumCode "kA.K-1"^^qudt:UCUMcs ;
@@ -18193,7 +18193,7 @@ unit:KiloL-PER-HR
   qudt:conversionMultiplierSN 2.777777777777777777777777777777778E-4 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAB121" ;
   qudt:plainTextDescription "unit of the volume kilolitres divided by the unit hour" ;
   qudt:symbol "kL/hr" ;
@@ -18524,7 +18524,7 @@ unit:KiloMOL-PER-KiloGM
   qudt:definedUnitOfSystem sou:SI ;
   qudt:expression "$kmol/kg$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A1E0L0I0M-1H0T0D0 ;
-  qudt:hasQuantityKind quantitykind:AmountOfSubstancePerUnitMass ;
+  qudt:hasQuantityKind quantitykind:AmountOfSubstancePerMass ;
   qudt:hasQuantityKind quantitykind:IonicStrength ;
   qudt:hasQuantityKind quantitykind:MolalityOfSolute ;
   qudt:iec61360Code "0112/2///62720#UAB404" ;
@@ -19495,7 +19495,7 @@ unit:L-PER-DAY
   qudt:conversionMultiplierSN 1.157407E-8 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA652" ;
   qudt:plainTextDescription "unit litre divided by the unit day" ;
   qudt:symbol "L/day" ;
@@ -19545,7 +19545,7 @@ unit:L-PER-HR
   qudt:conversionMultiplierSN 2.777778E-7 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA655" ;
   qudt:plainTextDescription "Unit litre divided by the unit hour" ;
   qudt:symbol "L/hr" ;
@@ -19656,7 +19656,7 @@ unit:L-PER-MIN
   qudt:conversionMultiplierSN 1.666667E-5 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA659" ;
   qudt:plainTextDescription "unit litre divided by the unit minute" ;
   qudt:symbol "L/min" ;
@@ -19754,7 +19754,7 @@ unit:L-PER-SEC
   qudt:conversionMultiplierSN 1.0E-3 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA664" ;
   qudt:plainTextDescription "unit litre divided by the SI base unit second" ;
   qudt:symbol "L/s" ;
@@ -23193,7 +23193,7 @@ unit:M3-PER-DAY
   qudt:conversionMultiplierSN 1.157407E-5 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA760" ;
   qudt:plainTextDescription "power of the SI base unit metre with the exponent 3 divided by the unit day" ;
   qudt:symbol "m³/day" ;
@@ -23275,7 +23275,7 @@ unit:M3-PER-HR
   qudt:expression "$m^{3}/h$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA763" ;
   qudt:symbol "m³/hr" ;
   qudt:ucumCode "m3.h-1"^^qudt:UCUMcs ;
@@ -23429,7 +23429,7 @@ unit:M3-PER-MIN
   qudt:conversionMultiplierSN 1.666667E-2 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA768" ;
   qudt:plainTextDescription "power of the SI base unit metre with the exponent 3 divided by the unit minute" ;
   qudt:symbol "m³/min" ;
@@ -23551,7 +23551,7 @@ unit:M3-PER-SEC
   qudt:hasQuantityKind quantitykind:RecombinationCoefficient ;
   qudt:hasQuantityKind quantitykind:SoundVolumeVelocity ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA772" ;
   qudt:iec61360Code "0112/2///62720#UAD705" ;
   qudt:symbol "m³/s" ;
@@ -23649,7 +23649,7 @@ unit:M3-PER-YR
   qudt:conversionMultiplierSN 3.168808781E-8 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:plainTextDescription "cubic meter divided by the unit year with 365 days" ;
   qudt:symbol "m³/a" ;
   qudt:ucumCode "m3.a-1"^^qudt:UCUMcs ;
@@ -24359,7 +24359,7 @@ unit:MOL-PER-KiloGM
   qudt:derivedCoherentUnitOfSystem sou:SI ;
   qudt:expression "$mol/kg$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A1E0L0I0M-1H0T0D0 ;
-  qudt:hasQuantityKind quantitykind:AmountOfSubstancePerUnitMass ;
+  qudt:hasQuantityKind quantitykind:AmountOfSubstancePerMass ;
   qudt:hasQuantityKind quantitykind:IonicStrength ;
   qudt:hasQuantityKind quantitykind:MolalityOfSolute ;
   qudt:iec61360Code "0112/2///62720#UAA885" ;
@@ -24376,7 +24376,7 @@ unit:MOL-PER-KiloGM-BAR
   qudt:conversionMultiplier 0.00001 ;
   qudt:conversionMultiplierSN 1.0E-5 ;
   qudt:hasDimensionVector qkdv:A1E0L1I0M-2H0T2D0 ;
-  qudt:hasQuantityKind quantitykind:AmountOfSubstancePerUnitMassPressure ;
+  qudt:hasQuantityKind quantitykind:AmountOfSubstancePerMassPressure ;
   qudt:iec61360Code "0112/2///62720#UAA887" ;
   qudt:symbol "mol/(kg·bar)" ;
   qudt:ucumCode "mol.kg-1.bar-1"^^qudt:UCUMcs ;
@@ -24408,7 +24408,7 @@ unit:MOL-PER-KiloGM-PA
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:expression "$mol/(kg.pa)$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A1E0L1I0M-2H0T2D0 ;
-  qudt:hasQuantityKind quantitykind:AmountOfSubstancePerUnitMassPressure ;
+  qudt:hasQuantityKind quantitykind:AmountOfSubstancePerMassPressure ;
   qudt:iec61360Code "0112/2///62720#UAB317" ;
   qudt:symbol "mol/(kg·Pa)" ;
   qudt:ucumCode "mol.kg-1.Pa-1"^^qudt:UCUMcs ;
@@ -24675,7 +24675,7 @@ unit:MOL-PER-TONNE
   qudt:conversionMultiplier 0.001 ;
   qudt:conversionMultiplierSN 1.0E-3 ;
   qudt:hasDimensionVector qkdv:A1E0L0I0M-1H0T0D0 ;
-  qudt:hasQuantityKind quantitykind:AmountOfSubstancePerUnitMass ;
+  qudt:hasQuantityKind quantitykind:AmountOfSubstancePerMass ;
   qudt:plainTextDescription "Mole Per Tonne (mol/t) is a unit of Molality" ;
   qudt:symbol "mol/t" ;
   qudt:ucumCode "mol.t-1"^^qudt:UCUMcs ;
@@ -24718,7 +24718,7 @@ unit:MOL_LB-PER-LB
   qudt:conversionMultiplier 999.9999999999999999999999999999998 ;
   qudt:conversionMultiplierSN 9.999999999999999999999999999999998E2 ;
   qudt:hasDimensionVector qkdv:A1E0L0I0M-1H0T0D0 ;
-  qudt:hasQuantityKind quantitykind:AmountOfSubstancePerUnitMass ;
+  qudt:hasQuantityKind quantitykind:AmountOfSubstancePerMass ;
   qudt:hasQuantityKind quantitykind:IonicStrength ;
   qudt:hasQuantityKind quantitykind:MolalityOfSolute ;
   qudt:iec61360Code "0112/2///62720#UAB405" ;
@@ -26187,7 +26187,7 @@ unit:MicroA-PER-K
   qudt:conversionMultiplier 0.000001 ;
   qudt:conversionMultiplierSN 1.0E-6 ;
   qudt:hasDimensionVector qkdv:A0E1L0I0M0H-1T0D0 ;
-  qudt:hasQuantityKind quantitykind:ElectricCurrentPerUnitTemperature ;
+  qudt:hasQuantityKind quantitykind:ElectricCurrentPerTemperature ;
   qudt:iec61360Code "0112/2///62720#UAD898" ;
   qudt:symbol "µA/K" ;
   qudt:ucumCode "uA.K-1"^^qudt:UCUMcs ;
@@ -27267,7 +27267,7 @@ unit:MicroMOL-PER-GM
   qudt:conversionMultiplier 0.001 ;
   qudt:conversionMultiplierSN 1.0E-3 ;
   qudt:hasDimensionVector qkdv:A1E0L0I0M-1H0T0D0 ;
-  qudt:hasQuantityKind quantitykind:AmountOfSubstancePerUnitMass ;
+  qudt:hasQuantityKind quantitykind:AmountOfSubstancePerMass ;
   qudt:hasQuantityKind quantitykind:IonicStrength ;
   qudt:hasQuantityKind quantitykind:MolalityOfSolute ;
   qudt:plainTextDescription "0.000001-fold of the SI base unit mol divided by the 0.001-fold of the SI base unit kilogram" ;
@@ -27309,7 +27309,7 @@ unit:MicroMOL-PER-KiloGM
   qudt:conversionMultiplier 0.000001 ;
   qudt:conversionMultiplierSN 1.0E-6 ;
   qudt:hasDimensionVector qkdv:A1E0L0I0M-1H0T0D0 ;
-  qudt:hasQuantityKind quantitykind:AmountOfSubstancePerUnitMass ;
+  qudt:hasQuantityKind quantitykind:AmountOfSubstancePerMass ;
   qudt:symbol "µmol/kg" ;
   qudt:ucumCode "umol.kg-1"^^qudt:UCUMcs ;
   qudt:ucumCode "umol/kg"^^qudt:UCUMcs ;
@@ -28030,7 +28030,7 @@ unit:MilliA-PER-K
   qudt:conversionMultiplier 0.001 ;
   qudt:conversionMultiplierSN 1.0E-3 ;
   qudt:hasDimensionVector qkdv:A0E1L0I0M0H-1T0D0 ;
-  qudt:hasQuantityKind quantitykind:ElectricCurrentPerUnitTemperature ;
+  qudt:hasQuantityKind quantitykind:ElectricCurrentPerTemperature ;
   qudt:iec61360Code "0112/2///62720#UAD897" ;
   qudt:symbol "mA/K" ;
   qudt:ucumCode "mA.K-1"^^qudt:UCUMcs ;
@@ -29776,7 +29776,7 @@ unit:MilliL-PER-DAY
   qudt:conversionMultiplierSN 1.157407E-11 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA847" ;
   qudt:plainTextDescription "0.001-fold of the unit litre divided by the unit day" ;
   qudt:symbol "mL/day" ;
@@ -29848,7 +29848,7 @@ unit:MilliL-PER-HR
   qudt:conversionMultiplierSN 2.777778E-10 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA850" ;
   qudt:plainTextDescription "0.001-fold of the unit litre divided by the unit hour" ;
   qudt:symbol "mL/hr" ;
@@ -29994,7 +29994,7 @@ unit:MilliL-PER-MIN
   qudt:conversionMultiplierSN 1.666667E-8 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA855" ;
   qudt:plainTextDescription "0.001-fold of the unit litre divided by the unit minute" ;
   qudt:symbol "mL/min" ;
@@ -30044,7 +30044,7 @@ unit:MilliL-PER-SEC
   qudt:conversionMultiplierSN 1.0E-6 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA859" ;
   qudt:plainTextDescription "0.001-fold of the unit litre divided by the SI base unit second" ;
   qudt:symbol "mL/s" ;
@@ -30467,7 +30467,7 @@ unit:MilliMOL-PER-GM
   qudt:conversionMultiplier 1.0 ;
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A1E0L0I0M-1H0T0D0 ;
-  qudt:hasQuantityKind quantitykind:AmountOfSubstancePerUnitMass ;
+  qudt:hasQuantityKind quantitykind:AmountOfSubstancePerMass ;
   qudt:hasQuantityKind quantitykind:IonicStrength ;
   qudt:iec61360Code "0112/2///62720#UAA878" ;
   qudt:plainTextDescription "0.001-fold of the SI base unit mol divided by the 0.001-fold of the SI base unit kilogram" ;
@@ -30485,7 +30485,7 @@ unit:MilliMOL-PER-KiloGM
   qudt:conversionMultiplier 0.001 ;
   qudt:conversionMultiplierSN 1.0E-3 ;
   qudt:hasDimensionVector qkdv:A1E0L0I0M-1H0T0D0 ;
-  qudt:hasQuantityKind quantitykind:AmountOfSubstancePerUnitMass ;
+  qudt:hasQuantityKind quantitykind:AmountOfSubstancePerMass ;
   qudt:hasQuantityKind quantitykind:IonicStrength ;
   qudt:iec61360Code "0112/2///62720#UAA879" ;
   qudt:plainTextDescription "0.001-fold of the SI base unit mol divided by the SI base unit kilogram" ;
@@ -31894,7 +31894,7 @@ unit:N-PER-A
   qudt:conversionMultiplier 1.0 ;
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E-1L1I0M1H0T-2D0 ;
-  qudt:hasQuantityKind quantitykind:MagneticFluxPerUnitLength ;
+  qudt:hasQuantityKind quantitykind:MagneticFluxPerLength ;
   qudt:iec61360Code "0112/2///62720#UAA236" ;
   qudt:plainTextDescription "SI derived unit newton divided by the SI base unit ampere" ;
   qudt:symbol "N/A" ;
@@ -32671,7 +32671,7 @@ unit:NanoA-PER-K
   qudt:conversionMultiplier 0.000000001 ;
   qudt:conversionMultiplierSN 1.0E-9 ;
   qudt:hasDimensionVector qkdv:A0E1L0I0M0H-1T0D0 ;
-  qudt:hasQuantityKind quantitykind:ElectricCurrentPerUnitTemperature ;
+  qudt:hasQuantityKind quantitykind:ElectricCurrentPerTemperature ;
   qudt:iec61360Code "0112/2///62720#UAD899" ;
   qudt:symbol "nA/K" ;
   qudt:ucumCode "nA.K-1"^^qudt:UCUMcs ;
@@ -33270,7 +33270,7 @@ unit:NanoMOL-PER-KiloGM
   qudt:conversionMultiplier 0.000000001 ;
   qudt:conversionMultiplierSN 1.0E-9 ;
   qudt:hasDimensionVector qkdv:A1E0L0I0M-1H0T0D0 ;
-  qudt:hasQuantityKind quantitykind:AmountOfSubstancePerUnitMass ;
+  qudt:hasQuantityKind quantitykind:AmountOfSubstancePerMass ;
   qudt:symbol "nmol/kg" ;
   qudt:ucumCode "nmol.kg-1"^^qudt:UCUMcs ;
   qudt:ucumCode "nmol/kg"^^qudt:UCUMcs ;
@@ -34614,7 +34614,7 @@ unit:OZ_VOL_UK-PER-DAY
   qudt:conversionMultiplierSN 3.288548900462962962962962962962962E-10 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA432" ;
   qudt:plainTextDescription "unit of the volume fluid ounce (UK) for fluids according to the Imperial system of units divided by the unit for time day" ;
   qudt:symbol "oz{UK}/day" ;
@@ -34632,7 +34632,7 @@ unit:OZ_VOL_UK-PER-HR
   qudt:conversionMultiplierSN 7.892517361111111111111111111111112E-9 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA433" ;
   qudt:plainTextDescription "unit of the volume fluid ounce (UK) for fluids according to the Imperial system of units divided by the unit for time hour" ;
   qudt:symbol "oz{UK}/hr" ;
@@ -34650,7 +34650,7 @@ unit:OZ_VOL_UK-PER-MIN
   qudt:conversionMultiplierSN 4.735510416666666666666666666666668E-7 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA434" ;
   qudt:plainTextDescription "unit of the volume fluid ounce (UK) for fluids according to the Imperial system of units divided by the unit for time minute" ;
   qudt:symbol "oz{UK}/min" ;
@@ -34668,7 +34668,7 @@ unit:OZ_VOL_UK-PER-SEC
   qudt:conversionMultiplierSN 2.84E-5 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA435" ;
   qudt:plainTextDescription "unit of the volume fluid ounce (UK) for fluids according to the Imperial system of units divided by the SI base unit second" ;
   qudt:symbol "oz{UK}/s" ;
@@ -34703,7 +34703,7 @@ unit:OZ_VOL_US-PER-DAY
   qudt:conversionMultiplierSN 3.42286E-10 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA436" ;
   qudt:plainTextDescription "unit of the volume fluid ounce (US) for fluids according to the Anglo-American system of units divided by unit for time day" ;
   qudt:symbol "fl oz{US}/day" ;
@@ -34721,7 +34721,7 @@ unit:OZ_VOL_US-PER-HR
   qudt:conversionMultiplierSN 8.214869E-9 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA437" ;
   qudt:plainTextDescription "unit of the volume fluid ounce (US) for fluids according to the Anglo-American system of units divided by the unit for time hour" ;
   qudt:symbol "fl oz{US}/hr" ;
@@ -34739,7 +34739,7 @@ unit:OZ_VOL_US-PER-MIN
   qudt:conversionMultiplierSN 4.92892E-7 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA438" ;
   qudt:plainTextDescription "unit of the volume fluid ounce (US) for fluids according to the Anglo-American system of units divided by the unit for time minute" ;
   qudt:symbol "fl oz{US}/min" ;
@@ -34757,7 +34757,7 @@ unit:OZ_VOL_US-PER-SEC
   qudt:conversionMultiplierSN 2.95735296E-5 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA439" ;
   qudt:plainTextDescription "unit of the volume fluid ounce (US) for fluids according to the Anglo-American system of units divided by the SI base unit second" ;
   qudt:symbol "fl oz{US}/s" ;
@@ -37980,7 +37980,7 @@ unit:PINT_UK-PER-DAY
   qudt:conversionMultiplierSN 6.577098E-9 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA953" ;
   qudt:plainTextDescription "unit of the volume pint (UK) (both for fluids and for dry measures) according to the Imperial system of units divided by the unit for time day" ;
   qudt:symbol "pt{UK}/day" ;
@@ -37997,7 +37997,7 @@ unit:PINT_UK-PER-HR
   qudt:conversionMultiplierSN 1.578504E-7 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA954" ;
   qudt:plainTextDescription "unit of the volume pint (UK) (both for fluids and for dry measures) according to the Imperial system of units divided by the unit for time hour" ;
   qudt:symbol "pt{UK}/hr" ;
@@ -38015,7 +38015,7 @@ unit:PINT_UK-PER-MIN
   qudt:conversionMultiplierSN 9.471022E-6 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA955" ;
   qudt:plainTextDescription "unit of the volume pint (UK) (both for fluids and for dry measures) according to the Imperial system of units divided by the unit for time minute" ;
   qudt:symbol "pt{UK}/min" ;
@@ -38033,7 +38033,7 @@ unit:PINT_UK-PER-SEC
   qudt:conversionMultiplierSN 5.682613E-4 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA956" ;
   qudt:plainTextDescription "unit of the volume pint (UK) (both for fluids and for dry measures) according to the Imperial system of units divided by the SI base unit second" ;
   qudt:symbol "pt{UK}/s" ;
@@ -38069,7 +38069,7 @@ unit:PINT_US-PER-DAY
   qudt:conversionMultiplierSN 5.47658E-9 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA958" ;
   qudt:plainTextDescription "unit of the volume pint (US liquid) according to the Anglo-American system of units divided by the unit for time day" ;
   qudt:symbol "pt{US}/day" ;
@@ -38087,7 +38087,7 @@ unit:PINT_US-PER-HR
   qudt:conversionMultiplierSN 1.314379E-7 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA959" ;
   qudt:plainTextDescription "unit of the volume pint (US liquid) according to the Anglo-American system of units divided by the unit for time hour" ;
   qudt:symbol "pt{US}/hr" ;
@@ -38105,7 +38105,7 @@ unit:PINT_US-PER-MIN
   qudt:conversionMultiplierSN 7.886275E-6 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA960" ;
   qudt:plainTextDescription "unit of the volume pint (US liquid) according to the Anglo-American system of units divided by the unit for time minute" ;
   qudt:symbol "pt{US}/min" ;
@@ -38123,7 +38123,7 @@ unit:PINT_US-PER-SEC
   qudt:conversionMultiplierSN 4.731765E-4 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA961" ;
   qudt:plainTextDescription "unit of the volume pint (US liquid) according to the Anglo-American system of units divided by the SI base unit second" ;
   qudt:symbol "pt{US}/s" ;
@@ -38185,7 +38185,7 @@ unit:PK_UK-PER-DAY
   qudt:conversionMultiplierSN 1.05233576E-7 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA940" ;
   qudt:plainTextDescription "unit of the volume peck (UK) according to the Imperial system of units divided by the unit for time day" ;
   qudt:symbol "peck{UK}/day" ;
@@ -38203,7 +38203,7 @@ unit:PK_UK-PER-HR
   qudt:conversionMultiplierSN 2.525605833E-6 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA941" ;
   qudt:plainTextDescription "unit of the volume peck (UK) according to the Imperial system of units divided by the unit for time hour" ;
   qudt:symbol "peck{UK}/hr" ;
@@ -38221,7 +38221,7 @@ unit:PK_UK-PER-MIN
   qudt:conversionMultiplierSN 1.5153635E-4 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA942" ;
   qudt:plainTextDescription "unit of the volume peck (UK) according to the Imperial system of units divided by the unit for time minute" ;
   qudt:symbol "peck{UK}/min" ;
@@ -38239,7 +38239,7 @@ unit:PK_UK-PER-SEC
   qudt:conversionMultiplierSN 9.092181E-3 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA943" ;
   qudt:plainTextDescription "unit of the volume peck (UK) according to the Imperial system of units divided by the SI base unit second" ;
   qudt:symbol "peck{UK}/s" ;
@@ -38275,7 +38275,7 @@ unit:PK_US_DRY-PER-DAY
   qudt:conversionMultiplierSN 1.01964902E-7 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA944" ;
   qudt:plainTextDescription "unit of the volume peck (US dry) as dry measure according to the Anglo-American system of units divided by the unit for time day" ;
   qudt:symbol "peck{US Dry}/day" ;
@@ -38293,7 +38293,7 @@ unit:PK_US_DRY-PER-HR
   qudt:conversionMultiplierSN 2.447157651E-6 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA945" ;
   qudt:plainTextDescription "unit of the volume peck (US dry) as dry measure according to the Anglo-American system of units divided by the unit for time hour" ;
   qudt:symbol "peck{US Dry}/hr" ;
@@ -38311,7 +38311,7 @@ unit:PK_US_DRY-PER-MIN
   qudt:conversionMultiplierSN 1.46829459067E-4 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA946" ;
   qudt:plainTextDescription "unit of the volume peck (US dry) as dry measure according to the Anglo-American system of units divided by the unit for time minute" ;
   qudt:symbol "peck{US Dry}/min" ;
@@ -38329,7 +38329,7 @@ unit:PK_US_DRY-PER-SEC
   qudt:conversionMultiplierSN 8.80976754E-3 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA947" ;
   qudt:plainTextDescription "unit of the volume peck (US dry) as dry measure according to the Anglo-American system of units divided by the SI base unit second" ;
   qudt:symbol "peck{US Dry}/s" ;
@@ -39399,7 +39399,7 @@ unit:PicoMOL-PER-KiloGM
   qudt:conversionMultiplier 0.000000000001 ;
   qudt:conversionMultiplierSN 1.0E-12 ;
   qudt:hasDimensionVector qkdv:A1E0L0I0M-1H0T0D0 ;
-  qudt:hasQuantityKind quantitykind:AmountOfSubstancePerUnitMass ;
+  qudt:hasQuantityKind quantitykind:AmountOfSubstancePerMass ;
   qudt:symbol "pmol/kg" ;
   qudt:ucumCode "pmol.kg-1"^^qudt:UCUMcs ;
   qudt:ucumCode "pmol/kg"^^qudt:UCUMcs ;
@@ -40009,7 +40009,7 @@ unit:QT_UK-PER-DAY
   qudt:conversionMultiplierSN 1.31542E-8 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA710" ;
   qudt:plainTextDescription "unit of the volume quart (UK liquid) for fluids according to the Imperial system of units divided by the unit for time day" ;
   qudt:symbol "qt{UK}/day" ;
@@ -40026,7 +40026,7 @@ unit:QT_UK-PER-HR
   qudt:conversionMultiplierSN 3.157007E-7 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA711" ;
   qudt:plainTextDescription "unit of the volume quart (UK liquid) for fluids according to the Imperial system of units divided by the unit for time hour" ;
   qudt:symbol "qt{UK}/hr" ;
@@ -40043,7 +40043,7 @@ unit:QT_UK-PER-MIN
   qudt:conversionMultiplierSN 1.894205E-5 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA712" ;
   qudt:plainTextDescription "unit of the volume quart (UK liquid) for fluids according to the Imperial system of units divided by the unit for time minute" ;
   qudt:symbol "qt{UK}/min" ;
@@ -40060,7 +40060,7 @@ unit:QT_UK-PER-SEC
   qudt:conversionMultiplierSN 1.1365225E-3 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA713" ;
   qudt:plainTextDescription "unit of the volume quart (UK liquid) for fluids according to the Imperial system of units divided by the SI base unit second" ;
   qudt:symbol "qt{UK}/s" ;
@@ -40095,7 +40095,7 @@ unit:QT_US-PER-DAY
   qudt:conversionMultiplierSN 1.095316E-8 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA714" ;
   qudt:plainTextDescription "unit fo the volume quart (US liquid) for fluids according to the Anglo-American system of units divided by the unit for time day" ;
   qudt:symbol "qt/day" ;
@@ -40113,7 +40113,7 @@ unit:QT_US-PER-HR
   qudt:conversionMultiplierSN 2.62875833E-7 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA715" ;
   qudt:plainTextDescription "unit fo the volume quart (US liquid) for fluids according to the Anglo-American system of units divided by the unit for time hour" ;
   qudt:symbol "qt/hr" ;
@@ -40131,7 +40131,7 @@ unit:QT_US-PER-MIN
   qudt:conversionMultiplierSN 1.577255E-5 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA716" ;
   qudt:plainTextDescription "unit fo the volume quart (US liquid) for fluids according to the Anglo-American system of units divided by the unit for time minute" ;
   qudt:symbol "qt/min" ;
@@ -40149,7 +40149,7 @@ unit:QT_US-PER-SEC
   qudt:conversionMultiplierSN 9.46353E-4 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA717" ;
   qudt:plainTextDescription "unit fo the volume quart (US liquid) for fluids according to the Anglo-American system of units divided by the SI base unit second" ;
   qudt:symbol "qt/s" ;
@@ -41827,7 +41827,7 @@ unit:T-M
   qudt:conversionMultiplier 1.0 ;
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E-1L1I0M1H0T-2D0 ;
-  qudt:hasQuantityKind quantitykind:MagneticFluxPerUnitLength ;
+  qudt:hasQuantityKind quantitykind:MagneticFluxPerLength ;
   qudt:symbol "T·m" ;
   qudt:ucumCode "T.m"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -44104,7 +44104,7 @@ unit:V-SEC-PER-M
   qudt:conversionMultiplier 1.0 ;
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E-1L1I0M1H0T-2D0 ;
-  qudt:hasQuantityKind quantitykind:MagneticFluxPerUnitLength ;
+  qudt:hasQuantityKind quantitykind:MagneticFluxPerLength ;
   qudt:hasQuantityKind quantitykind:MagneticVectorPotential ;
   qudt:hasQuantityKind quantitykind:ScalarMagneticPotential ;
   qudt:iec61360Code "0112/2///62720#UAA303" ;
@@ -45193,7 +45193,7 @@ unit:YD3-PER-DAY
   qudt:conversionMultiplierSN 8.84901456E-6 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAB037" ;
   qudt:plainTextDescription "power of the unit yard according to the Anglo-American and the Imperial system of units with the exponent 3 divided by the unit for time day" ;
   qudt:symbol "yd³/day" ;
@@ -45228,7 +45228,7 @@ unit:YD3-PER-HR
   qudt:conversionMultiplierSN 2.1237634944E-4 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAB038" ;
   qudt:plainTextDescription "power of the unit yard according to the Anglo-American and the Imperial system of units with the exponent 3 divided by the unit for the time hour" ;
   qudt:symbol "yd³/hr" ;
@@ -45251,7 +45251,7 @@ unit:YD3-PER-MIN
   qudt:expression "$yd^{3}/min$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAB040" ;
   qudt:symbol "yd³/min" ;
   qudt:ucumCode "[cyd_i].min-1"^^qudt:UCUMcs ;
@@ -45285,7 +45285,7 @@ unit:YD3-PER-SEC
   qudt:conversionMultiplierSN 7.64554857984E-1 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
-  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAB041" ;
   qudt:plainTextDescription "power of the unit and the Anglo-American and Imperial system of units with the exponent 3 divided by the SI base unit second" ;
   qudt:symbol "yd³/s" ;


### PR DESCRIPTION
Per our agreement to deprecate quantity kinds containing "PerUnit" in the URI.
I thought this would be trivial, but the qudt:exactMatch and qudt:deprecated relations thought otherwise!

All good now, I believe.