### PR TITLE
Replace `hr` with `h` in all units' symbol, expression, or description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
 - Changed the erroneously used 'qudt:hasDimensionVector' property in `vocab/types/VOCAB_QUDT_DATATYPES-v2.1.ttl`
   file with with a new property qudt:dimensions that denotes the dimensions of a matrix.
 - Introduced a maven based build process to automate the manual tasks required for merging PRs and making releases. 
-  This change does not affect the content of the ontologies.  
+  This change does not affect the content of the ontologies.
+- Replaced (hopefully) all occurrences of `hr` as a symbol for `unit:HR` with `h`.
 
 ## [2.1.44] - 2024-10-27
 

--- a/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -111,7 +111,7 @@ unit:A-HR
   qudt:iec61360Code "0112/2///62720#UAA102" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Ampere-hour"^^xsd:anyURI ;
   qudt:informativeReference "http://www.oxfordreference.com/view/10.1093/acref/9780199233991.001.0001/acref-9780199233991-e-86"^^xsd:anyURI ;
-  qudt:symbol "A·hr" ;
+  qudt:symbol "A·h" ;
   qudt:ucumCode "A.h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "AMH" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -1595,7 +1595,7 @@ unit:BBL_UK_PET-PER-HR
   qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA332" ;
   qudt:plainTextDescription "unit of the volume barrel (UK petroleum) for crude oil according to the Imperial system of units divided by the unit hour" ;
-  qudt:symbol "bbl{UK petroleum}/hr" ;
+  qudt:symbol "bbl{UK petroleum}/h" ;
   qudt:uneceCommonCode "J60" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Barrel (UK Petroleum) per Hour"@en .
@@ -1712,7 +1712,7 @@ unit:BBL_US_PET-PER-HR
   qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA336" ;
   qudt:plainTextDescription "unit of the volume barrel (US petroleum) for crude oil according to the Anglo-American system of units divided by the unit hour" ;
-  qudt:symbol "bbl{UK petroleum}/hr" ;
+  qudt:symbol "bbl{UK petroleum}/h" ;
   qudt:ucumCode "[bbl_us].h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[bbl_us]/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J62" ;
@@ -2137,20 +2137,20 @@ unit:BTU_IT-FT-PER-FT2-HR-DEG_F
   a qudt:DerivedUnit, qudt:Unit ;
   dcterms:description """
   A $BTU_{IT}$, $\\italic{Foot per Square Foot Hour Degree Fahrenheit}$ is an Imperial unit for 'Thermal Conductivity',
-   expressed as $Btu_{it} \\cdot ft/(hr \\cdot ft^2  \\cdot degF)$.
+   expressed as $Btu_{it} \\cdot ft/(h \\cdot ft^2  \\cdot degF)$.
   """^^qudt:LatexString ;
   qudt:applicableSystem sou:IMPERIAL ;
   qudt:applicableSystem sou:USCS ;
   qudt:conversionMultiplier 1.730734666 ;
   qudt:conversionMultiplierSN 1.730734666E0 ;
-  qudt:expression "$Btu(IT) ft/(hr ft^2 degF)$"^^qudt:LatexString ;
+  qudt:expression "$Btu(IT) ft/(h ft^2 degF)$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H-1T-3D0 ;
   qudt:hasQuantityKind quantitykind:ThermalConductivity ;
   qudt:iec61360Code "0112/2///62720#UAA115" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Thermal_conductivity"^^xsd:anyURI ;
   qudt:informativeReference "http://www.translatorscafe.com/cafe/EN/units-converter/thermal-conductivity/c/"^^xsd:anyURI ;
   qudt:plainTextDescription "British thermal unit (international table) foot per hour Square foot degree Fahrenheit is the unit of the thermal conductivity according to the Imperial system of units." ;
-  qudt:symbol "Btu{IT}·ft/(ft²·hr·°F)" ;
+  qudt:symbol "Btu{IT}·ft/(ft²·h·°F)" ;
   qudt:ucumCode "[Btu_IT].[ft_i].[ft_i]-2.h-1.[degF]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_IT].[ft_i]/([ft_i]2.h.[degF])"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J40" ;
@@ -2180,23 +2180,23 @@ unit:BTU_IT-IN
 unit:BTU_IT-IN-PER-FT2-HR-DEG_F
   a qudt:DerivedUnit, qudt:Unit ;
   dcterms:description """
-  $BTU_{th}$ Inch per Square Foot Hour Degree Fahrenheit is an Imperial unit for 'Thermal Conductivity' expressed as $Btu_{it}-in/(hr-ft^{2}-degF)$. 
+  $BTU_{th}$ Inch per Square Foot Hour Degree Fahrenheit is an Imperial unit for 'Thermal Conductivity' expressed as $Btu_{it}-in/(h-ft^{2}-degF)$.
   An International British thermal unit inch per second per square foot per degree Fahrenheit is a unit of thermal conductivity in the US Customary Units and British Imperial Units. 
-  $1\\,Btu_{it} \\cdot in/(hr \\cdot ft^{2} \\cdot degF)$ shows that one thermochemical BTU of heat per one hour moves through one square foot of material, which is one foot thick due to a temperature difference of one degree Fahrenheit.
+  $1\\,Btu_{it} \\cdot in/(h \\cdot ft^{2} \\cdot degF)$ shows that one thermochemical BTU of heat per one hour moves through one square foot of material, which is one foot thick due to a temperature difference of one degree Fahrenheit.
   """^^qudt:LatexString ;
   qudt:applicableSystem sou:IMPERIAL ;
   qudt:applicableSystem sou:USCS ;
   qudt:conversionMultiplier 0.144227889 ;
   qudt:conversionMultiplierSN 1.44227889E-1 ;
   qudt:exactMatch unit:BTU_IT-IN-PER-HR-FT2-DEG_F ;
-  qudt:expression "$Btu(it)-in-per-hr-ft2-degF$"^^qudt:LatexString ;
+  qudt:expression "$Btu(it)-in-per-h-ft2-degF$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H-1T-3D0 ;
   qudt:hasQuantityKind quantitykind:ThermalConductivity ;
   qudt:iec61360Code "0112/2///62720#UAA117" ;
   qudt:informativeReference "http://www.translatorscafe.com/cafe/EN/units-converter/thermal-conductivity/c/"^^xsd:anyURI ;
-  qudt:latexSymbol "$Btu_{it} \\cdot in/(hr \\cdot ft^{2}  \\cdot degF)$"^^qudt:LatexString ;
+  qudt:latexSymbol "$Btu_{it} \\cdot in/(h \\cdot ft^{2}  \\cdot degF)$"^^qudt:LatexString ;
   qudt:plainTextDescription "BTU (th) Inch per Square Foot Hour Degree Fahrenheit is an Imperial unit for 'Thermal Conductivity', an International British thermal unit inch per second per square foot per degree Fahrenheit is a unit of thermal conductivity in the US Customary Units and British Imperial Units." ;
-  qudt:symbol "Btu{IT}·in/(ft²·hr·°F)" ;
+  qudt:symbol "Btu{IT}·in/(ft²·h·°F)" ;
   qudt:ucumCode "[Btu_IT].[in_i].[ft_i]-2.h-1.[degF]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_IT].[in_i]/([ft_i]2.h.[degF])"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J41" ;
@@ -2237,7 +2237,7 @@ unit:BTU_IT-IN-PER-HR-FT2-DEG_F
   qudt:hasQuantityKind quantitykind:ThermalConductivity ;
   qudt:iec61360Code "0112/2///62720#UAA117" ;
   qudt:plainTextDescription "unit of the thermal conductivity according to the Imperial system of units" ;
-  qudt:symbol "Btu{IT}·in/(hr·ft²·°F)" ;
+  qudt:symbol "Btu{IT}·in/(h·ft²·°F)" ;
   qudt:ucumCode "[Btu_IT].[in_i].h-1.[ft_i]-2.[degF]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_IT].[in_i]/(h.[ft_i]2.[degF])"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J41" ;
@@ -2343,7 +2343,7 @@ unit:BTU_IT-PER-FT2-HR
 
 unit:BTU_IT-PER-FT2-HR-DEG_F
   a qudt:DerivedUnit, qudt:Unit ;
