### PR TITLE
Fix datatype of qudt:currencyNumber

### DIFF
--- a/collections/COLLECTION_QUDT_QA_TESTS_ALL-v2.1.ttl
+++ b/collections/COLLECTION_QUDT_QA_TESTS_ALL-v2.1.ttl
@@ -19,6 +19,8 @@
 @prefix voag: <http://voag.linkedmodel.org/schema/voag#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
+@prefix cur: <http://qudt.org/vocab/currency/> .
+
 <http://qudt.org/2.1/collection/qa/all>
   a owl:Ontology ;
   rdfs:isDefinedBy <http://qudt.org/2.1/collection/qa/all> ;
@@ -557,3 +559,15 @@ qudt:valueSnShape
     ] ;
   sh:targetClass qudt:ConstantValue ;
 .
+
+qudt:CurencyNumberShape
+    a sh:NodeShape ;
+    sh:targetSubjectsOf qudt:currencyNumber ;
+    sh:property [
+        sh:path qudt:currencyNumber ;
+        sh:datatype xsd:string ;
+        sh:pattern "^\\d{3}$" ;
+        sh:message "qudt:currencyNumber must have a string-typed value that contains exactly three digits." ;
+        sh:minCount 1 ;
+        sh:maxCount 1
+    ] .

--- a/schema/SCHEMA_QUDT-v2.1.ttl
+++ b/schema/SCHEMA_QUDT-v2.1.ttl
@@ -371,9 +371,15 @@ qudt:CurrencyUnit
   rdfs:subClassOf qudt:DimensionlessUnit ;
   rdfs:subClassOf [
       a owl:Restriction ;
-      owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+      owl:maxCardinality 1 ;
       owl:onProperty qudt:currencyExponent ;
     ] ;
+  rdfs:subClassOf [
+       a owl:Restriction ;
+       owl:maxCardinality 1 ;
+       xsd:pattern "^\\d{3}$" ;
+       owl:onProperty qudt:currencyCode ;
+     ] ;
 .
 qudt:DataEncoding
   a owl:Class ;
@@ -2241,7 +2247,7 @@ qudt:currencyNumber
   dcterms:description "Numeric currency Code as defined by ISO 4217. For example, US Dollar has the number 840."^^rdf:HTML ;
   rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
   rdfs:label "currency number" ;
-  rdfs:range xsd:positiveInteger ;
+  rdfs:range xsd:string ;
   rdfs:seeAlso "https://en.wikipedia.org/wiki/ISO_4217"^^xsd:anyURI ;
 .
 qudt:dataEncoding

--- a/schema/shacl/SCHEMA_QUDT_NoOWL-v2.1.ttl
+++ b/schema/shacl/SCHEMA_QUDT_NoOWL-v2.1.ttl
@@ -487,7 +487,8 @@ qudt:CurrencyUnit-currencyNumber
   a sh:PropertyShape ;
   sh:path qudt:currencyNumber ;
   rdfs:isDefinedBy <http://qudt.org/2.1/schema/shacl/qudt> ;
-  sh:datatype xsd:integer ;
+  sh:datatype xsd:string ;
+  sh:pattern "^\\d{3}$" ;
 .
 qudt:DataEncoding
   a rdfs:Class ;
@@ -2776,7 +2777,7 @@ qudt:currencyExponent
 .
 qudt:currencyNumber
   a rdf:Property ;
-  dcterms:description "Numeric Currency Code as defined by ISO 4217. For example, the currency number for the US dollar is 840."^^rdf:HTML ;
+  dcterms:description "Three-digit Currency Code as defined by ISO 4217. For example, the currency number for the US dollar is \"840\"."^^rdf:HTML ;
   rdfs:isDefinedBy <http://qudt.org/2.1/schema/shacl/qudt> ;
   rdfs:label "currency number" ;
 .

--- a/vocab/currency/VOCAB_QUDT-UNITS-CURRENCY-v2.1.ttl
+++ b/vocab/currency/VOCAB_QUDT-UNITS-CURRENCY-v2.1.ttl
@@ -33,7 +33,7 @@ cur:AED
   a qudt:CurrencyUnit ;
   qudt:currencyCode "AED" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 784 ;
+  qudt:currencyNumber "784" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/United_Arab_Emirates_dirham"^^xsd:anyURI ;
   qudt:expression "$AED$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -47,7 +47,7 @@ cur:AFN
   a qudt:CurrencyUnit ;
   qudt:currencyCode "AFN" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 971 ;
+  qudt:currencyNumber "971" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Afghani"^^xsd:anyURI ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -59,7 +59,7 @@ cur:ALL
   a qudt:CurrencyUnit ;
   qudt:currencyCode "ALL" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 008 ;
+  qudt:currencyNumber "008" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Lek"^^xsd:anyURI ;
   qudt:expression "$ALL$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -73,7 +73,7 @@ cur:AMD
   a qudt:CurrencyUnit ;
   qudt:currencyCode "AMD" ;
   qudt:currencyExponent 0 ;
-  qudt:currencyNumber 051 ;
+  qudt:currencyNumber "051" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Armenian_dram"^^xsd:anyURI ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -86,7 +86,7 @@ cur:ANG
   a qudt:CurrencyUnit ;
   qudt:currencyCode "ANG" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 532 ;
+  qudt:currencyNumber "532" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Netherlands_Antillean_guilder"^^xsd:anyURI ;
   qudt:expression "$ANG$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -99,7 +99,7 @@ cur:AOA
   a qudt:CurrencyUnit ;
   qudt:currencyCode "AOA" ;
   qudt:currencyExponent 1 ;
-  qudt:currencyNumber 973 ;
+  qudt:currencyNumber "973" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Angolan_kwanza"^^xsd:anyURI ;
   qudt:expression "$AOA$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -112,7 +112,7 @@ cur:ARS
   a qudt:CurrencyUnit ;
   qudt:currencyCode "ARS" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 032 ;
+  qudt:currencyNumber "032" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Argentine_peso"^^xsd:anyURI ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -124,7 +124,7 @@ cur:AUD
   a qudt:CurrencyUnit ;
   qudt:currencyCode "AUD" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 036 ;
+  qudt:currencyNumber "036" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Australian_dollar"^^xsd:anyURI ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -138,7 +138,7 @@ cur:AWG
   a qudt:CurrencyUnit ;
   qudt:currencyCode "AWG" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 533 ;
+  qudt:currencyNumber "533" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Aruban_florin"^^xsd:anyURI ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -150,7 +150,7 @@ cur:AZN
   a qudt:CurrencyUnit ;
   qudt:currencyCode "AZN" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 944 ;
+  qudt:currencyNumber "944" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Azerbaijani_manat"^^xsd:anyURI ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -163,7 +163,7 @@ cur:BAM
   a qudt:CurrencyUnit ;
   qudt:currencyCode "BAM" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 977 ;
