### PR TITLE
Add GITHUB_TOKEN env var to delete release via gh tool

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -48,6 +48,8 @@ jobs:
     # delete the snapshot release (the release action does not update the body, so we have to delete the whole thing)
     - name: Delete Snapshot Release
       if: ${{ env.MAKE_SNAPSHOT_RELEASE == 'true' }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: gh release delete snapshot --cleanup-tag --yes
 
     - name: change tag 'snapshot' to current commit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,6 +170,8 @@ jobs:
 
       # delete the snapshot release (so we do not accumulate snapshots of all versions over time)
       - name: Delete Snapshot Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release delete snapshot --cleanup-tag --yes
 
       # print the summary


### PR DESCRIPTION
Before this pr, attempting to delete the snapshot release fails.