-  dcterms:description """$\\textit{BTU per Square Foot Hour Degree Fahrenheit}$ is an Imperial unit for 'Coefficient Of Heat Transfer' expressed as $Btu/(hr-ft^{2}-degF)$.
+  dcterms:description """$\\textit{BTU per Square Foot Hour Degree Fahrenheit}$ is an Imperial unit for 'Coefficient Of Heat Transfer' expressed as $Btu/(h-ft^{2}-degF)$.
   """^^qudt:LatexString ;
   qudt:applicableSystem sou:IMPERIAL ;
   qudt:applicableSystem sou:USCS ;
@@ -2351,10 +2351,10 @@ unit:BTU_IT-PER-FT2-HR-DEG_F
   qudt:conversionMultiplierSN 5.678263341113487328270053328717809E0 ;
   qudt:definedUnitOfSystem sou:IMPERIAL ;
   qudt:definedUnitOfSystem sou:USCS ;
-  qudt:expression "$Btu/(hr-ft^{2}-degF)$"^^qudt:LatexString ;
+  qudt:expression "$Btu/(h-ft^{2}-degF)$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H-1T-3D0 ;
   qudt:hasQuantityKind quantitykind:CoefficientOfHeatTransfer ;
-  qudt:symbol "Btu{IT}/(ft²·hr·°F)" ;
+  qudt:symbol "Btu{IT}/(ft²·h·°F)" ;
   qudt:ucumCode "[Btu_IT].[ft_i]-2.h-1.[degF]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_IT]/([ft_i]2.h.[degF])"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -2432,13 +2432,13 @@ unit:BTU_IT-PER-HR
   qudt:conversionMultiplierSN 2.9307107E-1 ;
   qudt:definedUnitOfSystem sou:IMPERIAL ;
   qudt:definedUnitOfSystem sou:USCS ;
-  qudt:expression "$Btu/hr$"^^qudt:LatexString ;
+  qudt:expression "$Btu/h$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:HeatFlowRate ;
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAA116" ;
   qudt:informativeReference "http://www.simetric.co.uk/sibtu.htm"^^xsd:anyURI ;
-  qudt:symbol "Btu{IT}/hr" ;
+  qudt:symbol "Btu{IT}/h" ;
   qudt:ucumCode "[Btu_IT].h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_IT]/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "2I" ;
@@ -2447,7 +2447,7 @@ unit:BTU_IT-PER-HR
 
 unit:BTU_IT-PER-HR-FT2
   a qudt:DerivedUnit, qudt:Unit ;
-  dcterms:description "$\\textit{BTU per Hour Square Foot}$ is an Imperial unit for  'Power Per Area' expressed as $Btu/(hr-ft^2)$."^^qudt:LatexString ;
+  dcterms:description "$\\textit{BTU per Hour Square Foot}$ is an Imperial unit for  'Power Per Area' expressed as $Btu/(h-ft^2)$."^^qudt:LatexString ;
   qudt:applicableSystem sou:IMPERIAL ;
   qudt:applicableSystem sou:USCS ;
   qudt:conversionMultiplier 3.154590745063048768072844787664884 ;
@@ -2455,10 +2455,10 @@ unit:BTU_IT-PER-HR-FT2
   qudt:definedUnitOfSystem sou:IMPERIAL ;
   qudt:definedUnitOfSystem sou:USCS ;
   qudt:exactMatch unit:BTU_IT-PER-FT2-HR ;
-  qudt:expression "$Btu/(hr-ft^{2})$"^^qudt:LatexString ;
+  qudt:expression "$Btu/(h-ft^{2})$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:PowerPerArea ;
-  qudt:symbol "Btu{IT}/(hr·ft²)" ;
+  qudt:symbol "Btu{IT}/(h·ft²)" ;
   qudt:ucumCode "[Btu_IT].h-1.[ft_i]-2"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_IT]/(h.[ft_i]2)"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -2489,7 +2489,7 @@ unit:BTU_IT-PER-HR-FT2-DEG_R
   qudt:hasQuantityKind quantitykind:CoefficientOfHeatTransfer ;
   qudt:iec61360Code "0112/2///62720#UAB099" ;
   qudt:plainTextDescription "unit of the heat transfer coefficient according to the Imperial system of units" ;
-  qudt:symbol "Btu{IT}/(hr·ft²·°R)" ;
+  qudt:symbol "Btu{IT}/(h·ft²·°R)" ;
   qudt:ucumCode "[Btu_IT].h-1.[ft_i]-2.[degR]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_IT]/(h.[ft_i]2.[degR])"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A23" ;
@@ -2844,7 +2844,7 @@ unit:BTU_TH-FT-PER-FT2-HR-DEG_F
   a qudt:DerivedUnit, qudt:Unit ;
   dcterms:description """
   The $\\textit{BTU (TH) Foot per Square Foot Hour Degree Fahrenheit}$ is an Imperial unit for 'Thermal Conductivity' defined as:
-  $$Btu_{th} \\cdot ft/(hr \\cdot ft^2 \\cdot degF)$$.
+  $$Btu_{th} \\cdot ft/(h \\cdot ft^2 \\cdot degF)$$.
   """^^qudt:LatexString ;
   qudt:applicableSystem sou:IMPERIAL ;
   qudt:applicableSystem sou:USCS ;
@@ -2852,12 +2852,12 @@ unit:BTU_TH-FT-PER-FT2-HR-DEG_F
   qudt:conversionMultiplierSN 1.729577206E0 ;
   qudt:definedUnitOfSystem sou:IMPERIAL ;
   qudt:definedUnitOfSystem sou:USCS ;
-  qudt:expression "$Btu(IT) ft/(hr ft^2 degF)$"^^qudt:LatexString ;
+  qudt:expression "$Btu(IT) ft/(h ft^2 degF)$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H-1T-3D0 ;
   qudt:hasQuantityKind quantitykind:ThermalConductivity ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Thermal_conductivity"^^xsd:anyURI ;
   qudt:informativeReference "http://www.translatorscafe.com/cafe/EN/units-converter/thermal-conductivity/c/"^^xsd:anyURI ;
-  qudt:symbol "Btu{th}·ft/(ft²·hr·°F)" ;
+  qudt:symbol "Btu{th}·ft/(ft²·h·°F)" ;
   qudt:ucumCode "[Btu_th].[ft_i]-2.h-1.[degF]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_th]/([ft_i]2.h.[degF])"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -2876,7 +2876,7 @@ unit:BTU_TH-FT-PER-HR-FT2-DEG_F
   qudt:hasQuantityKind quantitykind:ThermalConductivity ;
   qudt:iec61360Code "0112/2///62720#UAA123" ;
   qudt:plainTextDescription "unit of the thermal conductivity according to the Imperial system of units" ;
-  qudt:symbol "Btu{th}·ft/(hr·ft²·°F)" ;
+  qudt:symbol "Btu{th}·ft/(h·ft²·°F)" ;
   qudt:ucumCode "[Btu_th].[ft_i].h-1.[ft_i]-2.[degF]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_th].[ft_i]/(h.[ft_i]2.[degF])"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J46" ;
@@ -2885,21 +2885,21 @@ unit:BTU_TH-FT-PER-HR-FT2-DEG_F
 
 unit:BTU_TH-IN-PER-FT2-HR-DEG_F
   a qudt:DerivedUnit, qudt:Unit ;
-  dcterms:description "${\\bf BTU_{th}}$, Inch per Square Foot Hour Degree Fahrenheit, is an Imperial unit for 'Thermal Conductivity' expressed as $Btu-in/(hr-ft^{2}-degF)$. A thermochemical British thermal unit inch per second per square foot per degree Fahrenheit is a unit of thermal conductivity in the US Customary Units and British Imperial Units. $1 Btu_{th} \\cdot in/(hr \\cdot ft^{2}  \\cdot degF)$ shows that one thermochemical BTU of heat per one hour moves through one square foot of material, which is one foot thick due to a temperature difference of one degree Fahrenheit."^^qudt:LatexString ;
+  dcterms:description "${\\bf BTU_{th}}$, Inch per Square Foot Hour Degree Fahrenheit, is an Imperial unit for 'Thermal Conductivity' expressed as $Btu-in/(h-ft^{2}-degF)$. A thermochemical British thermal unit inch per second per square foot per degree Fahrenheit is a unit of thermal conductivity in the US Customary Units and British Imperial Units. $1 Btu_{th} \\cdot in/(h \\cdot ft^{2}  \\cdot degF)$ shows that one thermochemical BTU of heat per one hour moves through one square foot of material, which is one foot thick due to a temperature difference of one degree Fahrenheit."^^qudt:LatexString ;
   qudt:applicableSystem sou:IMPERIAL ;
   qudt:applicableSystem sou:USCS ;
   qudt:conversionMultiplier 0.144131434 ;
   qudt:conversionMultiplierSN 1.44131434E-1 ;
   qudt:definedUnitOfSystem sou:IMPERIAL ;
   qudt:definedUnitOfSystem sou:USCS ;
-  qudt:expression "$Btu(th)-in-per-hr-ft2-degF$"^^qudt:LatexString ;
+  qudt:expression "$Btu(th)-in-per-h-ft2-degF$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H-1T-3D0 ;
   qudt:hasQuantityKind quantitykind:ThermalConductivity ;
   qudt:iec61360Code "0112/2///62720#UAA125" ;
   qudt:informativeReference "http://www.translatorscafe.com/cafe/EN/units-converter/thermal-conductivity/c/"^^xsd:anyURI ;
-  qudt:latexSymbol "$Btu_{th} \\cdot in/(hr \\cdot ft^{2}  \\cdot degF)$"^^qudt:LatexString ;
+  qudt:latexSymbol "$Btu_{th} \\cdot in/(h \\cdot ft^{2}  \\cdot degF)$"^^qudt:LatexString ;
   qudt:plainTextDescription "Unit of thermal conductivity according to the Imperial system of units" ;
-  qudt:symbol "Btu{th}·in/(ft²·hr·°F)" ;
+  qudt:symbol "Btu{th}·in/(ft²·h·°F)" ;
   qudt:ucumCode "[Btu_th].[in_i].[ft_i]-2.h-1.[degF]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_th].[in_i]/([ft_i]2.h.[degF])"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J48" ;
@@ -3045,7 +3045,7 @@ unit:BTU_TH-PER-HR
   qudt:hasQuantityKind quantitykind:HeatFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA124" ;
   qudt:plainTextDescription "unit of the heat energy according to the Imperial system of units divided by the unit hour" ;
-  qudt:symbol "Btu{th}/hr" ;
+  qudt:symbol "Btu{th}/h" ;
   qudt:ucumCode "[Btu_th].h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[Btu_th]/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J47" ;
@@ -3217,7 +3217,7 @@ unit:BU_UK-PER-HR
   qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA346" ;
   qudt:plainTextDescription "unit of the volume bushel (UK) (for fluids and for dry measures) according to the Imperial system of units divided by the unit for time hour" ;
-  qudt:symbol "bsh{UK}/hr" ;
+  qudt:symbol "bsh{UK}/h" ;
   qudt:ucumCode "[bu_br].h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J65" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -3310,7 +3310,7 @@ unit:BU_US_DRY-PER-HR
   qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA350" ;
   qudt:plainTextDescription "unit of the volume bushel (US dry) for dry measure according to the Anglo-American system of units divided by the unit for time hour" ;
-  qudt:symbol "bsh{US}/hr" ;
+  qudt:symbol "bsh{US}/h" ;
   qudt:ucumCode "[bu_us].h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[bu_us]/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J69" ;
@@ -4900,7 +4900,7 @@ unit:CentiM-PER-HR
   qudt:hasQuantityKind quantitykind:Velocity ;
   qudt:iec61360Code "0112/2///62720#UAA378" ;
   qudt:plainTextDescription "0.01-fold of the SI base unit metre divided by the unit hour" ;
-  qudt:symbol "cm/hr" ;
+  qudt:symbol "cm/h" ;
   qudt:ucumCode "cm.h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "cm/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H49" ;
@@ -5356,7 +5356,7 @@ unit:CentiM3-PER-HR
   qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA391" ;
   qudt:plainTextDescription "0.000001-fold of the power of the SI base unit metre with the exponent 3 divided by the unit hour" ;
-  qudt:symbol "cm³/hr" ;
+  qudt:symbol "cm³/h" ;
   qudt:ucumCode "cm3.h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "cm3/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G48" ;
@@ -6033,7 +6033,7 @@ unit:DEG-PER-HR
   qudt:expression "$deg/h$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:AngularVelocity ;
-  qudt:symbol "°/hr" ;
+  qudt:symbol "°/h" ;
   qudt:ucumCode "deg.h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "deg/h"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -6382,16 +6382,16 @@ unit:DEG_C-PER-BAR
 
 unit:DEG_C-PER-HR
   a qudt:Unit ;
-  dcterms:description "$\\textit{Degree Celsius per Hour}$ is a unit for 'Temperature Per Time' expressed as $degC / hr$."^^qudt:LatexString ;
+  dcterms:description "$\\textit{Degree Celsius per Hour}$ is a unit for 'Temperature Per Time' expressed as $degC / h$."^^qudt:LatexString ;
   qudt:applicableSystem sou:CGS ;
   qudt:applicableSystem sou:SI ;
   qudt:conversionMultiplier 0.0002777777777777777777777777777777778 ;
   qudt:conversionMultiplierSN 2.777777777777777777777777777777778E-4 ;
-  qudt:expression "$degC / hr$"^^qudt:LatexString ;
+  qudt:expression "$degC / h$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H1T-1D0 ;
   qudt:hasQuantityKind quantitykind:TemperaturePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA036" ;
-  qudt:symbol "°C/hr" ;
+  qudt:symbol "°C/h" ;
   qudt:ucumCode "Cel.h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "Cel/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H12" ;
@@ -6563,10 +6563,10 @@ unit:DEG_F-HR
   qudt:conversionMultiplierSN 2.00000000000000016E3 ;
   qudt:definedUnitOfSystem sou:IMPERIAL ;
   qudt:definedUnitOfSystem sou:USCS ;
-  qudt:expression "$degF-hr$"^^qudt:LatexString ;
+  qudt:expression "$degF-h$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H1T1D0 ;
   qudt:hasQuantityKind quantitykind:TimeTemperature ;
-  qudt:symbol "°F·hr" ;
+  qudt:symbol "°F·h" ;
   qudt:ucumCode "[degF].h"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Degree Fahrenheit Hour"@en .
@@ -6582,7 +6582,7 @@ unit:DEG_F-HR-FT2-PER-BTU_IT
   qudt:hasQuantityKind quantitykind:ThermalInsulance ;
   qudt:iec61360Code "0112/2///62720#UAA043" ;
   qudt:plainTextDescription "unit of the thermal resistor according to the Imperial system of units" ;
-  qudt:symbol "°F·hr·ft²/Btu{IT}" ;
+  qudt:symbol "°F·h·ft²/Btu{IT}" ;
   qudt:ucumCode "[degF].h-1.[ft_i]-2.[Btu_IT]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[degF]/(h.[ft_i]2.[Btu_IT])"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J22" ;
@@ -6597,7 +6597,7 @@ unit:DEG_F-HR-FT2-PER-BTU_IT-IN
   qudt:hasDimensionVector qkdv:A0E0L-1I0M-1H1T3D0 ;
   qudt:hasQuantityKind quantitykind:ThermalResistivity ;
   qudt:iec61360Code "0112/2///62720#UAB252" ;
-  qudt:symbol "°F·hr·ft²/(Btu{IT}·in)" ;
+  qudt:symbol "°F·h·ft²/(Btu{IT}·in)" ;
   qudt:ucumCode "[degF].h.[ft_i]2.[Btu_IT]-1.[in_i]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "N88" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -6614,7 +6614,7 @@ unit:DEG_F-HR-FT2-PER-BTU_TH
   qudt:hasQuantityKind quantitykind:ThermalInsulance ;
   qudt:iec61360Code "0112/2///62720#UAA040" ;
   qudt:plainTextDescription "unit of the thermal resistor according to the according to the Imperial system of units" ;
-  qudt:symbol "°F·hr·ft²/Btu{th}" ;
+  qudt:symbol "°F·h·ft²/Btu{th}" ;
   qudt:ucumCode "[degF].h-1.[ft_i]-2.[Btu_th]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[degF]/(h.[ft_i]2.[Btu_th])"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J19" ;
@@ -6629,7 +6629,7 @@ unit:DEG_F-HR-FT2-PER-BTU_TH-IN
   qudt:hasDimensionVector qkdv:A0E0L-1I0M-1H1T3D0 ;
   qudt:hasQuantityKind quantitykind:ThermalResistivity ;
   qudt:iec61360Code "0112/2///62720#UAB253" ;
-  qudt:symbol "°F·hr·ft²/(Btu{th}·in)" ;
+  qudt:symbol "°F·h·ft²/(Btu{th}·in)" ;
   qudt:ucumCode "[degF].h.[ft_i]2.[Btu_th]-1.[in_i]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "N89" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -6637,17 +6637,17 @@ unit:DEG_F-HR-FT2-PER-BTU_TH-IN
 
 unit:DEG_F-HR-PER-BTU_IT
   a qudt:DerivedUnit, qudt:Unit ;
-  dcterms:description "$\\textit{Degree Fahrenheit Hour per BTU}$ is an Imperial unit for 'Thermal Resistance' expressed as $degF-hr/Btu$."^^qudt:LatexString ;
+  dcterms:description "$\\textit{Degree Fahrenheit Hour per BTU}$ is an Imperial unit for 'Thermal Resistance' expressed as $degF-h/Btu$."^^qudt:LatexString ;
   qudt:applicableSystem sou:IMPERIAL ;
   qudt:applicableSystem sou:USCS ;
   qudt:conversionMultiplier 1.895634240626634551676309339081973 ;
   qudt:conversionMultiplierSN 1.895634240626634551676309339081973E0 ;
   qudt:definedUnitOfSystem sou:IMPERIAL ;
   qudt:definedUnitOfSystem sou:USCS ;
-  qudt:expression "$degF-hr/Btu$"^^qudt:LatexString ;
+  qudt:expression "$degF-h/Btu$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M-1H1T3D0 ;
   qudt:hasQuantityKind quantitykind:ThermalResistance ;
-  qudt:symbol "°F·hr/Btu{IT}" ;
+  qudt:symbol "°F·h/Btu{IT}" ;
   qudt:ucumCode "[degF].h.[Btu_IT]-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[degF].h/[Btu_IT]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "N84" ;
@@ -6698,7 +6698,7 @@ unit:DEG_F-PER-HR
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H1T-1D0 ;
   qudt:hasQuantityKind quantitykind:TemperaturePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA044" ;
-  qudt:symbol "°F/hr" ;
+  qudt:symbol "°F/h" ;
   qudt:ucumCode "[degF].h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[degF]/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J23" ;
@@ -6865,7 +6865,7 @@ unit:DEG_R-PER-HR
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H1T-1D0 ;
   qudt:hasQuantityKind quantitykind:TemperaturePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA051" ;
-  qudt:symbol "°R/hr" ;
+  qudt:symbol "°R/h" ;
   qudt:ucumCode "[degR].h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[degR]/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J28" ;
@@ -7736,7 +7736,7 @@ unit:DeciM3-PER-HR
   qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA416" ;
   qudt:plainTextDescription "0,001-fold of the power of the SI base unit metre with the exponent 3 divided by the unit hour" ;
-  qudt:symbol "dm³/hr" ;
+  qudt:symbol "dm³/h" ;
   qudt:ucumCode "dm3.h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "dm3/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E92" ;
@@ -8303,7 +8303,7 @@ unit:EUR-PER-KiloW-HR
   qudt:hasDimensionVector qkdv:A0E0L-2I0M-1H0T2D0 ;
   qudt:hasQuantityKind quantitykind:CostPerEnergy ;
   qudt:plainTextDescription "Unit for measuring the cost of electricity." ;
-  qudt:symbol "€/(kW·hr)" ;
+  qudt:symbol "€/(kW·h)" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Euro per kilowatt hour"@en .
 
@@ -8339,7 +8339,7 @@ unit:EUR-PER-W-HR
   qudt:hasDimensionVector qkdv:A0E0L-2I0M-1H0T2D0 ;
   qudt:hasQuantityKind quantitykind:CostPerEnergy ;
   qudt:plainTextDescription "Unit for measuring the cost of electricity." ;
-  qudt:symbol "€/(W·hr)" ;
+  qudt:symbol "€/(W·h)" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Euro per watt hour"@en .
 
@@ -9201,19 +9201,19 @@ unit:FT-LB_F-PER-FT2-SEC
 
 unit:FT-LB_F-PER-HR
   a qudt:Unit ;
-  dcterms:description "\"Foot Pound Force per Hour\" is an Imperial unit for  'Power' expressed as $ft-lbf/hr$."^^qudt:LatexString ;
+  dcterms:description "\"Foot Pound Force per Hour\" is an Imperial unit for  'Power' expressed as $ft-lbf/h$."^^qudt:LatexString ;
   qudt:applicableSystem sou:IMPERIAL ;
   qudt:applicableSystem sou:USCS ;
   qudt:conversionMultiplier 0.0003766161136565500904 ;
   qudt:conversionMultiplierSN 3.766161136565500904E-4 ;
   qudt:definedUnitOfSystem sou:IMPERIAL ;
   qudt:definedUnitOfSystem sou:USCS ;
-  qudt:expression "$ft-lbf/hr$"^^qudt:LatexString ;
+  qudt:expression "$ft-lbf/h$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:ActivePower ;
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAA444" ;
-  qudt:symbol "ft·lbf/hr" ;
+  qudt:symbol "ft·lbf/h" ;
   qudt:ucumCode "[ft_i].[lbf_av].h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K15" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -9346,19 +9346,19 @@ unit:FT-PER-DEG_F
 
 unit:FT-PER-HR
   a qudt:Unit ;
-  dcterms:description "\"Foot per Hour\" is an Imperial unit for  'Linear Velocity' expressed as $ft/hr$."^^qudt:LatexString ;
+  dcterms:description "\"Foot per Hour\" is an Imperial unit for  'Linear Velocity' expressed as $ft/h$."^^qudt:LatexString ;
   qudt:applicableSystem sou:IMPERIAL ;
   qudt:applicableSystem sou:USCS ;
   qudt:conversionMultiplier 0.00008466666666666667 ;
   qudt:conversionMultiplierSN 8.466666666666667E-5 ;
   qudt:definedUnitOfSystem sou:IMPERIAL ;
   qudt:definedUnitOfSystem sou:USCS ;
-  qudt:expression "$ft/hr$"^^qudt:LatexString ;
+  qudt:expression "$ft/h$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:LinearVelocity ;
   qudt:hasQuantityKind quantitykind:Velocity ;
   qudt:iec61360Code "0112/2///62720#UAA442" ;
-  qudt:symbol "ft/hr" ;
+  qudt:symbol "ft/h" ;
   qudt:ucumCode "[ft_i].h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[ft_i]/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K14" ;
@@ -9552,34 +9552,34 @@ unit:FT2-DEG_F
 
 unit:FT2-HR-DEG_F
   a qudt:DerivedUnit, qudt:Unit ;
-  dcterms:description "$\\textit{Square Foot Hour Degree Fahrenheit}$ is an Imperial unit for 'Area Time Temperature' expressed as $ft^{2}-hr-degF$."^^qudt:LatexString ;
+  dcterms:description "$\\textit{Square Foot Hour Degree Fahrenheit}$ is an Imperial unit for 'Area Time Temperature' expressed as $ft^{2}-h-degF$."^^qudt:LatexString ;
   qudt:applicableSystem sou:IMPERIAL ;
   qudt:applicableSystem sou:USCS ;
   qudt:conversionMultiplier 185.8060800000000148644864 ;
   qudt:conversionMultiplierSN 1.858060800000000148644864E2 ;
   qudt:definedUnitOfSystem sou:IMPERIAL ;
   qudt:definedUnitOfSystem sou:USCS ;
-  qudt:expression "$ft^{2}-hr-degF$"^^qudt:LatexString ;
+  qudt:expression "$ft^{2}-h-degF$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H1T1D0 ;
   qudt:hasQuantityKind quantitykind:AreaTimeTemperature ;
-  qudt:symbol "ft²·hr·°F" ;
+  qudt:symbol "ft²·h·°F" ;
   qudt:ucumCode "[sft_i].h.[degF]"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Square Foot Hour Degree Fahrenheit"@en .
 
 unit:FT2-HR-DEG_F-PER-BTU_IT
   a qudt:DerivedUnit, qudt:Unit ;
-  dcterms:description "$\\textit{Square Foot Hour Degree Fahrenheit per BTU}$ is an Imperial unit for 'Thermal Insulance' expressed as $(degF-hr-ft^{2})/Btu$."^^qudt:LatexString ;
+  dcterms:description "$\\textit{Square Foot Hour Degree Fahrenheit per BTU}$ is an Imperial unit for 'Thermal Insulance' expressed as $(degF-h-ft^{2})/Btu$."^^qudt:LatexString ;
   qudt:applicableSystem sou:IMPERIAL ;
   qudt:applicableSystem sou:USCS ;
   qudt:conversionMultiplier 0.1761101836823058548197662335811061 ;
   qudt:conversionMultiplierSN 1.761101836823058548197662335811061E-1 ;
   qudt:definedUnitOfSystem sou:IMPERIAL ;
   qudt:definedUnitOfSystem sou:USCS ;
-  qudt:expression "$sqft-hr-degF/btu$"^^qudt:LatexString ;
+  qudt:expression "$sqft-h-degF/btu$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M-1H1T3D0 ;
   qudt:hasQuantityKind quantitykind:ThermalInsulance ;
-  qudt:symbol "ft²·hr·°F/Btu{IT}" ;
+  qudt:symbol "ft²·h·°F/Btu{IT}" ;
   qudt:ucumCode "[sft_i].h.[degF].[Btu_IT]-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Square Foot Hour Degree Fahrenheit per BTU"@en .
@@ -9609,11 +9609,11 @@ unit:FT2-PER-HR
   qudt:conversionMultiplierSN 2.58064E-5 ;
   qudt:definedUnitOfSystem sou:IMPERIAL ;
   qudt:definedUnitOfSystem sou:USCS ;
-  qudt:expression "$ft^{2}/hr$"^^qudt:LatexString ;
+  qudt:expression "$ft^{2}/h$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:AreaPerTime ;
   qudt:iec61360Code "0112/2///62720#UAB247" ;
-  qudt:symbol "ft²/hr" ;
+  qudt:symbol "ft²/h" ;
   qudt:ucumCode "[sft_i].h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M79" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -9726,7 +9726,7 @@ unit:FT3-PER-HR
   qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA459" ;
   qudt:plainTextDescription "power of the unit foot according to the Anglo-American and the Imperial system of units with the exponent 3 divided by the unit hour" ;
-  qudt:symbol "ft³/hr" ;
+  qudt:symbol "ft³/h" ;
   qudt:ucumCode "[cft_i].h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "2K" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -10285,7 +10285,7 @@ unit:GAL_UK-PER-HR
   qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA502" ;
   qudt:plainTextDescription "unit gallon (UK dry or Liq.) according to the Imperial system of units divided by the SI unit hour" ;
-  qudt:symbol "gal{UK}/hr" ;
+  qudt:symbol "gal{UK}/h" ;
   qudt:ucumCode "[gal_br].h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K27" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -10372,7 +10372,7 @@ unit:GAL_US-PER-HR
   qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA507" ;
   qudt:plainTextDescription "unit gallon (US, liq.) according to the Anglo-American system of units divided by the SI unit hour" ;
-  qudt:symbol "gal{US}/hr" ;
+  qudt:symbol "gal{US}/h" ;
   qudt:ucumCode "[gal_us].h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[gal_us]/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G50" ;
@@ -10540,7 +10540,7 @@ unit:GI_UK-PER-HR
   qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA513" ;
   qudt:plainTextDescription "unit of the volume gill (UK) for fluids according to the Imperial system of units divided by the unit for time hour" ;
-  qudt:symbol "gill{UK}/hr" ;
+  qudt:symbol "gill{UK}/h" ;
   qudt:ucumCode "[gil_br].h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K33" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -10624,7 +10624,7 @@ unit:GI_US-PER-HR
   qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA518" ;
   qudt:plainTextDescription "unit of the volume gill (US) for fluids according to the Anglo-American system of units divided by the unit for time hour" ;
-  qudt:symbol "gill{US}/hr" ;
+  qudt:symbol "gill{US}/h" ;
   qudt:ucumCode "[gil_us].h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K37" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -11168,7 +11168,7 @@ unit:GM-PER-HR
   qudt:hasQuantityKind quantitykind:MassFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA478" ;
   qudt:plainTextDescription "0,001-fold of the SI base unit kilogram divided by the unit hour" ;
-  qudt:symbol "g/hr" ;
+  qudt:symbol "g/h" ;
   qudt:ucumCode "g.h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F27" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -12543,7 +12543,7 @@ unit:GigaJ-PER-HR
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:plainTextDescription "SI derived unit gigajoule divided by the 3600 times the SI base unit second" ;
-  qudt:symbol "GJ/hr" ;
+  qudt:symbol "GJ/h" ;
   qudt:ucumCode "GJ.h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P16" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -12761,7 +12761,7 @@ unit:GigaW-HR
   qudt:hasQuantityKind quantitykind:Energy ;
   qudt:iec61360Code "0112/2///62720#UAA155" ;
   qudt:plainTextDescription "1 000 000 000-fold of the product of the SI derived unit watt and the unit hour" ;
-  qudt:symbol "GW·hr" ;
+  qudt:symbol "GW·h" ;
   qudt:ucumCode "GW.h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "GWH" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -12771,7 +12771,7 @@ unit:Gs
   a qudt:Unit ;
   dcterms:description """
   The $gauss$, abbreviated as $G$, is the cgs unit of measurement of a magnetic field $B$, 