+  qudt:currencyNumber "977" ;
   qudt:expression "$BAM$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -175,7 +175,7 @@ cur:BBD
   a qudt:CurrencyUnit ;
   qudt:currencyCode "BBD" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 052 ;
+  qudt:currencyNumber "052" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Barbadian_dollar"^^xsd:anyURI ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -187,7 +187,7 @@ cur:BDT
   a qudt:CurrencyUnit ;
   qudt:currencyCode "BDT" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 050 ;
+  qudt:currencyNumber "050" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Bangladeshi_taka"^^xsd:anyURI ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -199,7 +199,7 @@ cur:BGN
   a qudt:CurrencyUnit ;
   qudt:currencyCode "BGN" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 975 ;
+  qudt:currencyNumber "975" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Bulgarian_lev"^^xsd:anyURI ;
   qudt:expression "$BGN$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -213,7 +213,7 @@ cur:BHD
   a qudt:CurrencyUnit ;
   qudt:currencyCode "BHD" ;
   qudt:currencyExponent 3 ;
-  qudt:currencyNumber 048 ;
+  qudt:currencyNumber "048" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Bahraini_dinar"^^xsd:anyURI ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -225,7 +225,7 @@ cur:BIF
   a qudt:CurrencyUnit ;
   qudt:currencyCode "BIF" ;
   qudt:currencyExponent 0 ;
-  qudt:currencyNumber 108 ;
+  qudt:currencyNumber "108" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Burundian_franc"^^xsd:anyURI ;
   qudt:expression "$BIF$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -238,7 +238,7 @@ cur:BMD
   a qudt:CurrencyUnit ;
   qudt:currencyCode "BMD" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 060 ;
+  qudt:currencyNumber "060" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Bermudian_dollar"^^xsd:anyURI ;
   qudt:expression "$BMD$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -251,7 +251,7 @@ cur:BND
   a qudt:CurrencyUnit ;
   qudt:currencyCode "BND" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 096 ;
+  qudt:currencyNumber "096" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Brunei_dollar"^^xsd:anyURI ;
   qudt:expression "$BND$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -264,7 +264,7 @@ cur:BOB
   a qudt:CurrencyUnit ;
   qudt:currencyCode "BOB" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 068 ;
+  qudt:currencyNumber "068" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Bolivian_boliviano"^^xsd:anyURI ;
   qudt:expression "$BOB$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -277,7 +277,7 @@ cur:BOV
   a qudt:CurrencyUnit ;
   qudt:currencyCode "BOV" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 984 ;
+  qudt:currencyNumber "984" ;
   qudt:expression "$BOV$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -288,7 +288,7 @@ cur:BRL
   a qudt:CurrencyUnit ;
   qudt:currencyCode "BRL" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 986 ;
+  qudt:currencyNumber "986" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Brazilian_real"^^xsd:anyURI ;
   qudt:expression "$BRL$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -303,7 +303,7 @@ cur:BSD
   a qudt:CurrencyUnit ;
   qudt:currencyCode "BSD" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 044 ;
+  qudt:currencyNumber "044" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Bahamian_dollar"^^xsd:anyURI ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -315,7 +315,7 @@ cur:BTN
   a qudt:CurrencyUnit ;
   qudt:currencyCode "BTN" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 064 ;
+  qudt:currencyNumber "064" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Bhutanese_ngultrum"^^xsd:anyURI ;
   qudt:expression "$BTN$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -328,7 +328,7 @@ cur:BWP
   a qudt:CurrencyUnit ;
   qudt:currencyCode "BWP" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 072 ;
+  qudt:currencyNumber "072" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Pula"^^xsd:anyURI ;
   qudt:expression "$BWP$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -341,7 +341,7 @@ cur:BYN
   a qudt:CurrencyUnit ;
   qudt:currencyCode "BYN" ;
   qudt:currencyExponent 0 ;
-  qudt:currencyNumber 933 ;
+  qudt:currencyNumber "933" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Belarusian_ruble"^^xsd:anyURI ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -354,7 +354,7 @@ cur:BZD
   a qudt:CurrencyUnit ;
   qudt:currencyCode "BZD" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 084 ;
+  qudt:currencyNumber "084" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Belize_dollar"^^xsd:anyURI ;
   qudt:expression "$BZD$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -367,7 +367,7 @@ cur:CAD
   a qudt:CurrencyUnit ;
   qudt:currencyCode "CAD" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 124 ;
+  qudt:currencyNumber "124" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Canadian_dollar"^^xsd:anyURI ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -381,7 +381,7 @@ cur:CDF
   a qudt:CurrencyUnit ;
   qudt:currencyCode "CDF" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 976 ;
+  qudt:currencyNumber "976" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Congolese_franc"^^xsd:anyURI ;
   qudt:expression "$CDF$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -394,7 +394,7 @@ cur:CHE
   a qudt:CurrencyUnit ;
   qudt:currencyCode "CHE" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 947 ;
+  qudt:currencyNumber "947" ;
   qudt:expression "$CHE$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -405,7 +405,7 @@ cur:CHF
   a qudt:CurrencyUnit ;
   qudt:currencyCode "CHF" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 756 ;
+  qudt:currencyNumber "756" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Swiss_franc"^^xsd:anyURI ;
   qudt:expression "$CHF$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -420,7 +420,7 @@ cur:CHW
   a qudt:CurrencyUnit ;
   qudt:currencyCode "CHW" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 948 ;
+  qudt:currencyNumber "948" ;
   qudt:expression "$CHW$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -431,7 +431,7 @@ cur:CLF
   a qudt:CurrencyUnit ;
   qudt:currencyCode "CLF" ;
   qudt:currencyExponent 0 ;
-  qudt:currencyNumber 990 ;
+  qudt:currencyNumber "990" ;
   qudt:expression "$CLF$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -442,7 +442,7 @@ cur:CLP
   a qudt:CurrencyUnit ;
   qudt:currencyCode "CLP" ;
   qudt:currencyExponent 0 ;
-  qudt:currencyNumber 152 ;
+  qudt:currencyNumber "152" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Chilean_peso"^^xsd:anyURI ;
   qudt:expression "$CLP$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -456,7 +456,7 @@ cur:CNY
   a qudt:CurrencyUnit ;
   qudt:currencyCode "CNY" ;
   qudt:currencyExponent 1 ;
-  qudt:currencyNumber 156 ;
+  qudt:currencyNumber "156" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Renminbi"^^xsd:anyURI ;
   qudt:expression "$CNY$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -470,7 +470,7 @@ cur:COP
   a qudt:CurrencyUnit ;
   qudt:currencyCode "COP" ;
   qudt:currencyExponent 0 ;
-  qudt:currencyNumber 170 ;
+  qudt:currencyNumber "170" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Colombian_peso"^^xsd:anyURI ;
   qudt:expression "$COP$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -484,7 +484,7 @@ cur:COU
   a qudt:CurrencyUnit ;
   qudt:currencyCode "COU" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 970 ;
