### PR TITLE
Delete snapshot release prior to making a new one

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -45,6 +45,11 @@ jobs:
     - name: Build with Maven
       run: mvn -Pzip install
 
+    # delete the snapshot release (the release action does not update the body, so we have to delete the whole thing)
+    - name: Delete Snapshot Release
+      if: ${{ env.MAKE_SNAPSHOT_RELEASE == 'true' }}
+      run: gh release delete snapshot --cleanup-tag --yes
+
     - name: change tag 'snapshot' to current commit
       if: ${{ env.MAKE_SNAPSHOT_RELEASE == 'true' }}
       run: |


### PR DESCRIPTION
The release action does not update the release body, but we want to see the latest changes in there. Therefore, we have to delete the snapshot release before we make a new one.