-  which is also known as the "magnetic flux density" or the "magnetic induction".  
+  which is also known as the "magnetic flux density" or the "magnetic induction".
   One gauss is defined as one maxwell per square centimeter; it equals $10^{-4} tesla$ (or $100 micro T$). 
   The Gauss is identical to maxwells per square centimetre; technically defined in a three-dimensional system, 
   it corresponds in the SI, with its extra base unit the ampere. 
@@ -13078,7 +13078,7 @@ unit:HP_Metric
 
 unit:HR
   a qudt:Unit ;
-  dcterms:description "The hour (common symbol: h or hr) is a unit of measurement of time. In modern usage, an hour comprises 60 minutes, or 3,600 seconds. It is approximately 1/24 of a mean solar day. An hour in the Universal Coordinated Time (UTC) time standard can include a negative or positive leap second, and may therefore have a duration of 3,599 or 3,601 seconds for adjustment purposes. Although it is not a standard defined by the International System of Units, the hour is a unit accepted for use with SI, represented by the symbol h."^^rdf:HTML ;
+  dcterms:description "The hour (common symbol: h or h) is a unit of measurement of time. In modern usage, an hour comprises 60 minutes, or 3,600 seconds. It is approximately 1/24 of a mean solar day. An hour in the Universal Coordinated Time (UTC) time standard can include a negative or positive leap second, and may therefore have a duration of 3,599 or 3,601 seconds for adjustment purposes. Although it is not a standard defined by the International System of Units, the hour is a unit accepted for use with SI, represented by the symbol h."^^rdf:HTML ;
   qudt:applicableSystem sou:CGS ;
   qudt:applicableSystem sou:CGS-EMU ;
   qudt:applicableSystem sou:CGS-GAUSS ;
@@ -13111,10 +13111,10 @@ unit:HR-FT2
   qudt:conversionMultiplierSN 3.34450944E2 ;
   qudt:definedUnitOfSystem sou:IMPERIAL ;
   qudt:definedUnitOfSystem sou:USCS ;
-  qudt:expression "$hr-ft^{2}$"^^qudt:LatexString ;
+  qudt:expression "$h-ft^{2}$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:AreaTime ;
-  qudt:symbol "hr·ft²" ;
+  qudt:symbol "h·ft²" ;
   qudt:ucumCode "h.[ft_i]2"^^qudt:UCUMcs ;
   qudt:ucumCode "h.[sft_i]"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -13146,9 +13146,9 @@ unit:HR-PER-YR
   qudt:plainTextDescription "hours (of activity) per year" ;
   qudt:qkdvDenominator qkdv:A0E0L0I0M0H0T1D0 ;
   qudt:qkdvNumerator qkdv:A0E0L0I0M0H0T1D0 ;
-  qudt:symbol "hr/a" ;
-  qudt:ucumCode "hr.a-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "hr/a"^^qudt:UCUMcs ;
+  qudt:symbol "h/a" ;
+  qudt:ucumCode "h.a-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "h/a"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Hours per Year"@en ;
   rdfs:label "Uur per Jaar"@nl .