+  qudt:currencyNumber "970" ;
   qudt:expression "$COU$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -495,7 +495,7 @@ cur:CRC
   a qudt:CurrencyUnit ;
   qudt:currencyCode "CRC" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 188 ;
+  qudt:currencyNumber "188" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Costa_Rican_col%C3%B3n"^^xsd:anyURI ;
   qudt:expression "$CRC$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -508,7 +508,7 @@ cur:CUP
   a qudt:CurrencyUnit ;
   qudt:currencyCode "CUP" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 192 ;
+  qudt:currencyNumber "192" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Cuban_peso"^^xsd:anyURI ;
   qudt:expression "$CUP$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -521,7 +521,7 @@ cur:CVE
   a qudt:CurrencyUnit ;
   qudt:currencyCode "CVE" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 132 ;
+  qudt:currencyNumber "132" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Cape_Verdean_escudo"^^xsd:anyURI ;
   qudt:expression "$CVE$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -534,7 +534,7 @@ cur:CYP
   a qudt:CurrencyUnit ;
   qudt:currencyCode "CYP" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 196 ;
+  qudt:currencyNumber "196" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Cypriot_pound"^^xsd:anyURI ;
   qudt:expression "$CYP$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -547,7 +547,7 @@ cur:CZK
   a qudt:CurrencyUnit ;
   qudt:currencyCode "CZK" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 203 ;
+  qudt:currencyNumber "203" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Czech_koruna"^^xsd:anyURI ;
   qudt:expression "$CZK$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -561,7 +561,7 @@ cur:DJF
   a qudt:CurrencyUnit ;
   qudt:currencyCode "DJF" ;
   qudt:currencyExponent 0 ;
-  qudt:currencyNumber 262 ;
+  qudt:currencyNumber "262" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Djiboutian_franc"^^xsd:anyURI ;
   qudt:expression "$DJF$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -574,7 +574,7 @@ cur:DKK
   a qudt:CurrencyUnit ;
   qudt:currencyCode "DKK" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 208 ;
+  qudt:currencyNumber "208" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Danish_krone"^^xsd:anyURI ;
   qudt:expression "$DKK$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -588,7 +588,7 @@ cur:DOP
   a qudt:CurrencyUnit ;
   qudt:currencyCode "DOP" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 214 ;
+  qudt:currencyNumber "214" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Dominican_peso"^^xsd:anyURI ;
   qudt:expression "$DOP$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -601,7 +601,7 @@ cur:DZD
   a qudt:CurrencyUnit ;
   qudt:currencyCode "DZD" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 012 ;
+  qudt:currencyNumber "012" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Algerian_dinar"^^xsd:anyURI ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -613,7 +613,7 @@ cur:EEK
   a qudt:CurrencyUnit ;
   qudt:currencyCode "EEK" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 233 ;
+  qudt:currencyNumber "233" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Estonian_kroon"^^xsd:anyURI ;
   qudt:expression "$EEK$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -626,7 +626,7 @@ cur:EGP
   a qudt:CurrencyUnit ;
   qudt:currencyCode "EGP" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 818 ;
+  qudt:currencyNumber "818" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Egyptian_pound"^^xsd:anyURI ;
   qudt:expression "$EGP$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -639,7 +639,7 @@ cur:ERN
   a qudt:CurrencyUnit ;
   qudt:currencyCode "ERN" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 232 ;
+  qudt:currencyNumber "232" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Nakfa"^^xsd:anyURI ;
   qudt:expression "$ERN$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -652,7 +652,7 @@ cur:ETB
   a qudt:CurrencyUnit ;
   qudt:currencyCode "ETB" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 230 ;
+  qudt:currencyNumber "230" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Ethiopian_birr"^^xsd:anyURI ;
   qudt:expression "$ETB$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -665,7 +665,7 @@ cur:EUR
   a qudt:CurrencyUnit ;
   qudt:currencyCode "EUR" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 978 ;
+  qudt:currencyNumber "978" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Euro"^^xsd:anyURI ;
   qudt:expression "$EUR$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -680,7 +680,7 @@ cur:FJD
   a qudt:CurrencyUnit ;
   qudt:currencyCode "FJD" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 242 ;
+  qudt:currencyNumber "242" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Fijian_dollar"^^xsd:anyURI ;
   qudt:expression "$FJD$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -693,7 +693,7 @@ cur:FKP
   a qudt:CurrencyUnit ;
   qudt:currencyCode "FKP" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 238 ;
+  qudt:currencyNumber "238" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Falkland_Islands_pound"^^xsd:anyURI ;
   qudt:expression "$FKP$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -706,7 +706,7 @@ cur:GBP
   a qudt:CurrencyUnit ;
   qudt:currencyCode "GBP" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 826 ;
+  qudt:currencyNumber "826" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Pound_sterling"^^xsd:anyURI ;
   qudt:expression "$GBP$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -721,7 +721,7 @@ cur:GEL
   a qudt:CurrencyUnit ;
   qudt:currencyCode "GEL" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 981 ;
+  qudt:currencyNumber "981" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Lari"^^xsd:anyURI ;
   qudt:expression "$GEL$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -735,7 +735,7 @@ cur:GHS
   a qudt:CurrencyUnit ;
   qudt:currencyCode "GHS" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 936 ;
+  qudt:currencyNumber "936" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Ghanaian_cedi"^^xsd:anyURI ;
   qudt:expression "$GHS$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -748,7 +748,7 @@ cur:GIP
   a qudt:CurrencyUnit ;
   qudt:currencyCode "GIP" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 292 ;
+  qudt:currencyNumber "292" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Gibraltar_pound"^^xsd:anyURI ;
   qudt:expression "$GIP$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -761,7 +761,7 @@ cur:GMD
   a qudt:CurrencyUnit ;
   qudt:currencyCode "GMD" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 270 ;
+  qudt:currencyNumber "270" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Gambian_dalasi"^^xsd:anyURI ;
   qudt:expression "$GMD$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -774,7 +774,7 @@ cur:GNF
   a qudt:CurrencyUnit ;
   qudt:currencyCode "GNF" ;
   qudt:currencyExponent 0 ;
-  qudt:currencyNumber 324 ;
+  qudt:currencyNumber "324" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Guinean_franc"^^xsd:anyURI ;
   qudt:expression "$GNF$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -787,7 +787,7 @@ cur:GTQ
   a qudt:CurrencyUnit ;
   qudt:currencyCode "GTQ" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 320 ;
+  qudt:currencyNumber "320" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Quetzal"^^xsd:anyURI ;
   qudt:expression "$GTQ$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -800,7 +800,7 @@ cur:GYD
   a qudt:CurrencyUnit ;
   qudt:currencyCode "GYD" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 328 ;
+  qudt:currencyNumber "328" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Guyanese_dollar"^^xsd:anyURI ;
   qudt:expression "$GYD$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -813,7 +813,7 @@ cur:HKD
   a qudt:CurrencyUnit ;
   qudt:currencyCode "HKD" ;
   qudt:currencyExponent 1 ;
