### PR TITLE
Force CHANGELOG.md update if there are changes in src/main

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -26,6 +26,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
     - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
@@ -43,8 +45,10 @@ jobs:
         git config user.name ${{ github.actor }}
         git config user.email "<>"
 
-    - name: Fetch base branch
-      run: git fetch origin "${{ github.base_ref }}:${{ github.base_ref }}"
+    - name: Fetch base and head branches
+      run: |
+        git fetch origin ${{ github.base_ref }}:${{ github.base_ref }}
+        git fetch origin ${{ github.head_ref }}:${{ github.head_ref }}
 
     - name: Fail if src/main changes without a CHANGELOG update
       run: |

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -26,8 +26,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
     - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -26,8 +26,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-      with:
-        fetch-depth: 1
     - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -26,12 +26,15 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
     - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
         java-version: '17'
         distribution: 'temurin'
         cache: maven
+
 
     - name: Check if a snapshot release should be made and set environment variable
       run: echo "MAKE_SNAPSHOT_RELEASE=${{ inputs.force_snapshot_release || (github.event.pull_request.base.ref == 'main' && github.event.action == 'closed' && github.event.pull_request.merged == true) }}" >> $GITHUB_ENV
@@ -41,6 +44,9 @@ jobs:
       run: |
         git config user.name ${{ github.actor }}
         git config user.email "<>"
+
+    - name: Fetch base branch
+      run: git fetch origin "${{ github.base_ref }}:${{ github.base_ref }}"
 
     - name: Fail if src/main changes without a CHANGELOG update
       run: |

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -48,12 +48,12 @@ jobs:
         git fetch origin ${{ github.base_ref }}:${{ github.base_ref }}
         git fetch origin ${{ github.head_ref }}:${{ github.head_ref }}
 
-    - name: Fail if src/main changes without a CHANGELOG update
+    - name: Fail if src/main has changes but CHANGELOG.md does not
       run: |
         set -e
         CHANGED_FILES=$(git diff --name-only ${{ github.base_ref }} ${{ github.head_ref }})
         if echo "$CHANGED_FILES" | grep -q '^src/main' && ! echo "$CHANGED_FILES" | grep -q '^CHANGELOG.md$'; then
-          echo "src directory changed without updating CHANGELOG.md."
+          echo "Directory src/main changed without an update of CHANGELOG.md, this is not allowed. Please update CHANGELOG.md"
           exit 1
         fi
 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -42,6 +42,15 @@ jobs:
         git config user.name ${{ github.actor }}
         git config user.email "<>"
 
+    - name: Fail if src/main changes without a CHANGELOG update
+      run: |
+        set -e
+        CHANGED_FILES=$(git diff --name-only ${{ github.base_ref }} ${{ github.head_ref }})
+        if echo "$CHANGED_FILES" | grep -q '^src/main' && ! echo "$CHANGED_FILES" | grep -q '^CHANGELOG.md$'; then
+          echo "src directory changed without updating CHANGELOG.md."
+          exit 1
+        fi
+
       # Read version changelog before anything else - if there is a formatting error
       # in the changelog (which happens), we fail fast
       # Do this even if we will not make the snapshot release, so the changelog is checked as part of a normal

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -61,7 +61,7 @@ jobs:
       # in the changelog (which happens), we fail fast
       # Do this even if we will not make the snapshot release, so the changelog is checked as part of a normal
       # ci run.
-    - id: get-changelog
+    - id: check changelog formatting
       name: Get version changelog
       uses: superfaceai/release-changelog-action@v1
       with:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
       with:
-        fetch-depth: 0
+        fetch-depth: 1
     - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:


### PR DESCRIPTION
With this PR, the `.github/workflows/maven.yml` workflow fails if there are changes in `src/main` but no changes to `CHANGELOG.md`