@@ -13167,7 +13167,7 @@ unit:HR_Sidereal
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Time ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Sidereal_time"^^xsd:anyURI ;
-  qudt:symbol "hr{sidereal}" ;
+  qudt:symbol "h{sidereal}" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Sidereal Hour"@en .
 
@@ -13573,7 +13573,7 @@ unit:HectoPA-PER-HR
   qudt:conversionMultiplierSN 2.77777777777778E-2 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerAreaTime ;
-  qudt:symbol "hPa/hr" ;
+  qudt:symbol "hPa/h" ;
   qudt:ucumCode "hPa.h-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Hectopascals per hour"@en .
@@ -13900,7 +13900,7 @@ unit:IN3-PER-HR
   qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA550" ;
   qudt:plainTextDescription "power of the unit inch according to the Anglo-American and the Imperial system of units with the exponent 3 divided by the unit hour" ;
-  qudt:symbol "in³/hr" ;
+  qudt:symbol "in³/h" ;
   qudt:ucumCode "[cin_i].h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G56" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -14390,7 +14390,7 @@ unit:J-PER-HR
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAB445" ;
   qudt:plainTextDescription "SI derived unit joule divided by the 3600 times the SI base unit second" ;
-  qudt:symbol "J/hr" ;
+  qudt:symbol "J/h" ;
   qudt:ucumCode "J.h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P16" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -15023,7 +15023,7 @@ unit:K-PER-HR
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H1T-1D0 ;
   qudt:hasQuantityKind quantitykind:TemperaturePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA189" ;
-  qudt:symbol "K/hr" ;
+  qudt:symbol "K/h" ;
   qudt:ucumCode "K.h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F10" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -15498,7 +15498,7 @@ unit:KiloA-HR
   qudt:hasQuantityKind quantitykind:ElectricCharge ;
   qudt:iec61360Code "0112/2///62720#UAB053" ;
   qudt:plainTextDescription "product of the 1 000-fold of the SI base unit ampere and the unit hour" ;
-  qudt:symbol "kA·hr" ;
+  qudt:symbol "kA·h" ;
   qudt:ucumCode "kA.h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "TAH" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -15710,11 +15710,11 @@ unit:KiloBTU_IT-PER-HR
   qudt:conversionMultiplierSN 2.9307107E2 ;
   qudt:definedUnitOfSystem sou:IMPERIAL ;
   qudt:definedUnitOfSystem sou:USCS ;
-  qudt:expression "$kBtu/hr$"^^qudt:LatexString ;
+  qudt:expression "$kBtu/h$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:HeatFlowRate ;
   qudt:hasQuantityKind quantitykind:Power ;
-  qudt:symbol "kBtu{IT}/hr" ;
+  qudt:symbol "kBtu{IT}/h" ;
   qudt:ucumCode "k[Btu_IT].h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "k[Btu_IT]/h"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -15744,7 +15744,7 @@ unit:KiloBTU_TH-PER-HR
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:HeatFlowRate ;
   qudt:plainTextDescription "unit of the heat energy according to the Imperial system of units divided by the unit hour" ;
-  qudt:symbol "kBtu{th}/hr" ;
+  qudt:symbol "kBtu{th}/h" ;
   qudt:ucumCode "k[Btu_th].h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "k[Btu_th]/h"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -16105,7 +16105,7 @@ unit:KiloCAL_IT-PER-HR-M-DEG_C
   qudt:hasQuantityKind quantitykind:ThermalConductivity ;
   qudt:iec61360Code "0112/2///62720#UAA588" ;
   qudt:plainTextDescription "1 000-fold of the no longer approved unit international calorie for energy divided by the product of the SI base unit metre, the unit hour for time and the unit degree Celsius for temperature" ;
-  qudt:symbol "kcal{IT}/(hr·m·°C)" ;
+  qudt:symbol "kcal{IT}/(h·m·°C)" ;
   qudt:ucumCode "kcal_IT.h-1.m-1.Cel-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K52" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -16162,7 +16162,7 @@ unit:KiloCAL_TH-PER-HR
   qudt:hasQuantityKind quantitykind:HeatFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAB184" ;
   qudt:plainTextDescription "1 000-fold of the non-legal unit thermochemical calorie divided by the unit hour" ;
-  qudt:symbol "kcal{th}/hr" ;
+  qudt:symbol "kcal{th}/h" ;
   qudt:ucumCode "kcal_th.h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E15" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -16799,7 +16799,7 @@ unit:KiloGM-PER-HR
   qudt:hasQuantityKind quantitykind:MassFlowRate ;
   qudt:hasQuantityKind quantitykind:MassPerTime ;
   qudt:iec61360Code "0112/2///62720#UAA607" ;
-  qudt:symbol "kg/hr" ;
+  qudt:symbol "kg/h" ;
   qudt:ucumCode "kg.h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "kg/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E93" ;
@@ -17038,7 +17038,7 @@ unit:KiloGM-PER-M-HR
   qudt:hasQuantityKind quantitykind:DynamicViscosity ;
   qudt:hasQuantityKind quantitykind:Viscosity ;
   qudt:iec61360Code "0112/2///62720#UAB432" ;
-  qudt:symbol "kg/(m·hr)" ;
+  qudt:symbol "kg/(m·h)" ;
   qudt:ucumCode "kg.m-1.h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "N40" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -18008,7 +18008,7 @@ unit:KiloL-PER-HR
   qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAB121" ;
   qudt:plainTextDescription "unit of the volume kilolitres divided by the unit hour" ;
-  qudt:symbol "kL/hr" ;
+  qudt:symbol "kL/h" ;
   qudt:ucumCode "kL.h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "kL/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "4X" ;
@@ -18154,7 +18154,7 @@ unit:KiloM-PER-DAY
 
 unit:KiloM-PER-HR
   a qudt:Unit ;
-  dcterms:description "\"Kilometer per Hour\" is a C.G.S System unit for  'Linear Velocity' expressed as $km/hr$."^^qudt:LatexString ;
+  dcterms:description "\"Kilometer per Hour\" is a C.G.S System unit for  'Linear Velocity' expressed as $km/h$."^^qudt:LatexString ;
   qudt:applicableSystem sou:CGS ;
   qudt:applicableSystem sou:CGS-EMU ;
   qudt:applicableSystem sou:CGS-GAUSS ;
@@ -18162,13 +18162,13 @@ unit:KiloM-PER-HR
   qudt:conversionMultiplier 0.2777777777777778 ;
   qudt:conversionMultiplierSN 2.777777777777778E-1 ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Kilometres_per_hour"^^xsd:anyURI ;
-  qudt:expression "$km/hr$"^^qudt:LatexString ;
+  qudt:expression "$km/h$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:LinearVelocity ;
   qudt:hasQuantityKind quantitykind:Velocity ;
   qudt:iec61360Code "0112/2///62720#UAA638" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Kilometres_per_hour?oldid=487674812"^^xsd:anyURI ;
-  qudt:symbol "km/hr" ;
+  qudt:symbol "km/h" ;
   qudt:ucumCode "km.h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "km/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "KMH" ;
@@ -18318,7 +18318,7 @@ unit:KiloMOL-PER-HR
   qudt:hasQuantityKind quantitykind:CatalyticActivity ;
   qudt:iec61360Code "0112/2///62720#UAA641" ;
   qudt:plainTextDescription "1 000-fold of the SI base unit mole divided by the unit for time hour" ;
-  qudt:symbol "kmol/hr" ;
+  qudt:symbol "kmol/h" ;
   qudt:ucumCode "kmol.h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "kmol/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K58" ;
@@ -19011,7 +19011,7 @@ unit:KiloV-A-HR
   qudt:hasQuantityKind quantitykind:Energy ;
   qudt:iec61360Code "0112/2///62720#UAB160" ;
   qudt:plainTextDescription "product of the 1 000-fold of the unit for apparent by ampere and the unit hour" ;
-  qudt:symbol "kV·A·hr" ;
+  qudt:symbol "kV·A·h" ;
   qudt:ucumCode "kV.A.h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C79" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -19054,7 +19054,7 @@ unit:KiloV-A_Reactive-HR
   qudt:hasQuantityKind quantitykind:Energy ;
   qudt:iec61360Code "0112/2///62720#UAB195" ;
   qudt:plainTextDescription "product of the 1 000-fold of the unit volt ampere reactive and the unit hour" ;
-  qudt:symbol "kV·A{Reactive}·hr" ;
+  qudt:symbol "kV·A{Reactive}·h" ;
   qudt:ucumCode "kV.A.h{reactive}"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K3" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -19130,7 +19130,7 @@ unit:KiloW-HR
   qudt:hasQuantityKind quantitykind:Energy ;
   qudt:iec61360Code "0112/2///62720#UAA584" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Kilowatt_hour?oldid=494927235"^^xsd:anyURI ;
-  qudt:symbol "kW·hr" ;
+  qudt:symbol "kW·h" ;
   qudt:ucumCode "kW.h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "KWH" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -19150,7 +19150,7 @@ unit:KiloW-HR-PER-M2
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:EnergyPerArea ;
   qudt:plainTextDescription "A unit of energy per unit area, equivalent to 3 600 000 joules per square metre." ;
-  qudt:symbol "kW·hr/m²" ;
+  qudt:symbol "kW·h/m²" ;
   qudt:ucumCode "kW.h.m-2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Kilowatt hour per square metre"@en .
@@ -19356,7 +19356,7 @@ unit:L-PER-HR
   qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA655" ;
   qudt:plainTextDescription "Unit litre divided by the unit hour" ;
-  qudt:symbol "L/hr" ;
+  qudt:symbol "L/h" ;
   qudt:ucumCode "L.h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "L/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E32" ;
@@ -19904,7 +19904,7 @@ unit:LB-HR-PER-GAL_UK2
   qudt:hasDimensionVector qkdv:A0E0L-6I0M1H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAC861" ;
-  qudt:symbol "lbm·hr/gal{UK}²" ;
+  qudt:symbol "lbm·h/gal{UK}²" ;
   qudt:ucumCode "[lb_av].h.[gal_br]-2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "pound hour per square gallon (UK)" .
@@ -20464,19 +20464,19 @@ unit:LB-PER-FT-DAY
 
 unit:LB-PER-FT-HR
   a qudt:Unit ;