-  qudt:currencyNumber 344 ;
+  qudt:currencyNumber "344" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Hong_Kong_dollar"^^xsd:anyURI ;
   qudt:expression "$HKD$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -828,7 +828,7 @@ cur:HNL
   a qudt:CurrencyUnit ;
   qudt:currencyCode "HNL" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 340 ;
+  qudt:currencyNumber "340" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Lempira"^^xsd:anyURI ;
   qudt:expression "$HNL$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -841,7 +841,7 @@ cur:HRK
   a qudt:CurrencyUnit ;
   qudt:currencyCode "HRK" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 191 ;
+  qudt:currencyNumber "191" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Croatian_kuna"^^xsd:anyURI ;
   qudt:expression "$HRK$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -854,7 +854,7 @@ cur:HTG
   a qudt:CurrencyUnit ;
   qudt:currencyCode "HTG" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 332 ;
+  qudt:currencyNumber "332" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Haitian_gourde"^^xsd:anyURI ;
   qudt:expression "$HTG$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -867,7 +867,7 @@ cur:HUF
   a qudt:CurrencyUnit ;
   qudt:currencyCode "HUF" ;
   qudt:currencyExponent 0 ;
-  qudt:currencyNumber 348 ;
+  qudt:currencyNumber "348" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Hungarian_forint"^^xsd:anyURI ;
   qudt:expression "$HUF$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -881,7 +881,7 @@ cur:IDR
   a qudt:CurrencyUnit ;
   qudt:currencyCode "IDR" ;
   qudt:currencyExponent 0 ;
-  qudt:currencyNumber 360 ;
+  qudt:currencyNumber "360" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Indonesian_rupiah"^^xsd:anyURI ;
   qudt:expression "$IDR$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -895,7 +895,7 @@ cur:ILS
   a qudt:CurrencyUnit ;
   qudt:currencyCode "ILS" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 376 ;
+  qudt:currencyNumber "376" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Israeli_new_sheqel"^^xsd:anyURI ;
   qudt:expression "$ILS$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -909,7 +909,7 @@ cur:INR
   a qudt:CurrencyUnit ;
   qudt:currencyCode "INR" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 356 ;
+  qudt:currencyNumber "356" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Indian_rupee"^^xsd:anyURI ;
   qudt:expression "$INR$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -924,7 +924,7 @@ cur:IQD
   a qudt:CurrencyUnit ;
   qudt:currencyCode "IQD" ;
   qudt:currencyExponent 0 ;
-  qudt:currencyNumber 368 ;
+  qudt:currencyNumber "368" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Iraqi_dinar"^^xsd:anyURI ;
   qudt:expression "$IQD$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -937,7 +937,7 @@ cur:IRR
   a qudt:CurrencyUnit ;
   qudt:currencyCode "IRR" ;
   qudt:currencyExponent 0 ;
-  qudt:currencyNumber 364 ;
+  qudt:currencyNumber "364" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Iranian_rial"^^xsd:anyURI ;
   qudt:expression "$IRR$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -950,7 +950,7 @@ cur:ISK
   a qudt:CurrencyUnit ;
   qudt:currencyCode "ISK" ;
   qudt:currencyExponent 0 ;
-  qudt:currencyNumber 352 ;
+  qudt:currencyNumber "352" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Icelandic_kr%C3%B3na"^^xsd:anyURI ;
   qudt:expression "$ISK$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -964,7 +964,7 @@ cur:JMD
   a qudt:CurrencyUnit ;
   qudt:currencyCode "JMD" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 388 ;
+  qudt:currencyNumber "388" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Jamaican_dollar"^^xsd:anyURI ;
   qudt:expression "$JMD$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -977,7 +977,7 @@ cur:JOD
   a qudt:CurrencyUnit ;
   qudt:currencyCode "JOD" ;
   qudt:currencyExponent 3 ;
-  qudt:currencyNumber 400 ;
+  qudt:currencyNumber "400" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Jordanian_dinar"^^xsd:anyURI ;
   qudt:expression "$JOD$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -990,7 +990,7 @@ cur:JPY
   a qudt:CurrencyUnit ;
   qudt:currencyCode "JPY" ;
   qudt:currencyExponent 0 ;
-  qudt:currencyNumber 392 ;
+  qudt:currencyNumber "392" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Japanese_yen"^^xsd:anyURI ;
   qudt:expression "$JPY$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1005,7 +1005,7 @@ cur:KES
   a qudt:CurrencyUnit ;
   qudt:currencyCode "KES" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 404 ;
+  qudt:currencyNumber "404" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Kenyan_shilling"^^xsd:anyURI ;
   qudt:expression "$KES$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1018,7 +1018,7 @@ cur:KGS
   a qudt:CurrencyUnit ;
   qudt:currencyCode "KGS" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 417 ;
+  qudt:currencyNumber "417" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Som"^^xsd:anyURI ;
   qudt:expression "$KGS$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1031,7 +1031,7 @@ cur:KHR
   a qudt:CurrencyUnit ;
   qudt:currencyCode "KHR" ;
   qudt:currencyExponent 0 ;
-  qudt:currencyNumber 116 ;
+  qudt:currencyNumber "116" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Riel"^^xsd:anyURI ;
   qudt:expression "$KHR$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1044,7 +1044,7 @@ cur:KMF
   a qudt:CurrencyUnit ;
   qudt:currencyCode "KMF" ;
   qudt:currencyExponent 0 ;
-  qudt:currencyNumber 174 ;
+  qudt:currencyNumber "174" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Comorian_franc"^^xsd:anyURI ;
   qudt:expression "$KMF$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1057,7 +1057,7 @@ cur:KPW
   a qudt:CurrencyUnit ;
   qudt:currencyCode "KPW" ;
   qudt:currencyExponent 0 ;
-  qudt:currencyNumber 408 ;
+  qudt:currencyNumber "408" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/North_Korean_won"^^xsd:anyURI ;
   qudt:expression "$KPW$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1070,7 +1070,7 @@ cur:KRW
   a qudt:CurrencyUnit ;
   qudt:currencyCode "KRW" ;
   qudt:currencyExponent 0 ;
-  qudt:currencyNumber 410 ;
+  qudt:currencyNumber "410" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/South_Korean_won"^^xsd:anyURI ;
   qudt:expression "$KRW$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1085,7 +1085,7 @@ cur:KWD
   a qudt:CurrencyUnit ;
   qudt:currencyCode "KWD" ;
   qudt:currencyExponent 3 ;
-  qudt:currencyNumber 414 ;
+  qudt:currencyNumber "414" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Kuwaiti_dinar"^^xsd:anyURI ;
   qudt:expression "$KWD$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1098,7 +1098,7 @@ cur:KYD
   a qudt:CurrencyUnit ;
   qudt:currencyCode "KYD" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 136 ;
+  qudt:currencyNumber "136" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Cayman_Islands_dollar"^^xsd:anyURI ;
   qudt:expression "$KYD$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1111,7 +1111,7 @@ cur:KZT
   a qudt:CurrencyUnit ;
   qudt:currencyCode "KZT" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 398 ;
