### PR TITLE
Fix github action 'maven CI'

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -36,7 +36,7 @@ jobs:
     - name: change tag 'snapshot' to current commit
       if: ${{ github.event.pull_request.base.ref == 'main' && github.event.action == 'closed' && github.event.pull_request.merged == true}} # only make snapshot release if it is a push to main
       run: |
-            git tag -fa snapshot
+            git tag -f snapshot
             git push -f origin --tags
 
     - name: Release


### PR DESCRIPTION
Create a lightweight tag for snapshot, not an annotated one