### PR TITLE
Allow manually formatting sources via github action

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -36,7 +36,7 @@ jobs:
 
       # Check formatting and exit early (with success) if format is ok
       - name: Check formatting
-        run: mvn spotless:check || ( echo "Source was already formatted, nothing was touched." >> $GITHUB_STEP_SUMMARY ; exit 0 )
+        run: mvn spotless:check && ( echo "Source was already formatted, nothing was touched." >> $GITHUB_STEP_SUMMARY ; exit 0 )
 
       # Apply formatting (changelog was touched)
       - name: Apply formatting

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,57 @@
+name: Format sources and commit to branch
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    # setting the environment on the job is mandatory, otherwise it cannot access environment secrets.
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check write access to repo
+        run: |
+          token_login=$(curl -H "Authorization: Bearer ${token}" https://api.github.com/user | jq -r '.login')
+          echo token login is ${token_login}
+          echo $(curl  -H "Authorization: Bearer ${token}" https://api.github.com/repos/${repo}/collaborators/${token_login}/permission) > result
+          cat result | jq  '.permission == "admin" // .permission == "write"' > /dev/null || ( echo "Token does not have write access to ${repo}" >> ${GITHUB_STEP_SUMMARY}; exit 1)
+          curl -sS -f -I -H "Authorization: Bearer ${token}" https://api.github.com | grep 'x-oauth-scopes:' | grep 'repo' > /dev/null && exit 0 || echo "Token does not have repo scope on ${repo}" >> ${GITHUB_STEP_SUMMARY}
+        env:
+          repo: ${{ github.repository }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Set up java with maven cache
+      - uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: 'maven'
+
+      # configure git
+      - name: Setup git config
+        run: |
+          git config user.name ${{ github.actor }}
+          git config user.email "<>"
+
+      # Check formatting and exit early (with success) if format is ok
+      - name: Check formatting
+        run: mvn spotless:check || ( echo "Source was already formatted, nothing was touched." >> $GITHUB_STEP_SUMMARY ; exit 0 )
+
+      # Apply formatting (changelog was touched)
+      - name: Apply formatting
+        run: mvn spotless:apply
+
+      # Commit changes
+      - name: Commit changes
+        run: git commit -m "Apply formatting rules"
+
+      # Push changes to branch
+      - name: Push changes to branch
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: git push origin
+
+      # print the summary
+      - name: Print summary
+        run: echo "Successfully formatted the source files and made a commit." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,7 +1,7 @@
 # This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
-name: Java CI with Maven
+name: Build
 
 on:
   push:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -33,7 +33,7 @@ jobs:
         distribution: 'temurin'
         cache: maven
 
-    - name: Check if a snapshot release should be made
+    - name: Check if a snapshot release should be made and set environment variable
       run: |
         echo "MAKE_SNAPSHOT_RELEASE=${{ inputs.force_snapshot_release \
           || (github.event.pull_request.base.ref == 'main' \

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,13 +1,17 @@
 # This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
-name: Build
+name: CI Build
 
 on:
-  push:
-    branches: [ "main" ]
+  pull_request_target:
+    branches:
+      - main
+    types:
+      - closed
   pull_request:
-    branches: [ "main" ]
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -35,7 +35,7 @@ jobs:
 
     - name: Check if a snapshot release should be made
       id: snapshot_release
-      run: echo "::set-output name=should_make::${{ force_snapshot_release || (github.event.pull_request.base.ref == 'main' && github.event.action == 'closed' && github.event.pull_request.merged == true) }}"
+      run: echo "::set-output name=should_make::${{ inputs.force_snapshot_release || (github.event.pull_request.base.ref == 'main' && github.event.action == 'closed' && github.event.pull_request.merged == true) }}"
 
       # configure git
     - name: setup git config

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -34,12 +34,12 @@ jobs:
         cache: maven
 
     - name: Check if a snapshot release should be made
-      id: snapshot_release
-      run: echo "MAKE_SNAPSHOT_RELEASE=${{ inputs.force_snapshot_release \
-        || (github.event.pull_request.base.ref == 'main' \
-        && github.event.action == 'closed' \
-        && github.event.pull_request.merged == true) }}" \
-        >> GITHUB_ENV
+      run: |
+        echo "MAKE_SNAPSHOT_RELEASE=${{ inputs.force_snapshot_release \
+          || (github.event.pull_request.base.ref == 'main' \
+          && github.event.action == 'closed' \
+          && github.event.pull_request.merged == true) }}" \
+          >> GITHUB_ENV
 
       # configure git
     - name: setup git config

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -34,12 +34,7 @@ jobs:
         cache: maven
 
     - name: Check if a snapshot release should be made and set environment variable
-      run: |
-        echo "MAKE_SNAPSHOT_RELEASE=${{ inputs.force_snapshot_release \
-          || (github.event.pull_request.base.ref == 'main' \
-          && github.event.action == 'closed' \
-          && github.event.pull_request.merged == true) }}" \
-          >> GITHUB_ENV
+      run: echo "MAKE_SNAPSHOT_RELEASE=${{ inputs.force_snapshot_release || (github.event.pull_request.base.ref == 'main' && github.event.action == 'closed' && github.event.pull_request.merged == true) }}" >> GITHUB_ENV
 
       # configure git
     - name: setup git config

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -35,7 +35,11 @@ jobs:
 
     - name: Check if a snapshot release should be made
       id: snapshot_release
-      run: echo "::set-output name=should_make::${{ inputs.force_snapshot_release || (github.event.pull_request.base.ref == 'main' && github.event.action == 'closed' && github.event.pull_request.merged == true) }}"
+      run: echo "MAKE_SNAPSHOT_RELEASE=${{ inputs.force_snapshot_release \
+        || (github.event.pull_request.base.ref == 'main' \
+        && github.event.action == 'closed' \
+        && github.event.pull_request.merged == true) }}" \
+        >> GITHUB_ENV
 
       # configure git
     - name: setup git config
@@ -47,7 +51,7 @@ jobs:
       run: mvn -Pzip install
 
     - name: change tag 'snapshot' to current commit
-      if: ${{ steps.snapshot_release.outputs.should_make == 'true' }}
+      if: ${{ env.MAKE_SNAPSHOT_RELEASE == 'true' }}
       run: |
         git tag -f snapshot
         git push -f origin --tags
@@ -55,7 +59,7 @@ jobs:
     # Read version changelog
     - id: get-changelog
       name: Get version changelog
-      if: ${{ steps.snapshot_release.outputs.should_make == 'true' }}
+      if: ${{ env.MAKE_SNAPSHOT_RELEASE  == 'true' }}
       uses: superfaceai/release-changelog-action@v1
       with:
         path-to-changelog: CHANGELOG.md
@@ -63,7 +67,7 @@ jobs:
         operation: read
 
     - name: Make Release Body
-      if: ${{ steps.snapshot_release.outputs.should_make == 'true' }}
+      if: ${{ env.MAKE_SNAPSHOT_RELEASE  == 'true' }}
       run: |
         cat src/build/snapshot-release/release-body-header.md > target/release-body.md
         echo "# Changes" >> target/release-body.md 
@@ -73,7 +77,7 @@ jobs:
     # Make github release
     - name: Release
       uses: softprops/action-gh-release@v2
-      if: ${{ steps.snapshot_release.outputs.should_make == 'true' }}
+      if: ${{ env.MAKE_SNAPSHOT_RELEASE  == 'true' }}
       with:
         name: Latest snapshot release
         tag_name: snapshot

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,6 +13,11 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      force_snapshot_release:
+        description: 'Update the snapshot release on github'
+        required: false
+        type: boolean
 
 jobs:
   build:
@@ -28,6 +33,10 @@ jobs:
         distribution: 'temurin'
         cache: maven
 
+    - name: Check if a snapshot release should be made
+      id: snapshot_release
+      run: echo "::set-output name=should_make::${{ force_snapshot_release || (github.event.pull_request.base.ref == 'main' && github.event.action == 'closed' && github.event.pull_request.merged == true) }}"
+
       # configure git
     - name: setup git config
       run: |
@@ -38,7 +47,7 @@ jobs:
       run: mvn -Pzip install
 
     - name: change tag 'snapshot' to current commit
-      if: ${{ github.event.pull_request.base.ref == 'main' && github.event.action == 'closed' && github.event.pull_request.merged == true}} # only make snapshot release if it is a push to main
+      if: ${{ steps.snapshot_release.outputs.should_make == 'true' }}
       run: |
         git tag -f snapshot
         git push -f origin --tags
@@ -46,7 +55,7 @@ jobs:
     # Read version changelog
     - id: get-changelog
       name: Get version changelog
-      if: ${{ github.event.pull_request.base.ref == 'main' && github.event.action == 'closed' && github.event.pull_request.merged == true}} # only make snapshot release if it is a push to main
+      if: ${{ steps.snapshot_release.outputs.should_make == 'true' }}
       uses: superfaceai/release-changelog-action@v1
       with:
         path-to-changelog: CHANGELOG.md
@@ -54,7 +63,7 @@ jobs:
         operation: read
 
     - name: Make Release Body
-      if: ${{ github.event.pull_request.base.ref == 'main' && github.event.action == 'closed' && github.event.pull_request.merged == true}} # only make snapshot release if it is a push to main
+      if: ${{ steps.snapshot_release.outputs.should_make == 'true' }}
       run: |
         cat src/build/snapshot-release/release-body-header.md > target/release-body.md
         echo "# Changes" >> target/release-body.md 
@@ -64,7 +73,7 @@ jobs:
     # Make github release
     - name: Release
       uses: softprops/action-gh-release@v2
-      if: ${{ github.event.pull_request.base.ref == 'main' && github.event.action == 'closed' && github.event.pull_request.merged == true}} # only make snapshot release if it is a push to main
+      if: ${{ steps.snapshot_release.outputs.should_make == 'true' }}
       with:
         name: Latest snapshot release
         tag_name: snapshot

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -34,7 +34,7 @@ jobs:
         cache: maven
 
     - name: Check if a snapshot release should be made and set environment variable
-      run: echo "MAKE_SNAPSHOT_RELEASE=${{ inputs.force_snapshot_release || (github.event.pull_request.base.ref == 'main' && github.event.action == 'closed' && github.event.pull_request.merged == true) }}" >> GITHUB_ENV
+      run: echo "MAKE_SNAPSHOT_RELEASE=${{ inputs.force_snapshot_release || (github.event.pull_request.base.ref == 'main' && github.event.action == 'closed' && github.event.pull_request.merged == true) }}" >> $GITHUB_ENV
 
       # configure git
     - name: setup git config


### PR DESCRIPTION
Fixes #1056 

- Allow manually formatting sources via github action. This creates a commit on the branch it is run on.
- Allow to force making the snapshot release when manually running the CI build action
- Refactor the way the snapshot release condition is evaluated