+  qudt:currencyNumber "398" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Kazakhstani_tenge"^^xsd:anyURI ;
   qudt:expression "$KZT$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1124,7 +1124,7 @@ cur:LAK
   a qudt:CurrencyUnit ;
   qudt:currencyCode "LAK" ;
   qudt:currencyExponent 0 ;
-  qudt:currencyNumber 418 ;
+  qudt:currencyNumber "418" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
   qudt:symbol " ₭" ;
@@ -1135,7 +1135,7 @@ cur:LBP
   a qudt:CurrencyUnit ;
   qudt:currencyCode "LBP" ;
   qudt:currencyExponent 0 ;
-  qudt:currencyNumber 422 ;
+  qudt:currencyNumber "422" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Lebanese_pound"^^xsd:anyURI ;
   qudt:expression "$LBP$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1148,7 +1148,7 @@ cur:LKR
   a qudt:CurrencyUnit ;
   qudt:currencyCode "LKR" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 144 ;
+  qudt:currencyNumber "144" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Sri_Lankan_rupee"^^xsd:anyURI ;
   qudt:expression "$LKR$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1161,7 +1161,7 @@ cur:LRD
   a qudt:CurrencyUnit ;
   qudt:currencyCode "LRD" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 430 ;
+  qudt:currencyNumber "430" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Liberian_dollar"^^xsd:anyURI ;
   qudt:expression "$LRD$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1174,7 +1174,7 @@ cur:LSL
   a qudt:CurrencyUnit ;
   qudt:currencyCode "LSL" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 426 ;
+  qudt:currencyNumber "426" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Loti"^^xsd:anyURI ;
   qudt:expression "$LSL$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1187,7 +1187,7 @@ cur:LTL
   a qudt:CurrencyUnit ;
   qudt:currencyCode "LTL" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 440 ;
+  qudt:currencyNumber "440" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Lithuanian_litas"^^xsd:anyURI ;
   qudt:expression "$LTL$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1200,7 +1200,7 @@ cur:LVL
   a qudt:CurrencyUnit ;
   qudt:currencyCode "LVL" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 428 ;
+  qudt:currencyNumber "428" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Latvian_lats"^^xsd:anyURI ;
   qudt:expression "$LVL$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1213,7 +1213,7 @@ cur:LYD
   a qudt:CurrencyUnit ;
   qudt:currencyCode "LYD" ;
   qudt:currencyExponent 3 ;
-  qudt:currencyNumber 434 ;
+  qudt:currencyNumber "434" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Libyan_dinar"^^xsd:anyURI ;
   qudt:expression "$LYD$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1226,7 +1226,7 @@ cur:MAD
   a qudt:CurrencyUnit ;
   qudt:currencyCode "MAD" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 504 ;
+  qudt:currencyNumber "504" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Moroccan_dirham"^^xsd:anyURI ;
   qudt:expression "$MAD$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1239,7 +1239,7 @@ cur:MDL
   a qudt:CurrencyUnit ;
   qudt:currencyCode "MDL" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 498 ;
+  qudt:currencyNumber "498" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Moldovan_leu"^^xsd:anyURI ;
   qudt:expression "$MDL$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1253,7 +1253,7 @@ cur:MGA
   a qudt:CurrencyUnit ;
   qudt:currencyCode "MGA" ;
   qudt:currencyExponent 0 ;
-  qudt:currencyNumber 969 ;
+  qudt:currencyNumber "969" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Malagasy_ariary"^^xsd:anyURI ;
   qudt:expression "$MGA$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1266,7 +1266,7 @@ cur:MKD
   a qudt:CurrencyUnit ;
   qudt:currencyCode "MKD" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 807 ;
+  qudt:currencyNumber "807" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Macedonian_denar"^^xsd:anyURI ;
   qudt:expression "$MKD$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1280,7 +1280,7 @@ cur:MMK
   a qudt:CurrencyUnit ;
   qudt:currencyCode "MMK" ;
   qudt:currencyExponent 0 ;
-  qudt:currencyNumber 104 ;
+  qudt:currencyNumber "104" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Myanma_kyat"^^xsd:anyURI ;
   qudt:expression "$MMK$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1303,7 +1303,7 @@ cur:MOP
   a qudt:CurrencyUnit ;
   qudt:currencyCode "MOP" ;
   qudt:currencyExponent 1 ;
-  qudt:currencyNumber 446 ;
+  qudt:currencyNumber "446" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Pataca"^^xsd:anyURI ;
   qudt:expression "$MOP$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1316,7 +1316,7 @@ cur:MRU
   a qudt:CurrencyUnit ;
   qudt:currencyCode "MRU" ;
   qudt:currencyExponent 0 ;
-  qudt:currencyNumber 929 ;
+  qudt:currencyNumber "929" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Mauritanian_ouguiya"^^xsd:anyURI ;
   qudt:expression "$MRO$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1328,7 +1328,7 @@ cur:MRU
 cur:MTL
   a qudt:CurrencyUnit ;
   qudt:currencyCode "MTL" ;
-  qudt:currencyNumber 470 ;
+  qudt:currencyNumber "470" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Maltese_lira"^^xsd:anyURI ;
   qudt:expression "$MTL$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1341,7 +1341,7 @@ cur:MUR
   a qudt:CurrencyUnit ;
   qudt:currencyCode "MUR" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 480 ;
+  qudt:currencyNumber "480" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Mauritian_rupee"^^xsd:anyURI ;
   qudt:expression "$MUR$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1354,7 +1354,7 @@ cur:MVR
   a qudt:CurrencyUnit ;
   qudt:currencyCode "MVR" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 462 ;
+  qudt:currencyNumber "462" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Maldivian_rufiyaa"^^xsd:anyURI ;
   qudt:expression "$MVR$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1367,7 +1367,7 @@ cur:MWK
   a qudt:CurrencyUnit ;
   qudt:currencyCode "MWK" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 454 ;
+  qudt:currencyNumber "454" ;
   qudt:expression "$MWK$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1378,7 +1378,7 @@ cur:MXN
   a qudt:CurrencyUnit ;
   qudt:currencyCode "MXN" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 484 ;
+  qudt:currencyNumber "484" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Mexican_peso"^^xsd:anyURI ;
   qudt:expression "$MXN$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1393,7 +1393,7 @@ cur:MXV
   a qudt:CurrencyUnit ;
   qudt:currencyCode "MXV" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 979 ;
+  qudt:currencyNumber "979" ;
   qudt:expression "$MXV$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1404,7 +1404,7 @@ cur:MYR
   a qudt:CurrencyUnit ;
   qudt:currencyCode "MYR" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 458 ;
+  qudt:currencyNumber "458" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Malaysian_ringgit"^^xsd:anyURI ;
   qudt:expression "$MYR$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1418,7 +1418,7 @@ cur:MZN
   a qudt:CurrencyUnit ;
   qudt:currencyCode "MZN" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 943 ;