-  dcterms:description "\"Pound per Foot Hour\" is an Imperial unit for  'Dynamic Viscosity' expressed as $lb/(ft-hr)$."^^qudt:LatexString ;
+  dcterms:description "\"Pound per Foot Hour\" is an Imperial unit for  'Dynamic Viscosity' expressed as $lb/(ft-h)$."^^qudt:LatexString ;
   qudt:applicableSystem sou:IMPERIAL ;
   qudt:applicableSystem sou:USCS ;
   qudt:conversionMultiplier 0.0004133788732137649 ;
   qudt:conversionMultiplierSN 4.133788732137649E-4 ;
   qudt:definedUnitOfSystem sou:IMPERIAL ;
   qudt:definedUnitOfSystem sou:USCS ;
-  qudt:expression "$lb/(ft-hr)$"^^qudt:LatexString ;
+  qudt:expression "$lb/(ft-h)$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:DynamicViscosity ;
   qudt:hasQuantityKind quantitykind:Viscosity ;
   qudt:iec61360Code "0112/2///62720#UAA674" ;
-  qudt:symbol "lbm/(ft·hr)" ;
+  qudt:symbol "lbm/(ft·h)" ;
   qudt:ucumCode "[lb_av].[ft_i]-1.h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K67" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -20666,7 +20666,7 @@ unit:LB-PER-HR
   qudt:hasQuantityKind quantitykind:MassPerTime ;
   qudt:iec61360Code "0112/2///62720#UAA682" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Pound_per_hour?oldid=328571072"^^xsd:anyURI ;
-  qudt:symbol "lbm/hr" ;
+  qudt:symbol "lbm/h" ;
   qudt:ucumCode "[lb_av].h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "4U" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -21696,13 +21696,13 @@ unit:LUX-HR
   qudt:conversionMultiplier 3600.0 ;
   qudt:conversionMultiplierSN 3.6E3 ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Lux"^^xsd:anyURI ;
-  qudt:expression "$lx hr$"^^qudt:LatexString ;
+  qudt:expression "$lx h$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L-2I1M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:LuminousExposure ;
   qudt:iec61360Code "0112/2///62720#UAA724" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Lux?oldid=494700274"^^xsd:anyURI ;
-  qudt:siUnitsExpression "lm-hr/m^2" ;
-  qudt:symbol "lx·hr" ;
+  qudt:siUnitsExpression "lm-h/m^2" ;
+  qudt:symbol "lx·h" ;
   qudt:ucumCode "lx.h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B63" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -21936,7 +21936,7 @@ unit:M-PER-HR
   qudt:hasQuantityKind quantitykind:LinearVelocity ;
   qudt:hasQuantityKind quantitykind:Velocity ;
   qudt:iec61360Code "0112/2///62720#UAB328" ;
-  qudt:symbol "m/hr" ;
+  qudt:symbol "m/h" ;
   qudt:ucumCode "m.h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "m/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M60" ;
@@ -22246,7 +22246,7 @@ unit:M2-HR-DEG_C-PER-KiloCAL_IT
   qudt:hasQuantityKind quantitykind:ThermalInsulance ;
   qudt:iec61360Code "0112/2///62720#UAA749" ;
   qudt:plainTextDescription "product of the power of the SI base unit metre with the exponent 2, of the unit hour for time and the unit degree Celsius for temperature divided by the 1000-fold of the out of use unit for energy international calorie" ;
-  qudt:symbol "m²·hr·°C/kcal{IT}" ;
+  qudt:symbol "m²·h·°C/kcal{IT}" ;
   qudt:ucumCode "m2.h.Cel/kcal_IT"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L14" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -23043,7 +23043,7 @@ unit:M3-PER-HA-YR
 
 unit:M3-PER-HR
   a qudt:DerivedUnit, qudt:Unit ;
-  dcterms:description "Cubic Meter Per Hour (m3/h) is a unit in the category of Volume flow rate. It is also known as cubic meters per hour, cubic metre per hour, cubic metres per hour, cubic meter/hour, cubic metre/hour, cubic meter/hr, cubic metre/hr, flowrate. Cubic Meter Per Hour (m3/h) has a dimension of L3T-1 where $L$ is length, and $T$ is time. It can be converted to the corresponding standard SI unit m3/s by multiplying its value by a factor of 0.00027777777."^^rdf:HTML ;
+  dcterms:description "Cubic Meter Per Hour (m3/h) is a unit in the category of Volume flow rate. It is also known as cubic meters per hour, cubic metre per hour, cubic metres per hour, cubic meter/hour, cubic metre/hour, cubic meter/h, cubic metre/h, flowrate. Cubic Meter Per Hour (m3/h) has a dimension of L3T-1 where $L$ is length, and $T$ is time. It can be converted to the corresponding standard SI unit m3/s by multiplying its value by a factor of 0.00027777777."^^rdf:HTML ;
   qudt:applicableSystem sou:CGS ;
   qudt:applicableSystem sou:CGS-EMU ;
   qudt:applicableSystem sou:CGS-GAUSS ;
@@ -23055,7 +23055,7 @@ unit:M3-PER-HR
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA763" ;
-  qudt:symbol "m³/hr" ;
+  qudt:symbol "m³/h" ;
   qudt:ucumCode "m3.h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "m3/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "MQH" ;
@@ -23623,13 +23623,13 @@ unit:MI-PER-HR
   qudt:dbpediaMatch "http://dbpedia.org/resource/Miles_per_hour"^^xsd:anyURI ;
   qudt:definedUnitOfSystem sou:IMPERIAL ;
   qudt:definedUnitOfSystem sou:USCS ;
-  qudt:expression "$mi/hr$"^^qudt:LatexString ;
+  qudt:expression "$mi/h$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:LinearVelocity ;
   qudt:hasQuantityKind quantitykind:Velocity ;
   qudt:iec61360Code "0112/2///62720#UAB111" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Miles_per_hour?oldid=482840548"^^xsd:anyURI ;
-  qudt:symbol "mi/hr" ;
+  qudt:symbol "mi/h" ;
   qudt:ucumCode "[mi_i].h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[mi_i]/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "HM" ;
@@ -23847,7 +23847,7 @@ unit:MI_N-PER-HR
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:LinearVelocity ;
   qudt:hasQuantityKind quantitykind:Velocity ;
-  qudt:symbol "nmi/hr" ;
+  qudt:symbol "nmi/h" ;
   qudt:ucumCode "[nmi_i].h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[nmi_i]/h"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -24091,7 +24091,7 @@ unit:MOL-PER-GM-HR
   qudt:conversionMultiplierSN 2.77777777777778E-1 ;
   qudt:hasDimensionVector qkdv:A1E0L0I0M-1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "mol/(g·hr)" ;
+  qudt:symbol "mol/(g·h)" ;
   qudt:ucumCode "mol.g-1.h-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Moles per gram hour"@en .
@@ -24106,7 +24106,7 @@ unit:MOL-PER-HR
   qudt:hasQuantityKind quantitykind:MolarFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA884" ;
   qudt:plainTextDescription "SI base unit mole divided by the unit for time hour" ;
-  qudt:symbol "mol/hr" ;
+  qudt:symbol "mol/h" ;
   qudt:ucumCode "mol.h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "mol/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L23" ;
@@ -24822,11 +24822,11 @@ unit:MegaBTU_IT-PER-HR
   qudt:conversionMultiplierSN 2.9307107E5 ;
   qudt:definedUnitOfSystem sou:IMPERIAL ;
   qudt:definedUnitOfSystem sou:USCS ;
-  qudt:expression "$MBtu/hr$"^^qudt:LatexString ;
+  qudt:expression "$MBtu/h$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:HeatFlowRate ;
   qudt:hasQuantityKind quantitykind:Power ;
-  qudt:symbol "MBtu{IT}/hr" ;
+  qudt:symbol "MBtu{IT}/h" ;
   qudt:ucumCode "M[Btu_IT].h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "M[Btu_IT]/h"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -25204,7 +25204,7 @@ unit:MegaJ-PER-HR
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:plainTextDescription "SI derived unit Megajoule divided by the 3600 times the SI base unit second" ;
-  qudt:symbol "MJ/hr" ;
+  qudt:symbol "MJ/h" ;
   qudt:ucumCode "MJ.h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P16" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -25785,7 +25785,7 @@ unit:MegaV-A-HR
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Energy ;
   qudt:plainTextDescription "product of the 1,000,000-fold of the unit for apparent by ampere and the unit hour" ;
-  qudt:symbol "MV·A·hr" ;
+  qudt:symbol "MV·A·h" ;
   qudt:ucumCode "MV.A.h"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Megavolt Ampere Hour"@en .
@@ -25814,7 +25814,7 @@ unit:MegaV-A_Reactive-HR
   qudt:hasQuantityKind quantitykind:Energy ;
   qudt:iec61360Code "0112/2///62720#UAB198" ;
   qudt:plainTextDescription "product of the 1,000,000-fold of the unit volt ampere reactive and the unit hour" ;
-  qudt:symbol "MV·A{Reactive}·hr" ;
+  qudt:symbol "MV·A{Reactive}·h" ;
   qudt:ucumCode "MV.A{reactive}.h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "MAH" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -25873,7 +25873,7 @@ unit:MegaW-HR
   qudt:hasQuantityKind quantitykind:Energy ;
   qudt:iec61360Code "0112/2///62720#UAA225" ;
   qudt:plainTextDescription "1 000 000-fold of the product of the SI derived unit watt and the unit hour" ;
-  qudt:symbol "MW·hr" ;
+  qudt:symbol "MW·h" ;
   qudt:ucumCode "MW.h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "MWH" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -26378,7 +26378,7 @@ unit:MicroGM-PER-L-HR
   qudt:conversionMultiplierSN 2.77777777777778E-10 ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "μg/(L·hr)" ;
+  qudt:symbol "μg/(L·h)" ;
   qudt:ucumCode "ug.L-1.h-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Micrograms per litre hour"@en .
@@ -26444,7 +26444,7 @@ unit:MicroGM-PER-M3-HR
   qudt:conversionMultiplierSN 2.77777777777778E-13 ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "μg/(m³·hr)" ;
+  qudt:symbol "μg/(m³·h)" ;
   qudt:ucumCode "ug.m-3.h-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Micrograms per cubic metre hour"@en .
@@ -27026,7 +27026,7 @@ unit:MicroMOL-PER-GM-HR
   qudt:conversionMultiplierSN 2.77777777777778E-7 ;
   qudt:hasDimensionVector qkdv:A1E0L0I0M-1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "µmol/(g·hr)" ;
