### PR TITLE
Fix broken maven CI workflow

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -36,14 +36,33 @@ jobs:
     - name: change tag 'snapshot' to current commit
       if: ${{ github.event.pull_request.base.ref == 'main' && github.event.action == 'closed' && github.event.pull_request.merged == true}} # only make snapshot release if it is a push to main
       run: |
-            git tag -f snapshot
-            git push -f origin --tags
+        git tag -f snapshot
+        git push -f origin --tags
 
+    # Read version changelog
+    - id: get-changelog
+      name: Get version changelog
+      if: ${{ github.event.pull_request.base.ref == 'main' && github.event.action == 'closed' && github.event.pull_request.merged == true}} # only make snapshot release if it is a push to main
+      uses: superfaceai/release-changelog-action@v1
+      with:
+        path-to-changelog: CHANGELOG.md
+        version: ${{ inputs.release_version }}
+        operation: read
+
+    - name: Make Release Body
+      if: ${{ github.event.pull_request.base.ref == 'main' && github.event.action == 'closed' && github.event.pull_request.merged == true}} # only make snapshot release if it is a push to main
+      run: |
+        cat src/build/snapshot-release/release-body-header.md > target/release-body.md
+        echo "# Changes" >> target/release-body.md 
+        echo "${{ steps.get-changelog.outputs.changelog }}" >> target/release-body.md
+        cat src/build/snapshot-release/release-body-footer.md > target/release-body.md        
+
+    # Make github release
     - name: Release
       uses: softprops/action-gh-release@v2
       if: ${{ github.event.pull_request.base.ref == 'main' && github.event.action == 'closed' && github.event.pull_request.merged == true}} # only make snapshot release if it is a push to main
       with:
         name: Latest snapshot release
         tag_name: snapshot
-        body_path: src/build/release/release-body.md
+        body_path: target/release-body.md
         files: target/qudt-public-repo-*.zip

--- a/src/build/snapshot-release/release-body-footer.md
+++ b/src/build/snapshot-release/release-body-footer.md
@@ -1,0 +1,2 @@
+
+And as always, a big thank-you to all of you for bringing many of these issues to our attention, and even better, for providing submissions to extend the coverage and capabilities of QUDT!

--- a/src/build/snapshot-release/release-body-header.md
+++ b/src/build/snapshot-release/release-body-header.md
@@ -1,0 +1,7 @@
+# Snapshot Release
+
+This release and the corresponding git tag are updated every time a PR is merged to `main`. 
+Use it to access the latest state of the repository without having to build it yourself. Expect further
+changes before the upcoming release.
+
+


### PR DESCRIPTION
Forgot to adapt the snapshot release to the latest changes to the release body.  This PR fixes that by building the snapshot release body with the files in `src/build/snapshot-release/`