+  qudt:currencyNumber "943" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Mozambican_metical"^^xsd:anyURI ;
   qudt:expression "$MZN$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1441,7 +1441,7 @@ cur:NAD
   a qudt:CurrencyUnit ;
   qudt:currencyCode "NAD" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 516 ;
+  qudt:currencyNumber "516" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Namibian_dollar"^^xsd:anyURI ;
   qudt:expression "$NAD$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1454,7 +1454,7 @@ cur:NGN
   a qudt:CurrencyUnit ;
   qudt:currencyCode "NGN" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 566 ;
+  qudt:currencyNumber "566" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Nigerian_naira"^^xsd:anyURI ;
   qudt:expression "$NGN$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1467,7 +1467,7 @@ cur:NIO
   a qudt:CurrencyUnit ;
   qudt:currencyCode "NIO" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 558 ;
+  qudt:currencyNumber "558" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Nicaraguan_c%C3%B3rdoba"^^xsd:anyURI ;
   qudt:expression "$NIO$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1480,7 +1480,7 @@ cur:NOK
   a qudt:CurrencyUnit ;
   qudt:currencyCode "NOK" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 578 ;
+  qudt:currencyNumber "578" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Norwegian_krone"^^xsd:anyURI ;
   qudt:expression "$NOK$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1495,7 +1495,7 @@ cur:NPR
   a qudt:CurrencyUnit ;
   qudt:currencyCode "NPR" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 524 ;
+  qudt:currencyNumber "524" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Nepalese_rupee"^^xsd:anyURI ;
   qudt:expression "$NPR$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1508,7 +1508,7 @@ cur:NZD
   a qudt:CurrencyUnit ;
   qudt:currencyCode "NZD" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 554 ;
+  qudt:currencyNumber "554" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/New_Zealand_dollar"^^xsd:anyURI ;
   qudt:expression "$NZD$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1523,7 +1523,7 @@ cur:OMR
   a qudt:CurrencyUnit ;
   qudt:currencyCode "OMR" ;
   qudt:currencyExponent 3 ;
-  qudt:currencyNumber 512 ;
+  qudt:currencyNumber "512" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Omani_rial"^^xsd:anyURI ;
   qudt:expression "$OMR$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1536,7 +1536,7 @@ cur:PAB
   a qudt:CurrencyUnit ;
   qudt:currencyCode "PAB" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 590 ;
+  qudt:currencyNumber "590" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Balboa"^^xsd:anyURI ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1548,7 +1548,7 @@ cur:PEN
   a qudt:CurrencyUnit ;
   qudt:currencyCode "PEN" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 604 ;
+  qudt:currencyNumber "604" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Peruvian_nuevo_sol"^^xsd:anyURI ;
   qudt:expression "$PEN$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1561,7 +1561,7 @@ cur:PGK
   a qudt:CurrencyUnit ;
   qudt:currencyCode "PGK" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 598 ;
+  qudt:currencyNumber "598" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Kina"^^xsd:anyURI ;
   qudt:expression "$PGK$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1574,7 +1574,7 @@ cur:PHP
   a qudt:CurrencyUnit ;
   qudt:currencyCode "PHP" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 608 ;
+  qudt:currencyNumber "608" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Philippine_peso"^^xsd:anyURI ;
   qudt:expression "$PHP$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1588,7 +1588,7 @@ cur:PKR
   a qudt:CurrencyUnit ;
   qudt:currencyCode "PKR" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 586 ;
+  qudt:currencyNumber "586" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Pakistani_rupee"^^xsd:anyURI ;
   qudt:expression "$PKR$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1601,7 +1601,7 @@ cur:PLN
   a qudt:CurrencyUnit ;
   qudt:currencyCode "PLN" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 985 ;
+  qudt:currencyNumber "985" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Polish_z%C5%82oty"^^xsd:anyURI ;
   qudt:expression "$PLN$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1615,7 +1615,7 @@ cur:PYG
   a qudt:CurrencyUnit ;
   qudt:currencyCode "PYG" ;
   qudt:currencyExponent 0 ;
-  qudt:currencyNumber 600 ;
+  qudt:currencyNumber "600" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Guaran%C3%AD"^^xsd:anyURI ;
   qudt:expression "$PYG$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1628,7 +1628,7 @@ cur:QAR
   a qudt:CurrencyUnit ;
   qudt:currencyCode "QAR" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 634 ;
+  qudt:currencyNumber "634" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Qatari_riyal"^^xsd:anyURI ;
   qudt:expression "$QAR$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1641,7 +1641,7 @@ cur:RON
   a qudt:CurrencyUnit ;
   qudt:currencyCode "RON" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 946 ;
+  qudt:currencyNumber "946" ;
   qudt:expression "$RON$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1653,7 +1653,7 @@ cur:RSD
   a qudt:CurrencyUnit ;
   qudt:currencyCode "RSD" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 941 ;
+  qudt:currencyNumber "941" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Serbian_dinar"^^xsd:anyURI ;
   qudt:expression "$RSD$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1667,7 +1667,7 @@ cur:RUB
   a qudt:CurrencyUnit ;
   qudt:currencyCode "RUB" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 643 ;
+  qudt:currencyNumber "643" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Russian_ruble"^^xsd:anyURI ;
   qudt:expression "$RUB$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1681,7 +1681,7 @@ cur:RWF
   a qudt:CurrencyUnit ;
   qudt:currencyCode "RWF" ;
   qudt:currencyExponent 0 ;
-  qudt:currencyNumber 646 ;
+  qudt:currencyNumber "646" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Rwandan_franc"^^xsd:anyURI ;
   qudt:expression "$RWF$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1694,7 +1694,7 @@ cur:SAR
   a qudt:CurrencyUnit ;
   qudt:currencyCode "SAR" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 682 ;
+  qudt:currencyNumber "682" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Saudi_riyal"^^xsd:anyURI ;
   qudt:expression "$SAR$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1708,7 +1708,7 @@ cur:SBD
   a qudt:CurrencyUnit ;
   qudt:currencyCode "SBD" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 090 ;
+  qudt:currencyNumber "090" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Solomon_Islands_dollar"^^xsd:anyURI ;
   qudt:expression "$SBD$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1721,7 +1721,7 @@ cur:SCR
   a qudt:CurrencyUnit ;
   qudt:currencyCode "SCR" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 690 ;
+  qudt:currencyNumber "690" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Seychellois_rupee"^^xsd:anyURI ;
   qudt:expression "$SCR$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1734,7 +1734,7 @@ cur:SDG
   a qudt:CurrencyUnit ;
   qudt:currencyCode "SDG" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 938 ;
+  qudt:currencyNumber "938" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Sudanese_pound"^^xsd:anyURI ;
   qudt:expression "$SDG$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1747,7 +1747,7 @@ cur:SEK
   a qudt:CurrencyUnit ;
   qudt:currencyCode "SEK" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 752 ;
