### PR TITLE
correct label for mol-per-m3-pa

### DIFF
--- a/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -24603,7 +24603,7 @@ unit:MOL-PER-M3-PA
   qudt:ucumCode "mol.m-3.Pa-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P52" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
-  rdfs:label "mol per cubic metre pascal" ;
+  rdfs:label "mole per cubic metre pascal" ;
 .
 unit:MOL-PER-M3-SEC
   a qudt:Unit ;


### PR DESCRIPTION
correct "mol" to "mole" as per other labels