### PR TITLE
Change a unit from having quantity kind Surface Tension to a broader quantity kind

### DIFF
--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -4588,6 +4588,18 @@ unit:CHAIN_US
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "chain (based on U.S. survey foot)" ;
 .
+unit:CHF-PER-KiloGM
+  a qudt:Unit ;
+  qudt:applicableSystem sou:SI ;
+  qudt:conversionMultiplier 1.0 ;
+  qudt:conversionMultiplierSN 1.0E0 ;
+  qudt:hasDimensionVector qkdv:A0E0L0I0M-1H0T0D0 ;
+  qudt:hasQuantityKind quantitykind:CostPerMass ;
+  qudt:plainTextDescription "Unit for measuring the hardware cost of substance or material" ;
+  qudt:symbol "CHF/kg" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Swiss Francs per kilogram"@en ;
+.
 unit:CI-PER-KiloGM
   a qudt:Unit ;
   dcterms:description "1,000-fold of the unit curie divided by the SI base unit kilogram" ;
@@ -8362,18 +8374,6 @@ unit:EU-PER-L
   qudt:symbol "U/L" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "enzyme units per litre" ;
-.
-unit:CHF-PER-KiloGM
-  a qudt:Unit ;
-  qudt:applicableSystem sou:SI ;
-  qudt:conversionMultiplier 1.0 ;
-  qudt:conversionMultiplierSN 1.0E0 ;
-  qudt:hasQuantityKind quantitykind:CostPerMass ;
-  qudt:hasDimensionVector qkdv:A0E0L0I0M-1H0T0D0 ;
-  qudt:plainTextDescription "Unit for measuring the hardware cost of substance or material" ;
-  qudt:symbol "CHF/kg" ;
-  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
-  rdfs:label "Swiss Francs per kilogram"@en ;
 .
 unit:EUR-PER-KiloW
   a qudt:Unit ;
@@ -21542,8 +21542,8 @@ unit:LB_F-PER-IN
   qudt:definedUnitOfSystem sou:USCS ;
   qudt:expression "$lbf/in$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-2D0 ;
+  qudt:hasQuantityKind quantitykind:EnergyPerArea ;
   qudt:hasQuantityKind quantitykind:ForcePerLength ;
-  qudt:hasQuantityKind quantitykind:SurfaceTension ;
   qudt:iec61360Code "0112/2///62720#UAA700" ;
   qudt:symbol "lbf/in" ;
   qudt:ucumCode "[lbf_av].[in_i]-1"^^qudt:UCUMcs ;


### PR DESCRIPTION
`unit:LB_F-PER-IN` had quantity kind `quantitykind:SurfaceTension`, which causes a problem because it was the only unit that had that quantity kind. `quantitykind:SurfaceTension` was inheriting all its applicable units from the broader quantity kind `quantitykind:EnergyPerArea` and now it only has that one as applicable. This changes `unit:LB_F-PER-IN` to have quantity kind `quantitykind:EnergyPerArea` to fix the issue.

Whether or not it is the most appropriate for `unit:LB_F-PER-IN` to have quantity kind `quantitykind:EnergyPerArea` is another question, but I didn't want to remove it now if someone else was using that way.