+  qudt:currencyNumber "752" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Swedish_krona"^^xsd:anyURI ;
   qudt:expression "$SEK$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1762,7 +1762,7 @@ cur:SGD
   a qudt:CurrencyUnit ;
   qudt:currencyCode "SGD" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 702 ;
+  qudt:currencyNumber "702" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Singapore_dollar"^^xsd:anyURI ;
   qudt:expression "$SGD$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1777,7 +1777,7 @@ cur:SHP
   a qudt:CurrencyUnit ;
   qudt:currencyCode "SHP" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 654 ;
+  qudt:currencyNumber "654" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Saint_Helena_pound"^^xsd:anyURI ;
   qudt:expression "$SHP$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1789,7 +1789,7 @@ cur:SHP
 cur:SKK
   a qudt:CurrencyUnit ;
   qudt:currencyCode "SKK" ;
-  qudt:currencyNumber 703 ;
+  qudt:currencyNumber "703" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Slovak_koruna"^^xsd:anyURI ;
   qudt:expression "$SKK$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1803,7 +1803,7 @@ cur:SLE
   a qudt:CurrencyUnit ;
   qudt:currencyCode "SLE" ;
   qudt:currencyExponent 0 ;
-  qudt:currencyNumber 925 ;
+  qudt:currencyNumber "925" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Sierra_Leonean_leone"^^xsd:anyURI ;
   qudt:expression "$SLL$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1816,7 +1816,7 @@ cur:SOS
   a qudt:CurrencyUnit ;
   qudt:currencyCode "SOS" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 706 ;
+  qudt:currencyNumber "706" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Somali_shilling"^^xsd:anyURI ;
   qudt:expression "$SOS$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1829,7 +1829,7 @@ cur:SRD
   a qudt:CurrencyUnit ;
   qudt:currencyCode "SRD" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 968 ;
+  qudt:currencyNumber "968" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Surinamese_dollar"^^xsd:anyURI ;
   qudt:expression "$SRD$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1842,7 +1842,7 @@ cur:STN
   a qudt:CurrencyUnit ;
   qudt:currencyCode "STN" ;
   qudt:currencyExponent 0 ;
-  qudt:currencyNumber 930 ;
+  qudt:currencyNumber "930" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Dobra"^^xsd:anyURI ;
   qudt:expression "$STD$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1855,7 +1855,7 @@ cur:SYP
   a qudt:CurrencyUnit ;
   qudt:currencyCode "SYP" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 760 ;
+  qudt:currencyNumber "760" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Syrian_pound"^^xsd:anyURI ;
   qudt:expression "$SYP$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1868,7 +1868,7 @@ cur:SZL
   a qudt:CurrencyUnit ;
   qudt:currencyCode "SZL" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 748 ;
+  qudt:currencyNumber "748" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Swazi_lilangeni"^^xsd:anyURI ;
   qudt:expression "$SZL$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1881,7 +1881,7 @@ cur:THB
   a qudt:CurrencyUnit ;
   qudt:currencyCode "THB" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 764 ;
+  qudt:currencyNumber "764" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Thai_baht"^^xsd:anyURI ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1894,7 +1894,7 @@ cur:TJS
   a qudt:CurrencyUnit ;
   qudt:currencyCode "TJS" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 972 ;
+  qudt:currencyNumber "972" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Tajikistani_somoni"^^xsd:anyURI ;
   qudt:expression "$TJS$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1907,7 +1907,7 @@ cur:TMT
   a qudt:CurrencyUnit ;
   qudt:currencyCode "TMT" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 934 ;
+  qudt:currencyNumber "934" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Manat"^^xsd:anyURI ;
   qudt:expression "$TMM$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1920,7 +1920,7 @@ cur:TND
   a qudt:CurrencyUnit ;
   qudt:currencyCode "TND" ;
   qudt:currencyExponent 3 ;
-  qudt:currencyNumber 788 ;
+  qudt:currencyNumber "788" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Tunisian_dinar"^^xsd:anyURI ;
   qudt:expression "$TND$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1933,7 +1933,7 @@ cur:TOP
   a qudt:CurrencyUnit ;
   qudt:currencyCode "TOP" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 776 ;
+  qudt:currencyNumber "776" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Tongan_pa%CA%BBanga"^^xsd:anyURI ;
   qudt:expression "$TOP$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1946,7 +1946,7 @@ cur:TRY
   a qudt:CurrencyUnit ;
   qudt:currencyCode "TRY" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 949 ;
+  qudt:currencyNumber "949" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Turkish_lira"^^xsd:anyURI ;
   qudt:expression "$TRY$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1960,7 +1960,7 @@ cur:TTD
   a qudt:CurrencyUnit ;
   qudt:currencyCode "TTD" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 780 ;
+  qudt:currencyNumber "780" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Trinidad_and_Tobago_dollar"^^xsd:anyURI ;
   qudt:expression "$TTD$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1973,7 +1973,7 @@ cur:TWD
   a qudt:CurrencyUnit ;
   qudt:currencyCode "TWD" ;
   qudt:currencyExponent 1 ;
-  qudt:currencyNumber 901 ;
+  qudt:currencyNumber "901" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/New_Taiwan_dollar"^^xsd:anyURI ;
   qudt:expression "$TWD$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -1987,7 +1987,7 @@ cur:TZS
   a qudt:CurrencyUnit ;
   qudt:currencyCode "TZS" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 834 ;
+  qudt:currencyNumber "834" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Tanzanian_shilling"^^xsd:anyURI ;
   qudt:expression "$TZS$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -2000,7 +2000,7 @@ cur:UAH
   a qudt:CurrencyUnit ;
   qudt:currencyCode "UAH" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 980 ;
+  qudt:currencyNumber "980" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Ukrainian_hryvnia"^^xsd:anyURI ;
   qudt:expression "$UAH$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -2014,7 +2014,7 @@ cur:UGX
   a qudt:CurrencyUnit ;
   qudt:currencyCode "UGX" ;
   qudt:currencyExponent 0 ;
-  qudt:currencyNumber 800 ;
+  qudt:currencyNumber "800" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Ugandan_shilling"^^xsd:anyURI ;
   qudt:expression "$UGX$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -2027,7 +2027,7 @@ cur:USD
   a qudt:CurrencyUnit ;
   qudt:currencyCode "USD" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 840 ;
+  qudt:currencyNumber "840" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
   qudt:symbol "$" ;
@@ -2039,7 +2039,7 @@ cur:USN
   a qudt:CurrencyUnit ;
   qudt:currencyCode "USN" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 997 ;
+  qudt:currencyNumber "997" ;
   qudt:expression "$USN$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -2050,7 +2050,7 @@ cur:USS
   a qudt:CurrencyUnit ;
   qudt:currencyCode "USS" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 998 ;
+  qudt:currencyNumber "998" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/currency> ;
@@ -2060,7 +2060,7 @@ cur:UYU
   a qudt:CurrencyUnit ;
   qudt:currencyCode "UYU" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 858 ;
