### PR TITLE
Trigger maven CI action upon push to main

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -4,6 +4,8 @@
 name: Java CI with Maven
 
 on:
+  push:
+    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 


### PR DESCRIPTION
The last change to the maven CI action removed the `push` trigger. This resulted in the action not being executed on the main branch when a PR was rebased onto main. 

This PR reintroduces the `push` event as a trigger and limits it to the `main` branch, so it does not trigger the action upon push to any branch. Hopefully this leads to the action running on the main branch after a PR merge. Direct pushes to `main` are not allowed, so there should not be any other effect.