+  qudt:symbol "µmol/(g·h)" ;
   qudt:ucumCode "umol.g-1.h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "umol/g/h"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -27079,7 +27079,7 @@ unit:MicroMOL-PER-L-HR
   qudt:conversionMultiplierSN 2.77777777777778E-7 ;
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:CatalyticActivityConcentration ;
-  qudt:symbol "µmol/(L·hr)" ;
+  qudt:symbol "µmol/(L·h)" ;
   qudt:ucumCode "umol.L-1.h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "umol/L/h"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -27119,7 +27119,7 @@ unit:MicroMOL-PER-M2-HR
   qudt:conversionMultiplierSN 2.77777777777778E-10 ;
   qudt:hasDimensionVector qkdv:A1E0L-2I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:PhotosyntheticPhotonFluxDensity ;
-  qudt:symbol "µmol/(m²·hr)" ;
+  qudt:symbol "µmol/(m²·h)" ;
   qudt:ucumCode "umol.m-2.h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "umol/m2/h"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -27453,7 +27453,7 @@ unit:MicroSV-PER-HR
   qudt:informativeReference "http://www.oxfordreference.com/view/10.1093/acref/9780198605225.001.0001/acref-9780198605225-e-1284"^^xsd:anyURI ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/sievert> ;
   qudt:siUnitsExpression "J/kg" ;
-  qudt:symbol "µSv/hr" ;
+  qudt:symbol "µSv/h" ;
   qudt:ucumCode "uSv.h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P72" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -27695,7 +27695,7 @@ unit:MilliA-HR
   qudt:hasQuantityKind quantitykind:ElectricCharge ;
   qudt:iec61360Code "0112/2///62720#UAA777" ;
   qudt:plainTextDescription "product of the 0.001-fold of the SI base unit ampere and the unit hour" ;
-  qudt:symbol "mA·hr" ;
+  qudt:symbol "mA·h" ;
   qudt:ucumCode "mA.h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E09" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -28568,7 +28568,7 @@ unit:MilliGM-PER-HR
   qudt:hasQuantityKind quantitykind:MassFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA823" ;
   qudt:plainTextDescription "0.000001-fold of the SI base unit kilogram divided by the unit hour" ;
-  qudt:symbol "mg/hr" ;
+  qudt:symbol "mg/h" ;
   qudt:ucumCode "mg.h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "mg/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "4M" ;
@@ -28783,7 +28783,7 @@ unit:MilliGM-PER-M2-HR
   qudt:conversionMultiplierSN 2.77777777777778E-10 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:MassPerAreaTime ;
-  qudt:symbol "mg/(m²·hr)" ;
+  qudt:symbol "mg/(m²·h)" ;
   qudt:ucumCode "mg.m-2.h-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Milligrams per square metre hour"@en .
@@ -28879,7 +28879,7 @@ unit:MilliGM-PER-M3-HR
   qudt:conversionMultiplierSN 2.77777777777778E-10 ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "mg/(m³·hr)" ;
+  qudt:symbol "mg/(m³·h)" ;
   qudt:ucumCode "mg.m-3.h-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Milligrams per cubic metre hour"@en .
@@ -29577,7 +29577,7 @@ unit:MilliL-PER-HR
   qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA850" ;
   qudt:plainTextDescription "0.001-fold of the unit litre divided by the unit hour" ;
-  qudt:symbol "mL/hr" ;
+  qudt:symbol "mL/h" ;
   qudt:ucumCode "mL.h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "mL/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G55" ;
@@ -29898,7 +29898,7 @@ unit:MilliM-PER-HR
   qudt:hasQuantityKind quantitykind:Velocity ;
   qudt:iec61360Code "0112/2///62720#UAA866" ;
   qudt:plainTextDescription "0001-fold of the SI base unit metre divided by the unit hour" ;
-  qudt:symbol "mm/hr" ;
+  qudt:symbol "mm/h" ;
   qudt:ucumCode "mm.h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "mm/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H67" ;
@@ -30677,7 +30677,7 @@ unit:MilliRAD_R-PER-HR
   qudt:hasQuantityKind quantitykind:AbsorbedDoseRate ;
   qudt:hasQuantityKind quantitykind:KermaRate ;
   qudt:hasQuantityKind quantitykind:SpecificPower ;
-  qudt:symbol "mrad/hr" ;
+  qudt:symbol "mrad/h" ;
   qudt:ucumCode "mRAD.h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "mRAD/h"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -32164,7 +32164,7 @@ unit:NUM-PER-HR
   qudt:exactMatch unit:PER-HR ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Frequency ;