+  qudt:currencyNumber "858" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Uruguayan_peso"^^xsd:anyURI ;
   qudt:expression "$UYU$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -2073,7 +2073,7 @@ cur:UZS
   a qudt:CurrencyUnit ;
   qudt:currencyCode "UZS" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 860 ;
+  qudt:currencyNumber "860" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Uzbekistani_som"^^xsd:anyURI ;
   qudt:expression "$UZS$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -2086,7 +2086,7 @@ cur:VES
   a qudt:CurrencyUnit ;
   qudt:currencyCode "VES" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 928 ;
+  qudt:currencyNumber "928" ;
   qudt:expression "$VEB$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -2097,7 +2097,7 @@ cur:VND
   a qudt:CurrencyUnit ;
   qudt:currencyCode "VND" ;
   qudt:currencyExponent 0 ;
-  qudt:currencyNumber 704 ;
+  qudt:currencyNumber "704" ;
   qudt:expression "$VND$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -2108,7 +2108,7 @@ cur:VUV
   a qudt:CurrencyUnit ;
   qudt:currencyCode "VUV" ;
   qudt:currencyExponent 0 ;
-  qudt:currencyNumber 548 ;
+  qudt:currencyNumber "548" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Vanuatu_vatu"^^xsd:anyURI ;
   qudt:expression "$VUV$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -2121,7 +2121,7 @@ cur:WST
   a qudt:CurrencyUnit ;
   qudt:currencyCode "WST" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 882 ;
+  qudt:currencyNumber "882" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Samoan_tala"^^xsd:anyURI ;
   qudt:expression "$WST$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -2134,7 +2134,7 @@ cur:XAF
   a qudt:CurrencyUnit ;
   qudt:currencyCode "XAF" ;
   qudt:currencyExponent 0 ;
-  qudt:currencyNumber 950 ;
+  qudt:currencyNumber "950" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/currency> ;
@@ -2143,7 +2143,7 @@ cur:XAF
 cur:XAG
   a qudt:CurrencyUnit ;
   qudt:currencyCode "XAG" ;
-  qudt:currencyNumber 961 ;
+  qudt:currencyNumber "961" ;
   qudt:expression "$XAG$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -2154,7 +2154,7 @@ cur:XAG
 cur:XAU
   a qudt:CurrencyUnit ;
   qudt:currencyCode "XAU" ;
-  qudt:currencyNumber 959 ;
+  qudt:currencyNumber "959" ;
   qudt:expression "$XAU$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -2165,7 +2165,7 @@ cur:XAU
 cur:XBA
   a qudt:CurrencyUnit ;
   qudt:currencyCode "XBA" ;
-  qudt:currencyNumber 955 ;
+  qudt:currencyNumber "955" ;
   qudt:expression "$XBA$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -2175,7 +2175,7 @@ cur:XBA
 cur:XBB
   a qudt:CurrencyUnit ;
   qudt:currencyCode "XBB" ;
-  qudt:currencyNumber 956 ;
+  qudt:currencyNumber "956" ;
   qudt:expression "$XBB$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -2185,7 +2185,7 @@ cur:XBB
 cur:XBC
   a qudt:CurrencyUnit ;
   qudt:currencyCode "XBC" ;
-  qudt:currencyNumber 957 ;
+  qudt:currencyNumber "957" ;
   qudt:expression "$XBC$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -2195,7 +2195,7 @@ cur:XBC
 cur:XBD
   a qudt:CurrencyUnit ;
   qudt:currencyCode "XBD" ;
-  qudt:currencyNumber 958 ;
+  qudt:currencyNumber "958" ;
   qudt:expression "$XBD$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -2206,7 +2206,7 @@ cur:XCD
   a qudt:CurrencyUnit ;
   qudt:currencyCode "XCD" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 951 ;
+  qudt:currencyNumber "951" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/East_Caribbean_dollar"^^xsd:anyURI ;
   qudt:expression "$XCD$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -2218,7 +2218,7 @@ cur:XCD
 cur:XDR
   a qudt:CurrencyUnit ;
   qudt:currencyCode "XDR" ;
-  qudt:currencyNumber 960 ;
+  qudt:currencyNumber "960" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Special_Drawing_Rights"^^xsd:anyURI ;
   qudt:expression "$XDR$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -2249,7 +2249,7 @@ cur:XOF
   a qudt:CurrencyUnit ;
   qudt:currencyCode "XOF" ;
   qudt:currencyExponent 0 ;
-  qudt:currencyNumber 952 ;
+  qudt:currencyNumber "952" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/currency> ;
@@ -2258,7 +2258,7 @@ cur:XOF
 cur:XPD
   a qudt:CurrencyUnit ;
   qudt:currencyCode "XPD" ;
-  qudt:currencyNumber 964 ;
+  qudt:currencyNumber "964" ;
   qudt:expression "$XPD$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -2270,7 +2270,7 @@ cur:XPF
   a qudt:CurrencyUnit ;
   qudt:currencyCode "XPF" ;
   qudt:currencyExponent 0 ;
-  qudt:currencyNumber 953 ;
+  qudt:currencyNumber "953" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/currency> ;
@@ -2279,7 +2279,7 @@ cur:XPF
 cur:XPT
   a qudt:CurrencyUnit ;
   qudt:currencyCode "XPT" ;
-  qudt:currencyNumber 962 ;
+  qudt:currencyNumber "962" ;
   qudt:expression "$XPT$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -2291,7 +2291,7 @@ cur:YER
   a qudt:CurrencyUnit ;
   qudt:currencyCode "YER" ;
   qudt:currencyExponent 0 ;
-  qudt:currencyNumber 886 ;
+  qudt:currencyNumber "886" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Yemeni_rial"^^xsd:anyURI ;
   qudt:expression "$YER$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -2304,7 +2304,7 @@ cur:ZAR
   a qudt:CurrencyUnit ;
   qudt:currencyCode "ZAR" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 710 ;
+  qudt:currencyNumber "710" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/South_African_rand"^^xsd:anyURI ;
   qudt:expression "$ZAR$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -2319,7 +2319,7 @@ cur:ZMW
   a qudt:CurrencyUnit ;
   qudt:currencyCode "ZMW" ;
   qudt:currencyExponent 0 ;
-  qudt:currencyNumber 967 ;
+  qudt:currencyNumber "967" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Zambian_kwacha"^^xsd:anyURI ;
   qudt:expression "$ZMK$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
@@ -2332,7 +2332,7 @@ cur:ZWL
   a qudt:CurrencyUnit ;
   qudt:currencyCode "ZWL" ;
   qudt:currencyExponent 2 ;
-  qudt:currencyNumber 932 ;
+  qudt:currencyNumber "932" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Zimbabwean_dollar"^^xsd:anyURI ;
   qudt:expression "$ZWD$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;


### PR DESCRIPTION
Change the type from xsd:integer to xsd:string and enforce the pattern "^\\d{3}$" (three digits).

Fixes #973 