### PR TITLE
Fix broken changelog body generation

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -55,7 +55,7 @@ jobs:
         cat src/build/snapshot-release/release-body-header.md > target/release-body.md
         echo "# Changes" >> target/release-body.md 
         echo "${{ steps.get-changelog.outputs.changelog }}" >> target/release-body.md
-        cat src/build/snapshot-release/release-body-footer.md > target/release-body.md        
+        cat src/build/snapshot-release/release-body-footer.md >> target/release-body.md        
 
     # Make github release
     - name: Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,7 +135,7 @@ jobs:
           cat src/build/release/release-body-header.md > target/release-body.md
           echo "# Changes" >> target/release-body.md 
           echo "${{ steps.get-changelog.outputs.changelog }}" >> target/release-body.md
-          cat src/build/release/release-body-footer.md > target/release-body.md
+          cat src/build/release/release-body-footer.md >> target/release-body.md
       - name: Release
         uses: softprops/action-gh-release@v2
         with:

--- a/src/build/snapshot-release/release-body-footer.md
+++ b/src/build/snapshot-release/release-body-footer.md
@@ -1,2 +1,0 @@
-
-And as always, a big thank-you to all of you for bringing many of these issues to our attention, and even better, for providing submissions to extend the coverage and capabilities of QUDT!


### PR DESCRIPTION
- the footer was overwriting anything that was added before
- also, the release footer does not fit so well for the snapshot release, so the content was removed.