-  qudt:symbol "/hr" ;
+  qudt:symbol "/h" ;
   qudt:ucumCode "/h"^^qudt:UCUMcs ;
   qudt:ucumCode "{#}.h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "{#}/h"^^qudt:UCUMcs ;
@@ -32947,7 +32947,7 @@ unit:NanoMOL-PER-CentiM3-HR
   qudt:conversionMultiplierSN 2.77777777777778E-7 ;
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:CatalyticActivityConcentration ;
-  qudt:symbol "nmol/(cm³·hr)" ;
+  qudt:symbol "nmol/(cm³·h)" ;
   qudt:ucumCode "nmol.cm-3.h-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Nanomoles per cubic centimetre hour"@en .
@@ -33010,7 +33010,7 @@ unit:NanoMOL-PER-L-HR
   qudt:conversionMultiplierSN 2.77777777777778E-10 ;
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:CatalyticActivityConcentration ;
-  qudt:symbol "nmol/(L·hr)" ;
+  qudt:symbol "nmol/(L·h)" ;
   qudt:ucumCode "nmol.L-1.h-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Nanomoles per litre hour"@en .
@@ -33034,7 +33034,7 @@ unit:NanoMOL-PER-MicroGM-HR
   qudt:conversionMultiplierSN 2.77777777777778E-4 ;
   qudt:hasDimensionVector qkdv:A1E0L0I0M-1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
-  qudt:symbol "nmol/(µg·hr)" ;
+  qudt:symbol "nmol/(µg·h)" ;
   qudt:ucumCode "nmol.ug-1.h-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Nanomoles per microgram hour"@en .
@@ -34013,7 +34013,7 @@ unit:OZ-PER-HR
   qudt:hasQuantityKind quantitykind:MassFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA920" ;
   qudt:plainTextDescription "traditional unit of the mass avoirdupois ounce according to the avoirdupois system of units divided by the unit for time hour" ;
-  qudt:symbol "oz/hr" ;
+  qudt:symbol "oz/h" ;
   qudt:ucumCode "[oz_av].h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[oz_av]/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L34" ;
@@ -34329,7 +34329,7 @@ unit:OZ_VOL_UK-PER-HR
   qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA433" ;
   qudt:plainTextDescription "unit of the volume fluid ounce (UK) for fluids according to the Imperial system of units divided by the unit for time hour" ;
-  qudt:symbol "oz{UK}/hr" ;
+  qudt:symbol "oz{UK}/h" ;
   qudt:ucumCode "[foz_br].h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[foz_br]/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J96" ;
@@ -34418,7 +34418,7 @@ unit:OZ_VOL_US-PER-HR
   qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA437" ;
   qudt:plainTextDescription "unit of the volume fluid ounce (US) for fluids according to the Anglo-American system of units divided by the unit for time hour" ;
-  qudt:symbol "fl oz{US}/hr" ;
+  qudt:symbol "fl oz{US}/h" ;
   qudt:ucumCode "[foz_us].h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[foz_us]/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K10" ;
@@ -34691,10 +34691,10 @@ unit:PA-PER-HR
   qudt:applicableSystem sou:SI ;
   qudt:conversionMultiplier 0.000277777778 ;
   qudt:conversionMultiplierSN 2.77777778E-4 ;
-  qudt:expression "$P / hr$"^^qudt:LatexString ;
+  qudt:expression "$P / h$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerAreaTime ;
-  qudt:symbol "Pa/hr" ;
+  qudt:symbol "Pa/h" ;
   qudt:ucumCode "Pa.h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "Pa/h"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -35378,7 +35378,7 @@ unit:PER-HR
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Frequency ;
   qudt:iec61360Code "0112/2///62720#UAA526" ;
-  qudt:symbol "/hr" ;
+  qudt:symbol "/h" ;
   qudt:ucumCode "/h"^^qudt:UCUMcs ;
   qudt:ucumCode "h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H10" ;
@@ -35586,7 +35586,7 @@ unit:PER-KiloV-A-HR
   qudt:hasQuantityKind quantitykind:InverseEnergy ;
   qudt:iec61360Code "0112/2///62720#UAA098" ;
   qudt:plainTextDescription "reciprocal of the 1,000-fold of the product of the SI derived unit volt and the SI base unit ampere and the unit hour" ;
-  qudt:symbol "/(kV·A·hr)" ;
+  qudt:symbol "/(kV·A·h)" ;
   qudt:ucumCode "kV-1.A-1.h-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Reciprocal Kilovolt Ampere Hour"@en .
@@ -37714,7 +37714,7 @@ unit:PINT_UK-PER-HR
   qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA954" ;
   qudt:plainTextDescription "unit of the volume pint (UK) (both for fluids and for dry measures) according to the Imperial system of units divided by the unit for time hour" ;
-  qudt:symbol "pt{UK}/hr" ;
+  qudt:symbol "pt{UK}/h" ;
   qudt:ucumCode "[pt_br].h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[pt_br]/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L54" ;
@@ -37804,7 +37804,7 @@ unit:PINT_US-PER-HR
   qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA959" ;
   qudt:plainTextDescription "unit of the volume pint (US liquid) according to the Anglo-American system of units divided by the unit for time hour" ;
-  qudt:symbol "pt{US}/hr" ;
+  qudt:symbol "pt{US}/h" ;
   qudt:ucumCode "[pt_us].h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[pt_us]/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L58" ;
@@ -37920,7 +37920,7 @@ unit:PK_UK-PER-HR
   qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA941" ;
   qudt:plainTextDescription "unit of the volume peck (UK) according to the Imperial system of units divided by the unit for time hour" ;
-  qudt:symbol "peck{UK}/hr" ;
+  qudt:symbol "peck{UK}/h" ;
   qudt:ucumCode "[pk_br].h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[pk_br]/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L45" ;
@@ -38010,7 +38010,7 @@ unit:PK_US_DRY-PER-HR
   qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA945" ;
   qudt:plainTextDescription "unit of the volume peck (US dry) as dry measure according to the Anglo-American system of units divided by the unit for time hour" ;
-  qudt:symbol "peck{US Dry}/hr" ;
+  qudt:symbol "peck{US Dry}/h" ;
   qudt:ucumCode "[pk_us].h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[pk_us]/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L49" ;
@@ -38271,7 +38271,7 @@ unit:PPTH-PER-HR
   qudt:conversionMultiplierSN 2.77777777777778E-7 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Frequency ;
-  qudt:symbol "‰/hr" ;
+  qudt:symbol "‰/h" ;
   qudt:ucumCode "[ppth].h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[ppth]/h"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -39148,7 +39148,7 @@ unit:PicoMOL-PER-L-HR
   qudt:conversionMultiplierSN 2.77777777777778E-13 ;
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:CatalyticActivityConcentration ;
-  qudt:symbol "pmol/(L·hr)" ;
+  qudt:symbol "pmol/(L·h)" ;
   qudt:ucumCode "pmol.L-1.h-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Picomoles per litre hour"@en .
@@ -39737,7 +39737,7 @@ unit:QT_UK-PER-HR
   qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA711" ;
   qudt:plainTextDescription "unit of the volume quart (UK liquid) for fluids according to the Imperial system of units divided by the unit for time hour" ;
-  qudt:symbol "qt{UK}/hr" ;
+  qudt:symbol "qt{UK}/h" ;
   qudt:ucumCode "[qt_br].h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K95" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -39824,7 +39824,7 @@ unit:QT_US-PER-HR
   qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA715" ;
   qudt:plainTextDescription "unit fo the volume quart (US liquid) for fluids according to the Anglo-American system of units divided by the unit for time hour" ;
-  qudt:symbol "qt/hr" ;
+  qudt:symbol "qt/h" ;
   qudt:ucumCode "[qt_us].h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[qt_us]/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K99" ;
@@ -40062,7 +40062,7 @@ unit:RAD-PER-HR
   qudt:expression "$rad/h$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:AngularVelocity ;
-  qudt:symbol "rad/hr" ;
+  qudt:symbol "rad/h" ;
   qudt:ucumCode "rad.h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "rad/h"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -40288,7 +40288,7 @@ unit:REV-PER-HR
   qudt:expression "$rev/h$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:AngularVelocity ;
-  qudt:symbol "rev/hr" ;
+  qudt:symbol "rev/h" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Revolution per Hour"@en .
 
@@ -41013,7 +41013,7 @@ unit:SLUG-PER-HR
   qudt:hasQuantityKind quantitykind:MassFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA982" ;
   qudt:plainTextDescription "unit slug for mass slug according to the English engineering system divided by the unit hour" ;
-  qudt:symbol "slug/hr" ;
+  qudt:symbol "slug/h" ;
   qudt:uneceCommonCode "L66" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Slug per Hour"@en .
@@ -41646,16 +41646,16 @@ unit:THM_US
 
 unit:THM_US-PER-HR
   a qudt:DerivedUnit, qudt:Unit ;
-  dcterms:description "$\\textit{Therm}$ (symbol $thm$) is a non-SI unit of heat energy. It was defined in the United States in 1968 as the energy equivalent of burning 100 cubic feet of natural gas at standard temperature and pressure. Industrial processes in the U.S. use therm/hr unit most often in the power, steam generation, heating, and air conditioning industries."^^qudt:LatexString ;
+  dcterms:description "$\\textit{Therm}$ (symbol $thm$) is a non-SI unit of heat energy. It was defined in the United States in 1968 as the energy equivalent of burning 100 cubic feet of natural gas at standard temperature and pressure. Industrial processes in the U.S. use therm/h unit most often in the power, steam generation, heating, and air conditioning industries."^^qudt:LatexString ;
   qudt:applicableSystem sou:USCS ;
   qudt:conversionMultiplier 29300.1111 ;
   qudt:conversionMultiplierSN 2.93001111E4 ;
-  qudt:expression "$thm/hr$"^^qudt:LatexString ;
+  qudt:expression "$thm/h$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:HeatFlowRate ;
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:informativeReference "http://www.convertunits.com/info/therm%2B%5BU.S.%5D"^^xsd:anyURI ;
-  qudt:symbol "thm{US}/hr" ;
+  qudt:symbol "thm{US}/h" ;
   qudt:ucumCode "[thm{US}].h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[thm{US}]/h"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -41836,7 +41836,7 @@ unit:TONNE-PER-HR
   qudt:hasQuantityKind quantitykind:MassFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAB994" ;
   qudt:plainTextDescription "unit tonne divided by the unit for time hour" ;
-  qudt:symbol "t/hr" ;
+  qudt:symbol "t/h" ;
   qudt:ucumCode "t.h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "t/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E18" ;
@@ -42123,7 +42123,7 @@ unit:TON_FG-HR
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ThermalEnergy ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Ton_of_refrigeration?oldid=494342824"^^xsd:anyURI ;
-  qudt:symbol "TOR·hr" ;
+  qudt:symbol "TOR·h" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Ton of Refrigeration Hour"@en .
 
@@ -42304,7 +42304,7 @@ unit:TON_Metric-PER-HR
   qudt:hasQuantityKind quantitykind:MassFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAB994" ;
   qudt:plainTextDescription "unit tonne divided by the unit for time hour" ;
-  qudt:symbol "t/hr" ;
+  qudt:symbol "t/h" ;
   qudt:ucumCode "t.h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "t/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E18" ;
@@ -42580,11 +42580,11 @@ unit:TON_SHORT-PER-HR
   qudt:definedUnitOfSystem sou:IMPERIAL ;
   qudt:definedUnitOfSystem sou:USCS ;
   qudt:exactMatch unit:TON_US-PER-HR ;
-  qudt:expression "$ton/hr$"^^qudt:LatexString ;
+  qudt:expression "$ton/h$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:MassFlowRate ;
   qudt:hasQuantityKind quantitykind:MassPerTime ;
-  qudt:symbol "ton{short}/hr" ;
+  qudt:symbol "ton{short}/h" ;
   qudt:ucumCode "[ston_av].h-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Short Ton per Hour"@en .
@@ -42597,7 +42597,7 @@ unit:TON_SHORT-PER-HR-DEG_F
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAB015" ;
-  qudt:symbol "ton{short}/(hr·°F)" ;
+  qudt:symbol "ton{short}/(h·°F)" ;
   qudt:ucumCode "[ston_av].h-1.[degF]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L89" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -42611,7 +42611,7 @@ unit:TON_SHORT-PER-HR-PSI
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAB016" ;
-  qudt:symbol "ton{short}/(hr·psi)" ;
+  qudt:symbol "ton{short}/(h·psi)" ;
   qudt:ucumCode "[ston_av].h-1.[psi]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L90" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -42748,7 +42748,7 @@ unit:TON_US-PER-HR
   qudt:iec61360Code "0112/2///62720#UAA994" ;
   qudt:iec61360Code "0112/2///62720#UAB019" ;
   qudt:plainTextDescription "unit ton divided by the unit for time hour" ;
-  qudt:symbol "ton{US}/hr" ;
+  qudt:symbol "ton{US}/h" ;
   qudt:ucumCode "[ston_av].h-1"^^qudt:UCUMcs ;
   qudt:ucumCode "[ston_av]/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "4W" ;
@@ -43170,7 +43170,7 @@ unit:TeraW-HR
   qudt:hasQuantityKind quantitykind:Energy ;
   qudt:iec61360Code "0112/2///62720#UAA290" ;
   qudt:plainTextDescription "1,000,000,000,000-fold of the product of the SI derived unit watt and the unit hour" ;
-  qudt:symbol "TW·hr" ;
+  qudt:symbol "TW·h" ;
   qudt:ucumCode "TW/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D32" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -43449,7 +43449,7 @@ unit:V-A-HR
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Energy ;
   qudt:plainTextDescription "product of the unit for apparent by ampere and the unit hour" ;
-  qudt:symbol "V·A·hr" ;
+  qudt:symbol "V·A·h" ;
   qudt:ucumCode "V.A.h"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Volt Ampere Hour"@en .
@@ -43491,7 +43491,7 @@ unit:V-A_Reactive-HR
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Energy ;
   qudt:plainTextDescription "product of the unit volt ampere reactive and the unit hour" ;
-  qudt:symbol "V·A{reactive}·hr" ;
+  qudt:symbol "V·A{reactive}·h" ;
   qudt:ucumCode "V.A{reactive}.h"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Volt Ampere Reactive Hour"@en .
@@ -43989,7 +43989,7 @@ unit:W-HR
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Energy ;
   qudt:iec61360Code "0112/2///62720#UAA308" ;
-  qudt:symbol "W·hr" ;
+  qudt:symbol "W·h" ;
   qudt:ucumCode "W.h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "WHR" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
@@ -44037,7 +44037,7 @@ unit:W-HR-PER-M2
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:EnergyPerArea ;
   qudt:plainTextDescription "A unit of energy per unit area, equivalent to 3,600 joules per square metre." ;
-  qudt:symbol "W·hr/m²" ;
+  qudt:symbol "W·h/m²" ;
   qudt:ucumCode "W.h.m-2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Watt hour per square metre"@en .
@@ -44053,7 +44053,7 @@ unit:W-HR-PER-M3
   qudt:conversionMultiplierSN 3.6E3 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:EnergyDensity ;
-  qudt:symbol "W·hr/m³" ;
+  qudt:symbol "W·h/m³" ;
   qudt:ucumCode "W.h.m-3"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Watthour per Cubic meter"@en-us ;
@@ -44903,7 +44903,7 @@ unit:YD3-PER-HR
   qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAB038" ;
   qudt:plainTextDescription "power of the unit yard according to the Anglo-American and the Imperial system of units with the exponent 3 divided by the unit for the time hour" ;
-  qudt:symbol "yd³/hr" ;
+  qudt:symbol "yd³/h" ;
   qudt:ucumCode "[cyd_i].h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M13" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;


### PR DESCRIPTION
Some time ago, we changed the symbol for `unit:HR` from `hr` to `h`. However, many symbols in derived units remained unchanged. This PR fixes this.

### TODO
* [ ] update CHANGELOG.md as soon as #989 is merged