### PR TITLE
Fix many unit symbols

### DIFF
--- a/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
+++ b/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
@@ -45948,4 +45948,13348 @@ voag:QUDT-UNITS-VocabCatalogEntry
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "QUDT UNITS Vocab Catalog Entry" .
 
+# 456 Units with incorrect symbol:
+
+# unit:A-PER-A-HR
+# unit:AC-FT_US
+# unit:ATM-PER-M
+# unit:BBL_UK_PET-PER-DAY
+# unit:BBL_US-PER-DAY
+# unit:BIT-PER-M
+# unit:BIT-PER-M2
+# unit:BTU_IT-PER-FT2-HR
+# unit:BTU_IT-PER-FT2-SEC
+# unit:BTU_IT-PER-HR-FT2-DEG_F
+# unit:BTU_IT-PER-IN2-SEC
+# unit:BTU_IT-PER-LB
+# unit:BTU_IT-PER-MOL_LB
+# unit:BTU_IT-PER-SEC-FT2-DEG_F
+# unit:BTU_TH-PER-DEG_F
+# unit:BTU_TH-PER-DEG_R
+# unit:BTU_TH-PER-FT2
+# unit:BTU_TH-PER-FT2-HR
+# unit:BTU_TH-PER-FT2-MIN
+# unit:BTU_TH-PER-FT2-SEC
+# unit:BTU_TH-PER-HR-FT2-DEG_F
+# unit:BTU_TH-PER-LB-DEG_R
+# unit:BTU_TH-PER-SEC-FT2-DEG_F
+# unit:BU_UK-PER-DAY
+# unit:BU_US
+# unit:BYTE-PER-SEC
+# unit:CAL_TH-PER-CentiM2
+# unit:CAL_TH-PER-CentiM2-MIN
+# unit:CAL_TH-PER-CentiM2-SEC
+# unit:CAL_TH-PER-CentiM3-K
+# unit:CentiM-PER-KiloYR
+# unit:CentiM3-PER-DAY
+# unit:DEG_F-HR-PER-BTU_TH
+# unit:DeciB-MilliW-PER-MegaHZ
+# unit:DeciB-W
+# unit:DeciM3-PER-DAY
+# unit:FT-HR-PER-GAL_UK
+# unit:FT-HR-PER-GAL_US
+# unit:FT-HR-PER-IN3
+# unit:FT-PER-DAY
+# unit:FT-SEC-PER-GAL_UK
+# unit:FT-SEC-PER-GAL_US
+# unit:FT-SEC-PER-IN3
+# unit:FT3-PER-DAY
+# unit:GAL_UK-PER-DAY
+# unit:GAL_US
+# unit:GAL_US-PER-DAY
+# unit:GI_UK-PER-DAY
+# unit:GI_US-PER-DAY
+# unit:GM-CentiM-PER-SEC
+# unit:GM-HR-PER-L-CentiM3
+# unit:GM-HR-PER-L-M3
+# unit:GM-HR-PER-L2
+# unit:GM-HR-PER-M3-CentiM3
+# unit:GM-HR-PER-M3-L
+# unit:GM-HR-PER-M6
+# unit:GM-MIN-PER-L-CentiM3
+# unit:GM-MIN-PER-L-M3
+# unit:GM-MIN-PER-L2
+# unit:GM-MIN-PER-M3-CentiM3
+# unit:GM-MIN-PER-M3-L
+# unit:GM-MIN-PER-M6
+# unit:GM-PER-DAY
+# unit:GM-PER-L-BAR
+# unit:GM-PER-L-CentiPOISE
+# unit:GM-PER-L-K
+# unit:GM-PER-L-MilliPA-SEC
+# unit:GM-PER-L-PA-SEC
+# unit:GM-PER-L-POISE
+# unit:GM-PER-M2-DAY
+# unit:GM-PER-M2-HR
+# unit:GM-PER-M2-YR
+# unit:GM-PER-M3-PA-SEC
+# unit:GM-PER-M3-POISE
+# unit:GM-PER-MilliL-BAR
+# unit:GM-PER-MilliL-K
+# unit:GM-SEC-PER-L-CentiM3
+# unit:GM-SEC-PER-L-M3
+# unit:GM-SEC-PER-L2
+# unit:GM-SEC-PER-M3-CentiM3
+# unit:GM-SEC-PER-M3-L
+# unit:GM-SEC-PER-M6
+# unit:GigaBIT-PER-SEC
+# unit:GigaBYTE-PER-SEC
+# unit:GigaOHM-M
+# unit:GigaOHM-PER-M
+# unit:HR-PER-FT2
+# unit:IN-PER-YR
+# unit:J-PER-CentiM2-DAY
+# unit:J-PER-KiloGM-K
+# unit:J-PER-KiloGM-K-M3
+# unit:J-PER-KiloGM-K-PA
+# unit:K-DAY
+# unit:KAT-PER-MicroL
+# unit:KiloBIT-PER-SEC
+# unit:KiloCAL_IT-PER-GM-K
+# unit:KiloCAL_TH-PER-HR
+# unit:KiloCAL_TH-PER-MIN
+# unit:KiloCAL_TH-PER-SEC
+# unit:KiloEV-PER-MicroM
+# unit:KiloGM-CentiM-PER-SEC
+# unit:KiloGM-K
+# unit:KiloGM-PER-DAY
+# unit:KiloGM-PER-HA-YR
+# unit:KiloGM-PER-L-BAR
+# unit:KiloGM-PER-L-K
+# unit:KiloJ-PER-KiloGM-K
+# unit:KiloM-PER-DAY
+# unit:KiloOHM-M
+# unit:KiloOHM-PER-BAR
+# unit:KiloOHM-PER-K
+# unit:KiloOHM-PER-M
+# unit:KiloTONNE-PER-YR
+# unit:KiloW-PER-M2
+# unit:L-PER-BAR
+# unit:L-PER-DAY
+# unit:L-PER-DAY-BAR
+# unit:L-PER-DAY-K
+# unit:L-PER-HR-BAR
+# unit:L-PER-HR-K
+# unit:L-PER-MIN-BAR
+# unit:L-PER-MIN-K
+# unit:L-PER-MOL-SEC
+# unit:L-PER-MicroMOL
+# unit:L-PER-SEC-BAR
+# unit:L-PER-SEC-K
+# unit:LB-FT-PER-SEC
+# unit:LB-FT2-PER-GAL_UK-LB_F-SEC
+# unit:LB-FT2-PER-GAL_US-LB_F-SEC
+# unit:LB-FT2-PER-IN3-LB_F-SEC
+# unit:LB-HR-PER-FT3-GAL_UK
+# unit:LB-HR-PER-FT3-GAL_US
+# unit:LB-HR-PER-FT3-IN3
+# unit:LB-HR-PER-FT3-YD3
+# unit:LB-HR-PER-FT6
+# unit:LB-HR-PER-GAL_UK-FT3
+# unit:LB-HR-PER-GAL_UK-IN3
+# unit:LB-HR-PER-GAL_UK-YD3
+# unit:LB-HR-PER-GAL_US-FT3
+# unit:LB-HR-PER-GAL_US-IN3
+# unit:LB-HR-PER-GAL_US-YD3
+# unit:LB-HR-PER-GAL_US2
+# unit:LB-HR-PER-IN3-FT3
+# unit:LB-HR-PER-IN3-GAL_UK
+# unit:LB-HR-PER-IN3-GAL_US
+# unit:LB-HR-PER-IN3-YD3
+# unit:LB-HR-PER-IN6
+# unit:LB-IN-PER-SEC
+# unit:LB-IN2-PER-FT3-LB_F-SEC
+# unit:LB-IN2-PER-GAL_UK-LB_F-SEC
+# unit:LB-IN2-PER-GAL_US-LB_F-SEC
+# unit:LB-IN2-PER-IN3-LB_F-SEC
+# unit:LB-MIN-PER-FT3-GAL_UK
+# unit:LB-MIN-PER-FT3-GAL_US
+# unit:LB-MIN-PER-FT3-IN3
+# unit:LB-MIN-PER-FT3-YD3
+# unit:LB-MIN-PER-FT6
+# unit:LB-MIN-PER-GAL_UK-FT3
+# unit:LB-MIN-PER-GAL_UK-IN3
+# unit:LB-MIN-PER-GAL_UK-YD3
+# unit:LB-MIN-PER-GAL_UK2
+# unit:LB-MIN-PER-GAL_US-FT3
+# unit:LB-MIN-PER-GAL_US-IN3
+# unit:LB-MIN-PER-GAL_US-YD3
+# unit:LB-MIN-PER-GAL_US2
+# unit:LB-MIN-PER-IN3-FT3
+# unit:LB-MIN-PER-IN3-GAL_UK
+# unit:LB-MIN-PER-IN3-GAL_US
+# unit:LB-MIN-PER-IN3-YD3
+# unit:LB-MIN-PER-IN6
+# unit:LB-PER-AC
+# unit:LB-PER-DAY
+# unit:LB-PER-DEG_F
+# unit:LB-PER-FT
+# unit:LB-PER-FT-DAY
+# unit:LB-PER-FT-LB_F-SEC
+# unit:LB-PER-FT-MIN
+# unit:LB-PER-FT3-DEG_F
+# unit:LB-PER-FT3-PSI
+# unit:LB-PER-HR-DEG_F
+# unit:LB-PER-HR-PSI
+# unit:LB-PER-IN3-DEG_F
+# unit:LB-PER-IN3-PSI
+# unit:LB-PER-LB
+# unit:LB-PER-MIN-DEG_F
+# unit:LB-PER-MIN-PSI
+# unit:LB-PER-PSI
+# unit:LB-PER-SEC-DEG_F
+# unit:LB-PER-SEC-PSI
+# unit:LB-PER-YD
+# unit:LB-PER-YD2
+# unit:LB-SEC-PER-FT3-GAL_UK
+# unit:LB-SEC-PER-FT3-GAL_US
+# unit:LB-SEC-PER-FT3-IN3
+# unit:LB-SEC-PER-FT3-YD3
+# unit:LB-SEC-PER-FT6
+# unit:LB-SEC-PER-GAL_UK-FT3
+# unit:LB-SEC-PER-GAL_UK-IN3
+# unit:LB-SEC-PER-GAL_UK-YD3
+# unit:LB-SEC-PER-GAL_UK2
+# unit:LB-SEC-PER-GAL_US-FT3
+# unit:LB-SEC-PER-GAL_US-IN3
+# unit:LB-SEC-PER-GAL_US-YD3
+# unit:LB-SEC-PER-GAL_US2
+# unit:LB-SEC-PER-IN3-FT3
+# unit:LB-SEC-PER-IN3-GAL_UK
+# unit:LB-SEC-PER-IN3-GAL_US
+# unit:LB-SEC-PER-IN3-YD3
+# unit:LB-SEC-PER-IN6
+# unit:M-PER-DAY
+# unit:M-PER-M2
+# unit:M3-PER-DAY
+# unit:MI_US2
+# unit:MOL-PER-KiloGM-K
+# unit:MOL-PER-L-BAR
+# unit:MOL-PER-L-K
+# unit:MOL-PER-M2-DAY
+# unit:MOL-PER-M2-SEC-M
+# unit:MOL-PER-M2-SEC-M-SR
+# unit:MegaBIT-PER-SEC
+# unit:MegaBYTE-PER-SEC
+# unit:MegaGM-PER-HA-YR
+# unit:MegaHZ-M
+# unit:MegaN-M
+# unit:MegaN-M-PER-M2
+# unit:MegaOHM-M
+# unit:MegaOHM-PER-BAR
+# unit:MegaOHM-PER-K
+# unit:MegaOHM-PER-KiloM
+# unit:MegaOHM-PER-M
+# unit:MicroA-PER-K
+# unit:MicroC-PER-M2
+# unit:MicroC-PER-M3
+# unit:MicroFARAD-PER-KiloM
+# unit:MicroFARAD-PER-M
+# unit:MicroGM-PER-CentiM2
+# unit:MicroGM-PER-GM-DAY
+# unit:MicroGM-PER-M2-DAY
+# unit:MicroGM-PER-M3-BAR
+# unit:MicroGM-PER-M3-K
+# unit:MicroGM-PER-MilliGM
+# unit:MicroGRAY-PER-HR
+# unit:MicroGRAY-PER-MIN
+# unit:MicroGRAY-PER-SEC
+# unit:MicroH-PER-KiloOHM
+# unit:MicroH-PER-M
+# unit:MicroH-PER-OHM
+# unit:MicroJ-PER-SEC
+# unit:MicroM-PER-K
+# unit:MicroM-PER-L-DAY
+# unit:MicroM-PER-M
+# unit:MicroM-PER-MilliL
+# unit:MicroM-PER-N
+# unit:MicroM3
+# unit:MicroM3-PER-M3
+# unit:MicroM3-PER-MilliL
+# unit:MicroMOL-PER-GM
+# unit:MicroMOL-PER-GM-HR
+# unit:MicroMOL-PER-KiloGM
+# unit:MicroMOL-PER-L
+# unit:MicroMOL-PER-L-HR
+# unit:MicroMOL-PER-M2
+# unit:MicroMOL-PER-M2-DAY
+# unit:MicroMOL-PER-M2-HR
+# unit:MicroMOL-PER-M2-SEC
+# unit:MicroMOL-PER-MOL
+# unit:MicroMOL-PER-MicroMOL-DAY
+# unit:MicroMOL-PER-SEC
+# unit:MicroMOL2-PER-M4-SEC2
+# unit:MicroN-M
+# unit:MicroN-M-PER-M2
+# unit:MicroOHM-M
+# unit:MilliA-PER-L-MIN
+# unit:MilliBQ-PER-M2-DAY
+# unit:MilliGM-HR-PER-L-CentiM3
+# unit:MilliGM-HR-PER-L-M3
+# unit:MilliGM-HR-PER-L2
+# unit:MilliGM-HR-PER-M3-CentiM3
+# unit:MilliGM-HR-PER-M3-L
+# unit:MilliGM-HR-PER-M6
+# unit:MilliGM-MIN-PER-L-CentiM3
+# unit:MilliGM-MIN-PER-L-M3
+# unit:MilliGM-MIN-PER-L2
+# unit:MilliGM-MIN-PER-M3-CentiM3
+# unit:MilliGM-MIN-PER-M3-L
+# unit:MilliGM-MIN-PER-M6
+# unit:MilliGM-PER-DAY
+# unit:MilliGM-PER-GM-HR
+# unit:MilliGM-PER-KiloGM-DAY
+# unit:MilliGM-PER-L-CentiPOISE
+# unit:MilliGM-PER-L-MilliPA-SEC
+# unit:MilliGM-PER-L-PA-SEC
+# unit:MilliGM-PER-L-POISE
+# unit:MilliGM-PER-M2-DAY
+# unit:MilliGM-PER-M3-CentiPOISE
+# unit:MilliGM-PER-M3-DAY
+# unit:MilliGM-PER-M3-MilliPA-SEC
+# unit:MilliGM-PER-M3-PA-SEC
+# unit:MilliGM-PER-M3-POISE
+# unit:MilliGM-SEC-PER-L-CentiM3
+# unit:MilliGM-SEC-PER-L-M3
+# unit:MilliGM-SEC-PER-L2
+# unit:MilliGM-SEC-PER-M3-CentiM3
+# unit:MilliGM-SEC-PER-M3-L
+# unit:MilliGM-SEC-PER-M6
+# unit:MilliL-PER-BAR
+# unit:MilliL-PER-DAY
+# unit:MilliL-PER-DAY-BAR
+# unit:MilliL-PER-DAY-K
+# unit:MilliL-PER-HR-BAR
+# unit:MilliL-PER-HR-K
+# unit:MilliL-PER-M2-DAY
+# unit:MilliL-PER-MIN-BAR
+# unit:MilliL-PER-MIN-K
+# unit:MilliL-PER-SEC-BAR
+# unit:MilliL-PER-SEC-K
+# unit:MilliM-PER-DAY
+# unit:MilliMOL-PER-M2-DAY
+# unit:MilliMOL-PER-M3-DAY
+# unit:MilliN-M
+# unit:MilliN-M-PER-M2
+# unit:MilliOHM-M
+# unit:MilliOHM-PER-BAR
+# unit:MilliOHM-PER-K
+# unit:MilliOHM-PER-M
+# unit:MilliW-PER-CentiM2-MicroM-SR
+# unit:MilliW-PER-M2-NanoM-SR
+# unit:NUM-PER-KiloGM
+# unit:NUM-PER-M2-DAY
+# unit:NUM-PER-MicroL
+# unit:NanoGM-PER-CentiM2-DAY
+# unit:NanoGM-PER-DAY
+# unit:NanoGM-PER-KiloGM
+# unit:NanoGM-PER-M2-PA-SEC
+# unit:NanoGM-PER-MicroL
+# unit:NanoMOL-PER-GM-HR
+# unit:NanoMOL-PER-L-DAY
+# unit:NanoMOL-PER-M2-DAY
+# unit:NanoMOL-PER-MicroGM-HR
+# unit:NanoMOL-PER-MicroMOL
+# unit:NanoMOL-PER-MicroMOL-DAY
+# unit:OHM-KiloM
+# unit:OHM-PER-BAR
+# unit:OHM-PER-K
+# unit:OHM-PER-KiloM
+# unit:OHM-PER-M
+# unit:OHM-PER-MI
+# unit:ONE-PER-ONE
+# unit:OZ-FT-HR-PER-IN3-LB
+# unit:OZ-FT-SEC-PER-IN3-LB
+# unit:OZ-FT2-PER-IN3-LB_F-SEC
+# unit:OZ-HR-PER-IN3-FT3
+# unit:OZ-HR-PER-IN3-GAL_UK
+# unit:OZ-HR-PER-IN3-GAL_US
+# unit:OZ-HR-PER-IN3-YD3
+# unit:OZ-HR-PER-IN6
+# unit:OZ-IN2-PER-IN3-LB_F-SEC
+# unit:OZ-MIN-PER-IN3-FT3
+# unit:OZ-MIN-PER-IN3-GAL_UK
+# unit:OZ-MIN-PER-IN3-GAL_US
+# unit:OZ-MIN-PER-IN3-YD3
+# unit:OZ-MIN-PER-IN6
+# unit:OZ-PER-DAY
+# unit:OZ-PER-FT2
+# unit:OZ-PER-YD2
+# unit:OZ-SEC-PER-IN3-FT3
+# unit:OZ-SEC-PER-IN3-GAL_UK
+# unit:OZ-SEC-PER-IN3-GAL_US
+# unit:OZ-SEC-PER-IN3-YD3
+# unit:OZ-SEC-PER-IN6
+# unit:OZ_VOL_UK-PER-DAY
+# unit:OZ_VOL_US-PER-DAY
+# unit:PA-M2-PER-KiloGM
+# unit:PA-SEC-PER-L
+# unit:PDL-SEC-PER-FT2
+# unit:PER-DAY
+# unit:PER-DEG_F
+# unit:PER-IN
+# unit:PER-J
+# unit:PER-KiloGM
+# unit:PER-LB
+# unit:PER-M3
+# unit:PER-MicroM
+# unit:PER-MicroMOL-L
+# unit:PER-MilliGM
+# unit:PER-OZ
+# unit:PER-PA
+# unit:PER-PlanckMass2
+# unit:PER-RAD
+# unit:PER-SEC-M2
+# unit:PER-SEC-M3
+# unit:PER-SEC-SR
+# unit:PER-SEC-SR-M2
+# unit:PER-TON
+# unit:PER-TONNE
+# unit:PER-V
+# unit:PER-V-A-SEC
+# unit:PERCENT-FT-HR-PER-LB
+# unit:PERCENT-FT-SEC-PER-LB
+# unit:PERCENT-FT2-PER-LB_F-SEC
+# unit:PERCENT-HR-PER-CentiM3
+# unit:PERCENT-HR-PER-FT3
+# unit:PERCENT-HR-PER-GAL_UK
+# unit:PERCENT-HR-PER-GAL_US
+# unit:PERCENT-HR-PER-IN3
+# unit:PERCENT-HR-PER-L
+# unit:PERCENT-HR-PER-M3
+# unit:PERCENT-HR-PER-YD3
+# unit:PERCENT-IN2-PER-LB_F-SEC
+# unit:PERCENT-MIN-PER-CentiM3
+# unit:PERCENT-MIN-PER-FT3
+# unit:PERCENT-MIN-PER-GAL_UK
+# unit:PERCENT-MIN-PER-GAL_US
+# unit:PERCENT-MIN-PER-IN3
+# unit:PERCENT-MIN-PER-L
+# unit:PERCENT-MIN-PER-M3
+# unit:PERCENT-MIN-PER-YD3
+# unit:PERCENT-PER-DAY
+# unit:PERCENT-PER-OHM
+# unit:PERCENT-SEC-PER-CentiM3
+# unit:PERCENT-SEC-PER-FT3
+# unit:PERCENT-SEC-PER-GAL_UK
+# unit:PERCENT-SEC-PER-GAL_US
+# unit:PERCENT-SEC-PER-IN3
+# unit:PERCENT-SEC-PER-L
+# unit:PERCENT-SEC-PER-M3
+# unit:PERCENT-SEC-PER-YD3
+# unit:PINT_UK-PER-DAY
+# unit:PINT_US-PER-DAY
+# unit:PK_UK-PER-DAY
+# unit:PK_US_DRY-PER-DAY
+# unit:PicoA-PER-MicroMOL-L
+# unit:PicoMOL-PER-L-DAY
+# unit:PicoMOL-PER-M2-DAY
+# unit:QT_UK-PER-DAY
+# unit:QT_US-PER-DAY
+# unit:QT_US-PER-HR
+# unit:QT_US-PER-MIN
+# unit:QT_US-PER-SEC
+# unit:REV-PER-MIN-SEC
+# unit:SCF-PER-HR
+# unit:SCF-PER-MIN
+# unit:SCM-PER-HR
+# unit:SCM-PER-MIN
+# unit:SEC-PER-FT2
+# unit:SLUG-PER-DAY
+# unit:TONNE-PER-DAY
+# unit:TONNE-PER-YR
+# unit:TON_Metric-PER-DAY
+# unit:TON_UK-PER-DAY
+# unit:TON_US-PER-DAY
+# unit:V-IN2-PER-LB_F
+# unit:V-PER-L-MIN
+# unit:W-HR-PER-L
+# unit:YD2
+# unit:YD3-PER-DAY
+
+
+# 0 Units without symbol:
+
+#
+
+
+# 456 Units with incorrect symbol:
+
+# unit:A-PER-A-HR
+# unit:AC-FT_US
+# unit:ATM-PER-M
+# unit:BBL_UK_PET-PER-DAY
+# unit:BBL_US-PER-DAY
+# unit:BIT-PER-M
+# unit:BIT-PER-M2
+# unit:BTU_IT-PER-FT2-HR
+# unit:BTU_IT-PER-FT2-SEC
+# unit:BTU_IT-PER-HR-FT2-DEG_F
+# unit:BTU_IT-PER-IN2-SEC
+# unit:BTU_IT-PER-LB
+# unit:BTU_IT-PER-MOL_LB
+# unit:BTU_IT-PER-SEC-FT2-DEG_F
+# unit:BTU_TH-PER-DEG_F
+# unit:BTU_TH-PER-DEG_R
+# unit:BTU_TH-PER-FT2
+# unit:BTU_TH-PER-FT2-HR
+# unit:BTU_TH-PER-FT2-MIN
+# unit:BTU_TH-PER-FT2-SEC
+# unit:BTU_TH-PER-HR-FT2-DEG_F
+# unit:BTU_TH-PER-LB-DEG_R
+# unit:BTU_TH-PER-SEC-FT2-DEG_F
+# unit:BU_UK-PER-DAY
+# unit:BU_US
+# unit:BYTE-PER-SEC
+# unit:CAL_TH-PER-CentiM2
+# unit:CAL_TH-PER-CentiM2-MIN
+# unit:CAL_TH-PER-CentiM2-SEC
+# unit:CAL_TH-PER-CentiM3-K
+# unit:CentiM-PER-KiloYR
+# unit:CentiM3-PER-DAY
+# unit:DEG_F-HR-PER-BTU_TH
+# unit:DeciB-MilliW-PER-MegaHZ
+# unit:DeciB-W
+# unit:DeciM3-PER-DAY
+# unit:FT-HR-PER-GAL_UK
+# unit:FT-HR-PER-GAL_US
+# unit:FT-HR-PER-IN3
+# unit:FT-PER-DAY
+# unit:FT-SEC-PER-GAL_UK
+# unit:FT-SEC-PER-GAL_US
+# unit:FT-SEC-PER-IN3
+# unit:FT3-PER-DAY
+# unit:GAL_UK-PER-DAY
+# unit:GAL_US
+# unit:GAL_US-PER-DAY
+# unit:GI_UK-PER-DAY
+# unit:GI_US-PER-DAY
+# unit:GM-CentiM-PER-SEC
+# unit:GM-HR-PER-L-CentiM3
+# unit:GM-HR-PER-L-M3
+# unit:GM-HR-PER-L2
+# unit:GM-HR-PER-M3-CentiM3
+# unit:GM-HR-PER-M3-L
+# unit:GM-HR-PER-M6
+# unit:GM-MIN-PER-L-CentiM3
+# unit:GM-MIN-PER-L-M3
+# unit:GM-MIN-PER-L2
+# unit:GM-MIN-PER-M3-CentiM3
+# unit:GM-MIN-PER-M3-L
+# unit:GM-MIN-PER-M6
+# unit:GM-PER-DAY
+# unit:GM-PER-L-BAR
+# unit:GM-PER-L-CentiPOISE
+# unit:GM-PER-L-K
+# unit:GM-PER-L-MilliPA-SEC
+# unit:GM-PER-L-PA-SEC
+# unit:GM-PER-L-POISE
+# unit:GM-PER-M2-DAY
+# unit:GM-PER-M2-HR
+# unit:GM-PER-M2-YR
+# unit:GM-PER-M3-PA-SEC
+# unit:GM-PER-M3-POISE
+# unit:GM-PER-MilliL-BAR
+# unit:GM-PER-MilliL-K
+# unit:GM-SEC-PER-L-CentiM3
+# unit:GM-SEC-PER-L-M3
+# unit:GM-SEC-PER-L2
+# unit:GM-SEC-PER-M3-CentiM3
+# unit:GM-SEC-PER-M3-L
+# unit:GM-SEC-PER-M6
+# unit:GigaBIT-PER-SEC
+# unit:GigaBYTE-PER-SEC
+# unit:GigaOHM-M
+# unit:GigaOHM-PER-M
+# unit:HR-PER-FT2
+# unit:IN-PER-YR
+# unit:J-PER-CentiM2-DAY
+# unit:J-PER-KiloGM-K
+# unit:J-PER-KiloGM-K-M3
+# unit:J-PER-KiloGM-K-PA
+# unit:K-DAY
+# unit:KAT-PER-MicroL
+# unit:KiloBIT-PER-SEC
+# unit:KiloCAL_IT-PER-GM-K
+# unit:KiloCAL_TH-PER-HR
+# unit:KiloCAL_TH-PER-MIN
+# unit:KiloCAL_TH-PER-SEC
+# unit:KiloEV-PER-MicroM
+# unit:KiloGM-CentiM-PER-SEC
+# unit:KiloGM-K
+# unit:KiloGM-PER-DAY
+# unit:KiloGM-PER-HA-YR
+# unit:KiloGM-PER-L-BAR
+# unit:KiloGM-PER-L-K
+# unit:KiloJ-PER-KiloGM-K
+# unit:KiloM-PER-DAY
+# unit:KiloOHM-M
+# unit:KiloOHM-PER-BAR
+# unit:KiloOHM-PER-K
+# unit:KiloOHM-PER-M
+# unit:KiloTONNE-PER-YR
+# unit:KiloW-PER-M2
+# unit:L-PER-BAR
+# unit:L-PER-DAY
+# unit:L-PER-DAY-BAR
+# unit:L-PER-DAY-K
+# unit:L-PER-HR-BAR
+# unit:L-PER-HR-K
+# unit:L-PER-MIN-BAR
+# unit:L-PER-MIN-K
+# unit:L-PER-MOL-SEC
+# unit:L-PER-MicroMOL
+# unit:L-PER-SEC-BAR
+# unit:L-PER-SEC-K
+# unit:LB-FT-PER-SEC
+# unit:LB-FT2-PER-GAL_UK-LB_F-SEC
+# unit:LB-FT2-PER-GAL_US-LB_F-SEC
+# unit:LB-FT2-PER-IN3-LB_F-SEC
+# unit:LB-HR-PER-FT3-GAL_UK
+# unit:LB-HR-PER-FT3-GAL_US
+# unit:LB-HR-PER-FT3-IN3
+# unit:LB-HR-PER-FT3-YD3
+# unit:LB-HR-PER-FT6
+# unit:LB-HR-PER-GAL_UK-FT3
+# unit:LB-HR-PER-GAL_UK-IN3
+# unit:LB-HR-PER-GAL_UK-YD3
+# unit:LB-HR-PER-GAL_US-FT3
+# unit:LB-HR-PER-GAL_US-IN3
+# unit:LB-HR-PER-GAL_US-YD3
+# unit:LB-HR-PER-GAL_US2
+# unit:LB-HR-PER-IN3-FT3
+# unit:LB-HR-PER-IN3-GAL_UK
+# unit:LB-HR-PER-IN3-GAL_US
+# unit:LB-HR-PER-IN3-YD3
+# unit:LB-HR-PER-IN6
+# unit:LB-IN-PER-SEC
+# unit:LB-IN2-PER-FT3-LB_F-SEC
+# unit:LB-IN2-PER-GAL_UK-LB_F-SEC
+# unit:LB-IN2-PER-GAL_US-LB_F-SEC
+# unit:LB-IN2-PER-IN3-LB_F-SEC
+# unit:LB-MIN-PER-FT3-GAL_UK
+# unit:LB-MIN-PER-FT3-GAL_US
+# unit:LB-MIN-PER-FT3-IN3
+# unit:LB-MIN-PER-FT3-YD3
+# unit:LB-MIN-PER-FT6
+# unit:LB-MIN-PER-GAL_UK-FT3
+# unit:LB-MIN-PER-GAL_UK-IN3
+# unit:LB-MIN-PER-GAL_UK-YD3
+# unit:LB-MIN-PER-GAL_UK2
+# unit:LB-MIN-PER-GAL_US-FT3
+# unit:LB-MIN-PER-GAL_US-IN3
+# unit:LB-MIN-PER-GAL_US-YD3
+# unit:LB-MIN-PER-GAL_US2
+# unit:LB-MIN-PER-IN3-FT3
+# unit:LB-MIN-PER-IN3-GAL_UK
+# unit:LB-MIN-PER-IN3-GAL_US
+# unit:LB-MIN-PER-IN3-YD3
+# unit:LB-MIN-PER-IN6
+# unit:LB-PER-AC
+# unit:LB-PER-DAY
+# unit:LB-PER-DEG_F
+# unit:LB-PER-FT
+# unit:LB-PER-FT-DAY
+# unit:LB-PER-FT-LB_F-SEC
+# unit:LB-PER-FT-MIN
+# unit:LB-PER-FT3-DEG_F
+# unit:LB-PER-FT3-PSI
+# unit:LB-PER-HR-DEG_F
+# unit:LB-PER-HR-PSI
+# unit:LB-PER-IN3-DEG_F
+# unit:LB-PER-IN3-PSI
+# unit:LB-PER-LB
+# unit:LB-PER-MIN-DEG_F
+# unit:LB-PER-MIN-PSI
+# unit:LB-PER-PSI
+# unit:LB-PER-SEC-DEG_F
+# unit:LB-PER-SEC-PSI
+# unit:LB-PER-YD
+# unit:LB-PER-YD2
+# unit:LB-SEC-PER-FT3-GAL_UK
+# unit:LB-SEC-PER-FT3-GAL_US
+# unit:LB-SEC-PER-FT3-IN3
+# unit:LB-SEC-PER-FT3-YD3
+# unit:LB-SEC-PER-FT6
+# unit:LB-SEC-PER-GAL_UK-FT3
+# unit:LB-SEC-PER-GAL_UK-IN3
+# unit:LB-SEC-PER-GAL_UK-YD3
+# unit:LB-SEC-PER-GAL_UK2
+# unit:LB-SEC-PER-GAL_US-FT3
+# unit:LB-SEC-PER-GAL_US-IN3
+# unit:LB-SEC-PER-GAL_US-YD3
+# unit:LB-SEC-PER-GAL_US2
+# unit:LB-SEC-PER-IN3-FT3
+# unit:LB-SEC-PER-IN3-GAL_UK
+# unit:LB-SEC-PER-IN3-GAL_US
+# unit:LB-SEC-PER-IN3-YD3
+# unit:LB-SEC-PER-IN6
+# unit:M-PER-DAY
+# unit:M-PER-M2
+# unit:M3-PER-DAY
+# unit:MI_US2
+# unit:MOL-PER-KiloGM-K
+# unit:MOL-PER-L-BAR
+# unit:MOL-PER-L-K
+# unit:MOL-PER-M2-DAY
+# unit:MOL-PER-M2-SEC-M
+# unit:MOL-PER-M2-SEC-M-SR
+# unit:MegaBIT-PER-SEC
+# unit:MegaBYTE-PER-SEC
+# unit:MegaGM-PER-HA-YR
+# unit:MegaHZ-M
+# unit:MegaN-M
+# unit:MegaN-M-PER-M2
+# unit:MegaOHM-M
+# unit:MegaOHM-PER-BAR
+# unit:MegaOHM-PER-K
+# unit:MegaOHM-PER-KiloM
+# unit:MegaOHM-PER-M
+# unit:MicroA-PER-K
+# unit:MicroC-PER-M2
+# unit:MicroC-PER-M3
+# unit:MicroFARAD-PER-KiloM
+# unit:MicroFARAD-PER-M
+# unit:MicroGM-PER-CentiM2
+# unit:MicroGM-PER-GM-DAY
+# unit:MicroGM-PER-M2-DAY
+# unit:MicroGM-PER-M3-BAR
+# unit:MicroGM-PER-M3-K
+# unit:MicroGM-PER-MilliGM
+# unit:MicroGRAY-PER-HR
+# unit:MicroGRAY-PER-MIN
+# unit:MicroGRAY-PER-SEC
+# unit:MicroH-PER-KiloOHM
+# unit:MicroH-PER-M
+# unit:MicroH-PER-OHM
+# unit:MicroJ-PER-SEC
+# unit:MicroM-PER-K
+# unit:MicroM-PER-L-DAY
+# unit:MicroM-PER-M
+# unit:MicroM-PER-MilliL
+# unit:MicroM-PER-N
+# unit:MicroM3
+# unit:MicroM3-PER-M3
+# unit:MicroM3-PER-MilliL
+# unit:MicroMOL-PER-GM
+# unit:MicroMOL-PER-GM-HR
+# unit:MicroMOL-PER-KiloGM
+# unit:MicroMOL-PER-L
+# unit:MicroMOL-PER-L-HR
+# unit:MicroMOL-PER-M2
+# unit:MicroMOL-PER-M2-DAY
+# unit:MicroMOL-PER-M2-HR
+# unit:MicroMOL-PER-M2-SEC
+# unit:MicroMOL-PER-MOL
+# unit:MicroMOL-PER-MicroMOL-DAY
+# unit:MicroMOL-PER-SEC
+# unit:MicroMOL2-PER-M4-SEC2
+# unit:MicroN-M
+# unit:MicroN-M-PER-M2
+# unit:MicroOHM-M
+# unit:MilliA-PER-L-MIN
+# unit:MilliBQ-PER-M2-DAY
+# unit:MilliGM-HR-PER-L-CentiM3
+# unit:MilliGM-HR-PER-L-M3
+# unit:MilliGM-HR-PER-L2
+# unit:MilliGM-HR-PER-M3-CentiM3
+# unit:MilliGM-HR-PER-M3-L
+# unit:MilliGM-HR-PER-M6
+# unit:MilliGM-MIN-PER-L-CentiM3
+# unit:MilliGM-MIN-PER-L-M3
+# unit:MilliGM-MIN-PER-L2
+# unit:MilliGM-MIN-PER-M3-CentiM3
+# unit:MilliGM-MIN-PER-M3-L
+# unit:MilliGM-MIN-PER-M6
+# unit:MilliGM-PER-DAY
+# unit:MilliGM-PER-GM-HR
+# unit:MilliGM-PER-KiloGM-DAY
+# unit:MilliGM-PER-L-CentiPOISE
+# unit:MilliGM-PER-L-MilliPA-SEC
+# unit:MilliGM-PER-L-PA-SEC
+# unit:MilliGM-PER-L-POISE
+# unit:MilliGM-PER-M2-DAY
+# unit:MilliGM-PER-M3-CentiPOISE
+# unit:MilliGM-PER-M3-DAY
+# unit:MilliGM-PER-M3-MilliPA-SEC
+# unit:MilliGM-PER-M3-PA-SEC
+# unit:MilliGM-PER-M3-POISE
+# unit:MilliGM-SEC-PER-L-CentiM3
+# unit:MilliGM-SEC-PER-L-M3
+# unit:MilliGM-SEC-PER-L2
+# unit:MilliGM-SEC-PER-M3-CentiM3
+# unit:MilliGM-SEC-PER-M3-L
+# unit:MilliGM-SEC-PER-M6
+# unit:MilliL-PER-BAR
+# unit:MilliL-PER-DAY
+# unit:MilliL-PER-DAY-BAR
+# unit:MilliL-PER-DAY-K
+# unit:MilliL-PER-HR-BAR
+# unit:MilliL-PER-HR-K
+# unit:MilliL-PER-M2-DAY
+# unit:MilliL-PER-MIN-BAR
+# unit:MilliL-PER-MIN-K
+# unit:MilliL-PER-SEC-BAR
+# unit:MilliL-PER-SEC-K
+# unit:MilliM-PER-DAY
+# unit:MilliMOL-PER-M2-DAY
+# unit:MilliMOL-PER-M3-DAY
+# unit:MilliN-M
+# unit:MilliN-M-PER-M2
+# unit:MilliOHM-M
+# unit:MilliOHM-PER-BAR
+# unit:MilliOHM-PER-K
+# unit:MilliOHM-PER-M
+# unit:MilliW-PER-CentiM2-MicroM-SR
+# unit:MilliW-PER-M2-NanoM-SR
+# unit:NUM-PER-KiloGM
+# unit:NUM-PER-M2-DAY
+# unit:NUM-PER-MicroL
+# unit:NanoGM-PER-CentiM2-DAY
+# unit:NanoGM-PER-DAY
+# unit:NanoGM-PER-KiloGM
+# unit:NanoGM-PER-M2-PA-SEC
+# unit:NanoGM-PER-MicroL
+# unit:NanoMOL-PER-GM-HR
+# unit:NanoMOL-PER-L-DAY
+# unit:NanoMOL-PER-M2-DAY
+# unit:NanoMOL-PER-MicroGM-HR
+# unit:NanoMOL-PER-MicroMOL
+# unit:NanoMOL-PER-MicroMOL-DAY
+# unit:OHM-KiloM
+# unit:OHM-PER-BAR
+# unit:OHM-PER-K
+# unit:OHM-PER-KiloM
+# unit:OHM-PER-M
+# unit:OHM-PER-MI
+# unit:ONE-PER-ONE
+# unit:OZ-FT-HR-PER-IN3-LB
+# unit:OZ-FT-SEC-PER-IN3-LB
+# unit:OZ-FT2-PER-IN3-LB_F-SEC
+# unit:OZ-HR-PER-IN3-FT3
+# unit:OZ-HR-PER-IN3-GAL_UK
+# unit:OZ-HR-PER-IN3-GAL_US
+# unit:OZ-HR-PER-IN3-YD3
+# unit:OZ-HR-PER-IN6
+# unit:OZ-IN2-PER-IN3-LB_F-SEC
+# unit:OZ-MIN-PER-IN3-FT3
+# unit:OZ-MIN-PER-IN3-GAL_UK
+# unit:OZ-MIN-PER-IN3-GAL_US
+# unit:OZ-MIN-PER-IN3-YD3
+# unit:OZ-MIN-PER-IN6
+# unit:OZ-PER-DAY
+# unit:OZ-PER-FT2
+# unit:OZ-PER-YD2
+# unit:OZ-SEC-PER-IN3-FT3
+# unit:OZ-SEC-PER-IN3-GAL_UK
+# unit:OZ-SEC-PER-IN3-GAL_US
+# unit:OZ-SEC-PER-IN3-YD3
+# unit:OZ-SEC-PER-IN6
+# unit:OZ_VOL_UK-PER-DAY
+# unit:OZ_VOL_US-PER-DAY
+# unit:PA-M2-PER-KiloGM
+# unit:PA-SEC-PER-L
+# unit:PDL-SEC-PER-FT2
+# unit:PER-DAY
+# unit:PER-DEG_F
+# unit:PER-IN
+# unit:PER-J
+# unit:PER-KiloGM
+# unit:PER-LB
+# unit:PER-M3
+# unit:PER-MicroM
+# unit:PER-MicroMOL-L
+# unit:PER-MilliGM
+# unit:PER-OZ
+# unit:PER-PA
+# unit:PER-PlanckMass2
+# unit:PER-RAD
+# unit:PER-SEC-M2
+# unit:PER-SEC-M3
+# unit:PER-SEC-SR
+# unit:PER-SEC-SR-M2
+# unit:PER-TON
+# unit:PER-TONNE
+# unit:PER-V
+# unit:PER-V-A-SEC
+# unit:PERCENT-FT-HR-PER-LB
+# unit:PERCENT-FT-SEC-PER-LB
+# unit:PERCENT-FT2-PER-LB_F-SEC
+# unit:PERCENT-HR-PER-CentiM3
+# unit:PERCENT-HR-PER-FT3
+# unit:PERCENT-HR-PER-GAL_UK
+# unit:PERCENT-HR-PER-GAL_US
+# unit:PERCENT-HR-PER-IN3
+# unit:PERCENT-HR-PER-L
+# unit:PERCENT-HR-PER-M3
+# unit:PERCENT-HR-PER-YD3
+# unit:PERCENT-IN2-PER-LB_F-SEC
+# unit:PERCENT-MIN-PER-CentiM3
+# unit:PERCENT-MIN-PER-FT3
+# unit:PERCENT-MIN-PER-GAL_UK
+# unit:PERCENT-MIN-PER-GAL_US
+# unit:PERCENT-MIN-PER-IN3
+# unit:PERCENT-MIN-PER-L
+# unit:PERCENT-MIN-PER-M3
+# unit:PERCENT-MIN-PER-YD3
+# unit:PERCENT-PER-DAY
+# unit:PERCENT-PER-OHM
+# unit:PERCENT-SEC-PER-CentiM3
+# unit:PERCENT-SEC-PER-FT3
+# unit:PERCENT-SEC-PER-GAL_UK
+# unit:PERCENT-SEC-PER-GAL_US
+# unit:PERCENT-SEC-PER-IN3
+# unit:PERCENT-SEC-PER-L
+# unit:PERCENT-SEC-PER-M3
+# unit:PERCENT-SEC-PER-YD3
+# unit:PINT_UK-PER-DAY
+# unit:PINT_US-PER-DAY
+# unit:PK_UK-PER-DAY
+# unit:PK_US_DRY-PER-DAY
+# unit:PicoA-PER-MicroMOL-L
+# unit:PicoMOL-PER-L-DAY
+# unit:PicoMOL-PER-M2-DAY
+# unit:QT_UK-PER-DAY
+# unit:QT_US-PER-DAY
+# unit:QT_US-PER-HR
+# unit:QT_US-PER-MIN
+# unit:QT_US-PER-SEC
+# unit:REV-PER-MIN-SEC
+# unit:SCF-PER-HR
+# unit:SCF-PER-MIN
+# unit:SCM-PER-HR
+# unit:SCM-PER-MIN
+# unit:SEC-PER-FT2
+# unit:SLUG-PER-DAY
+# unit:TONNE-PER-DAY
+# unit:TONNE-PER-YR
+# unit:TON_Metric-PER-DAY
+# unit:TON_UK-PER-DAY
+# unit:TON_US-PER-DAY
+# unit:V-IN2-PER-LB_F
+# unit:V-PER-L-MIN
+# unit:W-HR-PER-L
+# unit:YD2
+# unit:YD3-PER-DAY
+
+
+# 0 Units without symbol:
+
+#
+
+
+STATEMENTS TO ADD:
+
+
+  # WRONG SYMBOL  : unit:A-PER-A-HR - calculated from factors: A/(A·h), actual: A/A·h
+  #
+  #  ──┬ unit:A-PER-A-HR symbol: A/A·h (correct: A/(A·h))
+  #    ├─── unit:A symbol: A
+  #    ├─── unit:A^-1 symbol: A
+  #    └──┬ unit:HR^-1 symbol: h
+  #       └─── unit:SEC symbol: s
+unit:A-PER-A-HR qudt:symbol "A/(A·h)" .
+
+  # WRONG SYMBOL  : unit:AC-FT_US - calculated from factors: acre·ft{US Survey}, actual: acre-ft (US survey)
+  #
+  #  ──┬ unit:AC-FT_US symbol: acre-ft (US survey) (correct: acre·ft{US Survey})
+  #    ├──┬ unit:AC symbol: acre
+  #    │  └──┬ unit:M2 symbol: m²
+  #    │     └─── unit:M^2 symbol: m
+  #    └──┬ unit:FT_US symbol: ft{US Survey}
+  #       └─── unit:M symbol: m
+unit:AC-FT_US qudt:symbol "acre·ft{US Survey}" .
+
+  # WRONG SYMBOL  : unit:ATM-PER-M - calculated from factors: atm/m, actual: Atm/m
+  #
+  #  ──┬ unit:ATM-PER-M symbol: Atm/m (correct: atm/m)
+  #    ├──┬ unit:ATM symbol: atm
+  #    │  └──┬ unit:PA symbol: Pa
+  #    │     ├─── unit:M^-2 symbol: m
+  #    │     └──┬ unit:N symbol: N
+  #    │        ├──┬ unit:KiloGM symbol: kg
+  #    │        │  └─── unit:GM symbol: g
+  #    │        ├─── unit:M symbol: m
+  #    │        └─── unit:SEC^-2 symbol: s
+  #    └─── unit:M^-1 symbol: m
+unit:ATM-PER-M qudt:symbol "atm/m" .
+
+  # WRONG SYMBOL  : unit:BBL_UK_PET-PER-DAY - calculated from factors: bbl{UK petroleum}/d, actual: bbl{UK petroleum}/day
+  #
+  #  ──┬ unit:BBL_UK_PET-PER-DAY symbol: bbl{UK petroleum}/day (correct: bbl{UK petroleum}/d)
+  #    ├──┬ unit:BBL_UK_PET symbol: bbl{UK petroleum}
+  #    │  └──┬ unit:M3 symbol: m³
+  #    │     └─── unit:M^3 symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:BBL_UK_PET-PER-DAY qudt:symbol "bbl{UK petroleum}/d" .
+
+  # WRONG SYMBOL  : unit:BBL_US-PER-DAY - calculated from factors: bbl{US petroleum}/d, actual: bbl{US petroleum}/day
+  #
+  #  ──┬ unit:BBL_US-PER-DAY symbol: bbl{US petroleum}/day (correct: bbl{US petroleum}/d)
+  #    ├──┬ unit:BBL_US symbol: bbl{US petroleum}
+  #    │  └──┬ unit:M3 symbol: m³
+  #    │     └─── unit:M^3 symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:BBL_US-PER-DAY qudt:symbol "bbl{US petroleum}/d" .
+
+  # WRONG SYMBOL  : unit:BIT-PER-M - calculated from factors: b/m, actual: bit/m
+  #
+  #  ──┬ unit:BIT-PER-M symbol: bit/m (correct: b/m)
+  #    ├─── unit:BIT symbol: b
+  #    └─── unit:M^-1 symbol: m
+unit:BIT-PER-M qudt:symbol "b/m" .
+
+  # WRONG SYMBOL  : unit:BIT-PER-M2 - calculated from factors: b/m², actual: bit/m²
+  #
+  #  ──┬ unit:BIT-PER-M2 symbol: bit/m² (correct: b/m²)
+  #    ├─── unit:BIT symbol: b
+  #    └─── unit:M^-2 symbol: m
+unit:BIT-PER-M2 qudt:symbol "b/m²" .
+
+  # WRONG SYMBOL  : unit:BTU_IT-PER-FT2-HR - calculated from factors: Btu{IT}/(ft²·h), actual: BtuIT/(ft²·h)
+  #
+  #  ──┬ unit:BTU_IT-PER-FT2-HR symbol: BtuIT/(ft²·h) (correct: Btu{IT}/(ft²·h))
+  #    ├──┬ unit:BTU_IT symbol: Btu{IT}
+  #    │  └──┬ unit:J symbol: J
+  #    │     ├─── unit:M symbol: m
+  #    │     └──┬ unit:N symbol: N
+  #    │        ├──┬ unit:KiloGM symbol: kg
+  #    │        │  └─── unit:GM symbol: g
+  #    │        ├─── unit:M symbol: m
+  #    │        └─── unit:SEC^-2 symbol: s
+  #    ├──┬ unit:FT^-2 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:HR^-1 symbol: h
+  #       └─── unit:SEC symbol: s
+unit:BTU_IT-PER-FT2-HR qudt:symbol "Btu{IT}/(ft²·h)" .
+
+  # WRONG SYMBOL  : unit:BTU_IT-PER-FT2-SEC - calculated from factors: Btu{IT}/(ft²·s), actual: BtuIT/(ft²·s)
+  #
+  #  ──┬ unit:BTU_IT-PER-FT2-SEC symbol: BtuIT/(ft²·s) (correct: Btu{IT}/(ft²·s))
+  #    ├──┬ unit:BTU_IT symbol: Btu{IT}
+  #    │  └──┬ unit:J symbol: J
+  #    │     ├─── unit:M symbol: m
+  #    │     └──┬ unit:N symbol: N
+  #    │        ├──┬ unit:KiloGM symbol: kg
+  #    │        │  └─── unit:GM symbol: g
+  #    │        ├─── unit:M symbol: m
+  #    │        └─── unit:SEC^-2 symbol: s
+  #    ├──┬ unit:FT^-2 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └─── unit:SEC^-1 symbol: s
+unit:BTU_IT-PER-FT2-SEC qudt:symbol "Btu{IT}/(ft²·s)" .
+
+  # WRONG SYMBOL  : unit:BTU_IT-PER-HR-FT2-DEG_F - calculated from factors: Btu{IT}/(h·ft²·°F), actual: BtuIT/(h·ft²·°F)
+  #
+  #  ──┬ unit:BTU_IT-PER-HR-FT2-DEG_F symbol: BtuIT/(h·ft²·°F) (correct: Btu{IT}/(h·ft²·°F))
+  #    ├──┬ unit:BTU_IT symbol: Btu{IT}
+  #    │  └──┬ unit:J symbol: J
+  #    │     ├─── unit:M symbol: m
+  #    │     └──┬ unit:N symbol: N
+  #    │        ├──┬ unit:KiloGM symbol: kg
+  #    │        │  └─── unit:GM symbol: g
+  #    │        ├─── unit:M symbol: m
+  #    │        └─── unit:SEC^-2 symbol: s
+  #    ├──┬ unit:HR^-1 symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:FT^-2 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:DEG_F^-1 symbol: °F
+  #       └─── unit:K symbol: K
+unit:BTU_IT-PER-HR-FT2-DEG_F qudt:symbol "Btu{IT}/(h·ft²·°F)" .
+
+  # WRONG SYMBOL  : unit:BTU_IT-PER-IN2-SEC - calculated from factors: Btu{IT}/(in²·s), actual: BtuIT/(in²·s)
+  #
+  #  ──┬ unit:BTU_IT-PER-IN2-SEC symbol: BtuIT/(in²·s) (correct: Btu{IT}/(in²·s))
+  #    ├──┬ unit:BTU_IT symbol: Btu{IT}
+  #    │  └──┬ unit:J symbol: J
+  #    │     ├─── unit:M symbol: m
+  #    │     └──┬ unit:N symbol: N
+  #    │        ├──┬ unit:KiloGM symbol: kg
+  #    │        │  └─── unit:GM symbol: g
+  #    │        ├─── unit:M symbol: m
+  #    │        └─── unit:SEC^-2 symbol: s
+  #    ├──┬ unit:IN^-2 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └─── unit:SEC^-1 symbol: s
+unit:BTU_IT-PER-IN2-SEC qudt:symbol "Btu{IT}/(in²·s)" .
+
+  # WRONG SYMBOL  : unit:BTU_IT-PER-LB - calculated from factors: Btu{IT}/lbm, actual: Btu{IT}/lb
+  #
+  #  ──┬ unit:BTU_IT-PER-LB symbol: Btu{IT}/lb (correct: Btu{IT}/lbm)
+  #    ├──┬ unit:BTU_IT symbol: Btu{IT}
+  #    │  └──┬ unit:J symbol: J
+  #    │     ├─── unit:M symbol: m
+  #    │     └──┬ unit:N symbol: N
+  #    │        ├──┬ unit:KiloGM symbol: kg
+  #    │        │  └─── unit:GM symbol: g
+  #    │        ├─── unit:M symbol: m
+  #    │        └─── unit:SEC^-2 symbol: s
+  #    └──┬ unit:LB^-1 symbol: lbm
+  #       └──┬ unit:KiloGM symbol: kg
+  #          └─── unit:GM symbol: g
+unit:BTU_IT-PER-LB qudt:symbol "Btu{IT}/lbm" .
+
+  # WRONG SYMBOL  : unit:BTU_IT-PER-MOL_LB - calculated from factors: Btu{IT}/lb-mol, actual: Btu{IT}/(mol-lb)
+  #
+  #  ──┬ unit:BTU_IT-PER-MOL_LB symbol: Btu{IT}/(mol-lb) (correct: Btu{IT}/lb-mol)
+  #    ├──┬ unit:BTU_IT symbol: Btu{IT}
+  #    │  └──┬ unit:J symbol: J
+  #    │     ├─── unit:M symbol: m
+  #    │     └──┬ unit:N symbol: N
+  #    │        ├──┬ unit:KiloGM symbol: kg
+  #    │        │  └─── unit:GM symbol: g
+  #    │        ├─── unit:M symbol: m
+  #    │        └─── unit:SEC^-2 symbol: s
+  #    └──┬ unit:MOL_LB^-1 symbol: lb-mol
+  #       └─── unit:MOL symbol: mol
+unit:BTU_IT-PER-MOL_LB qudt:symbol "Btu{IT}/lb-mol" .
+
+  # WRONG SYMBOL  : unit:BTU_IT-PER-SEC-FT2-DEG_F - calculated from factors: Btu{IT}/(s·ft²·°F), actual: BtuIT/(s·ft²·°F)
+  #
+  #  ──┬ unit:BTU_IT-PER-SEC-FT2-DEG_F symbol: BtuIT/(s·ft²·°F) (correct: Btu{IT}/(s·ft²·°F))
+  #    ├──┬ unit:BTU_IT symbol: Btu{IT}
+  #    │  └──┬ unit:J symbol: J
+  #    │     ├─── unit:M symbol: m
+  #    │     └──┬ unit:N symbol: N
+  #    │        ├──┬ unit:KiloGM symbol: kg
+  #    │        │  └─── unit:GM symbol: g
+  #    │        ├─── unit:M symbol: m
+  #    │        └─── unit:SEC^-2 symbol: s
+  #    ├─── unit:SEC^-1 symbol: s
+  #    ├──┬ unit:FT^-2 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:DEG_F^-1 symbol: °F
+  #       └─── unit:K symbol: K
+unit:BTU_IT-PER-SEC-FT2-DEG_F qudt:symbol "Btu{IT}/(s·ft²·°F)" .
+
+  # WRONG SYMBOL  : unit:BTU_TH-PER-DEG_F - calculated from factors: Btu{th}/°F, actual: Btuth/°F
+  #
+  #  ──┬ unit:BTU_TH-PER-DEG_F symbol: Btuth/°F (correct: Btu{th}/°F)
+  #    ├──┬ unit:BTU_TH symbol: Btu{th}
+  #    │  └──┬ unit:J symbol: J
+  #    │     ├─── unit:M symbol: m
+  #    │     └──┬ unit:N symbol: N
+  #    │        ├──┬ unit:KiloGM symbol: kg
+  #    │        │  └─── unit:GM symbol: g
+  #    │        ├─── unit:M symbol: m
+  #    │        └─── unit:SEC^-2 symbol: s
+  #    └──┬ unit:DEG_F^-1 symbol: °F
+  #       └─── unit:K symbol: K
+unit:BTU_TH-PER-DEG_F qudt:symbol "Btu{th}/°F" .
+
+  # WRONG SYMBOL  : unit:BTU_TH-PER-DEG_R - calculated from factors: Btu{th}/°R, actual: Btuth/°R
+  #
+  #  ──┬ unit:BTU_TH-PER-DEG_R symbol: Btuth/°R (correct: Btu{th}/°R)
+  #    ├──┬ unit:BTU_TH symbol: Btu{th}
+  #    │  └──┬ unit:J symbol: J
+  #    │     ├─── unit:M symbol: m
+  #    │     └──┬ unit:N symbol: N
+  #    │        ├──┬ unit:KiloGM symbol: kg
+  #    │        │  └─── unit:GM symbol: g
+  #    │        ├─── unit:M symbol: m
+  #    │        └─── unit:SEC^-2 symbol: s
+  #    └──┬ unit:DEG_R^-1 symbol: °R
+  #       └─── unit:K symbol: K
+unit:BTU_TH-PER-DEG_R qudt:symbol "Btu{th}/°R" .
+
+  # WRONG SYMBOL  : unit:BTU_TH-PER-FT2 - calculated from factors: Btu{th}/ft², actual: Btuth/ft²
+  #
+  #  ──┬ unit:BTU_TH-PER-FT2 symbol: Btuth/ft² (correct: Btu{th}/ft²)
+  #    ├──┬ unit:BTU_TH symbol: Btu{th}
+  #    │  └──┬ unit:J symbol: J
+  #    │     ├─── unit:M symbol: m
+  #    │     └──┬ unit:N symbol: N
+  #    │        ├──┬ unit:KiloGM symbol: kg
+  #    │        │  └─── unit:GM symbol: g
+  #    │        ├─── unit:M symbol: m
+  #    │        └─── unit:SEC^-2 symbol: s
+  #    └──┬ unit:FT^-2 symbol: ft
+  #       └──┬ unit:IN symbol: in
+  #          └─── unit:M symbol: m
+unit:BTU_TH-PER-FT2 qudt:symbol "Btu{th}/ft²" .
+
+  # WRONG SYMBOL  : unit:BTU_TH-PER-FT2-HR - calculated from factors: Btu{th}/(ft²·h), actual: Btuth/(ft²·h)
+  #
+  #  ──┬ unit:BTU_TH-PER-FT2-HR symbol: Btuth/(ft²·h) (correct: Btu{th}/(ft²·h))
+  #    ├──┬ unit:BTU_TH symbol: Btu{th}
+  #    │  └──┬ unit:J symbol: J
+  #    │     ├─── unit:M symbol: m
+  #    │     └──┬ unit:N symbol: N
+  #    │        ├──┬ unit:KiloGM symbol: kg
+  #    │        │  └─── unit:GM symbol: g
+  #    │        ├─── unit:M symbol: m
+  #    │        └─── unit:SEC^-2 symbol: s
+  #    ├──┬ unit:FT^-2 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:HR^-1 symbol: h
+  #       └─── unit:SEC symbol: s
+unit:BTU_TH-PER-FT2-HR qudt:symbol "Btu{th}/(ft²·h)" .
+
+  # WRONG SYMBOL  : unit:BTU_TH-PER-FT2-MIN - calculated from factors: Btu{th}/(ft²·min), actual: Btuth/(ft²·min)
+  #
+  #  ──┬ unit:BTU_TH-PER-FT2-MIN symbol: Btuth/(ft²·min) (correct: Btu{th}/(ft²·min))
+  #    ├──┬ unit:BTU_TH symbol: Btu{th}
+  #    │  └──┬ unit:J symbol: J
+  #    │     ├─── unit:M symbol: m
+  #    │     └──┬ unit:N symbol: N
+  #    │        ├──┬ unit:KiloGM symbol: kg
+  #    │        │  └─── unit:GM symbol: g
+  #    │        ├─── unit:M symbol: m
+  #    │        └─── unit:SEC^-2 symbol: s
+  #    ├──┬ unit:FT^-2 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:MIN^-1 symbol: min
+  #       └─── unit:SEC symbol: s
+unit:BTU_TH-PER-FT2-MIN qudt:symbol "Btu{th}/(ft²·min)" .
+
+  # WRONG SYMBOL  : unit:BTU_TH-PER-FT2-SEC - calculated from factors: Btu{th}/(ft²·s), actual: Btuth/(ft²·s)
+  #
+  #  ──┬ unit:BTU_TH-PER-FT2-SEC symbol: Btuth/(ft²·s) (correct: Btu{th}/(ft²·s))
+  #    ├──┬ unit:BTU_TH symbol: Btu{th}
+  #    │  └──┬ unit:J symbol: J
+  #    │     ├─── unit:M symbol: m
+  #    │     └──┬ unit:N symbol: N
+  #    │        ├──┬ unit:KiloGM symbol: kg
+  #    │        │  └─── unit:GM symbol: g
+  #    │        ├─── unit:M symbol: m
+  #    │        └─── unit:SEC^-2 symbol: s
+  #    ├──┬ unit:FT^-2 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └─── unit:SEC^-1 symbol: s
+unit:BTU_TH-PER-FT2-SEC qudt:symbol "Btu{th}/(ft²·s)" .
+
+  # WRONG SYMBOL  : unit:BTU_TH-PER-HR-FT2-DEG_F - calculated from factors: Btu{th}/(h·ft²·°F), actual: Btuth/(h·ft²·°F)
+  #
+  #  ──┬ unit:BTU_TH-PER-HR-FT2-DEG_F symbol: Btuth/(h·ft²·°F) (correct: Btu{th}/(h·ft²·°F))
+  #    ├──┬ unit:BTU_TH symbol: Btu{th}
+  #    │  └──┬ unit:J symbol: J
+  #    │     ├─── unit:M symbol: m
+  #    │     └──┬ unit:N symbol: N
+  #    │        ├──┬ unit:KiloGM symbol: kg
+  #    │        │  └─── unit:GM symbol: g
+  #    │        ├─── unit:M symbol: m
+  #    │        └─── unit:SEC^-2 symbol: s
+  #    ├──┬ unit:HR^-1 symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:FT^-2 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:DEG_F^-1 symbol: °F
+  #       └─── unit:K symbol: K
+unit:BTU_TH-PER-HR-FT2-DEG_F qudt:symbol "Btu{th}/(h·ft²·°F)" .
+
+  # WRONG SYMBOL  : unit:BTU_TH-PER-LB-DEG_R - calculated from factors: Btu{th}/(lbm·°R), actual: Btuth/°R)/lb
+  #
+  #  ──┬ unit:BTU_TH-PER-LB-DEG_R symbol: Btuth/°R)/lb (correct: Btu{th}/(lbm·°R))
+  #    ├──┬ unit:BTU_TH symbol: Btu{th}
+  #    │  └──┬ unit:J symbol: J
+  #    │     ├─── unit:M symbol: m
+  #    │     └──┬ unit:N symbol: N
+  #    │        ├──┬ unit:KiloGM symbol: kg
+  #    │        │  └─── unit:GM symbol: g
+  #    │        ├─── unit:M symbol: m
+  #    │        └─── unit:SEC^-2 symbol: s
+  #    ├──┬ unit:LB^-1 symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    └──┬ unit:DEG_R^-1 symbol: °R
+  #       └─── unit:K symbol: K
+unit:BTU_TH-PER-LB-DEG_R qudt:symbol "Btu{th}/(lbm·°R)" .
+
+  # WRONG SYMBOL  : unit:BTU_TH-PER-SEC-FT2-DEG_F - calculated from factors: Btu{th}/(s·ft²·°F), actual: Btuth/(s·ft²·°F)
+  #
+  #  ──┬ unit:BTU_TH-PER-SEC-FT2-DEG_F symbol: Btuth/(s·ft²·°F) (correct: Btu{th}/(s·ft²·°F))
+  #    ├──┬ unit:BTU_TH symbol: Btu{th}
+  #    │  └──┬ unit:J symbol: J
+  #    │     ├─── unit:M symbol: m
+  #    │     └──┬ unit:N symbol: N
+  #    │        ├──┬ unit:KiloGM symbol: kg
+  #    │        │  └─── unit:GM symbol: g
+  #    │        ├─── unit:M symbol: m
+  #    │        └─── unit:SEC^-2 symbol: s
+  #    ├─── unit:SEC^-1 symbol: s
+  #    ├──┬ unit:FT^-2 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:DEG_F^-1 symbol: °F
+  #       └─── unit:K symbol: K
+unit:BTU_TH-PER-SEC-FT2-DEG_F qudt:symbol "Btu{th}/(s·ft²·°F)" .
+
+  # WRONG SYMBOL  : unit:BU_UK-PER-DAY - calculated from factors: bsh{UK}/d, actual: bsh{UK}/day
+  #
+  #  ──┬ unit:BU_UK-PER-DAY symbol: bsh{UK}/day (correct: bsh{UK}/d)
+  #    ├──┬ unit:BU_UK symbol: bsh{UK}
+  #    │  └──┬ unit:M3 symbol: m³
+  #    │     └─── unit:M^3 symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:BU_UK-PER-DAY qudt:symbol "bsh{UK}/d" .
+
+  # WRONG SYMBOL  : unit:BU_US - calculated from factors: in³, actual: bsh{US}
+  #
+  #  ──┬ unit:BU_US symbol: bsh{US} (correct: in³)
+  #    └──┬ unit:IN^3 symbol: in
+  #       └─── unit:M symbol: m
+unit:BU_US qudt:symbol "in³" .
+
+  # WRONG SYMBOL  : unit:BYTE-PER-SEC - calculated from factors: B/s, actual: byte/s
+  #
+  #  ──┬ unit:BYTE-PER-SEC symbol: byte/s (correct: B/s)
+  #    ├─── unit:BYTE symbol: B
+  #    └─── unit:SEC^-1 symbol: s
+unit:BYTE-PER-SEC qudt:symbol "B/s" .
+
+  # WRONG SYMBOL  : unit:CAL_TH-PER-CentiM2 - calculated from factors: cal/cm², actual: calth/cm²
+  #
+  #  ──┬ unit:CAL_TH-PER-CentiM2 symbol: calth/cm² (correct: cal/cm²)
+  #    ├──┬ unit:CAL_TH symbol: cal
+  #    │  └──┬ unit:J symbol: J
+  #    │     ├─── unit:M symbol: m
+  #    │     └──┬ unit:N symbol: N
+  #    │        ├──┬ unit:KiloGM symbol: kg
+  #    │        │  └─── unit:GM symbol: g
+  #    │        ├─── unit:M symbol: m
+  #    │        └─── unit:SEC^-2 symbol: s
+  #    └──┬ unit:CentiM^-2 symbol: cm
+  #       └─── unit:M symbol: m
+unit:CAL_TH-PER-CentiM2 qudt:symbol "cal/cm²" .
+
+  # WRONG SYMBOL  : unit:CAL_TH-PER-CentiM2-MIN - calculated from factors: cal/(cm²·min), actual: calth/(cm²·min)
+  #
+  #  ──┬ unit:CAL_TH-PER-CentiM2-MIN symbol: calth/(cm²·min) (correct: cal/(cm²·min))
+  #    ├──┬ unit:CAL_TH symbol: cal
+  #    │  └──┬ unit:J symbol: J
+  #    │     ├─── unit:M symbol: m
+  #    │     └──┬ unit:N symbol: N
+  #    │        ├──┬ unit:KiloGM symbol: kg
+  #    │        │  └─── unit:GM symbol: g
+  #    │        ├─── unit:M symbol: m
+  #    │        └─── unit:SEC^-2 symbol: s
+  #    ├──┬ unit:CentiM^-2 symbol: cm
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:MIN^-1 symbol: min
+  #       └─── unit:SEC symbol: s
+unit:CAL_TH-PER-CentiM2-MIN qudt:symbol "cal/(cm²·min)" .
+
+  # WRONG SYMBOL  : unit:CAL_TH-PER-CentiM2-SEC - calculated from factors: cal/(cm²·s), actual: calth/(cm²·s)
+  #
+  #  ──┬ unit:CAL_TH-PER-CentiM2-SEC symbol: calth/(cm²·s) (correct: cal/(cm²·s))
+  #    ├──┬ unit:CAL_TH symbol: cal
+  #    │  └──┬ unit:J symbol: J
+  #    │     ├─── unit:M symbol: m
+  #    │     └──┬ unit:N symbol: N
+  #    │        ├──┬ unit:KiloGM symbol: kg
+  #    │        │  └─── unit:GM symbol: g
+  #    │        ├─── unit:M symbol: m
+  #    │        └─── unit:SEC^-2 symbol: s
+  #    ├──┬ unit:CentiM^-2 symbol: cm
+  #    │  └─── unit:M symbol: m
+  #    └─── unit:SEC^-1 symbol: s
+unit:CAL_TH-PER-CentiM2-SEC qudt:symbol "cal/(cm²·s)" .
+
+  # WRONG SYMBOL  : unit:CAL_TH-PER-CentiM3-K - calculated from factors: cal/(cm³·K), actual: cal{th}/(cm³·K)
+  #
+  #  ──┬ unit:CAL_TH-PER-CentiM3-K symbol: cal{th}/(cm³·K) (correct: cal/(cm³·K))
+  #    ├──┬ unit:CAL_TH symbol: cal
+  #    │  └──┬ unit:J symbol: J
+  #    │     ├─── unit:M symbol: m
+  #    │     └──┬ unit:N symbol: N
+  #    │        ├──┬ unit:KiloGM symbol: kg
+  #    │        │  └─── unit:GM symbol: g
+  #    │        ├─── unit:M symbol: m
+  #    │        └─── unit:SEC^-2 symbol: s
+  #    ├──┬ unit:CentiM^-3 symbol: cm
+  #    │  └─── unit:M symbol: m
+  #    └─── unit:K^-1 symbol: K
+unit:CAL_TH-PER-CentiM3-K qudt:symbol "cal/(cm³·K)" .
+
+  # WRONG SYMBOL  : unit:CentiM-PER-KiloYR - calculated from factors: cm/1000 a, actual: cm/(1000 a)
+  #
+  #  ──┬ unit:CentiM-PER-KiloYR symbol: cm/(1000 a) (correct: cm/1000 a)
+  #    ├──┬ unit:CentiM symbol: cm
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:KiloYR^-1 symbol: 1000 a
+  #       └──┬ unit:YR symbol: a
+  #          └─── unit:SEC symbol: s
+unit:CentiM-PER-KiloYR qudt:symbol "cm/1000 a" .
+
+  # WRONG SYMBOL  : unit:CentiM3-PER-DAY - calculated from factors: cm³/d, actual: cm³/day
+  #
+  #  ──┬ unit:CentiM3-PER-DAY symbol: cm³/day (correct: cm³/d)
+  #    ├──┬ unit:CentiM^3 symbol: cm
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:CentiM3-PER-DAY qudt:symbol "cm³/d" .
+
+  # WRONG SYMBOL  : unit:DEG_F-HR-PER-BTU_TH - calculated from factors: °F·h/Btu{th}, actual: °F/(Btuth/h)
+  #
+  #  ──┬ unit:DEG_F-HR-PER-BTU_TH symbol: °F/(Btuth/h) (correct: °F·h/Btu{th})
+  #    ├──┬ unit:DEG_F symbol: °F
+  #    │  └─── unit:K symbol: K
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    └──┬ unit:BTU_TH^-1 symbol: Btu{th}
+  #       └──┬ unit:J symbol: J
+  #          ├─── unit:M symbol: m
+  #          └──┬ unit:N symbol: N
+  #             ├──┬ unit:KiloGM symbol: kg
+  #             │  └─── unit:GM symbol: g
+  #             ├─── unit:M symbol: m
+  #             └─── unit:SEC^-2 symbol: s
+unit:DEG_F-HR-PER-BTU_TH qudt:symbol "°F·h/Btu{th}" .
+
+  # WRONG SYMBOL  : unit:DeciB-MilliW-PER-MegaHZ - calculated from factors: dB·mW/MHz, actual: dB·mW/Mhz
+  #
+  #  ──┬ unit:DeciB-MilliW-PER-MegaHZ symbol: dB·mW/Mhz (correct: dB·mW/MHz)
+  #    ├──┬ unit:DeciB symbol: dB
+  #    │  └─── unit:B symbol: B
+  #    ├──┬ unit:MilliW symbol: mW
+  #    │  └──┬ unit:W symbol: W
+  #    │     ├──┬ unit:J symbol: J
+  #    │     │  ├─── unit:M symbol: m
+  #    │     │  └──┬ unit:N symbol: N
+  #    │     │     ├──┬ unit:KiloGM symbol: kg
+  #    │     │     │  └─── unit:GM symbol: g
+  #    │     │     ├─── unit:M symbol: m
+  #    │     │     └─── unit:SEC^-2 symbol: s
+  #    │     └─── unit:SEC^-1 symbol: s
+  #    └──┬ unit:MegaHZ^-1 symbol: MHz
+  #       └──┬ unit:HZ symbol: Hz
+  #          └─── unit:SEC^-1 symbol: s
+unit:DeciB-MilliW-PER-MegaHZ qudt:symbol "dB·mW/MHz" .
+
+  # WRONG SYMBOL  : unit:DeciB-W - calculated from factors: dB·W, actual: dBW
+  #
+  #  ──┬ unit:DeciB-W symbol: dBW (correct: dB·W)
+  #    ├──┬ unit:DeciB symbol: dB
+  #    │  └─── unit:B symbol: B
+  #    └──┬ unit:W symbol: W
+  #       ├──┬ unit:J symbol: J
+  #       │  ├─── unit:M symbol: m
+  #       │  └──┬ unit:N symbol: N
+  #       │     ├──┬ unit:KiloGM symbol: kg
+  #       │     │  └─── unit:GM symbol: g
+  #       │     ├─── unit:M symbol: m
+  #       │     └─── unit:SEC^-2 symbol: s
+  #       └─── unit:SEC^-1 symbol: s
+unit:DeciB-W qudt:symbol "dB·W" .
+
+  # WRONG SYMBOL  : unit:DeciM3-PER-DAY - calculated from factors: dm³/d, actual: dm³/day
+  #
+  #  ──┬ unit:DeciM3-PER-DAY symbol: dm³/day (correct: dm³/d)
+  #    ├──┬ unit:DeciM^3 symbol: dm
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:DeciM3-PER-DAY qudt:symbol "dm³/d" .
+
+  # WRONG SYMBOL  : unit:FT-HR-PER-GAL_UK - calculated from factors: ft·h/gal{UK}, actual: lb/(gal (UK))/(lb/(ft·h))
+  #
+  #  ──┬ unit:FT-HR-PER-GAL_UK symbol: lb/(gal (UK))/(lb/(ft·h)) (correct: ft·h/gal{UK})
+  #    ├──┬ unit:FT symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    └──┬ unit:GAL_UK^-1 symbol: gal{UK}
+  #       └──┬ unit:L symbol: L
+  #          └──┬ unit:DeciM3 symbol: dm³
+  #             └──┬ unit:DeciM^3 symbol: dm
+  #                └─── unit:M symbol: m
+unit:FT-HR-PER-GAL_UK qudt:symbol "ft·h/gal{UK}" .
+
+  # WRONG SYMBOL  : unit:FT-HR-PER-GAL_US - calculated from factors: ft·h/gal{US}, actual: lb/(gal (US))/(lb/(ft·h))
+  #
+  #  ──┬ unit:FT-HR-PER-GAL_US symbol: lb/(gal (US))/(lb/(ft·h)) (correct: ft·h/gal{US})
+  #    ├──┬ unit:FT symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    └──┬ unit:GAL_US^-1 symbol: gal{US}
+  #       └──┬ unit:IN^3 symbol: in
+  #          └─── unit:M symbol: m
+unit:FT-HR-PER-GAL_US qudt:symbol "ft·h/gal{US}" .
+
+  # WRONG SYMBOL  : unit:FT-HR-PER-IN3 - calculated from factors: ft·h/in³, actual: (lb/in³)/(lb/(ft·h))
+  #
+  #  ──┬ unit:FT-HR-PER-IN3 symbol: (lb/in³)/(lb/(ft·h)) (correct: ft·h/in³)
+  #    ├──┬ unit:FT symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    └──┬ unit:IN^-3 symbol: in
+  #       └─── unit:M symbol: m
+unit:FT-HR-PER-IN3 qudt:symbol "ft·h/in³" .
+
+  # WRONG SYMBOL  : unit:FT-PER-DAY - calculated from factors: ft/d, actual: ft/day
+  #
+  #  ──┬ unit:FT-PER-DAY symbol: ft/day (correct: ft/d)
+  #    ├──┬ unit:FT symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:FT-PER-DAY qudt:symbol "ft/d" .
+
+  # WRONG SYMBOL  : unit:FT-SEC-PER-GAL_UK - calculated from factors: ft·s/gal{UK}, actual: lb/(gal (UK))/(lb/(ft·s))
+  #
+  #  ──┬ unit:FT-SEC-PER-GAL_UK symbol: lb/(gal (UK))/(lb/(ft·s)) (correct: ft·s/gal{UK})
+  #    ├──┬ unit:FT symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    ├─── unit:SEC symbol: s
+  #    └──┬ unit:GAL_UK^-1 symbol: gal{UK}
+  #       └──┬ unit:L symbol: L
+  #          └──┬ unit:DeciM3 symbol: dm³
+  #             └──┬ unit:DeciM^3 symbol: dm
+  #                └─── unit:M symbol: m
+unit:FT-SEC-PER-GAL_UK qudt:symbol "ft·s/gal{UK}" .
+
+  # WRONG SYMBOL  : unit:FT-SEC-PER-GAL_US - calculated from factors: ft·s/gal{US}, actual: lb/(gal (US))/(lb/(ft·s))
+  #
+  #  ──┬ unit:FT-SEC-PER-GAL_US symbol: lb/(gal (US))/(lb/(ft·s)) (correct: ft·s/gal{US})
+  #    ├──┬ unit:FT symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    ├─── unit:SEC symbol: s
+  #    └──┬ unit:GAL_US^-1 symbol: gal{US}
+  #       └──┬ unit:IN^3 symbol: in
+  #          └─── unit:M symbol: m
+unit:FT-SEC-PER-GAL_US qudt:symbol "ft·s/gal{US}" .
+
+  # WRONG SYMBOL  : unit:FT-SEC-PER-IN3 - calculated from factors: ft·s/in³, actual: (lb/in³)/(lb/(ft·s))
+  #
+  #  ──┬ unit:FT-SEC-PER-IN3 symbol: (lb/in³)/(lb/(ft·s)) (correct: ft·s/in³)
+  #    ├──┬ unit:FT symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    ├─── unit:SEC symbol: s
+  #    └──┬ unit:IN^-3 symbol: in
+  #       └─── unit:M symbol: m
+unit:FT-SEC-PER-IN3 qudt:symbol "ft·s/in³" .
+
+  # WRONG SYMBOL  : unit:FT3-PER-DAY - calculated from factors: ft³/d, actual: ft³/day
+  #
+  #  ──┬ unit:FT3-PER-DAY symbol: ft³/day (correct: ft³/d)
+  #    ├──┬ unit:FT^3 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:FT3-PER-DAY qudt:symbol "ft³/d" .
+
+  # WRONG SYMBOL  : unit:GAL_UK-PER-DAY - calculated from factors: gal{UK}/d, actual: gal{UK}/day
+  #
+  #  ──┬ unit:GAL_UK-PER-DAY symbol: gal{UK}/day (correct: gal{UK}/d)
+  #    ├──┬ unit:GAL_UK symbol: gal{UK}
+  #    │  └──┬ unit:L symbol: L
+  #    │     └──┬ unit:DeciM3 symbol: dm³
+  #    │        └──┬ unit:DeciM^3 symbol: dm
+  #    │           └─── unit:M symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:GAL_UK-PER-DAY qudt:symbol "gal{UK}/d" .
+
+  # WRONG SYMBOL  : unit:GAL_US - calculated from factors: in³, actual: gal{US}
+  #
+  #  ──┬ unit:GAL_US symbol: gal{US} (correct: in³)
+  #    └──┬ unit:IN^3 symbol: in
+  #       └─── unit:M symbol: m
+unit:GAL_US qudt:symbol "in³" .
+
+  # WRONG SYMBOL  : unit:GAL_US-PER-DAY - calculated from factors: gal{US}/d, actual: gal{US}/day
+  #
+  #  ──┬ unit:GAL_US-PER-DAY symbol: gal{US}/day (correct: gal{US}/d)
+  #    ├──┬ unit:GAL_US symbol: gal{US}
+  #    │  └──┬ unit:IN^3 symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:GAL_US-PER-DAY qudt:symbol "gal{US}/d" .
+
+  # WRONG SYMBOL  : unit:GI_UK-PER-DAY - calculated from factors: gill{UK}/d, actual: gill{UK}/day
+  #
+  #  ──┬ unit:GI_UK-PER-DAY symbol: gill{UK}/day (correct: gill{UK}/d)
+  #    ├──┬ unit:GI_UK symbol: gill{UK}
+  #    │  └──┬ unit:M3 symbol: m³
+  #    │     └─── unit:M^3 symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:GI_UK-PER-DAY qudt:symbol "gill{UK}/d" .
+
+  # WRONG SYMBOL  : unit:GI_US-PER-DAY - calculated from factors: gill{US}/d, actual: gill{US}/day
+  #
+  #  ──┬ unit:GI_US-PER-DAY symbol: gill{US}/day (correct: gill{US}/d)
+  #    ├──┬ unit:GI_US symbol: gill{US}
+  #    │  └──┬ unit:M3 symbol: m³
+  #    │     └─── unit:M^3 symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:GI_US-PER-DAY qudt:symbol "gill{US}/d" .
+
+  # WRONG SYMBOL  : unit:GM-CentiM-PER-SEC - calculated from factors: g·cm/s, actual: g·(cm/s)
+  #
+  #  ──┬ unit:GM-CentiM-PER-SEC symbol: g·(cm/s) (correct: g·cm/s)
+  #    ├─── unit:GM symbol: g
+  #    ├──┬ unit:CentiM symbol: cm
+  #    │  └─── unit:M symbol: m
+  #    └─── unit:SEC^-1 symbol: s
+unit:GM-CentiM-PER-SEC qudt:symbol "g·cm/s" .
+
+  # WRONG SYMBOL  : unit:GM-HR-PER-L-CentiM3 - calculated from factors: g·h/(L·cm³), actual: (g/l)/(cm³/h)
+  #
+  #  ──┬ unit:GM-HR-PER-L-CentiM3 symbol: (g/l)/(cm³/h) (correct: g·h/(L·cm³))
+  #    ├─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └──┬ unit:CentiM^-3 symbol: cm
+  #       └─── unit:M symbol: m
+unit:GM-HR-PER-L-CentiM3 qudt:symbol "g·h/(L·cm³)" .
+
+  # WRONG SYMBOL  : unit:GM-HR-PER-L-M3 - calculated from factors: g·h/(L·m³), actual: (g/l)/(m³/h)
+  #
+  #  ──┬ unit:GM-HR-PER-L-M3 symbol: (g/l)/(m³/h) (correct: g·h/(L·m³))
+  #    ├─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └─── unit:M^-3 symbol: m
+unit:GM-HR-PER-L-M3 qudt:symbol "g·h/(L·m³)" .
+
+  # WRONG SYMBOL  : unit:GM-HR-PER-L2 - calculated from factors: g·h/L², actual: (g/l)/(l/h)
+  #
+  #  ──┬ unit:GM-HR-PER-L2 symbol: (g/l)/(l/h) (correct: g·h/L²)
+  #    ├─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    └──┬ unit:L^-2 symbol: L
+  #       └──┬ unit:DeciM3 symbol: dm³
+  #          └──┬ unit:DeciM^3 symbol: dm
+  #             └─── unit:M symbol: m
+unit:GM-HR-PER-L2 qudt:symbol "g·h/L²" .
+
+  # WRONG SYMBOL  : unit:GM-HR-PER-M3-CentiM3 - calculated from factors: g·h/(m³·cm³), actual: (g/m³)/(cm³/h)
+  #
+  #  ──┬ unit:GM-HR-PER-M3-CentiM3 symbol: (g/m³)/(cm³/h) (correct: g·h/(m³·cm³))
+  #    ├─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├─── unit:M^-3 symbol: m
+  #    └──┬ unit:CentiM^-3 symbol: cm
+  #       └─── unit:M symbol: m
+unit:GM-HR-PER-M3-CentiM3 qudt:symbol "g·h/(m³·cm³)" .
+
+  # WRONG SYMBOL  : unit:GM-HR-PER-M3-L - calculated from factors: g·h/(m³·L), actual: (g/m³)/(l/h)
+  #
+  #  ──┬ unit:GM-HR-PER-M3-L symbol: (g/m³)/(l/h) (correct: g·h/(m³·L))
+  #    ├─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├─── unit:M^-3 symbol: m
+  #    └──┬ unit:L^-1 symbol: L
+  #       └──┬ unit:DeciM3 symbol: dm³
+  #          └──┬ unit:DeciM^3 symbol: dm
+  #             └─── unit:M symbol: m
+unit:GM-HR-PER-M3-L qudt:symbol "g·h/(m³·L)" .
+
+  # WRONG SYMBOL  : unit:GM-HR-PER-M6 - calculated from factors: g·h/m⁶, actual: (g/m³)/(m³/h)
+  #
+  #  ──┬ unit:GM-HR-PER-M6 symbol: (g/m³)/(m³/h) (correct: g·h/m⁶)
+  #    ├─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    └─── unit:M^-6 symbol: m
+unit:GM-HR-PER-M6 qudt:symbol "g·h/m⁶" .
+
+  # WRONG SYMBOL  : unit:GM-MIN-PER-L-CentiM3 - calculated from factors: g·min/(L·cm³), actual: (g/l)/(cm³/min)
+  #
+  #  ──┬ unit:GM-MIN-PER-L-CentiM3 symbol: (g/l)/(cm³/min) (correct: g·min/(L·cm³))
+  #    ├─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └──┬ unit:CentiM^-3 symbol: cm
+  #       └─── unit:M symbol: m
+unit:GM-MIN-PER-L-CentiM3 qudt:symbol "g·min/(L·cm³)" .
+
+  # WRONG SYMBOL  : unit:GM-MIN-PER-L-M3 - calculated from factors: g·min/(L·m³), actual: (g/l)/(m³/min)
+  #
+  #  ──┬ unit:GM-MIN-PER-L-M3 symbol: (g/l)/(m³/min) (correct: g·min/(L·m³))
+  #    ├─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └─── unit:M^-3 symbol: m
+unit:GM-MIN-PER-L-M3 qudt:symbol "g·min/(L·m³)" .
+
+  # WRONG SYMBOL  : unit:GM-MIN-PER-L2 - calculated from factors: g·min/L², actual: (g/l)/(l/min)
+  #
+  #  ──┬ unit:GM-MIN-PER-L2 symbol: (g/l)/(l/min) (correct: g·min/L²)
+  #    ├─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    └──┬ unit:L^-2 symbol: L
+  #       └──┬ unit:DeciM3 symbol: dm³
+  #          └──┬ unit:DeciM^3 symbol: dm
+  #             └─── unit:M symbol: m
+unit:GM-MIN-PER-L2 qudt:symbol "g·min/L²" .
+
+  # WRONG SYMBOL  : unit:GM-MIN-PER-M3-CentiM3 - calculated from factors: g·min/(m³·cm³), actual: (g/m³)/(cm³/min)
+  #
+  #  ──┬ unit:GM-MIN-PER-M3-CentiM3 symbol: (g/m³)/(cm³/min) (correct: g·min/(m³·cm³))
+  #    ├─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    ├─── unit:M^-3 symbol: m
+  #    └──┬ unit:CentiM^-3 symbol: cm
+  #       └─── unit:M symbol: m
+unit:GM-MIN-PER-M3-CentiM3 qudt:symbol "g·min/(m³·cm³)" .
+
+  # WRONG SYMBOL  : unit:GM-MIN-PER-M3-L - calculated from factors: g·min/(m³·L), actual: (g/m³)/(l/min)
+  #
+  #  ──┬ unit:GM-MIN-PER-M3-L symbol: (g/m³)/(l/min) (correct: g·min/(m³·L))
+  #    ├─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    ├─── unit:M^-3 symbol: m
+  #    └──┬ unit:L^-1 symbol: L
+  #       └──┬ unit:DeciM3 symbol: dm³
+  #          └──┬ unit:DeciM^3 symbol: dm
+  #             └─── unit:M symbol: m
+unit:GM-MIN-PER-M3-L qudt:symbol "g·min/(m³·L)" .
+
+  # WRONG SYMBOL  : unit:GM-MIN-PER-M6 - calculated from factors: g·min/m⁶, actual: (g/m³)/(m³/min)
+  #
+  #  ──┬ unit:GM-MIN-PER-M6 symbol: (g/m³)/(m³/min) (correct: g·min/m⁶)
+  #    ├─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    └─── unit:M^-6 symbol: m
+unit:GM-MIN-PER-M6 qudt:symbol "g·min/m⁶" .
+
+  # WRONG SYMBOL  : unit:GM-PER-DAY - calculated from factors: g/d, actual: g/day
+  #
+  #  ──┬ unit:GM-PER-DAY symbol: g/day (correct: g/d)
+  #    ├─── unit:GM symbol: g
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:GM-PER-DAY qudt:symbol "g/d" .
+
+  # WRONG SYMBOL  : unit:GM-PER-L-BAR - calculated from factors: g/(L·bar), actual: g/(l·bar)
+  #
+  #  ──┬ unit:GM-PER-L-BAR symbol: g/(l·bar) (correct: g/(L·bar))
+  #    ├─── unit:GM symbol: g
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └──┬ unit:BAR^-1 symbol: bar
+  #       └──┬ unit:PA symbol: Pa
+  #          ├─── unit:M^-2 symbol: m
+  #          └──┬ unit:N symbol: N
+  #             ├──┬ unit:KiloGM symbol: kg
+  #             │  └─── unit:GM symbol: g
+  #             ├─── unit:M symbol: m
+  #             └─── unit:SEC^-2 symbol: s
+unit:GM-PER-L-BAR qudt:symbol "g/(L·bar)" .
+
+  # WRONG SYMBOL  : unit:GM-PER-L-CentiPOISE - calculated from factors: g/(L·cP), actual: (g/l)/cP
+  #
+  #  ──┬ unit:GM-PER-L-CentiPOISE symbol: (g/l)/cP (correct: g/(L·cP))
+  #    ├─── unit:GM symbol: g
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └──┬ unit:CentiPOISE^-1 symbol: cP
+  #       └──┬ unit:POISE symbol: P
+  #          └──┬ unit:KiloGM-PER-M-SEC symbol: kg/(m·s)
+  #             ├──┬ unit:KiloGM symbol: kg
+  #             │  └─── unit:GM symbol: g
+  #             ├─── unit:M^-1 symbol: m
+  #             └─── unit:SEC^-1 symbol: s
+unit:GM-PER-L-CentiPOISE qudt:symbol "g/(L·cP)" .
+
+  # WRONG SYMBOL  : unit:GM-PER-L-K - calculated from factors: g/(L·K), actual: g/(l·K)
+  #
+  #  ──┬ unit:GM-PER-L-K symbol: g/(l·K) (correct: g/(L·K))
+  #    ├─── unit:GM symbol: g
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └─── unit:K^-1 symbol: K
+unit:GM-PER-L-K qudt:symbol "g/(L·K)" .
+
+  # WRONG SYMBOL  : unit:GM-PER-L-MilliPA-SEC - calculated from factors: g/(L·mPa·s), actual: (g/l)/(mPa·s)
+  #
+  #  ──┬ unit:GM-PER-L-MilliPA-SEC symbol: (g/l)/(mPa·s) (correct: g/(L·mPa·s))
+  #    ├─── unit:GM symbol: g
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    ├──┬ unit:MilliPA^-1 symbol: mPa
+  #    │  └──┬ unit:PA symbol: Pa
+  #    │     ├─── unit:M^-2 symbol: m
+  #    │     └──┬ unit:N symbol: N
+  #    │        ├──┬ unit:KiloGM symbol: kg
+  #    │        │  └─── unit:GM symbol: g
+  #    │        ├─── unit:M symbol: m
+  #    │        └─── unit:SEC^-2 symbol: s
+  #    └─── unit:SEC^-1 symbol: s
+unit:GM-PER-L-MilliPA-SEC qudt:symbol "g/(L·mPa·s)" .
+
+  # WRONG SYMBOL  : unit:GM-PER-L-PA-SEC - calculated from factors: g/(L·Pa·s), actual: (g/l)/(Pa·s)
+  #
+  #  ──┬ unit:GM-PER-L-PA-SEC symbol: (g/l)/(Pa·s) (correct: g/(L·Pa·s))
+  #    ├─── unit:GM symbol: g
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    ├──┬ unit:PA^-1 symbol: Pa
+  #    │  ├─── unit:M^-2 symbol: m
+  #    │  └──┬ unit:N symbol: N
+  #    │     ├──┬ unit:KiloGM symbol: kg
+  #    │     │  └─── unit:GM symbol: g
+  #    │     ├─── unit:M symbol: m
+  #    │     └─── unit:SEC^-2 symbol: s
+  #    └─── unit:SEC^-1 symbol: s
+unit:GM-PER-L-PA-SEC qudt:symbol "g/(L·Pa·s)" .
+
+  # WRONG SYMBOL  : unit:GM-PER-L-POISE - calculated from factors: g/(L·P), actual: (g/l)/P
+  #
+  #  ──┬ unit:GM-PER-L-POISE symbol: (g/l)/P (correct: g/(L·P))
+  #    ├─── unit:GM symbol: g
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └──┬ unit:POISE^-1 symbol: P
+  #       └──┬ unit:KiloGM-PER-M-SEC symbol: kg/(m·s)
+  #          ├──┬ unit:KiloGM symbol: kg
+  #          │  └─── unit:GM symbol: g
+  #          ├─── unit:M^-1 symbol: m
+  #          └─── unit:SEC^-1 symbol: s
+unit:GM-PER-L-POISE qudt:symbol "g/(L·P)" .
+
+  # WRONG SYMBOL  : unit:GM-PER-M2-DAY - calculated from factors: g/(m²·d), actual: g/(m²·day)
+  #
+  #  ──┬ unit:GM-PER-M2-DAY symbol: g/(m²·day) (correct: g/(m²·d))
+  #    ├─── unit:GM symbol: g
+  #    ├─── unit:M^-2 symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:GM-PER-M2-DAY qudt:symbol "g/(m²·d)" .
+
+  # WRONG SYMBOL  : unit:GM-PER-M2-HR - calculated from factors: g/(m²·h), actual: g/m²·hr
+  #
+  #  ──┬ unit:GM-PER-M2-HR symbol: g/m²·hr (correct: g/(m²·h))
+  #    ├─── unit:GM symbol: g
+  #    ├─── unit:M^-2 symbol: m
+  #    └──┬ unit:HR^-1 symbol: h
+  #       └─── unit:SEC symbol: s
+unit:GM-PER-M2-HR qudt:symbol "g/(m²·h)" .
+
+  # WRONG SYMBOL  : unit:GM-PER-M2-YR - calculated from factors: g/(m²·a), actual: g/m²·yr
+  #
+  #  ──┬ unit:GM-PER-M2-YR symbol: g/m²·yr (correct: g/(m²·a))
+  #    ├─── unit:GM symbol: g
+  #    ├─── unit:M^-2 symbol: m
+  #    └──┬ unit:YR^-1 symbol: a
+  #       └─── unit:SEC symbol: s
+unit:GM-PER-M2-YR qudt:symbol "g/(m²·a)" .
+
+  # WRONG SYMBOL  : unit:GM-PER-M3-PA-SEC - calculated from factors: g/(m³·Pa·s), actual: g/(m³Pa·s)
+  #
+  #  ──┬ unit:GM-PER-M3-PA-SEC symbol: g/(m³Pa·s) (correct: g/(m³·Pa·s))
+  #    ├─── unit:GM symbol: g
+  #    ├─── unit:M^-3 symbol: m
+  #    ├──┬ unit:PA^-1 symbol: Pa
+  #    │  ├─── unit:M^-2 symbol: m
+  #    │  └──┬ unit:N symbol: N
+  #    │     ├──┬ unit:KiloGM symbol: kg
+  #    │     │  └─── unit:GM symbol: g
+  #    │     ├─── unit:M symbol: m
+  #    │     └─── unit:SEC^-2 symbol: s
+  #    └─── unit:SEC^-1 symbol: s
+unit:GM-PER-M3-PA-SEC qudt:symbol "g/(m³·Pa·s)" .
+
+  # WRONG SYMBOL  : unit:GM-PER-M3-POISE - calculated from factors: g/(m³·P), actual: (g/m³)/P
+  #
+  #  ──┬ unit:GM-PER-M3-POISE symbol: (g/m³)/P (correct: g/(m³·P))
+  #    ├─── unit:GM symbol: g
+  #    ├─── unit:M^-3 symbol: m
+  #    └──┬ unit:POISE^-1 symbol: P
+  #       └──┬ unit:KiloGM-PER-M-SEC symbol: kg/(m·s)
+  #          ├──┬ unit:KiloGM symbol: kg
+  #          │  └─── unit:GM symbol: g
+  #          ├─── unit:M^-1 symbol: m
+  #          └─── unit:SEC^-1 symbol: s
+unit:GM-PER-M3-POISE qudt:symbol "g/(m³·P)" .
+
+  # WRONG SYMBOL  : unit:GM-PER-MilliL-BAR - calculated from factors: g/(mL·bar), actual: g/(ml·bar)
+  #
+  #  ──┬ unit:GM-PER-MilliL-BAR symbol: g/(ml·bar) (correct: g/(mL·bar))
+  #    ├─── unit:GM symbol: g
+  #    ├──┬ unit:MilliL^-1 symbol: mL
+  #    │  └──┬ unit:L symbol: L
+  #    │     └──┬ unit:DeciM3 symbol: dm³
+  #    │        └──┬ unit:DeciM^3 symbol: dm
+  #    │           └─── unit:M symbol: m
+  #    └──┬ unit:BAR^-1 symbol: bar
+  #       └──┬ unit:PA symbol: Pa
+  #          ├─── unit:M^-2 symbol: m
+  #          └──┬ unit:N symbol: N
+  #             ├──┬ unit:KiloGM symbol: kg
+  #             │  └─── unit:GM symbol: g
+  #             ├─── unit:M symbol: m
+  #             └─── unit:SEC^-2 symbol: s
+unit:GM-PER-MilliL-BAR qudt:symbol "g/(mL·bar)" .
+
+  # WRONG SYMBOL  : unit:GM-PER-MilliL-K - calculated from factors: g/(mL·K), actual: g/(ml·K)
+  #
+  #  ──┬ unit:GM-PER-MilliL-K symbol: g/(ml·K) (correct: g/(mL·K))
+  #    ├─── unit:GM symbol: g
+  #    ├──┬ unit:MilliL^-1 symbol: mL
+  #    │  └──┬ unit:L symbol: L
+  #    │     └──┬ unit:DeciM3 symbol: dm³
+  #    │        └──┬ unit:DeciM^3 symbol: dm
+  #    │           └─── unit:M symbol: m
+  #    └─── unit:K^-1 symbol: K
+unit:GM-PER-MilliL-K qudt:symbol "g/(mL·K)" .
+
+  # WRONG SYMBOL  : unit:GM-SEC-PER-L-CentiM3 - calculated from factors: g·s/(L·cm³), actual: (g/l)/(cm³/s)
+  #
+  #  ──┬ unit:GM-SEC-PER-L-CentiM3 symbol: (g/l)/(cm³/s) (correct: g·s/(L·cm³))
+  #    ├─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └──┬ unit:CentiM^-3 symbol: cm
+  #       └─── unit:M symbol: m
+unit:GM-SEC-PER-L-CentiM3 qudt:symbol "g·s/(L·cm³)" .
+
+  # WRONG SYMBOL  : unit:GM-SEC-PER-L-M3 - calculated from factors: g·s/(L·m³), actual: (g/l)/(m³/s)
+  #
+  #  ──┬ unit:GM-SEC-PER-L-M3 symbol: (g/l)/(m³/s) (correct: g·s/(L·m³))
+  #    ├─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └─── unit:M^-3 symbol: m
+unit:GM-SEC-PER-L-M3 qudt:symbol "g·s/(L·m³)" .
+
+  # WRONG SYMBOL  : unit:GM-SEC-PER-L2 - calculated from factors: g·s/L², actual: (g/l)/(l/s)
+  #
+  #  ──┬ unit:GM-SEC-PER-L2 symbol: (g/l)/(l/s) (correct: g·s/L²)
+  #    ├─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    └──┬ unit:L^-2 symbol: L
+  #       └──┬ unit:DeciM3 symbol: dm³
+  #          └──┬ unit:DeciM^3 symbol: dm
+  #             └─── unit:M symbol: m
+unit:GM-SEC-PER-L2 qudt:symbol "g·s/L²" .
+
+  # WRONG SYMBOL  : unit:GM-SEC-PER-M3-CentiM3 - calculated from factors: g·s/(m³·cm³), actual: (g/m³)/(cm³/s)
+  #
+  #  ──┬ unit:GM-SEC-PER-M3-CentiM3 symbol: (g/m³)/(cm³/s) (correct: g·s/(m³·cm³))
+  #    ├─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    ├─── unit:M^-3 symbol: m
+  #    └──┬ unit:CentiM^-3 symbol: cm
+  #       └─── unit:M symbol: m
+unit:GM-SEC-PER-M3-CentiM3 qudt:symbol "g·s/(m³·cm³)" .
+
+  # WRONG SYMBOL  : unit:GM-SEC-PER-M3-L - calculated from factors: g·s/(m³·L), actual: (g/m³)/(l/s)
+  #
+  #  ──┬ unit:GM-SEC-PER-M3-L symbol: (g/m³)/(l/s) (correct: g·s/(m³·L))
+  #    ├─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    ├─── unit:M^-3 symbol: m
+  #    └──┬ unit:L^-1 symbol: L
+  #       └──┬ unit:DeciM3 symbol: dm³
+  #          └──┬ unit:DeciM^3 symbol: dm
+  #             └─── unit:M symbol: m
+unit:GM-SEC-PER-M3-L qudt:symbol "g·s/(m³·L)" .
+
+  # WRONG SYMBOL  : unit:GM-SEC-PER-M6 - calculated from factors: g·s/m⁶, actual: (g/m³)/(m³/s)
+  #
+  #  ──┬ unit:GM-SEC-PER-M6 symbol: (g/m³)/(m³/s) (correct: g·s/m⁶)
+  #    ├─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    └─── unit:M^-6 symbol: m
+unit:GM-SEC-PER-M6 qudt:symbol "g·s/m⁶" .
+
+  # WRONG SYMBOL  : unit:GigaBIT-PER-SEC - calculated from factors: Gbit/s, actual: Gbps
+  #
+  #  ──┬ unit:GigaBIT-PER-SEC symbol: Gbps (correct: Gbit/s)
+  #    ├──┬ unit:GigaBIT symbol: Gbit
+  #    │  └─── unit:BIT symbol: b
+  #    └─── unit:SEC^-1 symbol: s
+unit:GigaBIT-PER-SEC qudt:symbol "Gbit/s" .
+
+  # WRONG SYMBOL  : unit:GigaBYTE-PER-SEC - calculated from factors: GB/s, actual: Gbyte/s
+  #
+  #  ──┬ unit:GigaBYTE-PER-SEC symbol: Gbyte/s (correct: GB/s)
+  #    ├──┬ unit:GigaBYTE symbol: GB
+  #    │  └─── unit:BYTE symbol: B
+  #    └─── unit:SEC^-1 symbol: s
+unit:GigaBYTE-PER-SEC qudt:symbol "GB/s" .
+
+  # WRONG SYMBOL  : unit:GigaOHM-M - calculated from factors: GΩ·m, actual: GΩ·m
+  #
+  #  ──┬ unit:GigaOHM-M symbol: GΩ·m (correct: GΩ·m)
+  #    ├──┬ unit:GigaOHM symbol: GΩ
+  #    │  └──┬ unit:OHM symbol: Ω
+  #    │     ├─── unit:A^-1 symbol: A
+  #    │     └──┬ unit:V symbol: V
+  #    │        ├─── unit:A^-1 symbol: A
+  #    │        └──┬ unit:W symbol: W
+  #    │           ├──┬ unit:J symbol: J
+  #    │           │  ├─── unit:M symbol: m
+  #    │           │  └──┬ unit:N symbol: N
+  #    │           │     ├──┬ unit:KiloGM symbol: kg
+  #    │           │     │  └─── unit:GM symbol: g
+  #    │           │     ├─── unit:M symbol: m
+  #    │           │     └─── unit:SEC^-2 symbol: s
+  #    │           └─── unit:SEC^-1 symbol: s
+  #    └─── unit:M symbol: m
+unit:GigaOHM-M qudt:symbol "GΩ·m" .
+
+  # WRONG SYMBOL  : unit:GigaOHM-PER-M - calculated from factors: GΩ/m, actual: GΩ/m
+  #
+  #  ──┬ unit:GigaOHM-PER-M symbol: GΩ/m (correct: GΩ/m)
+  #    ├──┬ unit:GigaOHM symbol: GΩ
+  #    │  └──┬ unit:OHM symbol: Ω
+  #    │     ├─── unit:A^-1 symbol: A
+  #    │     └──┬ unit:V symbol: V
+  #    │        ├─── unit:A^-1 symbol: A
+  #    │        └──┬ unit:W symbol: W
+  #    │           ├──┬ unit:J symbol: J
+  #    │           │  ├─── unit:M symbol: m
+  #    │           │  └──┬ unit:N symbol: N
+  #    │           │     ├──┬ unit:KiloGM symbol: kg
+  #    │           │     │  └─── unit:GM symbol: g
+  #    │           │     ├─── unit:M symbol: m
+  #    │           │     └─── unit:SEC^-2 symbol: s
+  #    │           └─── unit:SEC^-1 symbol: s
+  #    └─── unit:M^-1 symbol: m
+unit:GigaOHM-PER-M qudt:symbol "GΩ/m" .
+
+  # WRONG SYMBOL  : unit:HR-PER-FT2 - calculated from factors: h/ft², actual: (lb/ft³)/(lb/(ft·h)
+  #
+  #  ──┬ unit:HR-PER-FT2 symbol: (lb/ft³)/(lb/(ft·h) (correct: h/ft²)
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    └──┬ unit:FT^-2 symbol: ft
+  #       └──┬ unit:IN symbol: in
+  #          └─── unit:M symbol: m
+unit:HR-PER-FT2 qudt:symbol "h/ft²" .
+
+  # WRONG SYMBOL  : unit:IN-PER-YR - calculated from factors: in/a, actual: in/y
+  #
+  #  ──┬ unit:IN-PER-YR symbol: in/y (correct: in/a)
+  #    ├──┬ unit:IN symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:YR^-1 symbol: a
+  #       └─── unit:SEC symbol: s
+unit:IN-PER-YR qudt:symbol "in/a" .
+
+  # WRONG SYMBOL  : unit:J-PER-CentiM2-DAY - calculated from factors: J/(cm²·d), actual: J/(cm²·day)
+  #
+  #  ──┬ unit:J-PER-CentiM2-DAY symbol: J/(cm²·day) (correct: J/(cm²·d))
+  #    ├──┬ unit:J symbol: J
+  #    │  ├─── unit:M symbol: m
+  #    │  └──┬ unit:N symbol: N
+  #    │     ├──┬ unit:KiloGM symbol: kg
+  #    │     │  └─── unit:GM symbol: g
+  #    │     ├─── unit:M symbol: m
+  #    │     └─── unit:SEC^-2 symbol: s
+  #    ├──┬ unit:CentiM^-2 symbol: cm
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:J-PER-CentiM2-DAY qudt:symbol "J/(cm²·d)" .
+
+  # WRONG SYMBOL  : unit:J-PER-KiloGM-K - calculated from factors: J/(K·kg), actual: J/(kg·K)
+  #
+  #  ──┬ unit:J-PER-KiloGM-K symbol: J/(kg·K) (correct: J/(K·kg))
+  #    ├──┬ unit:J symbol: J
+  #    │  ├─── unit:M symbol: m
+  #    │  └──┬ unit:N symbol: N
+  #    │     ├──┬ unit:KiloGM symbol: kg
+  #    │     │  └─── unit:GM symbol: g
+  #    │     ├─── unit:M symbol: m
+  #    │     └─── unit:SEC^-2 symbol: s
+  #    ├─── unit:K^-1 symbol: K
+  #    └──┬ unit:KiloGM^-1 symbol: kg
+  #       └─── unit:GM symbol: g
+unit:J-PER-KiloGM-K qudt:symbol "J/(K·kg)" .
+
+  # WRONG SYMBOL  : unit:J-PER-KiloGM-K-M3 - calculated from factors: J/(K·kg·m³), actual: J/(kg·K·m³)
+  #
+  #  ──┬ unit:J-PER-KiloGM-K-M3 symbol: J/(kg·K·m³) (correct: J/(K·kg·m³))
+  #    ├──┬ unit:J symbol: J
+  #    │  ├─── unit:M symbol: m
+  #    │  └──┬ unit:N symbol: N
+  #    │     ├──┬ unit:KiloGM symbol: kg
+  #    │     │  └─── unit:GM symbol: g
+  #    │     ├─── unit:M symbol: m
+  #    │     └─── unit:SEC^-2 symbol: s
+  #    ├─── unit:K^-1 symbol: K
+  #    ├──┬ unit:KiloGM^-1 symbol: kg
+  #    │  └─── unit:GM symbol: g
+  #    └─── unit:M^-3 symbol: m
+unit:J-PER-KiloGM-K-M3 qudt:symbol "J/(K·kg·m³)" .
+
+  # WRONG SYMBOL  : unit:J-PER-KiloGM-K-PA - calculated from factors: J/(K·kg·Pa), actual: J/(kg·K·Pa)
+  #
+  #  ──┬ unit:J-PER-KiloGM-K-PA symbol: J/(kg·K·Pa) (correct: J/(K·kg·Pa))
+  #    ├──┬ unit:J symbol: J
+  #    │  ├─── unit:M symbol: m
+  #    │  └──┬ unit:N symbol: N
+  #    │     ├──┬ unit:KiloGM symbol: kg
+  #    │     │  └─── unit:GM symbol: g
+  #    │     ├─── unit:M symbol: m
+  #    │     └─── unit:SEC^-2 symbol: s
+  #    ├─── unit:K^-1 symbol: K
+  #    ├──┬ unit:KiloGM^-1 symbol: kg
+  #    │  └─── unit:GM symbol: g
+  #    └──┬ unit:PA^-1 symbol: Pa
+  #       ├─── unit:M^-2 symbol: m
+  #       └──┬ unit:N symbol: N
+  #          ├──┬ unit:KiloGM symbol: kg
+  #          │  └─── unit:GM symbol: g
+  #          ├─── unit:M symbol: m
+  #          └─── unit:SEC^-2 symbol: s
+unit:J-PER-KiloGM-K-PA qudt:symbol "J/(K·kg·Pa)" .
+
+  # WRONG SYMBOL  : unit:K-DAY - calculated from factors: K·d, actual: K·day
+  #
+  #  ──┬ unit:K-DAY symbol: K·day (correct: K·d)
+  #    ├─── unit:K symbol: K
+  #    └──┬ unit:DAY symbol: d
+  #       └─── unit:SEC symbol: s
+unit:K-DAY qudt:symbol "K·d" .
+
+  # WRONG SYMBOL  : unit:KAT-PER-MicroL - calculated from factors: kat/μL, actual: kat/µL
+  #
+  #  ──┬ unit:KAT-PER-MicroL symbol: kat/µL (correct: kat/μL)
+  #    ├──┬ unit:KAT symbol: kat
+  #    │  ├─── unit:MOL symbol: mol
+  #    │  └─── unit:SEC^-1 symbol: s
+  #    └──┬ unit:MicroL^-1 symbol: μL
+  #       └──┬ unit:L symbol: L
+  #          └──┬ unit:DeciM3 symbol: dm³
+  #             └──┬ unit:DeciM^3 symbol: dm
+  #                └─── unit:M symbol: m
+unit:KAT-PER-MicroL qudt:symbol "kat/μL" .
+
+  # WRONG SYMBOL  : unit:KiloBIT-PER-SEC - calculated from factors: kbit/s, actual: kbps
+  #
+  #  ──┬ unit:KiloBIT-PER-SEC symbol: kbps (correct: kbit/s)
+  #    ├──┬ unit:KiloBIT symbol: kbit
+  #    │  └─── unit:BIT symbol: b
+  #    └─── unit:SEC^-1 symbol: s
+unit:KiloBIT-PER-SEC qudt:symbol "kbit/s" .
+
+  # WRONG SYMBOL  : unit:KiloCAL_IT-PER-GM-K - calculated from factors: kcal{IT}/(g·K), actual: kcalIT/(g·K)
+  #
+  #  ──┬ unit:KiloCAL_IT-PER-GM-K symbol: kcalIT/(g·K) (correct: kcal{IT}/(g·K))
+  #    ├──┬ unit:KiloCAL_IT symbol: kcal{IT}
+  #    │  └──┬ unit:CAL_IT symbol: cal{IT}
+  #    │     └──┬ unit:J symbol: J
+  #    │        ├─── unit:M symbol: m
+  #    │        └──┬ unit:N symbol: N
+  #    │           ├──┬ unit:KiloGM symbol: kg
+  #    │           │  └─── unit:GM symbol: g
+  #    │           ├─── unit:M symbol: m
+  #    │           └─── unit:SEC^-2 symbol: s
+  #    ├─── unit:GM^-1 symbol: g
+  #    └─── unit:K^-1 symbol: K
+unit:KiloCAL_IT-PER-GM-K qudt:symbol "kcal{IT}/(g·K)" .
+
+  # WRONG SYMBOL  : unit:KiloCAL_TH-PER-HR - calculated from factors: kcal/h, actual: kcal{th}/h
+  #
+  #  ──┬ unit:KiloCAL_TH-PER-HR symbol: kcal{th}/h (correct: kcal/h)
+  #    ├──┬ unit:KiloCAL_TH symbol: kcal
+  #    │  └──┬ unit:CAL_TH symbol: cal
+  #    │     └──┬ unit:J symbol: J
+  #    │        ├─── unit:M symbol: m
+  #    │        └──┬ unit:N symbol: N
+  #    │           ├──┬ unit:KiloGM symbol: kg
+  #    │           │  └─── unit:GM symbol: g
+  #    │           ├─── unit:M symbol: m
+  #    │           └─── unit:SEC^-2 symbol: s
+  #    └──┬ unit:HR^-1 symbol: h
+  #       └─── unit:SEC symbol: s
+unit:KiloCAL_TH-PER-HR qudt:symbol "kcal/h" .
+
+  # WRONG SYMBOL  : unit:KiloCAL_TH-PER-MIN - calculated from factors: kcal/min, actual: kcal{th}/min
+  #
+  #  ──┬ unit:KiloCAL_TH-PER-MIN symbol: kcal{th}/min (correct: kcal/min)
+  #    ├──┬ unit:KiloCAL_TH symbol: kcal
+  #    │  └──┬ unit:CAL_TH symbol: cal
+  #    │     └──┬ unit:J symbol: J
+  #    │        ├─── unit:M symbol: m
+  #    │        └──┬ unit:N symbol: N
+  #    │           ├──┬ unit:KiloGM symbol: kg
+  #    │           │  └─── unit:GM symbol: g
+  #    │           ├─── unit:M symbol: m
+  #    │           └─── unit:SEC^-2 symbol: s
+  #    └──┬ unit:MIN^-1 symbol: min
+  #       └─── unit:SEC symbol: s
+unit:KiloCAL_TH-PER-MIN qudt:symbol "kcal/min" .
+
+  # WRONG SYMBOL  : unit:KiloCAL_TH-PER-SEC - calculated from factors: kcal/s, actual: kcal{th}/s
+  #
+  #  ──┬ unit:KiloCAL_TH-PER-SEC symbol: kcal{th}/s (correct: kcal/s)
+  #    ├──┬ unit:KiloCAL_TH symbol: kcal
+  #    │  └──┬ unit:CAL_TH symbol: cal
+  #    │     └──┬ unit:J symbol: J
+  #    │        ├─── unit:M symbol: m
+  #    │        └──┬ unit:N symbol: N
+  #    │           ├──┬ unit:KiloGM symbol: kg
+  #    │           │  └─── unit:GM symbol: g
+  #    │           ├─── unit:M symbol: m
+  #    │           └─── unit:SEC^-2 symbol: s
+  #    └─── unit:SEC^-1 symbol: s
+unit:KiloCAL_TH-PER-SEC qudt:symbol "kcal/s" .
+
+  # WRONG SYMBOL  : unit:KiloEV-PER-MicroM - calculated from factors: keV/μm, actual: keV/µm
+  #
+  #  ──┬ unit:KiloEV-PER-MicroM symbol: keV/µm (correct: keV/μm)
+  #    ├──┬ unit:KiloEV symbol: keV
+  #    │  └──┬ unit:EV symbol: eV
+  #    │     └──┬ unit:J symbol: J
+  #    │        ├─── unit:M symbol: m
+  #    │        └──┬ unit:N symbol: N
+  #    │           ├──┬ unit:KiloGM symbol: kg
+  #    │           │  └─── unit:GM symbol: g
+  #    │           ├─── unit:M symbol: m
+  #    │           └─── unit:SEC^-2 symbol: s
+  #    └──┬ unit:MicroM^-1 symbol: μm
+  #       └─── unit:M symbol: m
+unit:KiloEV-PER-MicroM qudt:symbol "keV/μm" .
+
+  # WRONG SYMBOL  : unit:KiloGM-CentiM-PER-SEC - calculated from factors: kg·cm/s, actual: kg·(cm/s)
+  #
+  #  ──┬ unit:KiloGM-CentiM-PER-SEC symbol: kg·(cm/s) (correct: kg·cm/s)
+  #    ├──┬ unit:KiloGM symbol: kg
+  #    │  └─── unit:GM symbol: g
+  #    ├──┬ unit:CentiM symbol: cm
+  #    │  └─── unit:M symbol: m
+  #    └─── unit:SEC^-1 symbol: s
+unit:KiloGM-CentiM-PER-SEC qudt:symbol "kg·cm/s" .
+
+  # WRONG SYMBOL  : unit:KiloGM-K - calculated from factors: K·kg, actual: kg·K
+  #
+  #  ──┬ unit:KiloGM-K symbol: kg·K (correct: K·kg)
+  #    ├─── unit:K symbol: K
+  #    └──┬ unit:KiloGM symbol: kg
+  #       └─── unit:GM symbol: g
+unit:KiloGM-K qudt:symbol "K·kg" .
+
+  # WRONG SYMBOL  : unit:KiloGM-PER-DAY - calculated from factors: kg/d, actual: kg/day
+  #
+  #  ──┬ unit:KiloGM-PER-DAY symbol: kg/day (correct: kg/d)
+  #    ├──┬ unit:KiloGM symbol: kg
+  #    │  └─── unit:GM symbol: g
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:KiloGM-PER-DAY qudt:symbol "kg/d" .
+
+  # WRONG SYMBOL  : unit:KiloGM-PER-HA-YR - calculated from factors: kg/(ha·a), actual: kg/ha/year
+  #
+  #  ──┬ unit:KiloGM-PER-HA-YR symbol: kg/ha/year (correct: kg/(ha·a))
+  #    ├──┬ unit:KiloGM symbol: kg
+  #    │  └─── unit:GM symbol: g
+  #    ├──┬ unit:HA^-1 symbol: ha
+  #    │  └──┬ unit:M2 symbol: m²
+  #    │     └─── unit:M^2 symbol: m
+  #    └──┬ unit:YR^-1 symbol: a
+  #       └─── unit:SEC symbol: s
+unit:KiloGM-PER-HA-YR qudt:symbol "kg/(ha·a)" .
+
+  # WRONG SYMBOL  : unit:KiloGM-PER-L-BAR - calculated from factors: kg/(L·bar), actual: kg/(l·bar)
+  #
+  #  ──┬ unit:KiloGM-PER-L-BAR symbol: kg/(l·bar) (correct: kg/(L·bar))
+  #    ├──┬ unit:KiloGM symbol: kg
+  #    │  └─── unit:GM symbol: g
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └──┬ unit:BAR^-1 symbol: bar
+  #       └──┬ unit:PA symbol: Pa
+  #          ├─── unit:M^-2 symbol: m
+  #          └──┬ unit:N symbol: N
+  #             ├──┬ unit:KiloGM symbol: kg
+  #             │  └─── unit:GM symbol: g
+  #             ├─── unit:M symbol: m
+  #             └─── unit:SEC^-2 symbol: s
+unit:KiloGM-PER-L-BAR qudt:symbol "kg/(L·bar)" .
+
+  # WRONG SYMBOL  : unit:KiloGM-PER-L-K - calculated from factors: kg/(L·K), actual: kg/(l·K)
+  #
+  #  ──┬ unit:KiloGM-PER-L-K symbol: kg/(l·K) (correct: kg/(L·K))
+  #    ├──┬ unit:KiloGM symbol: kg
+  #    │  └─── unit:GM symbol: g
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └─── unit:K^-1 symbol: K
+unit:KiloGM-PER-L-K qudt:symbol "kg/(L·K)" .
+
+  # WRONG SYMBOL  : unit:KiloJ-PER-KiloGM-K - calculated from factors: kJ/(K·kg), actual: kJ/(kg·K)
+  #
+  #  ──┬ unit:KiloJ-PER-KiloGM-K symbol: kJ/(kg·K) (correct: kJ/(K·kg))
+  #    ├──┬ unit:KiloJ symbol: kJ
+  #    │  └──┬ unit:J symbol: J
+  #    │     ├─── unit:M symbol: m
+  #    │     └──┬ unit:N symbol: N
+  #    │        ├──┬ unit:KiloGM symbol: kg
+  #    │        │  └─── unit:GM symbol: g
+  #    │        ├─── unit:M symbol: m
+  #    │        └─── unit:SEC^-2 symbol: s
+  #    ├─── unit:K^-1 symbol: K
+  #    └──┬ unit:KiloGM^-1 symbol: kg
+  #       └─── unit:GM symbol: g
+unit:KiloJ-PER-KiloGM-K qudt:symbol "kJ/(K·kg)" .
+
+  # WRONG SYMBOL  : unit:KiloM-PER-DAY - calculated from factors: km/d, actual: km/day
+  #
+  #  ──┬ unit:KiloM-PER-DAY symbol: km/day (correct: km/d)
+  #    ├──┬ unit:KiloM symbol: km
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:KiloM-PER-DAY qudt:symbol "km/d" .
+
+  # WRONG SYMBOL  : unit:KiloOHM-M - calculated from factors: kΩ·m, actual: kΩ·m
+  #
+  #  ──┬ unit:KiloOHM-M symbol: kΩ·m (correct: kΩ·m)
+  #    ├──┬ unit:KiloOHM symbol: kΩ
+  #    │  └──┬ unit:OHM symbol: Ω
+  #    │     ├─── unit:A^-1 symbol: A
+  #    │     └──┬ unit:V symbol: V
+  #    │        ├─── unit:A^-1 symbol: A
+  #    │        └──┬ unit:W symbol: W
+  #    │           ├──┬ unit:J symbol: J
+  #    │           │  ├─── unit:M symbol: m
+  #    │           │  └──┬ unit:N symbol: N
+  #    │           │     ├──┬ unit:KiloGM symbol: kg
+  #    │           │     │  └─── unit:GM symbol: g
+  #    │           │     ├─── unit:M symbol: m
+  #    │           │     └─── unit:SEC^-2 symbol: s
+  #    │           └─── unit:SEC^-1 symbol: s
+  #    └─── unit:M symbol: m
+unit:KiloOHM-M qudt:symbol "kΩ·m" .
+
+  # WRONG SYMBOL  : unit:KiloOHM-PER-BAR - calculated from factors: kΩ/bar, actual: kΩ/bar
+  #
+  #  ──┬ unit:KiloOHM-PER-BAR symbol: kΩ/bar (correct: kΩ/bar)
+  #    ├──┬ unit:KiloOHM symbol: kΩ
+  #    │  └──┬ unit:OHM symbol: Ω
+  #    │     ├─── unit:A^-1 symbol: A
+  #    │     └──┬ unit:V symbol: V
+  #    │        ├─── unit:A^-1 symbol: A
+  #    │        └──┬ unit:W symbol: W
+  #    │           ├──┬ unit:J symbol: J
+  #    │           │  ├─── unit:M symbol: m
+  #    │           │  └──┬ unit:N symbol: N
+  #    │           │     ├──┬ unit:KiloGM symbol: kg
+  #    │           │     │  └─── unit:GM symbol: g
+  #    │           │     ├─── unit:M symbol: m
+  #    │           │     └─── unit:SEC^-2 symbol: s
+  #    │           └─── unit:SEC^-1 symbol: s
+  #    └──┬ unit:BAR^-1 symbol: bar
+  #       └──┬ unit:PA symbol: Pa
+  #          ├─── unit:M^-2 symbol: m
+  #          └──┬ unit:N symbol: N
+  #             ├──┬ unit:KiloGM symbol: kg
+  #             │  └─── unit:GM symbol: g
+  #             ├─── unit:M symbol: m
+  #             └─── unit:SEC^-2 symbol: s
+unit:KiloOHM-PER-BAR qudt:symbol "kΩ/bar" .
+
+  # WRONG SYMBOL  : unit:KiloOHM-PER-K - calculated from factors: kΩ/K, actual: kΩ/K
+  #
+  #  ──┬ unit:KiloOHM-PER-K symbol: kΩ/K (correct: kΩ/K)
+  #    ├──┬ unit:KiloOHM symbol: kΩ
+  #    │  └──┬ unit:OHM symbol: Ω
+  #    │     ├─── unit:A^-1 symbol: A
+  #    │     └──┬ unit:V symbol: V
+  #    │        ├─── unit:A^-1 symbol: A
+  #    │        └──┬ unit:W symbol: W
+  #    │           ├──┬ unit:J symbol: J
+  #    │           │  ├─── unit:M symbol: m
+  #    │           │  └──┬ unit:N symbol: N
+  #    │           │     ├──┬ unit:KiloGM symbol: kg
+  #    │           │     │  └─── unit:GM symbol: g
+  #    │           │     ├─── unit:M symbol: m
+  #    │           │     └─── unit:SEC^-2 symbol: s
+  #    │           └─── unit:SEC^-1 symbol: s
+  #    └─── unit:K^-1 symbol: K
+unit:KiloOHM-PER-K qudt:symbol "kΩ/K" .
+
+  # WRONG SYMBOL  : unit:KiloOHM-PER-M - calculated from factors: kΩ/m, actual: kΩ/m
+  #
+  #  ──┬ unit:KiloOHM-PER-M symbol: kΩ/m (correct: kΩ/m)
+  #    ├──┬ unit:KiloOHM symbol: kΩ
+  #    │  └──┬ unit:OHM symbol: Ω
+  #    │     ├─── unit:A^-1 symbol: A
+  #    │     └──┬ unit:V symbol: V
+  #    │        ├─── unit:A^-1 symbol: A
+  #    │        └──┬ unit:W symbol: W
+  #    │           ├──┬ unit:J symbol: J
+  #    │           │  ├─── unit:M symbol: m
+  #    │           │  └──┬ unit:N symbol: N
+  #    │           │     ├──┬ unit:KiloGM symbol: kg
+  #    │           │     │  └─── unit:GM symbol: g
+  #    │           │     ├─── unit:M symbol: m
+  #    │           │     └─── unit:SEC^-2 symbol: s
+  #    │           └─── unit:SEC^-1 symbol: s
+  #    └─── unit:M^-1 symbol: m
+unit:KiloOHM-PER-M qudt:symbol "kΩ/m" .
+
+  # WRONG SYMBOL  : unit:KiloTONNE-PER-YR - calculated from factors: kt/a, actual: kt/yr
+  #
+  #  ──┬ unit:KiloTONNE-PER-YR symbol: kt/yr (correct: kt/a)
+  #    ├──┬ unit:KiloTONNE symbol: kt
+  #    │  └──┬ unit:TONNE symbol: t
+  #    │     └──┬ unit:KiloGM symbol: kg
+  #    │        └─── unit:GM symbol: g
+  #    └──┬ unit:YR^-1 symbol: a
+  #       └─── unit:SEC symbol: s
+unit:KiloTONNE-PER-YR qudt:symbol "kt/a" .
+
+  # WRONG SYMBOL  : unit:KiloW-PER-M2 - calculated from factors: kW/m², actual: kW/m2
+  #
+  #  ──┬ unit:KiloW-PER-M2 symbol: kW/m2 (correct: kW/m²)
+  #    ├──┬ unit:KiloW symbol: kW
+  #    │  └──┬ unit:W symbol: W
+  #    │     ├──┬ unit:J symbol: J
+  #    │     │  ├─── unit:M symbol: m
+  #    │     │  └──┬ unit:N symbol: N
+  #    │     │     ├──┬ unit:KiloGM symbol: kg
+  #    │     │     │  └─── unit:GM symbol: g
+  #    │     │     ├─── unit:M symbol: m
+  #    │     │     └─── unit:SEC^-2 symbol: s
+  #    │     └─── unit:SEC^-1 symbol: s
+  #    └─── unit:M^-2 symbol: m
+unit:KiloW-PER-M2 qudt:symbol "kW/m²" .
+
+  # WRONG SYMBOL  : unit:L-PER-BAR - calculated from factors: L/bar, actual: l/bar
+  #
+  #  ──┬ unit:L-PER-BAR symbol: l/bar (correct: L/bar)
+  #    ├──┬ unit:L symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └──┬ unit:BAR^-1 symbol: bar
+  #       └──┬ unit:PA symbol: Pa
+  #          ├─── unit:M^-2 symbol: m
+  #          └──┬ unit:N symbol: N
+  #             ├──┬ unit:KiloGM symbol: kg
+  #             │  └─── unit:GM symbol: g
+  #             ├─── unit:M symbol: m
+  #             └─── unit:SEC^-2 symbol: s
+unit:L-PER-BAR qudt:symbol "L/bar" .
+
+  # WRONG SYMBOL  : unit:L-PER-DAY - calculated from factors: L/d, actual: L/day
+  #
+  #  ──┬ unit:L-PER-DAY symbol: L/day (correct: L/d)
+  #    ├──┬ unit:L symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:L-PER-DAY qudt:symbol "L/d" .
+
+  # WRONG SYMBOL  : unit:L-PER-DAY-BAR - calculated from factors: L/(d·bar), actual: l/(d·bar)
+  #
+  #  ──┬ unit:L-PER-DAY-BAR symbol: l/(d·bar) (correct: L/(d·bar))
+  #    ├──┬ unit:L symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    ├──┬ unit:DAY^-1 symbol: d
+  #    │  └─── unit:SEC symbol: s
+  #    └──┬ unit:BAR^-1 symbol: bar
+  #       └──┬ unit:PA symbol: Pa
+  #          ├─── unit:M^-2 symbol: m
+  #          └──┬ unit:N symbol: N
+  #             ├──┬ unit:KiloGM symbol: kg
+  #             │  └─── unit:GM symbol: g
+  #             ├─── unit:M symbol: m
+  #             └─── unit:SEC^-2 symbol: s
+unit:L-PER-DAY-BAR qudt:symbol "L/(d·bar)" .
+
+  # WRONG SYMBOL  : unit:L-PER-DAY-K - calculated from factors: L/(d·K), actual: l/(d·K)
+  #
+  #  ──┬ unit:L-PER-DAY-K symbol: l/(d·K) (correct: L/(d·K))
+  #    ├──┬ unit:L symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    ├──┬ unit:DAY^-1 symbol: d
+  #    │  └─── unit:SEC symbol: s
+  #    └─── unit:K^-1 symbol: K
+unit:L-PER-DAY-K qudt:symbol "L/(d·K)" .
+
+  # WRONG SYMBOL  : unit:L-PER-HR-BAR - calculated from factors: L/(h·bar), actual: l/(h·bar)
+  #
+  #  ──┬ unit:L-PER-HR-BAR symbol: l/(h·bar) (correct: L/(h·bar))
+  #    ├──┬ unit:L symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    ├──┬ unit:HR^-1 symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    └──┬ unit:BAR^-1 symbol: bar
+  #       └──┬ unit:PA symbol: Pa
+  #          ├─── unit:M^-2 symbol: m
+  #          └──┬ unit:N symbol: N
+  #             ├──┬ unit:KiloGM symbol: kg
+  #             │  └─── unit:GM symbol: g
+  #             ├─── unit:M symbol: m
+  #             └─── unit:SEC^-2 symbol: s
+unit:L-PER-HR-BAR qudt:symbol "L/(h·bar)" .
+
+  # WRONG SYMBOL  : unit:L-PER-HR-K - calculated from factors: L/(h·K), actual: l/(h·K)
+  #
+  #  ──┬ unit:L-PER-HR-K symbol: l/(h·K) (correct: L/(h·K))
+  #    ├──┬ unit:L symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    ├──┬ unit:HR^-1 symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    └─── unit:K^-1 symbol: K
+unit:L-PER-HR-K qudt:symbol "L/(h·K)" .
+
+  # WRONG SYMBOL  : unit:L-PER-MIN-BAR - calculated from factors: L/(min·bar), actual: l/(min·bar)
+  #
+  #  ──┬ unit:L-PER-MIN-BAR symbol: l/(min·bar) (correct: L/(min·bar))
+  #    ├──┬ unit:L symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    ├──┬ unit:MIN^-1 symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    └──┬ unit:BAR^-1 symbol: bar
+  #       └──┬ unit:PA symbol: Pa
+  #          ├─── unit:M^-2 symbol: m
+  #          └──┬ unit:N symbol: N
+  #             ├──┬ unit:KiloGM symbol: kg
+  #             │  └─── unit:GM symbol: g
+  #             ├─── unit:M symbol: m
+  #             └─── unit:SEC^-2 symbol: s
+unit:L-PER-MIN-BAR qudt:symbol "L/(min·bar)" .
+
+  # WRONG SYMBOL  : unit:L-PER-MIN-K - calculated from factors: L/(min·K), actual: l/(min·K)
+  #
+  #  ──┬ unit:L-PER-MIN-K symbol: l/(min·K) (correct: L/(min·K))
+  #    ├──┬ unit:L symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    ├──┬ unit:MIN^-1 symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    └─── unit:K^-1 symbol: K
+unit:L-PER-MIN-K qudt:symbol "L/(min·K)" .
+
+  # WRONG SYMBOL  : unit:L-PER-MOL-SEC - calculated from factors: L/(mol·s), actual: l/(mol·s)
+  #
+  #  ──┬ unit:L-PER-MOL-SEC symbol: l/(mol·s) (correct: L/(mol·s))
+  #    ├──┬ unit:L symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    ├─── unit:MOL^-1 symbol: mol
+  #    └─── unit:SEC^-1 symbol: s
+unit:L-PER-MOL-SEC qudt:symbol "L/(mol·s)" .
+
+  # WRONG SYMBOL  : unit:L-PER-MicroMOL - calculated from factors: L/μmol, actual: L/µmol
+  #
+  #  ──┬ unit:L-PER-MicroMOL symbol: L/µmol (correct: L/μmol)
+  #    ├──┬ unit:L symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └──┬ unit:MicroMOL^-1 symbol: μmol
+  #       └─── unit:MOL symbol: mol
+unit:L-PER-MicroMOL qudt:symbol "L/μmol" .
+
+  # WRONG SYMBOL  : unit:L-PER-SEC-BAR - calculated from factors: L/(s·bar), actual: l/(s·bar)
+  #
+  #  ──┬ unit:L-PER-SEC-BAR symbol: l/(s·bar) (correct: L/(s·bar))
+  #    ├──┬ unit:L symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    ├─── unit:SEC^-1 symbol: s
+  #    └──┬ unit:BAR^-1 symbol: bar
+  #       └──┬ unit:PA symbol: Pa
+  #          ├─── unit:M^-2 symbol: m
+  #          └──┬ unit:N symbol: N
+  #             ├──┬ unit:KiloGM symbol: kg
+  #             │  └─── unit:GM symbol: g
+  #             ├─── unit:M symbol: m
+  #             └─── unit:SEC^-2 symbol: s
+unit:L-PER-SEC-BAR qudt:symbol "L/(s·bar)" .
+
+  # WRONG SYMBOL  : unit:L-PER-SEC-K - calculated from factors: L/(s·K), actual: l/(s·K)
+  #
+  #  ──┬ unit:L-PER-SEC-K symbol: l/(s·K) (correct: L/(s·K))
+  #    ├──┬ unit:L symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    ├─── unit:SEC^-1 symbol: s
+  #    └─── unit:K^-1 symbol: K
+unit:L-PER-SEC-K qudt:symbol "L/(s·K)" .
+
+  # WRONG SYMBOL  : unit:LB-FT-PER-SEC - calculated from factors: lbm·ft/s, actual: lb·(ft/s)
+  #
+  #  ──┬ unit:LB-FT-PER-SEC symbol: lb·(ft/s) (correct: lbm·ft/s)
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:FT symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └─── unit:SEC^-1 symbol: s
+unit:LB-FT-PER-SEC qudt:symbol "lbm·ft/s" .
+
+  # WRONG SYMBOL  : unit:LB-FT2-PER-GAL_UK-LB_F-SEC - calculated from factors: lbm·ft²/(gal{UK}·lbf·s), actual: lb/(gal (UK))/(lbf·s/ft²)
+  #
+  #  ──┬ unit:LB-FT2-PER-GAL_UK-LB_F-SEC symbol: lb/(gal (UK))/(lbf·s/ft²) (correct: lbm·ft²/(gal{UK}·lbf·s))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:FT^2 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    ├──┬ unit:GAL_UK^-1 symbol: gal{UK}
+  #    │  └──┬ unit:L symbol: L
+  #    │     └──┬ unit:DeciM3 symbol: dm³
+  #    │        └──┬ unit:DeciM^3 symbol: dm
+  #    │           └─── unit:M symbol: m
+  #    ├──┬ unit:LB_F^-1 symbol: lbf
+  #    │  ├──┬ unit:FT symbol: ft
+  #    │  │  └──┬ unit:IN symbol: in
+  #    │  │     └─── unit:M symbol: m
+  #    │  ├─── unit:SEC^-2 symbol: s
+  #    │  └──┬ unit:SLUG symbol: slug
+  #    │     └──┬ unit:LB symbol: lbm
+  #    │        └──┬ unit:KiloGM symbol: kg
+  #    │           └─── unit:GM symbol: g
+  #    └─── unit:SEC^-1 symbol: s
+unit:LB-FT2-PER-GAL_UK-LB_F-SEC qudt:symbol "lbm·ft²/(gal{UK}·lbf·s)" .
+
+  # WRONG SYMBOL  : unit:LB-FT2-PER-GAL_US-LB_F-SEC - calculated from factors: lbm·ft²/(gal{US}·lbf·s), actual: lb/(gal (US))/(lbf·s/ft²)
+  #
+  #  ──┬ unit:LB-FT2-PER-GAL_US-LB_F-SEC symbol: lb/(gal (US))/(lbf·s/ft²) (correct: lbm·ft²/(gal{US}·lbf·s))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:FT^2 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    ├──┬ unit:GAL_US^-1 symbol: gal{US}
+  #    │  └──┬ unit:IN^3 symbol: in
+  #    │     └─── unit:M symbol: m
+  #    ├──┬ unit:LB_F^-1 symbol: lbf
+  #    │  ├──┬ unit:FT symbol: ft
+  #    │  │  └──┬ unit:IN symbol: in
+  #    │  │     └─── unit:M symbol: m
+  #    │  ├─── unit:SEC^-2 symbol: s
+  #    │  └──┬ unit:SLUG symbol: slug
+  #    │     └──┬ unit:LB symbol: lbm
+  #    │        └──┬ unit:KiloGM symbol: kg
+  #    │           └─── unit:GM symbol: g
+  #    └─── unit:SEC^-1 symbol: s
+unit:LB-FT2-PER-GAL_US-LB_F-SEC qudt:symbol "lbm·ft²/(gal{US}·lbf·s)" .
+
+  # WRONG SYMBOL  : unit:LB-FT2-PER-IN3-LB_F-SEC - calculated from factors: lbm·ft²/(in³·lbf·s), actual: (lb/in³)/(lbf·s/ft²)
+  #
+  #  ──┬ unit:LB-FT2-PER-IN3-LB_F-SEC symbol: (lb/in³)/(lbf·s/ft²) (correct: lbm·ft²/(in³·lbf·s))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:FT^2 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    ├──┬ unit:LB_F^-1 symbol: lbf
+  #    │  ├──┬ unit:FT symbol: ft
+  #    │  │  └──┬ unit:IN symbol: in
+  #    │  │     └─── unit:M symbol: m
+  #    │  ├─── unit:SEC^-2 symbol: s
+  #    │  └──┬ unit:SLUG symbol: slug
+  #    │     └──┬ unit:LB symbol: lbm
+  #    │        └──┬ unit:KiloGM symbol: kg
+  #    │           └─── unit:GM symbol: g
+  #    └─── unit:SEC^-1 symbol: s
+unit:LB-FT2-PER-IN3-LB_F-SEC qudt:symbol "lbm·ft²/(in³·lbf·s)" .
+
+  # WRONG SYMBOL  : unit:LB-HR-PER-FT3-GAL_UK - calculated from factors: lbm·h/(ft³·gal{UK}), actual: (lb/ft³)/(gal (UK)/h)
+  #
+  #  ──┬ unit:LB-HR-PER-FT3-GAL_UK symbol: (lb/ft³)/(gal (UK)/h) (correct: lbm·h/(ft³·gal{UK}))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:FT^-3 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:GAL_UK^-1 symbol: gal{UK}
+  #       └──┬ unit:L symbol: L
+  #          └──┬ unit:DeciM3 symbol: dm³
+  #             └──┬ unit:DeciM^3 symbol: dm
+  #                └─── unit:M symbol: m
+unit:LB-HR-PER-FT3-GAL_UK qudt:symbol "lbm·h/(ft³·gal{UK})" .
+
+  # WRONG SYMBOL  : unit:LB-HR-PER-FT3-GAL_US - calculated from factors: lbm·h/(ft³·gal{US}), actual: (lb/ft³)/(gal (US)/h)
+  #
+  #  ──┬ unit:LB-HR-PER-FT3-GAL_US symbol: (lb/ft³)/(gal (US)/h) (correct: lbm·h/(ft³·gal{US}))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:FT^-3 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:GAL_US^-1 symbol: gal{US}
+  #       └──┬ unit:IN^3 symbol: in
+  #          └─── unit:M symbol: m
+unit:LB-HR-PER-FT3-GAL_US qudt:symbol "lbm·h/(ft³·gal{US})" .
+
+  # WRONG SYMBOL  : unit:LB-HR-PER-FT3-IN3 - calculated from factors: lbm·h/(ft³·in³), actual: (lb/ft³)/(in³/h)
+  #
+  #  ──┬ unit:LB-HR-PER-FT3-IN3 symbol: (lb/ft³)/(in³/h) (correct: lbm·h/(ft³·in³))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:FT^-3 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:IN^-3 symbol: in
+  #       └─── unit:M symbol: m
+unit:LB-HR-PER-FT3-IN3 qudt:symbol "lbm·h/(ft³·in³)" .
+
+  # WRONG SYMBOL  : unit:LB-HR-PER-FT3-YD3 - calculated from factors: lbm·h/(ft³·yd³), actual: (lb/ft³)/(yd³/h)
+  #
+  #  ──┬ unit:LB-HR-PER-FT3-YD3 symbol: (lb/ft³)/(yd³/h) (correct: lbm·h/(ft³·yd³))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:FT^-3 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:YD^-3 symbol: yd
+  #       └──┬ unit:FT symbol: ft
+  #          └──┬ unit:IN symbol: in
+  #             └─── unit:M symbol: m
+unit:LB-HR-PER-FT3-YD3 qudt:symbol "lbm·h/(ft³·yd³)" .
+
+  # WRONG SYMBOL  : unit:LB-HR-PER-FT6 - calculated from factors: lbm·h/ft⁶, actual: (lb/ft³)/(ft³/h)
+  #
+  #  ──┬ unit:LB-HR-PER-FT6 symbol: (lb/ft³)/(ft³/h) (correct: lbm·h/ft⁶)
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    └──┬ unit:FT^-6 symbol: ft
+  #       └──┬ unit:IN symbol: in
+  #          └─── unit:M symbol: m
+unit:LB-HR-PER-FT6 qudt:symbol "lbm·h/ft⁶" .
+
+  # WRONG SYMBOL  : unit:LB-HR-PER-GAL_UK-FT3 - calculated from factors: lbm·h/(gal{UK}·ft³), actual: lb/(gal (UK))/(ft³/h)
+  #
+  #  ──┬ unit:LB-HR-PER-GAL_UK-FT3 symbol: lb/(gal (UK))/(ft³/h) (correct: lbm·h/(gal{UK}·ft³))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:GAL_UK^-1 symbol: gal{UK}
+  #    │  └──┬ unit:L symbol: L
+  #    │     └──┬ unit:DeciM3 symbol: dm³
+  #    │        └──┬ unit:DeciM^3 symbol: dm
+  #    │           └─── unit:M symbol: m
+  #    └──┬ unit:FT^-3 symbol: ft
+  #       └──┬ unit:IN symbol: in
+  #          └─── unit:M symbol: m
+unit:LB-HR-PER-GAL_UK-FT3 qudt:symbol "lbm·h/(gal{UK}·ft³)" .
+
+  # WRONG SYMBOL  : unit:LB-HR-PER-GAL_UK-IN3 - calculated from factors: lbm·h/(gal{UK}·in³), actual: lb/(gal (UK))/(in³/h)
+  #
+  #  ──┬ unit:LB-HR-PER-GAL_UK-IN3 symbol: lb/(gal (UK))/(in³/h) (correct: lbm·h/(gal{UK}·in³))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:GAL_UK^-1 symbol: gal{UK}
+  #    │  └──┬ unit:L symbol: L
+  #    │     └──┬ unit:DeciM3 symbol: dm³
+  #    │        └──┬ unit:DeciM^3 symbol: dm
+  #    │           └─── unit:M symbol: m
+  #    └──┬ unit:IN^-3 symbol: in
+  #       └─── unit:M symbol: m
+unit:LB-HR-PER-GAL_UK-IN3 qudt:symbol "lbm·h/(gal{UK}·in³)" .
+
+  # WRONG SYMBOL  : unit:LB-HR-PER-GAL_UK-YD3 - calculated from factors: lbm·h/(gal{UK}·yd³), actual: lb/(gal (UK))/(yd³/h)
+  #
+  #  ──┬ unit:LB-HR-PER-GAL_UK-YD3 symbol: lb/(gal (UK))/(yd³/h) (correct: lbm·h/(gal{UK}·yd³))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:GAL_UK^-1 symbol: gal{UK}
+  #    │  └──┬ unit:L symbol: L
+  #    │     └──┬ unit:DeciM3 symbol: dm³
+  #    │        └──┬ unit:DeciM^3 symbol: dm
+  #    │           └─── unit:M symbol: m
+  #    └──┬ unit:YD^-3 symbol: yd
+  #       └──┬ unit:FT symbol: ft
+  #          └──┬ unit:IN symbol: in
+  #             └─── unit:M symbol: m
+unit:LB-HR-PER-GAL_UK-YD3 qudt:symbol "lbm·h/(gal{UK}·yd³)" .
+
+  # WRONG SYMBOL  : unit:LB-HR-PER-GAL_US-FT3 - calculated from factors: lbm·h/(gal{US}·ft³), actual: lb/(gal (US))/(ft³/h)
+  #
+  #  ──┬ unit:LB-HR-PER-GAL_US-FT3 symbol: lb/(gal (US))/(ft³/h) (correct: lbm·h/(gal{US}·ft³))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:GAL_US^-1 symbol: gal{US}
+  #    │  └──┬ unit:IN^3 symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:FT^-3 symbol: ft
+  #       └──┬ unit:IN symbol: in
+  #          └─── unit:M symbol: m
+unit:LB-HR-PER-GAL_US-FT3 qudt:symbol "lbm·h/(gal{US}·ft³)" .
+
+  # WRONG SYMBOL  : unit:LB-HR-PER-GAL_US-IN3 - calculated from factors: lbm·h/(gal{US}·in³), actual: lb/(gal (US))/(in³/h)
+  #
+  #  ──┬ unit:LB-HR-PER-GAL_US-IN3 symbol: lb/(gal (US))/(in³/h) (correct: lbm·h/(gal{US}·in³))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:GAL_US^-1 symbol: gal{US}
+  #    │  └──┬ unit:IN^3 symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:IN^-3 symbol: in
+  #       └─── unit:M symbol: m
+unit:LB-HR-PER-GAL_US-IN3 qudt:symbol "lbm·h/(gal{US}·in³)" .
+
+  # WRONG SYMBOL  : unit:LB-HR-PER-GAL_US-YD3 - calculated from factors: lbm·h/(gal{US}·yd³), actual: lb/(gal (US))/(yd³/h)
+  #
+  #  ──┬ unit:LB-HR-PER-GAL_US-YD3 symbol: lb/(gal (US))/(yd³/h) (correct: lbm·h/(gal{US}·yd³))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:GAL_US^-1 symbol: gal{US}
+  #    │  └──┬ unit:IN^3 symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:YD^-3 symbol: yd
+  #       └──┬ unit:FT symbol: ft
+  #          └──┬ unit:IN symbol: in
+  #             └─── unit:M symbol: m
+unit:LB-HR-PER-GAL_US-YD3 qudt:symbol "lbm·h/(gal{US}·yd³)" .
+
+  # WRONG SYMBOL  : unit:LB-HR-PER-GAL_US2 - calculated from factors: lbm·h/gal{US}², actual: lb/(gal (US))/(gal (US)/h)
+  #
+  #  ──┬ unit:LB-HR-PER-GAL_US2 symbol: lb/(gal (US))/(gal (US)/h) (correct: lbm·h/gal{US}²)
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    └──┬ unit:GAL_US^-2 symbol: gal{US}
+  #       └──┬ unit:IN^3 symbol: in
+  #          └─── unit:M symbol: m
+unit:LB-HR-PER-GAL_US2 qudt:symbol "lbm·h/gal{US}²" .
+
+  # WRONG SYMBOL  : unit:LB-HR-PER-IN3-FT3 - calculated from factors: lbm·h/(in³·ft³), actual: (lb/in³)/(ft³/h)
+  #
+  #  ──┬ unit:LB-HR-PER-IN3-FT3 symbol: (lb/in³)/(ft³/h) (correct: lbm·h/(in³·ft³))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:FT^-3 symbol: ft
+  #       └──┬ unit:IN symbol: in
+  #          └─── unit:M symbol: m
+unit:LB-HR-PER-IN3-FT3 qudt:symbol "lbm·h/(in³·ft³)" .
+
+  # WRONG SYMBOL  : unit:LB-HR-PER-IN3-GAL_UK - calculated from factors: lbm·h/(in³·gal{UK}), actual: (lb/in³)/(gal (UK)/h)
+  #
+  #  ──┬ unit:LB-HR-PER-IN3-GAL_UK symbol: (lb/in³)/(gal (UK)/h) (correct: lbm·h/(in³·gal{UK}))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:GAL_UK^-1 symbol: gal{UK}
+  #       └──┬ unit:L symbol: L
+  #          └──┬ unit:DeciM3 symbol: dm³
+  #             └──┬ unit:DeciM^3 symbol: dm
+  #                └─── unit:M symbol: m
+unit:LB-HR-PER-IN3-GAL_UK qudt:symbol "lbm·h/(in³·gal{UK})" .
+
+  # WRONG SYMBOL  : unit:LB-HR-PER-IN3-GAL_US - calculated from factors: lbm·h/(in³·gal{US}), actual: (lb/in³)/(gal (US)/h)
+  #
+  #  ──┬ unit:LB-HR-PER-IN3-GAL_US symbol: (lb/in³)/(gal (US)/h) (correct: lbm·h/(in³·gal{US}))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:GAL_US^-1 symbol: gal{US}
+  #       └──┬ unit:IN^3 symbol: in
+  #          └─── unit:M symbol: m
+unit:LB-HR-PER-IN3-GAL_US qudt:symbol "lbm·h/(in³·gal{US})" .
+
+  # WRONG SYMBOL  : unit:LB-HR-PER-IN3-YD3 - calculated from factors: lbm·h/(in³·yd³), actual: (lb/in³)/(yd³/h)
+  #
+  #  ──┬ unit:LB-HR-PER-IN3-YD3 symbol: (lb/in³)/(yd³/h) (correct: lbm·h/(in³·yd³))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:YD^-3 symbol: yd
+  #       └──┬ unit:FT symbol: ft
+  #          └──┬ unit:IN symbol: in
+  #             └─── unit:M symbol: m
+unit:LB-HR-PER-IN3-YD3 qudt:symbol "lbm·h/(in³·yd³)" .
+
+  # WRONG SYMBOL  : unit:LB-HR-PER-IN6 - calculated from factors: lbm·h/in⁶, actual: (lb/in³)/(in³/h)
+  #
+  #  ──┬ unit:LB-HR-PER-IN6 symbol: (lb/in³)/(in³/h) (correct: lbm·h/in⁶)
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    └──┬ unit:IN^-6 symbol: in
+  #       └─── unit:M symbol: m
+unit:LB-HR-PER-IN6 qudt:symbol "lbm·h/in⁶" .
+
+  # WRONG SYMBOL  : unit:LB-IN-PER-SEC - calculated from factors: lbm·in/s, actual: lb·(in/s)
+  #
+  #  ──┬ unit:LB-IN-PER-SEC symbol: lb·(in/s) (correct: lbm·in/s)
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:IN symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └─── unit:SEC^-1 symbol: s
+unit:LB-IN-PER-SEC qudt:symbol "lbm·in/s" .
+
+  # WRONG SYMBOL  : unit:LB-IN2-PER-FT3-LB_F-SEC - calculated from factors: lbm·in²/(ft³·lbf·s), actual: (lb/ft³)/(lbf·s/in²)
+  #
+  #  ──┬ unit:LB-IN2-PER-FT3-LB_F-SEC symbol: (lb/ft³)/(lbf·s/in²) (correct: lbm·in²/(ft³·lbf·s))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:IN^2 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    ├──┬ unit:FT^-3 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    ├──┬ unit:LB_F^-1 symbol: lbf
+  #    │  ├──┬ unit:FT symbol: ft
+  #    │  │  └──┬ unit:IN symbol: in
+  #    │  │     └─── unit:M symbol: m
+  #    │  ├─── unit:SEC^-2 symbol: s
+  #    │  └──┬ unit:SLUG symbol: slug
+  #    │     └──┬ unit:LB symbol: lbm
+  #    │        └──┬ unit:KiloGM symbol: kg
+  #    │           └─── unit:GM symbol: g
+  #    └─── unit:SEC^-1 symbol: s
+unit:LB-IN2-PER-FT3-LB_F-SEC qudt:symbol "lbm·in²/(ft³·lbf·s)" .
+
+  # WRONG SYMBOL  : unit:LB-IN2-PER-GAL_UK-LB_F-SEC - calculated from factors: lbm·in²/(gal{UK}·lbf·s), actual: lb/(gal (UK))/(lbf·s/in²)
+  #
+  #  ──┬ unit:LB-IN2-PER-GAL_UK-LB_F-SEC symbol: lb/(gal (UK))/(lbf·s/in²) (correct: lbm·in²/(gal{UK}·lbf·s))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:IN^2 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    ├──┬ unit:GAL_UK^-1 symbol: gal{UK}
+  #    │  └──┬ unit:L symbol: L
+  #    │     └──┬ unit:DeciM3 symbol: dm³
+  #    │        └──┬ unit:DeciM^3 symbol: dm
+  #    │           └─── unit:M symbol: m
+  #    ├──┬ unit:LB_F^-1 symbol: lbf
+  #    │  ├──┬ unit:FT symbol: ft
+  #    │  │  └──┬ unit:IN symbol: in
+  #    │  │     └─── unit:M symbol: m
+  #    │  ├─── unit:SEC^-2 symbol: s
+  #    │  └──┬ unit:SLUG symbol: slug
+  #    │     └──┬ unit:LB symbol: lbm
+  #    │        └──┬ unit:KiloGM symbol: kg
+  #    │           └─── unit:GM symbol: g
+  #    └─── unit:SEC^-1 symbol: s
+unit:LB-IN2-PER-GAL_UK-LB_F-SEC qudt:symbol "lbm·in²/(gal{UK}·lbf·s)" .
+
+  # WRONG SYMBOL  : unit:LB-IN2-PER-GAL_US-LB_F-SEC - calculated from factors: lbm·in²/(gal{US}·lbf·s), actual: lb/(gal (US))/(lbf·s/in²)
+  #
+  #  ──┬ unit:LB-IN2-PER-GAL_US-LB_F-SEC symbol: lb/(gal (US))/(lbf·s/in²) (correct: lbm·in²/(gal{US}·lbf·s))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:IN^2 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    ├──┬ unit:GAL_US^-1 symbol: gal{US}
+  #    │  └──┬ unit:IN^3 symbol: in
+  #    │     └─── unit:M symbol: m
+  #    ├──┬ unit:LB_F^-1 symbol: lbf
+  #    │  ├──┬ unit:FT symbol: ft
+  #    │  │  └──┬ unit:IN symbol: in
+  #    │  │     └─── unit:M symbol: m
+  #    │  ├─── unit:SEC^-2 symbol: s
+  #    │  └──┬ unit:SLUG symbol: slug
+  #    │     └──┬ unit:LB symbol: lbm
+  #    │        └──┬ unit:KiloGM symbol: kg
+  #    │           └─── unit:GM symbol: g
+  #    └─── unit:SEC^-1 symbol: s
+unit:LB-IN2-PER-GAL_US-LB_F-SEC qudt:symbol "lbm·in²/(gal{US}·lbf·s)" .
+
+  # WRONG SYMBOL  : unit:LB-IN2-PER-IN3-LB_F-SEC - calculated from factors: lbm·in²/(in³·lbf·s), actual: (lb/in³)/(lbf·s/in²)
+  #
+  #  ──┬ unit:LB-IN2-PER-IN3-LB_F-SEC symbol: (lb/in³)/(lbf·s/in²) (correct: lbm·in²/(in³·lbf·s))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:IN^2 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    ├──┬ unit:LB_F^-1 symbol: lbf
+  #    │  ├──┬ unit:FT symbol: ft
+  #    │  │  └──┬ unit:IN symbol: in
+  #    │  │     └─── unit:M symbol: m
+  #    │  ├─── unit:SEC^-2 symbol: s
+  #    │  └──┬ unit:SLUG symbol: slug
+  #    │     └──┬ unit:LB symbol: lbm
+  #    │        └──┬ unit:KiloGM symbol: kg
+  #    │           └─── unit:GM symbol: g
+  #    └─── unit:SEC^-1 symbol: s
+unit:LB-IN2-PER-IN3-LB_F-SEC qudt:symbol "lbm·in²/(in³·lbf·s)" .
+
+  # WRONG SYMBOL  : unit:LB-MIN-PER-FT3-GAL_UK - calculated from factors: lbm·min/(ft³·gal{UK}), actual: lb·min/(ft³·gal (UK))
+  #
+  #  ──┬ unit:LB-MIN-PER-FT3-GAL_UK symbol: lb·min/(ft³·gal (UK)) (correct: lbm·min/(ft³·gal{UK}))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:FT^-3 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:GAL_UK^-1 symbol: gal{UK}
+  #       └──┬ unit:L symbol: L
+  #          └──┬ unit:DeciM3 symbol: dm³
+  #             └──┬ unit:DeciM^3 symbol: dm
+  #                └─── unit:M symbol: m
+unit:LB-MIN-PER-FT3-GAL_UK qudt:symbol "lbm·min/(ft³·gal{UK})" .
+
+  # WRONG SYMBOL  : unit:LB-MIN-PER-FT3-GAL_US - calculated from factors: lbm·min/(ft³·gal{US}), actual: (lb/ft³)/(gal (US)/min)
+  #
+  #  ──┬ unit:LB-MIN-PER-FT3-GAL_US symbol: (lb/ft³)/(gal (US)/min) (correct: lbm·min/(ft³·gal{US}))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:FT^-3 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:GAL_US^-1 symbol: gal{US}
+  #       └──┬ unit:IN^3 symbol: in
+  #          └─── unit:M symbol: m
+unit:LB-MIN-PER-FT3-GAL_US qudt:symbol "lbm·min/(ft³·gal{US})" .
+
+  # WRONG SYMBOL  : unit:LB-MIN-PER-FT3-IN3 - calculated from factors: lbm·min/(ft³·in³), actual: (lb/ft³)/(in³/min)
+  #
+  #  ──┬ unit:LB-MIN-PER-FT3-IN3 symbol: (lb/ft³)/(in³/min) (correct: lbm·min/(ft³·in³))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:FT^-3 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:IN^-3 symbol: in
+  #       └─── unit:M symbol: m
+unit:LB-MIN-PER-FT3-IN3 qudt:symbol "lbm·min/(ft³·in³)" .
+
+  # WRONG SYMBOL  : unit:LB-MIN-PER-FT3-YD3 - calculated from factors: lbm·min/(ft³·yd³), actual: (lb/ft³)/(yd³/min)
+  #
+  #  ──┬ unit:LB-MIN-PER-FT3-YD3 symbol: (lb/ft³)/(yd³/min) (correct: lbm·min/(ft³·yd³))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:FT^-3 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:YD^-3 symbol: yd
+  #       └──┬ unit:FT symbol: ft
+  #          └──┬ unit:IN symbol: in
+  #             └─── unit:M symbol: m
+unit:LB-MIN-PER-FT3-YD3 qudt:symbol "lbm·min/(ft³·yd³)" .
+
+  # WRONG SYMBOL  : unit:LB-MIN-PER-FT6 - calculated from factors: lbm·min/ft⁶, actual: (lb/ft³)/(ft³/min)
+  #
+  #  ──┬ unit:LB-MIN-PER-FT6 symbol: (lb/ft³)/(ft³/min) (correct: lbm·min/ft⁶)
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    └──┬ unit:FT^-6 symbol: ft
+  #       └──┬ unit:IN symbol: in
+  #          └─── unit:M symbol: m
+unit:LB-MIN-PER-FT6 qudt:symbol "lbm·min/ft⁶" .
+
+  # WRONG SYMBOL  : unit:LB-MIN-PER-GAL_UK-FT3 - calculated from factors: lbm·min/(gal{UK}·ft³), actual: lb/(gal (UK))/(ft³/min)
+  #
+  #  ──┬ unit:LB-MIN-PER-GAL_UK-FT3 symbol: lb/(gal (UK))/(ft³/min) (correct: lbm·min/(gal{UK}·ft³))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:GAL_UK^-1 symbol: gal{UK}
+  #    │  └──┬ unit:L symbol: L
+  #    │     └──┬ unit:DeciM3 symbol: dm³
+  #    │        └──┬ unit:DeciM^3 symbol: dm
+  #    │           └─── unit:M symbol: m
+  #    └──┬ unit:FT^-3 symbol: ft
+  #       └──┬ unit:IN symbol: in
+  #          └─── unit:M symbol: m
+unit:LB-MIN-PER-GAL_UK-FT3 qudt:symbol "lbm·min/(gal{UK}·ft³)" .
+
+  # WRONG SYMBOL  : unit:LB-MIN-PER-GAL_UK-IN3 - calculated from factors: lbm·min/(gal{UK}·in³), actual: lb/(gal (UK))/(in³/min)
+  #
+  #  ──┬ unit:LB-MIN-PER-GAL_UK-IN3 symbol: lb/(gal (UK))/(in³/min) (correct: lbm·min/(gal{UK}·in³))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:GAL_UK^-1 symbol: gal{UK}
+  #    │  └──┬ unit:L symbol: L
+  #    │     └──┬ unit:DeciM3 symbol: dm³
+  #    │        └──┬ unit:DeciM^3 symbol: dm
+  #    │           └─── unit:M symbol: m
+  #    └──┬ unit:IN^-3 symbol: in
+  #       └─── unit:M symbol: m
+unit:LB-MIN-PER-GAL_UK-IN3 qudt:symbol "lbm·min/(gal{UK}·in³)" .
+
+  # WRONG SYMBOL  : unit:LB-MIN-PER-GAL_UK-YD3 - calculated from factors: lbm·min/(gal{UK}·yd³), actual: lb/(gal (UK))/(yd³/min)
+  #
+  #  ──┬ unit:LB-MIN-PER-GAL_UK-YD3 symbol: lb/(gal (UK))/(yd³/min) (correct: lbm·min/(gal{UK}·yd³))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:GAL_UK^-1 symbol: gal{UK}
+  #    │  └──┬ unit:L symbol: L
+  #    │     └──┬ unit:DeciM3 symbol: dm³
+  #    │        └──┬ unit:DeciM^3 symbol: dm
+  #    │           └─── unit:M symbol: m
+  #    └──┬ unit:YD^-3 symbol: yd
+  #       └──┬ unit:FT symbol: ft
+  #          └──┬ unit:IN symbol: in
+  #             └─── unit:M symbol: m
+unit:LB-MIN-PER-GAL_UK-YD3 qudt:symbol "lbm·min/(gal{UK}·yd³)" .
+
+  # WRONG SYMBOL  : unit:LB-MIN-PER-GAL_UK2 - calculated from factors: lbm·min/gal{UK}², actual: lb/(gal (UK))/(gal (UK)/min)
+  #
+  #  ──┬ unit:LB-MIN-PER-GAL_UK2 symbol: lb/(gal (UK))/(gal (UK)/min) (correct: lbm·min/gal{UK}²)
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    └──┬ unit:GAL_UK^-2 symbol: gal{UK}
+  #       └──┬ unit:L symbol: L
+  #          └──┬ unit:DeciM3 symbol: dm³
+  #             └──┬ unit:DeciM^3 symbol: dm
+  #                └─── unit:M symbol: m
+unit:LB-MIN-PER-GAL_UK2 qudt:symbol "lbm·min/gal{UK}²" .
+
+  # WRONG SYMBOL  : unit:LB-MIN-PER-GAL_US-FT3 - calculated from factors: lbm·min/(gal{US}·ft³), actual: lb/(gal (US))/(ft³/min)
+  #
+  #  ──┬ unit:LB-MIN-PER-GAL_US-FT3 symbol: lb/(gal (US))/(ft³/min) (correct: lbm·min/(gal{US}·ft³))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:GAL_US^-1 symbol: gal{US}
+  #    │  └──┬ unit:IN^3 symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:FT^-3 symbol: ft
+  #       └──┬ unit:IN symbol: in
+  #          └─── unit:M symbol: m
+unit:LB-MIN-PER-GAL_US-FT3 qudt:symbol "lbm·min/(gal{US}·ft³)" .
+
+  # WRONG SYMBOL  : unit:LB-MIN-PER-GAL_US-IN3 - calculated from factors: lbm·min/(gal{US}·in³), actual: lb/(gal (US))/(in³/min)
+  #
+  #  ──┬ unit:LB-MIN-PER-GAL_US-IN3 symbol: lb/(gal (US))/(in³/min) (correct: lbm·min/(gal{US}·in³))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:GAL_US^-1 symbol: gal{US}
+  #    │  └──┬ unit:IN^3 symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:IN^-3 symbol: in
+  #       └─── unit:M symbol: m
+unit:LB-MIN-PER-GAL_US-IN3 qudt:symbol "lbm·min/(gal{US}·in³)" .
+
+  # WRONG SYMBOL  : unit:LB-MIN-PER-GAL_US-YD3 - calculated from factors: lbm·min/(gal{US}·yd³), actual: lb/(gal (US))/(yd³/min)
+  #
+  #  ──┬ unit:LB-MIN-PER-GAL_US-YD3 symbol: lb/(gal (US))/(yd³/min) (correct: lbm·min/(gal{US}·yd³))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:GAL_US^-1 symbol: gal{US}
+  #    │  └──┬ unit:IN^3 symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:YD^-3 symbol: yd
+  #       └──┬ unit:FT symbol: ft
+  #          └──┬ unit:IN symbol: in
+  #             └─── unit:M symbol: m
+unit:LB-MIN-PER-GAL_US-YD3 qudt:symbol "lbm·min/(gal{US}·yd³)" .
+
+  # WRONG SYMBOL  : unit:LB-MIN-PER-GAL_US2 - calculated from factors: lbm·min/gal{US}², actual: lb/(gal (US))/(gal (US)/min)
+  #
+  #  ──┬ unit:LB-MIN-PER-GAL_US2 symbol: lb/(gal (US))/(gal (US)/min) (correct: lbm·min/gal{US}²)
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    └──┬ unit:GAL_US^-2 symbol: gal{US}
+  #       └──┬ unit:IN^3 symbol: in
+  #          └─── unit:M symbol: m
+unit:LB-MIN-PER-GAL_US2 qudt:symbol "lbm·min/gal{US}²" .
+
+  # WRONG SYMBOL  : unit:LB-MIN-PER-IN3-FT3 - calculated from factors: lbm·min/(in³·ft³), actual: (lb/in³)/(ft³/min)
+  #
+  #  ──┬ unit:LB-MIN-PER-IN3-FT3 symbol: (lb/in³)/(ft³/min) (correct: lbm·min/(in³·ft³))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:FT^-3 symbol: ft
+  #       └──┬ unit:IN symbol: in
+  #          └─── unit:M symbol: m
+unit:LB-MIN-PER-IN3-FT3 qudt:symbol "lbm·min/(in³·ft³)" .
+
+  # WRONG SYMBOL  : unit:LB-MIN-PER-IN3-GAL_UK - calculated from factors: lbm·min/(in³·gal{UK}), actual: lb·min/(in³·gal (UK))
+  #
+  #  ──┬ unit:LB-MIN-PER-IN3-GAL_UK symbol: lb·min/(in³·gal (UK)) (correct: lbm·min/(in³·gal{UK}))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:GAL_UK^-1 symbol: gal{UK}
+  #       └──┬ unit:L symbol: L
+  #          └──┬ unit:DeciM3 symbol: dm³
+  #             └──┬ unit:DeciM^3 symbol: dm
+  #                └─── unit:M symbol: m
+unit:LB-MIN-PER-IN3-GAL_UK qudt:symbol "lbm·min/(in³·gal{UK})" .
+
+  # WRONG SYMBOL  : unit:LB-MIN-PER-IN3-GAL_US - calculated from factors: lbm·min/(in³·gal{US}), actual: (lb/in³)/(gal (US)/min)
+  #
+  #  ──┬ unit:LB-MIN-PER-IN3-GAL_US symbol: (lb/in³)/(gal (US)/min) (correct: lbm·min/(in³·gal{US}))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:GAL_US^-1 symbol: gal{US}
+  #       └──┬ unit:IN^3 symbol: in
+  #          └─── unit:M symbol: m
+unit:LB-MIN-PER-IN3-GAL_US qudt:symbol "lbm·min/(in³·gal{US})" .
+
+  # WRONG SYMBOL  : unit:LB-MIN-PER-IN3-YD3 - calculated from factors: lbm·min/(in³·yd³), actual: (lb/in³)/(yd³/min)
+  #
+  #  ──┬ unit:LB-MIN-PER-IN3-YD3 symbol: (lb/in³)/(yd³/min) (correct: lbm·min/(in³·yd³))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:YD^-3 symbol: yd
+  #       └──┬ unit:FT symbol: ft
+  #          └──┬ unit:IN symbol: in
+  #             └─── unit:M symbol: m
+unit:LB-MIN-PER-IN3-YD3 qudt:symbol "lbm·min/(in³·yd³)" .
+
+  # WRONG SYMBOL  : unit:LB-MIN-PER-IN6 - calculated from factors: lbm·min/in⁶, actual: (lb/in³)/(in³/min)
+  #
+  #  ──┬ unit:LB-MIN-PER-IN6 symbol: (lb/in³)/(in³/min) (correct: lbm·min/in⁶)
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    └──┬ unit:IN^-6 symbol: in
+  #       └─── unit:M symbol: m
+unit:LB-MIN-PER-IN6 qudt:symbol "lbm·min/in⁶" .
+
+  # WRONG SYMBOL  : unit:LB-PER-AC - calculated from factors: lbm/acre, actual: lb/acre
+  #
+  #  ──┬ unit:LB-PER-AC symbol: lb/acre (correct: lbm/acre)
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    └──┬ unit:AC^-1 symbol: acre
+  #       └──┬ unit:M2 symbol: m²
+  #          └─── unit:M^2 symbol: m
+unit:LB-PER-AC qudt:symbol "lbm/acre" .
+
+  # WRONG SYMBOL  : unit:LB-PER-DAY - calculated from factors: lbm/d, actual: lbm/day
+  #
+  #  ──┬ unit:LB-PER-DAY symbol: lbm/day (correct: lbm/d)
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:LB-PER-DAY qudt:symbol "lbm/d" .
+
+  # WRONG SYMBOL  : unit:LB-PER-DEG_F - calculated from factors: lbm/°F, actual: lb/°F
+  #
+  #  ──┬ unit:LB-PER-DEG_F symbol: lb/°F (correct: lbm/°F)
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    └──┬ unit:DEG_F^-1 symbol: °F
+  #       └─── unit:K symbol: K
+unit:LB-PER-DEG_F qudt:symbol "lbm/°F" .
+
+  # WRONG SYMBOL  : unit:LB-PER-FT - calculated from factors: lbm/ft, actual: lb/ft
+  #
+  #  ──┬ unit:LB-PER-FT symbol: lb/ft (correct: lbm/ft)
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    └──┬ unit:FT^-1 symbol: ft
+  #       └──┬ unit:IN symbol: in
+  #          └─── unit:M symbol: m
+unit:LB-PER-FT qudt:symbol "lbm/ft" .
+
+  # WRONG SYMBOL  : unit:LB-PER-FT-DAY - calculated from factors: lbm/(ft·d), actual: lb/(ft·d)
+  #
+  #  ──┬ unit:LB-PER-FT-DAY symbol: lb/(ft·d) (correct: lbm/(ft·d))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:FT^-1 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:LB-PER-FT-DAY qudt:symbol "lbm/(ft·d)" .
+
+  # WRONG SYMBOL  : unit:LB-PER-FT-LB_F-SEC - calculated from factors: lbm/(ft·lbf·s), actual: (lb/ft³)/(lbf·s/ft²)
+  #
+  #  ──┬ unit:LB-PER-FT-LB_F-SEC symbol: (lb/ft³)/(lbf·s/ft²) (correct: lbm/(ft·lbf·s))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:FT^-1 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    ├──┬ unit:LB_F^-1 symbol: lbf
+  #    │  ├──┬ unit:FT symbol: ft
+  #    │  │  └──┬ unit:IN symbol: in
+  #    │  │     └─── unit:M symbol: m
+  #    │  ├─── unit:SEC^-2 symbol: s
+  #    │  └──┬ unit:SLUG symbol: slug
+  #    │     └──┬ unit:LB symbol: lbm
+  #    │        └──┬ unit:KiloGM symbol: kg
+  #    │           └─── unit:GM symbol: g
+  #    └─── unit:SEC^-1 symbol: s
+unit:LB-PER-FT-LB_F-SEC qudt:symbol "lbm/(ft·lbf·s)" .
+
+  # WRONG SYMBOL  : unit:LB-PER-FT-MIN - calculated from factors: lbm/(ft·min), actual: lb/(ft·min)
+  #
+  #  ──┬ unit:LB-PER-FT-MIN symbol: lb/(ft·min) (correct: lbm/(ft·min))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:FT^-1 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:MIN^-1 symbol: min
+  #       └─── unit:SEC symbol: s
+unit:LB-PER-FT-MIN qudt:symbol "lbm/(ft·min)" .
+
+  # WRONG SYMBOL  : unit:LB-PER-FT3-DEG_F - calculated from factors: lbm/(ft³·°F), actual: lb/(ft³·°F)
+  #
+  #  ──┬ unit:LB-PER-FT3-DEG_F symbol: lb/(ft³·°F) (correct: lbm/(ft³·°F))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:FT^-3 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:DEG_F^-1 symbol: °F
+  #       └─── unit:K symbol: K
+unit:LB-PER-FT3-DEG_F qudt:symbol "lbm/(ft³·°F)" .
+
+  # WRONG SYMBOL  : unit:LB-PER-FT3-PSI - calculated from factors: lbm/(ft³·psi), actual: lb/(ft³·psi)
+  #
+  #  ──┬ unit:LB-PER-FT3-PSI symbol: lb/(ft³·psi) (correct: lbm/(ft³·psi))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:FT^-3 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:PSI^-1 symbol: psi
+  #       ├──┬ unit:IN^-2 symbol: in
+  #       │  └─── unit:M symbol: m
+  #       └──┬ unit:LB_F symbol: lbf
+  #          ├──┬ unit:FT symbol: ft
+  #          │  └──┬ unit:IN symbol: in
+  #          │     └─── unit:M symbol: m
+  #          ├─── unit:SEC^-2 symbol: s
+  #          └──┬ unit:SLUG symbol: slug
+  #             └──┬ unit:LB symbol: lbm
+  #                └──┬ unit:KiloGM symbol: kg
+  #                   └─── unit:GM symbol: g
+unit:LB-PER-FT3-PSI qudt:symbol "lbm/(ft³·psi)" .
+
+  # WRONG SYMBOL  : unit:LB-PER-HR-DEG_F - calculated from factors: lbm/(h·°F), actual: lb/(h·°F)
+  #
+  #  ──┬ unit:LB-PER-HR-DEG_F symbol: lb/(h·°F) (correct: lbm/(h·°F))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:HR^-1 symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    └──┬ unit:DEG_F^-1 symbol: °F
+  #       └─── unit:K symbol: K
+unit:LB-PER-HR-DEG_F qudt:symbol "lbm/(h·°F)" .
+
+  # WRONG SYMBOL  : unit:LB-PER-HR-PSI - calculated from factors: lbm/(h·psi), actual: lb/(h·psi)
+  #
+  #  ──┬ unit:LB-PER-HR-PSI symbol: lb/(h·psi) (correct: lbm/(h·psi))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:HR^-1 symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    └──┬ unit:PSI^-1 symbol: psi
+  #       ├──┬ unit:IN^-2 symbol: in
+  #       │  └─── unit:M symbol: m
+  #       └──┬ unit:LB_F symbol: lbf
+  #          ├──┬ unit:FT symbol: ft
+  #          │  └──┬ unit:IN symbol: in
+  #          │     └─── unit:M symbol: m
+  #          ├─── unit:SEC^-2 symbol: s
+  #          └──┬ unit:SLUG symbol: slug
+  #             └──┬ unit:LB symbol: lbm
+  #                └──┬ unit:KiloGM symbol: kg
+  #                   └─── unit:GM symbol: g
+unit:LB-PER-HR-PSI qudt:symbol "lbm/(h·psi)" .
+
+  # WRONG SYMBOL  : unit:LB-PER-IN3-DEG_F - calculated from factors: lbm/(in³·°F), actual: lb/(in³·°F)
+  #
+  #  ──┬ unit:LB-PER-IN3-DEG_F symbol: lb/(in³·°F) (correct: lbm/(in³·°F))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:DEG_F^-1 symbol: °F
+  #       └─── unit:K symbol: K
+unit:LB-PER-IN3-DEG_F qudt:symbol "lbm/(in³·°F)" .
+
+  # WRONG SYMBOL  : unit:LB-PER-IN3-PSI - calculated from factors: lbm/(in³·psi), actual: lb/(in³·psi)
+  #
+  #  ──┬ unit:LB-PER-IN3-PSI symbol: lb/(in³·psi) (correct: lbm/(in³·psi))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:PSI^-1 symbol: psi
+  #       ├──┬ unit:IN^-2 symbol: in
+  #       │  └─── unit:M symbol: m
+  #       └──┬ unit:LB_F symbol: lbf
+  #          ├──┬ unit:FT symbol: ft
+  #          │  └──┬ unit:IN symbol: in
+  #          │     └─── unit:M symbol: m
+  #          ├─── unit:SEC^-2 symbol: s
+  #          └──┬ unit:SLUG symbol: slug
+  #             └──┬ unit:LB symbol: lbm
+  #                └──┬ unit:KiloGM symbol: kg
+  #                   └─── unit:GM symbol: g
+unit:LB-PER-IN3-PSI qudt:symbol "lbm/(in³·psi)" .
+
+  # WRONG SYMBOL  : unit:LB-PER-LB - calculated from factors: lbm/lbm, actual: lb/lb
+  #
+  #  ──┬ unit:LB-PER-LB symbol: lb/lb (correct: lbm/lbm)
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    └──┬ unit:LB^-1 symbol: lbm
+  #       └──┬ unit:KiloGM symbol: kg
+  #          └─── unit:GM symbol: g
+unit:LB-PER-LB qudt:symbol "lbm/lbm" .
+
+  # WRONG SYMBOL  : unit:LB-PER-MIN-DEG_F - calculated from factors: lbm/(min·°F), actual: lb/(min·°F)
+  #
+  #  ──┬ unit:LB-PER-MIN-DEG_F symbol: lb/(min·°F) (correct: lbm/(min·°F))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:MIN^-1 symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    └──┬ unit:DEG_F^-1 symbol: °F
+  #       └─── unit:K symbol: K
+unit:LB-PER-MIN-DEG_F qudt:symbol "lbm/(min·°F)" .
+
+  # WRONG SYMBOL  : unit:LB-PER-MIN-PSI - calculated from factors: lbm/(min·psi), actual: lb/(min·psi)
+  #
+  #  ──┬ unit:LB-PER-MIN-PSI symbol: lb/(min·psi) (correct: lbm/(min·psi))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:MIN^-1 symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    └──┬ unit:PSI^-1 symbol: psi
+  #       ├──┬ unit:IN^-2 symbol: in
+  #       │  └─── unit:M symbol: m
+  #       └──┬ unit:LB_F symbol: lbf
+  #          ├──┬ unit:FT symbol: ft
+  #          │  └──┬ unit:IN symbol: in
+  #          │     └─── unit:M symbol: m
+  #          ├─── unit:SEC^-2 symbol: s
+  #          └──┬ unit:SLUG symbol: slug
+  #             └──┬ unit:LB symbol: lbm
+  #                └──┬ unit:KiloGM symbol: kg
+  #                   └─── unit:GM symbol: g
+unit:LB-PER-MIN-PSI qudt:symbol "lbm/(min·psi)" .
+
+  # WRONG SYMBOL  : unit:LB-PER-PSI - calculated from factors: lbm/psi, actual: lb/psi
+  #
+  #  ──┬ unit:LB-PER-PSI symbol: lb/psi (correct: lbm/psi)
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    └──┬ unit:PSI^-1 symbol: psi
+  #       ├──┬ unit:IN^-2 symbol: in
+  #       │  └─── unit:M symbol: m
+  #       └──┬ unit:LB_F symbol: lbf
+  #          ├──┬ unit:FT symbol: ft
+  #          │  └──┬ unit:IN symbol: in
+  #          │     └─── unit:M symbol: m
+  #          ├─── unit:SEC^-2 symbol: s
+  #          └──┬ unit:SLUG symbol: slug
+  #             └──┬ unit:LB symbol: lbm
+  #                └──┬ unit:KiloGM symbol: kg
+  #                   └─── unit:GM symbol: g
+unit:LB-PER-PSI qudt:symbol "lbm/psi" .
+
+  # WRONG SYMBOL  : unit:LB-PER-SEC-DEG_F - calculated from factors: lbm/(s·°F), actual: lb/(s·°F)
+  #
+  #  ──┬ unit:LB-PER-SEC-DEG_F symbol: lb/(s·°F) (correct: lbm/(s·°F))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├─── unit:SEC^-1 symbol: s
+  #    └──┬ unit:DEG_F^-1 symbol: °F
+  #       └─── unit:K symbol: K
+unit:LB-PER-SEC-DEG_F qudt:symbol "lbm/(s·°F)" .
+
+  # WRONG SYMBOL  : unit:LB-PER-SEC-PSI - calculated from factors: lbm/(s·psi), actual: lb/(s·psi)
+  #
+  #  ──┬ unit:LB-PER-SEC-PSI symbol: lb/(s·psi) (correct: lbm/(s·psi))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├─── unit:SEC^-1 symbol: s
+  #    └──┬ unit:PSI^-1 symbol: psi
+  #       ├──┬ unit:IN^-2 symbol: in
+  #       │  └─── unit:M symbol: m
+  #       └──┬ unit:LB_F symbol: lbf
+  #          ├──┬ unit:FT symbol: ft
+  #          │  └──┬ unit:IN symbol: in
+  #          │     └─── unit:M symbol: m
+  #          ├─── unit:SEC^-2 symbol: s
+  #          └──┬ unit:SLUG symbol: slug
+  #             └──┬ unit:LB symbol: lbm
+  #                └──┬ unit:KiloGM symbol: kg
+  #                   └─── unit:GM symbol: g
+unit:LB-PER-SEC-PSI qudt:symbol "lbm/(s·psi)" .
+
+  # WRONG SYMBOL  : unit:LB-PER-YD - calculated from factors: lbm/yd, actual: lb/yd
+  #
+  #  ──┬ unit:LB-PER-YD symbol: lb/yd (correct: lbm/yd)
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    └──┬ unit:YD^-1 symbol: yd
+  #       └──┬ unit:FT symbol: ft
+  #          └──┬ unit:IN symbol: in
+  #             └─── unit:M symbol: m
+unit:LB-PER-YD qudt:symbol "lbm/yd" .
+
+  # WRONG SYMBOL  : unit:LB-PER-YD2 - calculated from factors: lbm/yd², actual: lb/yd²
+  #
+  #  ──┬ unit:LB-PER-YD2 symbol: lb/yd² (correct: lbm/yd²)
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    └──┬ unit:YD^-2 symbol: yd
+  #       └──┬ unit:FT symbol: ft
+  #          └──┬ unit:IN symbol: in
+  #             └─── unit:M symbol: m
+unit:LB-PER-YD2 qudt:symbol "lbm/yd²" .
+
+  # WRONG SYMBOL  : unit:LB-SEC-PER-FT3-GAL_UK - calculated from factors: lbm·s/(ft³·gal{UK}), actual: (lb/ft³)/(gal (UK)/s)
+  #
+  #  ──┬ unit:LB-SEC-PER-FT3-GAL_UK symbol: (lb/ft³)/(gal (UK)/s) (correct: lbm·s/(ft³·gal{UK}))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    ├──┬ unit:FT^-3 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:GAL_UK^-1 symbol: gal{UK}
+  #       └──┬ unit:L symbol: L
+  #          └──┬ unit:DeciM3 symbol: dm³
+  #             └──┬ unit:DeciM^3 symbol: dm
+  #                └─── unit:M symbol: m
+unit:LB-SEC-PER-FT3-GAL_UK qudt:symbol "lbm·s/(ft³·gal{UK})" .
+
+  # WRONG SYMBOL  : unit:LB-SEC-PER-FT3-GAL_US - calculated from factors: lbm·s/(ft³·gal{US}), actual: (lb/ft³)/(gal (US)/s)
+  #
+  #  ──┬ unit:LB-SEC-PER-FT3-GAL_US symbol: (lb/ft³)/(gal (US)/s) (correct: lbm·s/(ft³·gal{US}))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    ├──┬ unit:FT^-3 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:GAL_US^-1 symbol: gal{US}
+  #       └──┬ unit:IN^3 symbol: in
+  #          └─── unit:M symbol: m
+unit:LB-SEC-PER-FT3-GAL_US qudt:symbol "lbm·s/(ft³·gal{US})" .
+
+  # WRONG SYMBOL  : unit:LB-SEC-PER-FT3-IN3 - calculated from factors: lbm·s/(ft³·in³), actual: (lb/ft³)/(in³/s)
+  #
+  #  ──┬ unit:LB-SEC-PER-FT3-IN3 symbol: (lb/ft³)/(in³/s) (correct: lbm·s/(ft³·in³))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    ├──┬ unit:FT^-3 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:IN^-3 symbol: in
+  #       └─── unit:M symbol: m
+unit:LB-SEC-PER-FT3-IN3 qudt:symbol "lbm·s/(ft³·in³)" .
+
+  # WRONG SYMBOL  : unit:LB-SEC-PER-FT3-YD3 - calculated from factors: lbm·s/(ft³·yd³), actual: (lb/ft³)/(yd³/s)
+  #
+  #  ──┬ unit:LB-SEC-PER-FT3-YD3 symbol: (lb/ft³)/(yd³/s) (correct: lbm·s/(ft³·yd³))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    ├──┬ unit:FT^-3 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:YD^-3 symbol: yd
+  #       └──┬ unit:FT symbol: ft
+  #          └──┬ unit:IN symbol: in
+  #             └─── unit:M symbol: m
+unit:LB-SEC-PER-FT3-YD3 qudt:symbol "lbm·s/(ft³·yd³)" .
+
+  # WRONG SYMBOL  : unit:LB-SEC-PER-FT6 - calculated from factors: lbm·s/ft⁶, actual: (lb/ft³)/(ft³/s)
+  #
+  #  ──┬ unit:LB-SEC-PER-FT6 symbol: (lb/ft³)/(ft³/s) (correct: lbm·s/ft⁶)
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    └──┬ unit:FT^-6 symbol: ft
+  #       └──┬ unit:IN symbol: in
+  #          └─── unit:M symbol: m
+unit:LB-SEC-PER-FT6 qudt:symbol "lbm·s/ft⁶" .
+
+  # WRONG SYMBOL  : unit:LB-SEC-PER-GAL_UK-FT3 - calculated from factors: lbm·s/(gal{UK}·ft³), actual: (lb/(gal (UK))/(ft³/s)
+  #
+  #  ──┬ unit:LB-SEC-PER-GAL_UK-FT3 symbol: (lb/(gal (UK))/(ft³/s) (correct: lbm·s/(gal{UK}·ft³))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    ├──┬ unit:GAL_UK^-1 symbol: gal{UK}
+  #    │  └──┬ unit:L symbol: L
+  #    │     └──┬ unit:DeciM3 symbol: dm³
+  #    │        └──┬ unit:DeciM^3 symbol: dm
+  #    │           └─── unit:M symbol: m
+  #    └──┬ unit:FT^-3 symbol: ft
+  #       └──┬ unit:IN symbol: in
+  #          └─── unit:M symbol: m
+unit:LB-SEC-PER-GAL_UK-FT3 qudt:symbol "lbm·s/(gal{UK}·ft³)" .
+
+  # WRONG SYMBOL  : unit:LB-SEC-PER-GAL_UK-IN3 - calculated from factors: lbm·s/(gal{UK}·in³), actual: (lb/(gal (UK))/(in³/s)
+  #
+  #  ──┬ unit:LB-SEC-PER-GAL_UK-IN3 symbol: (lb/(gal (UK))/(in³/s) (correct: lbm·s/(gal{UK}·in³))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    ├──┬ unit:GAL_UK^-1 symbol: gal{UK}
+  #    │  └──┬ unit:L symbol: L
+  #    │     └──┬ unit:DeciM3 symbol: dm³
+  #    │        └──┬ unit:DeciM^3 symbol: dm
+  #    │           └─── unit:M symbol: m
+  #    └──┬ unit:IN^-3 symbol: in
+  #       └─── unit:M symbol: m
+unit:LB-SEC-PER-GAL_UK-IN3 qudt:symbol "lbm·s/(gal{UK}·in³)" .
+
+  # WRONG SYMBOL  : unit:LB-SEC-PER-GAL_UK-YD3 - calculated from factors: lbm·s/(gal{UK}·yd³), actual: (lb/(gal (UK))/(yd³/s)
+  #
+  #  ──┬ unit:LB-SEC-PER-GAL_UK-YD3 symbol: (lb/(gal (UK))/(yd³/s) (correct: lbm·s/(gal{UK}·yd³))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    ├──┬ unit:GAL_UK^-1 symbol: gal{UK}
+  #    │  └──┬ unit:L symbol: L
+  #    │     └──┬ unit:DeciM3 symbol: dm³
+  #    │        └──┬ unit:DeciM^3 symbol: dm
+  #    │           └─── unit:M symbol: m
+  #    └──┬ unit:YD^-3 symbol: yd
+  #       └──┬ unit:FT symbol: ft
+  #          └──┬ unit:IN symbol: in
+  #             └─── unit:M symbol: m
+unit:LB-SEC-PER-GAL_UK-YD3 qudt:symbol "lbm·s/(gal{UK}·yd³)" .
+
+  # WRONG SYMBOL  : unit:LB-SEC-PER-GAL_UK2 - calculated from factors: lbm·s/gal{UK}², actual: (lb/(gal (UK))/(gal (UK)/s)
+  #
+  #  ──┬ unit:LB-SEC-PER-GAL_UK2 symbol: (lb/(gal (UK))/(gal (UK)/s) (correct: lbm·s/gal{UK}²)
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    └──┬ unit:GAL_UK^-2 symbol: gal{UK}
+  #       └──┬ unit:L symbol: L
+  #          └──┬ unit:DeciM3 symbol: dm³
+  #             └──┬ unit:DeciM^3 symbol: dm
+  #                └─── unit:M symbol: m
+unit:LB-SEC-PER-GAL_UK2 qudt:symbol "lbm·s/gal{UK}²" .
+
+  # WRONG SYMBOL  : unit:LB-SEC-PER-GAL_US-FT3 - calculated from factors: lbm·s/(gal{US}·ft³), actual: lb/(gal (US))/(ft³/s)
+  #
+  #  ──┬ unit:LB-SEC-PER-GAL_US-FT3 symbol: lb/(gal (US))/(ft³/s) (correct: lbm·s/(gal{US}·ft³))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    ├──┬ unit:GAL_US^-1 symbol: gal{US}
+  #    │  └──┬ unit:IN^3 symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:FT^-3 symbol: ft
+  #       └──┬ unit:IN symbol: in
+  #          └─── unit:M symbol: m
+unit:LB-SEC-PER-GAL_US-FT3 qudt:symbol "lbm·s/(gal{US}·ft³)" .
+
+  # WRONG SYMBOL  : unit:LB-SEC-PER-GAL_US-IN3 - calculated from factors: lbm·s/(gal{US}·in³), actual: lb/(gal (US))/(in³/s)
+  #
+  #  ──┬ unit:LB-SEC-PER-GAL_US-IN3 symbol: lb/(gal (US))/(in³/s) (correct: lbm·s/(gal{US}·in³))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    ├──┬ unit:GAL_US^-1 symbol: gal{US}
+  #    │  └──┬ unit:IN^3 symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:IN^-3 symbol: in
+  #       └─── unit:M symbol: m
+unit:LB-SEC-PER-GAL_US-IN3 qudt:symbol "lbm·s/(gal{US}·in³)" .
+
+  # WRONG SYMBOL  : unit:LB-SEC-PER-GAL_US-YD3 - calculated from factors: lbm·s/(gal{US}·yd³), actual: (lb/(gal (US))/(yd³/s)
+  #
+  #  ──┬ unit:LB-SEC-PER-GAL_US-YD3 symbol: (lb/(gal (US))/(yd³/s) (correct: lbm·s/(gal{US}·yd³))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    ├──┬ unit:GAL_US^-1 symbol: gal{US}
+  #    │  └──┬ unit:IN^3 symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:YD^-3 symbol: yd
+  #       └──┬ unit:FT symbol: ft
+  #          └──┬ unit:IN symbol: in
+  #             └─── unit:M symbol: m
+unit:LB-SEC-PER-GAL_US-YD3 qudt:symbol "lbm·s/(gal{US}·yd³)" .
+
+  # WRONG SYMBOL  : unit:LB-SEC-PER-GAL_US2 - calculated from factors: lbm·s/gal{US}², actual: (lb/(gal (US))/(gal (US)/s)
+  #
+  #  ──┬ unit:LB-SEC-PER-GAL_US2 symbol: (lb/(gal (US))/(gal (US)/s) (correct: lbm·s/gal{US}²)
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    └──┬ unit:GAL_US^-2 symbol: gal{US}
+  #       └──┬ unit:IN^3 symbol: in
+  #          └─── unit:M symbol: m
+unit:LB-SEC-PER-GAL_US2 qudt:symbol "lbm·s/gal{US}²" .
+
+  # WRONG SYMBOL  : unit:LB-SEC-PER-IN3-FT3 - calculated from factors: lbm·s/(in³·ft³), actual: (lb/in³)/(ft³/s)
+  #
+  #  ──┬ unit:LB-SEC-PER-IN3-FT3 symbol: (lb/in³)/(ft³/s) (correct: lbm·s/(in³·ft³))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:FT^-3 symbol: ft
+  #       └──┬ unit:IN symbol: in
+  #          └─── unit:M symbol: m
+unit:LB-SEC-PER-IN3-FT3 qudt:symbol "lbm·s/(in³·ft³)" .
+
+  # WRONG SYMBOL  : unit:LB-SEC-PER-IN3-GAL_UK - calculated from factors: lbm·s/(in³·gal{UK}), actual: (lb/in³)/(gal (UK)/s)
+  #
+  #  ──┬ unit:LB-SEC-PER-IN3-GAL_UK symbol: (lb/in³)/(gal (UK)/s) (correct: lbm·s/(in³·gal{UK}))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:GAL_UK^-1 symbol: gal{UK}
+  #       └──┬ unit:L symbol: L
+  #          └──┬ unit:DeciM3 symbol: dm³
+  #             └──┬ unit:DeciM^3 symbol: dm
+  #                └─── unit:M symbol: m
+unit:LB-SEC-PER-IN3-GAL_UK qudt:symbol "lbm·s/(in³·gal{UK})" .
+
+  # WRONG SYMBOL  : unit:LB-SEC-PER-IN3-GAL_US - calculated from factors: lbm·s/(in³·gal{US}), actual: (lb/in³)/(gal (US)/s)
+  #
+  #  ──┬ unit:LB-SEC-PER-IN3-GAL_US symbol: (lb/in³)/(gal (US)/s) (correct: lbm·s/(in³·gal{US}))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:GAL_US^-1 symbol: gal{US}
+  #       └──┬ unit:IN^3 symbol: in
+  #          └─── unit:M symbol: m
+unit:LB-SEC-PER-IN3-GAL_US qudt:symbol "lbm·s/(in³·gal{US})" .
+
+  # WRONG SYMBOL  : unit:LB-SEC-PER-IN3-YD3 - calculated from factors: lbm·s/(in³·yd³), actual: (lb/in³)/(yd³/s)
+  #
+  #  ──┬ unit:LB-SEC-PER-IN3-YD3 symbol: (lb/in³)/(yd³/s) (correct: lbm·s/(in³·yd³))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:YD^-3 symbol: yd
+  #       └──┬ unit:FT symbol: ft
+  #          └──┬ unit:IN symbol: in
+  #             └─── unit:M symbol: m
+unit:LB-SEC-PER-IN3-YD3 qudt:symbol "lbm·s/(in³·yd³)" .
+
+  # WRONG SYMBOL  : unit:LB-SEC-PER-IN6 - calculated from factors: lbm·s/in⁶, actual: (lb/in³)/(in³/s
+  #
+  #  ──┬ unit:LB-SEC-PER-IN6 symbol: (lb/in³)/(in³/s (correct: lbm·s/in⁶)
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    └──┬ unit:IN^-6 symbol: in
+  #       └─── unit:M symbol: m
+unit:LB-SEC-PER-IN6 qudt:symbol "lbm·s/in⁶" .
+
+  # WRONG SYMBOL  : unit:M-PER-DAY - calculated from factors: m/d, actual: m/day
+  #
+  #  ──┬ unit:M-PER-DAY symbol: m/day (correct: m/d)
+  #    ├─── unit:M symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:M-PER-DAY qudt:symbol "m/d" .
+
+  # WRONG SYMBOL  : unit:M-PER-M2 - calculated from factors: m/m², actual: m/m2
+  #
+  #  ──┬ unit:M-PER-M2 symbol: m/m2 (correct: m/m²)
+  #    ├─── unit:M symbol: m
+  #    └─── unit:M^-2 symbol: m
+unit:M-PER-M2 qudt:symbol "m/m²" .
+
+  # WRONG SYMBOL  : unit:M3-PER-DAY - calculated from factors: m³/d, actual: m³/day
+  #
+  #  ──┬ unit:M3-PER-DAY symbol: m³/day (correct: m³/d)
+  #    ├─── unit:M^3 symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:M3-PER-DAY qudt:symbol "m³/d" .
+
+  # WRONG SYMBOL  : unit:MI_US2 - calculated from factors: mi{US}², actual: mi² {US}
+  #
+  #  ──┬ unit:MI_US2 symbol: mi² {US} (correct: mi{US}²)
+  #    └──┬ unit:MI_US^2 symbol: mi{US}
+  #       └─── unit:M symbol: m
+unit:MI_US2 qudt:symbol "mi{US}²" .
+
+  # WRONG SYMBOL  : unit:MOL-PER-KiloGM-K - calculated from factors: mol/(K·kg), actual: mol/(kg·K)
+  #
+  #  ──┬ unit:MOL-PER-KiloGM-K symbol: mol/(kg·K) (correct: mol/(K·kg))
+  #    ├─── unit:MOL symbol: mol
+  #    ├─── unit:K^-1 symbol: K
+  #    └──┬ unit:KiloGM^-1 symbol: kg
+  #       └─── unit:GM symbol: g
+unit:MOL-PER-KiloGM-K qudt:symbol "mol/(K·kg)" .
+
+  # WRONG SYMBOL  : unit:MOL-PER-L-BAR - calculated from factors: mol/(L·bar), actual: mol/(l·bar)
+  #
+  #  ──┬ unit:MOL-PER-L-BAR symbol: mol/(l·bar) (correct: mol/(L·bar))
+  #    ├─── unit:MOL symbol: mol
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └──┬ unit:BAR^-1 symbol: bar
+  #       └──┬ unit:PA symbol: Pa
+  #          ├─── unit:M^-2 symbol: m
+  #          └──┬ unit:N symbol: N
+  #             ├──┬ unit:KiloGM symbol: kg
+  #             │  └─── unit:GM symbol: g
+  #             ├─── unit:M symbol: m
+  #             └─── unit:SEC^-2 symbol: s
+unit:MOL-PER-L-BAR qudt:symbol "mol/(L·bar)" .
+
+  # WRONG SYMBOL  : unit:MOL-PER-L-K - calculated from factors: mol/(L·K), actual: mol/(l·K)
+  #
+  #  ──┬ unit:MOL-PER-L-K symbol: mol/(l·K) (correct: mol/(L·K))
+  #    ├─── unit:MOL symbol: mol
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └─── unit:K^-1 symbol: K
+unit:MOL-PER-L-K qudt:symbol "mol/(L·K)" .
+
+  # WRONG SYMBOL  : unit:MOL-PER-M2-DAY - calculated from factors: mol/(m²·d), actual: mol/(m²·day)
+  #
+  #  ──┬ unit:MOL-PER-M2-DAY symbol: mol/(m²·day) (correct: mol/(m²·d))
+  #    ├─── unit:MOL symbol: mol
+  #    ├─── unit:M^-2 symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:MOL-PER-M2-DAY qudt:symbol "mol/(m²·d)" .
+
+  # WRONG SYMBOL  : unit:MOL-PER-M2-SEC-M - calculated from factors: mol/(m²·m·s), actual: mol/(m²·s·m)
+  #
+  #  ──┬ unit:MOL-PER-M2-SEC-M symbol: mol/(m²·s·m) (correct: mol/(m²·m·s))
+  #    ├─── unit:MOL symbol: mol
+  #    ├─── unit:M^-2 symbol: m
+  #    ├─── unit:M^-1 symbol: m
+  #    └─── unit:SEC^-1 symbol: s
+unit:MOL-PER-M2-SEC-M qudt:symbol "mol/(m²·m·s)" .
+
+  # WRONG SYMBOL  : unit:MOL-PER-M2-SEC-M-SR - calculated from factors: mol/(m²·m·s·sr), actual: mol/(m²·s·m·sr)
+  #
+  #  ──┬ unit:MOL-PER-M2-SEC-M-SR symbol: mol/(m²·s·m·sr) (correct: mol/(m²·m·s·sr))
+  #    ├─── unit:MOL symbol: mol
+  #    ├─── unit:M^-2 symbol: m
+  #    ├─── unit:M^-1 symbol: m
+  #    ├─── unit:SEC^-1 symbol: s
+  #    └──┬ unit:SR^-1 symbol: sr
+  #       ├─── unit:M^-2 symbol: m
+  #       └─── unit:M^2 symbol: m
+unit:MOL-PER-M2-SEC-M-SR qudt:symbol "mol/(m²·m·s·sr)" .
+
+  # WRONG SYMBOL  : unit:MegaBIT-PER-SEC - calculated from factors: Mbit/s, actual: mbps
+  #
+  #  ──┬ unit:MegaBIT-PER-SEC symbol: mbps (correct: Mbit/s)
+  #    ├──┬ unit:MegaBIT symbol: Mbit
+  #    │  └─── unit:BIT symbol: b
+  #    └─── unit:SEC^-1 symbol: s
+unit:MegaBIT-PER-SEC qudt:symbol "Mbit/s" .
+
+  # WRONG SYMBOL  : unit:MegaBYTE-PER-SEC - calculated from factors: MB/s, actual: Mbyte/s
+  #
+  #  ──┬ unit:MegaBYTE-PER-SEC symbol: Mbyte/s (correct: MB/s)
+  #    ├──┬ unit:MegaBYTE symbol: MB
+  #    │  └─── unit:BYTE symbol: B
+  #    └─── unit:SEC^-1 symbol: s
+unit:MegaBYTE-PER-SEC qudt:symbol "MB/s" .
+
+  # WRONG SYMBOL  : unit:MegaGM-PER-HA-YR - calculated from factors: Mg/(ha·a), actual: Mg/(ha·yr)
+  #
+  #  ──┬ unit:MegaGM-PER-HA-YR symbol: Mg/(ha·yr) (correct: Mg/(ha·a))
+  #    ├──┬ unit:MegaGM symbol: Mg
+  #    │  └─── unit:GM symbol: g
+  #    ├──┬ unit:HA^-1 symbol: ha
+  #    │  └──┬ unit:M2 symbol: m²
+  #    │     └─── unit:M^2 symbol: m
+  #    └──┬ unit:YR^-1 symbol: a
+  #       └─── unit:SEC symbol: s
+unit:MegaGM-PER-HA-YR qudt:symbol "Mg/(ha·a)" .
+
+  # WRONG SYMBOL  : unit:MegaHZ-M - calculated from factors: m·MHz, actual: MHz·m
+  #
+  #  ──┬ unit:MegaHZ-M symbol: MHz·m (correct: m·MHz)
+  #    ├─── unit:M symbol: m
+  #    └──┬ unit:MegaHZ symbol: MHz
+  #       └──┬ unit:HZ symbol: Hz
+  #          └─── unit:SEC^-1 symbol: s
+unit:MegaHZ-M qudt:symbol "m·MHz" .
+
+  # WRONG SYMBOL  : unit:MegaN-M - calculated from factors: m·MN, actual: MN·m
+  #
+  #  ──┬ unit:MegaN-M symbol: MN·m (correct: m·MN)
+  #    ├─── unit:M symbol: m
+  #    └──┬ unit:MegaN symbol: MN
+  #       └──┬ unit:N symbol: N
+  #          ├──┬ unit:KiloGM symbol: kg
+  #          │  └─── unit:GM symbol: g
+  #          ├─── unit:M symbol: m
+  #          └─── unit:SEC^-2 symbol: s
+unit:MegaN-M qudt:symbol "m·MN" .
+
+  # WRONG SYMBOL  : unit:MegaN-M-PER-M2 - calculated from factors: m·MN/m², actual: MN·m/m²
+  #
+  #  ──┬ unit:MegaN-M-PER-M2 symbol: MN·m/m² (correct: m·MN/m²)
+  #    ├─── unit:M symbol: m
+  #    ├──┬ unit:MegaN symbol: MN
+  #    │  └──┬ unit:N symbol: N
+  #    │     ├──┬ unit:KiloGM symbol: kg
+  #    │     │  └─── unit:GM symbol: g
+  #    │     ├─── unit:M symbol: m
+  #    │     └─── unit:SEC^-2 symbol: s
+  #    └─── unit:M^-2 symbol: m
+unit:MegaN-M-PER-M2 qudt:symbol "m·MN/m²" .
+
+  # WRONG SYMBOL  : unit:MegaOHM-M - calculated from factors: m·MΩ, actual: MΩ·m
+  #
+  #  ──┬ unit:MegaOHM-M symbol: MΩ·m (correct: m·MΩ)
+  #    ├─── unit:M symbol: m
+  #    └──┬ unit:MegaOHM symbol: MΩ
+  #       └──┬ unit:OHM symbol: Ω
+  #          ├─── unit:A^-1 symbol: A
+  #          └──┬ unit:V symbol: V
+  #             ├─── unit:A^-1 symbol: A
+  #             └──┬ unit:W symbol: W
+  #                ├──┬ unit:J symbol: J
+  #                │  ├─── unit:M symbol: m
+  #                │  └──┬ unit:N symbol: N
+  #                │     ├──┬ unit:KiloGM symbol: kg
+  #                │     │  └─── unit:GM symbol: g
+  #                │     ├─── unit:M symbol: m
+  #                │     └─── unit:SEC^-2 symbol: s
+  #                └─── unit:SEC^-1 symbol: s
+unit:MegaOHM-M qudt:symbol "m·MΩ" .
+
+  # WRONG SYMBOL  : unit:MegaOHM-PER-BAR - calculated from factors: MΩ/bar, actual: MΩ/bar
+  #
+  #  ──┬ unit:MegaOHM-PER-BAR symbol: MΩ/bar (correct: MΩ/bar)
+  #    ├──┬ unit:MegaOHM symbol: MΩ
+  #    │  └──┬ unit:OHM symbol: Ω
+  #    │     ├─── unit:A^-1 symbol: A
+  #    │     └──┬ unit:V symbol: V
+  #    │        ├─── unit:A^-1 symbol: A
+  #    │        └──┬ unit:W symbol: W
+  #    │           ├──┬ unit:J symbol: J
+  #    │           │  ├─── unit:M symbol: m
+  #    │           │  └──┬ unit:N symbol: N
+  #    │           │     ├──┬ unit:KiloGM symbol: kg
+  #    │           │     │  └─── unit:GM symbol: g
+  #    │           │     ├─── unit:M symbol: m
+  #    │           │     └─── unit:SEC^-2 symbol: s
+  #    │           └─── unit:SEC^-1 symbol: s
+  #    └──┬ unit:BAR^-1 symbol: bar
+  #       └──┬ unit:PA symbol: Pa
+  #          ├─── unit:M^-2 symbol: m
+  #          └──┬ unit:N symbol: N
+  #             ├──┬ unit:KiloGM symbol: kg
+  #             │  └─── unit:GM symbol: g
+  #             ├─── unit:M symbol: m
+  #             └─── unit:SEC^-2 symbol: s
+unit:MegaOHM-PER-BAR qudt:symbol "MΩ/bar" .
+
+  # WRONG SYMBOL  : unit:MegaOHM-PER-K - calculated from factors: MΩ/K, actual: MΩ/K
+  #
+  #  ──┬ unit:MegaOHM-PER-K symbol: MΩ/K (correct: MΩ/K)
+  #    ├──┬ unit:MegaOHM symbol: MΩ
+  #    │  └──┬ unit:OHM symbol: Ω
+  #    │     ├─── unit:A^-1 symbol: A
+  #    │     └──┬ unit:V symbol: V
+  #    │        ├─── unit:A^-1 symbol: A
+  #    │        └──┬ unit:W symbol: W
+  #    │           ├──┬ unit:J symbol: J
+  #    │           │  ├─── unit:M symbol: m
+  #    │           │  └──┬ unit:N symbol: N
+  #    │           │     ├──┬ unit:KiloGM symbol: kg
+  #    │           │     │  └─── unit:GM symbol: g
+  #    │           │     ├─── unit:M symbol: m
+  #    │           │     └─── unit:SEC^-2 symbol: s
+  #    │           └─── unit:SEC^-1 symbol: s
+  #    └─── unit:K^-1 symbol: K
+unit:MegaOHM-PER-K qudt:symbol "MΩ/K" .
+
+  # WRONG SYMBOL  : unit:MegaOHM-PER-KiloM - calculated from factors: MΩ/km, actual: MΩ/km
+  #
+  #  ──┬ unit:MegaOHM-PER-KiloM symbol: MΩ/km (correct: MΩ/km)
+  #    ├──┬ unit:MegaOHM symbol: MΩ
+  #    │  └──┬ unit:OHM symbol: Ω
+  #    │     ├─── unit:A^-1 symbol: A
+  #    │     └──┬ unit:V symbol: V
+  #    │        ├─── unit:A^-1 symbol: A
+  #    │        └──┬ unit:W symbol: W
+  #    │           ├──┬ unit:J symbol: J
+  #    │           │  ├─── unit:M symbol: m
+  #    │           │  └──┬ unit:N symbol: N
+  #    │           │     ├──┬ unit:KiloGM symbol: kg
+  #    │           │     │  └─── unit:GM symbol: g
+  #    │           │     ├─── unit:M symbol: m
+  #    │           │     └─── unit:SEC^-2 symbol: s
+  #    │           └─── unit:SEC^-1 symbol: s
+  #    └──┬ unit:KiloM^-1 symbol: km
+  #       └─── unit:M symbol: m
+unit:MegaOHM-PER-KiloM qudt:symbol "MΩ/km" .
+
+  # WRONG SYMBOL  : unit:MegaOHM-PER-M - calculated from factors: MΩ/m, actual: MΩ/m
+  #
+  #  ──┬ unit:MegaOHM-PER-M symbol: MΩ/m (correct: MΩ/m)
+  #    ├──┬ unit:MegaOHM symbol: MΩ
+  #    │  └──┬ unit:OHM symbol: Ω
+  #    │     ├─── unit:A^-1 symbol: A
+  #    │     └──┬ unit:V symbol: V
+  #    │        ├─── unit:A^-1 symbol: A
+  #    │        └──┬ unit:W symbol: W
+  #    │           ├──┬ unit:J symbol: J
+  #    │           │  ├─── unit:M symbol: m
+  #    │           │  └──┬ unit:N symbol: N
+  #    │           │     ├──┬ unit:KiloGM symbol: kg
+  #    │           │     │  └─── unit:GM symbol: g
+  #    │           │     ├─── unit:M symbol: m
+  #    │           │     └─── unit:SEC^-2 symbol: s
+  #    │           └─── unit:SEC^-1 symbol: s
+  #    └─── unit:M^-1 symbol: m
+unit:MegaOHM-PER-M qudt:symbol "MΩ/m" .
+
+  # WRONG SYMBOL  : unit:MicroA-PER-K - calculated from factors: μA/K, actual: µA/K
+  #
+  #  ──┬ unit:MicroA-PER-K symbol: µA/K (correct: μA/K)
+  #    ├──┬ unit:MicroA symbol: μA
+  #    │  └─── unit:A symbol: A
+  #    └─── unit:K^-1 symbol: K
+unit:MicroA-PER-K qudt:symbol "μA/K" .
+
+  # WRONG SYMBOL  : unit:MicroC-PER-M2 - calculated from factors: μC/m², actual: µC/m²
+  #
+  #  ──┬ unit:MicroC-PER-M2 symbol: µC/m² (correct: μC/m²)
+  #    ├──┬ unit:MicroC symbol: μC
+  #    │  └──┬ unit:C symbol: C
+  #    │     ├─── unit:A symbol: A
+  #    │     └─── unit:SEC symbol: s
+  #    └─── unit:M^-2 symbol: m
+unit:MicroC-PER-M2 qudt:symbol "μC/m²" .
+
+  # WRONG SYMBOL  : unit:MicroC-PER-M3 - calculated from factors: μC/m³, actual: µC/m³
+  #
+  #  ──┬ unit:MicroC-PER-M3 symbol: µC/m³ (correct: μC/m³)
+  #    ├──┬ unit:MicroC symbol: μC
+  #    │  └──┬ unit:C symbol: C
+  #    │     ├─── unit:A symbol: A
+  #    │     └─── unit:SEC symbol: s
+  #    └─── unit:M^-3 symbol: m
+unit:MicroC-PER-M3 qudt:symbol "μC/m³" .
+
+  # WRONG SYMBOL  : unit:MicroFARAD-PER-KiloM - calculated from factors: μF/km, actual: µF/km
+  #
+  #  ──┬ unit:MicroFARAD-PER-KiloM symbol: µF/km (correct: μF/km)
+  #    ├──┬ unit:MicroFARAD symbol: μF
+  #    │  └──┬ unit:FARAD symbol: F
+  #    │     ├──┬ unit:C symbol: C
+  #    │     │  ├─── unit:A symbol: A
+  #    │     │  └─── unit:SEC symbol: s
+  #    │     └──┬ unit:V^-1 symbol: V
+  #    │        ├─── unit:A^-1 symbol: A
+  #    │        └──┬ unit:W symbol: W
+  #    │           ├──┬ unit:J symbol: J
+  #    │           │  ├─── unit:M symbol: m
+  #    │           │  └──┬ unit:N symbol: N
+  #    │           │     ├──┬ unit:KiloGM symbol: kg
+  #    │           │     │  └─── unit:GM symbol: g
+  #    │           │     ├─── unit:M symbol: m
+  #    │           │     └─── unit:SEC^-2 symbol: s
+  #    │           └─── unit:SEC^-1 symbol: s
+  #    └──┬ unit:KiloM^-1 symbol: km
+  #       └─── unit:M symbol: m
+unit:MicroFARAD-PER-KiloM qudt:symbol "μF/km" .
+
+  # WRONG SYMBOL  : unit:MicroFARAD-PER-M - calculated from factors: μF/m, actual: µF/m
+  #
+  #  ──┬ unit:MicroFARAD-PER-M symbol: µF/m (correct: μF/m)
+  #    ├──┬ unit:MicroFARAD symbol: μF
+  #    │  └──┬ unit:FARAD symbol: F
+  #    │     ├──┬ unit:C symbol: C
+  #    │     │  ├─── unit:A symbol: A
+  #    │     │  └─── unit:SEC symbol: s
+  #    │     └──┬ unit:V^-1 symbol: V
+  #    │        ├─── unit:A^-1 symbol: A
+  #    │        └──┬ unit:W symbol: W
+  #    │           ├──┬ unit:J symbol: J
+  #    │           │  ├─── unit:M symbol: m
+  #    │           │  └──┬ unit:N symbol: N
+  #    │           │     ├──┬ unit:KiloGM symbol: kg
+  #    │           │     │  └─── unit:GM symbol: g
+  #    │           │     ├─── unit:M symbol: m
+  #    │           │     └─── unit:SEC^-2 symbol: s
+  #    │           └─── unit:SEC^-1 symbol: s
+  #    └─── unit:M^-1 symbol: m
+unit:MicroFARAD-PER-M qudt:symbol "μF/m" .
+
+  # WRONG SYMBOL  : unit:MicroGM-PER-CentiM2 - calculated from factors: μg/cm², actual: µG/cm²
+  #
+  #  ──┬ unit:MicroGM-PER-CentiM2 symbol: µG/cm² (correct: μg/cm²)
+  #    ├──┬ unit:MicroGM symbol: μg
+  #    │  └─── unit:GM symbol: g
+  #    └──┬ unit:CentiM^-2 symbol: cm
+  #       └─── unit:M symbol: m
+unit:MicroGM-PER-CentiM2 qudt:symbol "μg/cm²" .
+
+  # WRONG SYMBOL  : unit:MicroGM-PER-GM-DAY - calculated from factors: μg/(g·d), actual: ug/g/day
+  #
+  #  ──┬ unit:MicroGM-PER-GM-DAY symbol: ug/g/day (correct: μg/(g·d))
+  #    ├──┬ unit:MicroGM symbol: μg
+  #    │  └─── unit:GM symbol: g
+  #    ├─── unit:GM^-1 symbol: g
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:MicroGM-PER-GM-DAY qudt:symbol "μg/(g·d)" .
+
+  # WRONG SYMBOL  : unit:MicroGM-PER-M2-DAY - calculated from factors: μg/(m²·d), actual: μg/(m²·day)
+  #
+  #  ──┬ unit:MicroGM-PER-M2-DAY symbol: μg/(m²·day) (correct: μg/(m²·d))
+  #    ├──┬ unit:MicroGM symbol: μg
+  #    │  └─── unit:GM symbol: g
+  #    ├─── unit:M^-2 symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:MicroGM-PER-M2-DAY qudt:symbol "μg/(m²·d)" .
+
+  # WRONG SYMBOL  : unit:MicroGM-PER-M3-BAR - calculated from factors: μg/(m³·bar), actual: µg/(m³·bar)
+  #
+  #  ──┬ unit:MicroGM-PER-M3-BAR symbol: µg/(m³·bar) (correct: μg/(m³·bar))
+  #    ├──┬ unit:MicroGM symbol: μg
+  #    │  └─── unit:GM symbol: g
+  #    ├─── unit:M^-3 symbol: m
+  #    └──┬ unit:BAR^-1 symbol: bar
+  #       └──┬ unit:PA symbol: Pa
+  #          ├─── unit:M^-2 symbol: m
+  #          └──┬ unit:N symbol: N
+  #             ├──┬ unit:KiloGM symbol: kg
+  #             │  └─── unit:GM symbol: g
+  #             ├─── unit:M symbol: m
+  #             └─── unit:SEC^-2 symbol: s
+unit:MicroGM-PER-M3-BAR qudt:symbol "μg/(m³·bar)" .
+
+  # WRONG SYMBOL  : unit:MicroGM-PER-M3-K - calculated from factors: μg/(m³·K), actual: µg/(m³·K)
+  #
+  #  ──┬ unit:MicroGM-PER-M3-K symbol: µg/(m³·K) (correct: μg/(m³·K))
+  #    ├──┬ unit:MicroGM symbol: μg
+  #    │  └─── unit:GM symbol: g
+  #    ├─── unit:M^-3 symbol: m
+  #    └─── unit:K^-1 symbol: K
+unit:MicroGM-PER-M3-K qudt:symbol "μg/(m³·K)" .
+
+  # WRONG SYMBOL  : unit:MicroGM-PER-MilliGM - calculated from factors: μg/mg, actual: ug/mg
+  #
+  #  ──┬ unit:MicroGM-PER-MilliGM symbol: ug/mg (correct: μg/mg)
+  #    ├──┬ unit:MicroGM symbol: μg
+  #    │  └─── unit:GM symbol: g
+  #    └──┬ unit:MilliGM^-1 symbol: mg
+  #       └─── unit:GM symbol: g
+unit:MicroGM-PER-MilliGM qudt:symbol "μg/mg" .
+
+  # WRONG SYMBOL  : unit:MicroGRAY-PER-HR - calculated from factors: μGy/h, actual: µGy/h
+  #
+  #  ──┬ unit:MicroGRAY-PER-HR symbol: µGy/h (correct: μGy/h)
+  #    ├──┬ unit:MicroGRAY symbol: μGy
+  #    │  └──┬ unit:GRAY symbol: Gy
+  #    │     ├──┬ unit:J symbol: J
+  #    │     │  ├─── unit:M symbol: m
+  #    │     │  └──┬ unit:N symbol: N
+  #    │     │     ├──┬ unit:KiloGM symbol: kg
+  #    │     │     │  └─── unit:GM symbol: g
+  #    │     │     ├─── unit:M symbol: m
+  #    │     │     └─── unit:SEC^-2 symbol: s
+  #    │     └──┬ unit:KiloGM^-1 symbol: kg
+  #    │        └─── unit:GM symbol: g
+  #    └──┬ unit:HR^-1 symbol: h
+  #       └─── unit:SEC symbol: s
+unit:MicroGRAY-PER-HR qudt:symbol "μGy/h" .
+
+  # WRONG SYMBOL  : unit:MicroGRAY-PER-MIN - calculated from factors: μGy/min, actual: µGy/min
+  #
+  #  ──┬ unit:MicroGRAY-PER-MIN symbol: µGy/min (correct: μGy/min)
+  #    ├──┬ unit:MicroGRAY symbol: μGy
+  #    │  └──┬ unit:GRAY symbol: Gy
+  #    │     ├──┬ unit:J symbol: J
+  #    │     │  ├─── unit:M symbol: m
+  #    │     │  └──┬ unit:N symbol: N
+  #    │     │     ├──┬ unit:KiloGM symbol: kg
+  #    │     │     │  └─── unit:GM symbol: g
+  #    │     │     ├─── unit:M symbol: m
+  #    │     │     └─── unit:SEC^-2 symbol: s
+  #    │     └──┬ unit:KiloGM^-1 symbol: kg
+  #    │        └─── unit:GM symbol: g
+  #    └──┬ unit:MIN^-1 symbol: min
+  #       └─── unit:SEC symbol: s
+unit:MicroGRAY-PER-MIN qudt:symbol "μGy/min" .
+
+  # WRONG SYMBOL  : unit:MicroGRAY-PER-SEC - calculated from factors: μGy/s, actual: µGy/s
+  #
+  #  ──┬ unit:MicroGRAY-PER-SEC symbol: µGy/s (correct: μGy/s)
+  #    ├──┬ unit:MicroGRAY symbol: μGy
+  #    │  └──┬ unit:GRAY symbol: Gy
+  #    │     ├──┬ unit:J symbol: J
+  #    │     │  ├─── unit:M symbol: m
+  #    │     │  └──┬ unit:N symbol: N
+  #    │     │     ├──┬ unit:KiloGM symbol: kg
+  #    │     │     │  └─── unit:GM symbol: g
+  #    │     │     ├─── unit:M symbol: m
+  #    │     │     └─── unit:SEC^-2 symbol: s
+  #    │     └──┬ unit:KiloGM^-1 symbol: kg
+  #    │        └─── unit:GM symbol: g
+  #    └─── unit:SEC^-1 symbol: s
+unit:MicroGRAY-PER-SEC qudt:symbol "μGy/s" .
+
+  # WRONG SYMBOL  : unit:MicroH-PER-KiloOHM - calculated from factors: μH/kΩ, actual: µH/kΩ
+  #
+  #  ──┬ unit:MicroH-PER-KiloOHM symbol: µH/kΩ (correct: μH/kΩ)
+  #    ├──┬ unit:MicroH symbol: μH
+  #    │  └──┬ unit:H symbol: H
+  #    │     ├─── unit:A^-1 symbol: A
+  #    │     └──┬ unit:WB symbol: Wb
+  #    │        ├─── unit:A^-1 symbol: A
+  #    │        └──┬ unit:J symbol: J
+  #    │           ├─── unit:M symbol: m
+  #    │           └──┬ unit:N symbol: N
+  #    │              ├──┬ unit:KiloGM symbol: kg
+  #    │              │  └─── unit:GM symbol: g
+  #    │              ├─── unit:M symbol: m
+  #    │              └─── unit:SEC^-2 symbol: s
+  #    └──┬ unit:KiloOHM^-1 symbol: kΩ
+  #       └──┬ unit:OHM symbol: Ω
+  #          ├─── unit:A^-1 symbol: A
+  #          └──┬ unit:V symbol: V
+  #             ├─── unit:A^-1 symbol: A
+  #             └──┬ unit:W symbol: W
+  #                ├──┬ unit:J symbol: J
+  #                │  ├─── unit:M symbol: m
+  #                │  └──┬ unit:N symbol: N
+  #                │     ├──┬ unit:KiloGM symbol: kg
+  #                │     │  └─── unit:GM symbol: g
+  #                │     ├─── unit:M symbol: m
+  #                │     └─── unit:SEC^-2 symbol: s
+  #                └─── unit:SEC^-1 symbol: s
+unit:MicroH-PER-KiloOHM qudt:symbol "μH/kΩ" .
+
+  # WRONG SYMBOL  : unit:MicroH-PER-M - calculated from factors: μH/m, actual: µH/m
+  #
+  #  ──┬ unit:MicroH-PER-M symbol: µH/m (correct: μH/m)
+  #    ├──┬ unit:MicroH symbol: μH
+  #    │  └──┬ unit:H symbol: H
+  #    │     ├─── unit:A^-1 symbol: A
+  #    │     └──┬ unit:WB symbol: Wb
+  #    │        ├─── unit:A^-1 symbol: A
+  #    │        └──┬ unit:J symbol: J
+  #    │           ├─── unit:M symbol: m
+  #    │           └──┬ unit:N symbol: N
+  #    │              ├──┬ unit:KiloGM symbol: kg
+  #    │              │  └─── unit:GM symbol: g
+  #    │              ├─── unit:M symbol: m
+  #    │              └─── unit:SEC^-2 symbol: s
+  #    └─── unit:M^-1 symbol: m
+unit:MicroH-PER-M qudt:symbol "μH/m" .
+
+  # WRONG SYMBOL  : unit:MicroH-PER-OHM - calculated from factors: μH/Ω, actual: µH/Ω
+  #
+  #  ──┬ unit:MicroH-PER-OHM symbol: µH/Ω (correct: μH/Ω)
+  #    ├──┬ unit:MicroH symbol: μH
+  #    │  └──┬ unit:H symbol: H
+  #    │     ├─── unit:A^-1 symbol: A
+  #    │     └──┬ unit:WB symbol: Wb
+  #    │        ├─── unit:A^-1 symbol: A
+  #    │        └──┬ unit:J symbol: J
+  #    │           ├─── unit:M symbol: m
+  #    │           └──┬ unit:N symbol: N
+  #    │              ├──┬ unit:KiloGM symbol: kg
+  #    │              │  └─── unit:GM symbol: g
+  #    │              ├─── unit:M symbol: m
+  #    │              └─── unit:SEC^-2 symbol: s
+  #    └──┬ unit:OHM^-1 symbol: Ω
+  #       ├─── unit:A^-1 symbol: A
+  #       └──┬ unit:V symbol: V
+  #          ├─── unit:A^-1 symbol: A
+  #          └──┬ unit:W symbol: W
+  #             ├──┬ unit:J symbol: J
+  #             │  ├─── unit:M symbol: m
+  #             │  └──┬ unit:N symbol: N
+  #             │     ├──┬ unit:KiloGM symbol: kg
+  #             │     │  └─── unit:GM symbol: g
+  #             │     ├─── unit:M symbol: m
+  #             │     └─── unit:SEC^-2 symbol: s
+  #             └─── unit:SEC^-1 symbol: s
+unit:MicroH-PER-OHM qudt:symbol "μH/Ω" .
+
+  # WRONG SYMBOL  : unit:MicroJ-PER-SEC - calculated from factors: μJ/s, actual: µJ/s
+  #
+  #  ──┬ unit:MicroJ-PER-SEC symbol: µJ/s (correct: μJ/s)
+  #    ├──┬ unit:MicroJ symbol: μJ
+  #    │  └──┬ unit:J symbol: J
+  #    │     ├─── unit:M symbol: m
+  #    │     └──┬ unit:N symbol: N
+  #    │        ├──┬ unit:KiloGM symbol: kg
+  #    │        │  └─── unit:GM symbol: g
+  #    │        ├─── unit:M symbol: m
+  #    │        └─── unit:SEC^-2 symbol: s
+  #    └─── unit:SEC^-1 symbol: s
+unit:MicroJ-PER-SEC qudt:symbol "μJ/s" .
+
+  # WRONG SYMBOL  : unit:MicroM-PER-K - calculated from factors: μm/K, actual: µm/K
+  #
+  #  ──┬ unit:MicroM-PER-K symbol: µm/K (correct: μm/K)
+  #    ├──┬ unit:MicroM symbol: μm
+  #    │  └─── unit:M symbol: m
+  #    └─── unit:K^-1 symbol: K
+unit:MicroM-PER-K qudt:symbol "μm/K" .
+
+  # WRONG SYMBOL  : unit:MicroM-PER-L-DAY - calculated from factors: μm/(L·d), actual: µm/(L·day)
+  #
+  #  ──┬ unit:MicroM-PER-L-DAY symbol: µm/(L·day) (correct: μm/(L·d))
+  #    ├──┬ unit:MicroM symbol: μm
+  #    │  └─── unit:M symbol: m
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:MicroM-PER-L-DAY qudt:symbol "μm/(L·d)" .
+
+  # WRONG SYMBOL  : unit:MicroM-PER-M - calculated from factors: μm/m, actual: µm/m
+  #
+  #  ──┬ unit:MicroM-PER-M symbol: µm/m (correct: μm/m)
+  #    ├──┬ unit:MicroM symbol: μm
+  #    │  └─── unit:M symbol: m
+  #    └─── unit:M^-1 symbol: m
+unit:MicroM-PER-M qudt:symbol "μm/m" .
+
+  # WRONG SYMBOL  : unit:MicroM-PER-MilliL - calculated from factors: μm/mL, actual: µm/mL
+  #
+  #  ──┬ unit:MicroM-PER-MilliL symbol: µm/mL (correct: μm/mL)
+  #    ├──┬ unit:MicroM symbol: μm
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:MilliL^-1 symbol: mL
+  #       └──┬ unit:L symbol: L
+  #          └──┬ unit:DeciM3 symbol: dm³
+  #             └──┬ unit:DeciM^3 symbol: dm
+  #                └─── unit:M symbol: m
+unit:MicroM-PER-MilliL qudt:symbol "μm/mL" .
+
+  # WRONG SYMBOL  : unit:MicroM-PER-N - calculated from factors: μm/N, actual: µm/N
+  #
+  #  ──┬ unit:MicroM-PER-N symbol: µm/N (correct: μm/N)
+  #    ├──┬ unit:MicroM symbol: μm
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:N^-1 symbol: N
+  #       ├──┬ unit:KiloGM symbol: kg
+  #       │  └─── unit:GM symbol: g
+  #       ├─── unit:M symbol: m
+  #       └─── unit:SEC^-2 symbol: s
+unit:MicroM-PER-N qudt:symbol "μm/N" .
+
+  # WRONG SYMBOL  : unit:MicroM3 - calculated from factors: μm³, actual: µm³
+  #
+  #  ──┬ unit:MicroM3 symbol: µm³ (correct: μm³)
+  #    └──┬ unit:MicroM^3 symbol: μm
+  #       └─── unit:M symbol: m
+unit:MicroM3 qudt:symbol "μm³" .
+
+  # WRONG SYMBOL  : unit:MicroM3-PER-M3 - calculated from factors: μm³/m³, actual: µm³/m³
+  #
+  #  ──┬ unit:MicroM3-PER-M3 symbol: µm³/m³ (correct: μm³/m³)
+  #    ├──┬ unit:MicroM^3 symbol: μm
+  #    │  └─── unit:M symbol: m
+  #    └─── unit:M^-3 symbol: m
+unit:MicroM3-PER-M3 qudt:symbol "μm³/m³" .
+
+  # WRONG SYMBOL  : unit:MicroM3-PER-MilliL - calculated from factors: μm³/mL, actual: µm³/mL
+  #
+  #  ──┬ unit:MicroM3-PER-MilliL symbol: µm³/mL (correct: μm³/mL)
+  #    ├──┬ unit:MicroM^3 symbol: μm
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:MilliL^-1 symbol: mL
+  #       └──┬ unit:L symbol: L
+  #          └──┬ unit:DeciM3 symbol: dm³
+  #             └──┬ unit:DeciM^3 symbol: dm
+  #                └─── unit:M symbol: m
+unit:MicroM3-PER-MilliL qudt:symbol "μm³/mL" .
+
+  # WRONG SYMBOL  : unit:MicroMOL-PER-GM - calculated from factors: μmol/g, actual: µmol/g
+  #
+  #  ──┬ unit:MicroMOL-PER-GM symbol: µmol/g (correct: μmol/g)
+  #    ├──┬ unit:MicroMOL symbol: μmol
+  #    │  └─── unit:MOL symbol: mol
+  #    └─── unit:GM^-1 symbol: g
+unit:MicroMOL-PER-GM qudt:symbol "μmol/g" .
+
+  # WRONG SYMBOL  : unit:MicroMOL-PER-GM-HR - calculated from factors: μmol/(g·h), actual: µmol/(g·h)
+  #
+  #  ──┬ unit:MicroMOL-PER-GM-HR symbol: µmol/(g·h) (correct: μmol/(g·h))
+  #    ├──┬ unit:MicroMOL symbol: μmol
+  #    │  └─── unit:MOL symbol: mol
+  #    ├─── unit:GM^-1 symbol: g
+  #    └──┬ unit:HR^-1 symbol: h
+  #       └─── unit:SEC symbol: s
+unit:MicroMOL-PER-GM-HR qudt:symbol "μmol/(g·h)" .
+
+  # WRONG SYMBOL  : unit:MicroMOL-PER-KiloGM - calculated from factors: μmol/kg, actual: µmol/kg
+  #
+  #  ──┬ unit:MicroMOL-PER-KiloGM symbol: µmol/kg (correct: μmol/kg)
+  #    ├──┬ unit:MicroMOL symbol: μmol
+  #    │  └─── unit:MOL symbol: mol
+  #    └──┬ unit:KiloGM^-1 symbol: kg
+  #       └─── unit:GM symbol: g
+unit:MicroMOL-PER-KiloGM qudt:symbol "μmol/kg" .
+
+  # WRONG SYMBOL  : unit:MicroMOL-PER-L - calculated from factors: μmol/L, actual: µmol/L
+  #
+  #  ──┬ unit:MicroMOL-PER-L symbol: µmol/L (correct: μmol/L)
+  #    ├──┬ unit:MicroMOL symbol: μmol
+  #    │  └─── unit:MOL symbol: mol
+  #    └──┬ unit:L^-1 symbol: L
+  #       └──┬ unit:DeciM3 symbol: dm³
+  #          └──┬ unit:DeciM^3 symbol: dm
+  #             └─── unit:M symbol: m
+unit:MicroMOL-PER-L qudt:symbol "μmol/L" .
+
+  # WRONG SYMBOL  : unit:MicroMOL-PER-L-HR - calculated from factors: μmol/(L·h), actual: µmol/(L·h)
+  #
+  #  ──┬ unit:MicroMOL-PER-L-HR symbol: µmol/(L·h) (correct: μmol/(L·h))
+  #    ├──┬ unit:MicroMOL symbol: μmol
+  #    │  └─── unit:MOL symbol: mol
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └──┬ unit:HR^-1 symbol: h
+  #       └─── unit:SEC symbol: s
+unit:MicroMOL-PER-L-HR qudt:symbol "μmol/(L·h)" .
+
+  # WRONG SYMBOL  : unit:MicroMOL-PER-M2 - calculated from factors: μmol/m², actual: µmol/m²
+  #
+  #  ──┬ unit:MicroMOL-PER-M2 symbol: µmol/m² (correct: μmol/m²)
+  #    ├──┬ unit:MicroMOL symbol: μmol
+  #    │  └─── unit:MOL symbol: mol
+  #    └─── unit:M^-2 symbol: m
+unit:MicroMOL-PER-M2 qudt:symbol "μmol/m²" .
+
+  # WRONG SYMBOL  : unit:MicroMOL-PER-M2-DAY - calculated from factors: μmol/(m²·d), actual: µmol/(m²·day)
+  #
+  #  ──┬ unit:MicroMOL-PER-M2-DAY symbol: µmol/(m²·day) (correct: μmol/(m²·d))
+  #    ├──┬ unit:MicroMOL symbol: μmol
+  #    │  └─── unit:MOL symbol: mol
+  #    ├─── unit:M^-2 symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:MicroMOL-PER-M2-DAY qudt:symbol "μmol/(m²·d)" .
+
+  # WRONG SYMBOL  : unit:MicroMOL-PER-M2-HR - calculated from factors: μmol/(m²·h), actual: µmol/(m²·h)
+  #
+  #  ──┬ unit:MicroMOL-PER-M2-HR symbol: µmol/(m²·h) (correct: μmol/(m²·h))
+  #    ├──┬ unit:MicroMOL symbol: μmol
+  #    │  └─── unit:MOL symbol: mol
+  #    ├─── unit:M^-2 symbol: m
+  #    └──┬ unit:HR^-1 symbol: h
+  #       └─── unit:SEC symbol: s
+unit:MicroMOL-PER-M2-HR qudt:symbol "μmol/(m²·h)" .
+
+  # WRONG SYMBOL  : unit:MicroMOL-PER-M2-SEC - calculated from factors: μmol/(m²·s), actual: µmol/(m²·s)
+  #
+  #  ──┬ unit:MicroMOL-PER-M2-SEC symbol: µmol/(m²·s) (correct: μmol/(m²·s))
+  #    ├──┬ unit:MicroMOL symbol: μmol
+  #    │  └─── unit:MOL symbol: mol
+  #    ├─── unit:M^-2 symbol: m
+  #    └─── unit:SEC^-1 symbol: s
+unit:MicroMOL-PER-M2-SEC qudt:symbol "μmol/(m²·s)" .
+
+  # WRONG SYMBOL  : unit:MicroMOL-PER-MOL - calculated from factors: μmol/mol, actual: µmol/mol
+  #
+  #  ──┬ unit:MicroMOL-PER-MOL symbol: µmol/mol (correct: μmol/mol)
+  #    ├──┬ unit:MicroMOL symbol: μmol
+  #    │  └─── unit:MOL symbol: mol
+  #    └─── unit:MOL^-1 symbol: mol
+unit:MicroMOL-PER-MOL qudt:symbol "μmol/mol" .
+
+  # WRONG SYMBOL  : unit:MicroMOL-PER-MicroMOL-DAY - calculated from factors: μmol/(μmol·d), actual: μmol/(µmol·day)
+  #
+  #  ──┬ unit:MicroMOL-PER-MicroMOL-DAY symbol: μmol/(µmol·day) (correct: μmol/(μmol·d))
+  #    ├──┬ unit:MicroMOL symbol: μmol
+  #    │  └─── unit:MOL symbol: mol
+  #    ├──┬ unit:MicroMOL^-1 symbol: μmol
+  #    │  └─── unit:MOL symbol: mol
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:MicroMOL-PER-MicroMOL-DAY qudt:symbol "μmol/(μmol·d)" .
+
+  # WRONG SYMBOL  : unit:MicroMOL-PER-SEC - calculated from factors: μmol/s, actual: µmol/s
+  #
+  #  ──┬ unit:MicroMOL-PER-SEC symbol: µmol/s (correct: μmol/s)
+  #    ├──┬ unit:MicroMOL symbol: μmol
+  #    │  └─── unit:MOL symbol: mol
+  #    └─── unit:SEC^-1 symbol: s
+unit:MicroMOL-PER-SEC qudt:symbol "μmol/s" .
+
+  # WRONG SYMBOL  : unit:MicroMOL2-PER-M4-SEC2 - calculated from factors: μmol²/(m⁴·s²), actual: (uM/m^2/s)^2
+  #
+  #  ──┬ unit:MicroMOL2-PER-M4-SEC2 symbol: (uM/m^2/s)^2 (correct: μmol²/(m⁴·s²))
+  #    ├──┬ unit:MicroMOL^2 symbol: μmol
+  #    │  └─── unit:MOL symbol: mol
+  #    ├─── unit:M^-4 symbol: m
+  #    └─── unit:SEC^-2 symbol: s
+unit:MicroMOL2-PER-M4-SEC2 qudt:symbol "μmol²/(m⁴·s²)" .
+
+  # WRONG SYMBOL  : unit:MicroN-M - calculated from factors: m·μN, actual: μN·m
+  #
+  #  ──┬ unit:MicroN-M symbol: μN·m (correct: m·μN)
+  #    ├─── unit:M symbol: m
+  #    └──┬ unit:MicroN symbol: μN
+  #       └──┬ unit:N symbol: N
+  #          ├──┬ unit:KiloGM symbol: kg
+  #          │  └─── unit:GM symbol: g
+  #          ├─── unit:M symbol: m
+  #          └─── unit:SEC^-2 symbol: s
+unit:MicroN-M qudt:symbol "m·μN" .
+
+  # WRONG SYMBOL  : unit:MicroN-M-PER-M2 - calculated from factors: m·μN/m², actual: µN·m/m²
+  #
+  #  ──┬ unit:MicroN-M-PER-M2 symbol: µN·m/m² (correct: m·μN/m²)
+  #    ├─── unit:M symbol: m
+  #    ├──┬ unit:MicroN symbol: μN
+  #    │  └──┬ unit:N symbol: N
+  #    │     ├──┬ unit:KiloGM symbol: kg
+  #    │     │  └─── unit:GM symbol: g
+  #    │     ├─── unit:M symbol: m
+  #    │     └─── unit:SEC^-2 symbol: s
+  #    └─── unit:M^-2 symbol: m
+unit:MicroN-M-PER-M2 qudt:symbol "m·μN/m²" .
+
+  # WRONG SYMBOL  : unit:MicroOHM-M - calculated from factors: m·μΩ, actual: µΩ·m
+  #
+  #  ──┬ unit:MicroOHM-M symbol: µΩ·m (correct: m·μΩ)
+  #    ├─── unit:M symbol: m
+  #    └──┬ unit:MicroOHM symbol: μΩ
+  #       └──┬ unit:OHM symbol: Ω
+  #          ├─── unit:A^-1 symbol: A
+  #          └──┬ unit:V symbol: V
+  #             ├─── unit:A^-1 symbol: A
+  #             └──┬ unit:W symbol: W
+  #                ├──┬ unit:J symbol: J
+  #                │  ├─── unit:M symbol: m
+  #                │  └──┬ unit:N symbol: N
+  #                │     ├──┬ unit:KiloGM symbol: kg
+  #                │     │  └─── unit:GM symbol: g
+  #                │     ├─── unit:M symbol: m
+  #                │     └─── unit:SEC^-2 symbol: s
+  #                └─── unit:SEC^-1 symbol: s
+unit:MicroOHM-M qudt:symbol "m·μΩ" .
+
+  # WRONG SYMBOL  : unit:MilliA-PER-L-MIN - calculated from factors: mA/(L·min), actual: mA/(l·min)
+  #
+  #  ──┬ unit:MilliA-PER-L-MIN symbol: mA/(l·min) (correct: mA/(L·min))
+  #    ├──┬ unit:MilliA symbol: mA
+  #    │  └─── unit:A symbol: A
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └──┬ unit:MIN^-1 symbol: min
+  #       └─── unit:SEC symbol: s
+unit:MilliA-PER-L-MIN qudt:symbol "mA/(L·min)" .
+
+  # WRONG SYMBOL  : unit:MilliBQ-PER-M2-DAY - calculated from factors: mBq/(m²·d), actual: mBq/(m²·day)
+  #
+  #  ──┬ unit:MilliBQ-PER-M2-DAY symbol: mBq/(m²·day) (correct: mBq/(m²·d))
+  #    ├──┬ unit:MilliBQ symbol: mBq
+  #    │  └──┬ unit:BQ symbol: Bq
+  #    │     └─── unit:SEC^-1 symbol: s
+  #    ├─── unit:M^-2 symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:MilliBQ-PER-M2-DAY qudt:symbol "mBq/(m²·d)" .
+
+  # WRONG SYMBOL  : unit:MilliGM-HR-PER-L-CentiM3 - calculated from factors: mg·h/(L·cm³), actual: (mg/l)/(cm³/h)
+  #
+  #  ──┬ unit:MilliGM-HR-PER-L-CentiM3 symbol: (mg/l)/(cm³/h) (correct: mg·h/(L·cm³))
+  #    ├──┬ unit:MilliGM symbol: mg
+  #    │  └─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └──┬ unit:CentiM^-3 symbol: cm
+  #       └─── unit:M symbol: m
+unit:MilliGM-HR-PER-L-CentiM3 qudt:symbol "mg·h/(L·cm³)" .
+
+  # WRONG SYMBOL  : unit:MilliGM-HR-PER-L-M3 - calculated from factors: mg·h/(L·m³), actual: (mg/l)/(m³/h)
+  #
+  #  ──┬ unit:MilliGM-HR-PER-L-M3 symbol: (mg/l)/(m³/h) (correct: mg·h/(L·m³))
+  #    ├──┬ unit:MilliGM symbol: mg
+  #    │  └─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └─── unit:M^-3 symbol: m
+unit:MilliGM-HR-PER-L-M3 qudt:symbol "mg·h/(L·m³)" .
+
+  # WRONG SYMBOL  : unit:MilliGM-HR-PER-L2 - calculated from factors: mg·h/L², actual: (mg/l)/(l/h)
+  #
+  #  ──┬ unit:MilliGM-HR-PER-L2 symbol: (mg/l)/(l/h) (correct: mg·h/L²)
+  #    ├──┬ unit:MilliGM symbol: mg
+  #    │  └─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    └──┬ unit:L^-2 symbol: L
+  #       └──┬ unit:DeciM3 symbol: dm³
+  #          └──┬ unit:DeciM^3 symbol: dm
+  #             └─── unit:M symbol: m
+unit:MilliGM-HR-PER-L2 qudt:symbol "mg·h/L²" .
+
+  # WRONG SYMBOL  : unit:MilliGM-HR-PER-M3-CentiM3 - calculated from factors: mg·h/(m³·cm³), actual: (mg/m³)/(cm³/h)
+  #
+  #  ──┬ unit:MilliGM-HR-PER-M3-CentiM3 symbol: (mg/m³)/(cm³/h) (correct: mg·h/(m³·cm³))
+  #    ├──┬ unit:MilliGM symbol: mg
+  #    │  └─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├─── unit:M^-3 symbol: m
+  #    └──┬ unit:CentiM^-3 symbol: cm
+  #       └─── unit:M symbol: m
+unit:MilliGM-HR-PER-M3-CentiM3 qudt:symbol "mg·h/(m³·cm³)" .
+
+  # WRONG SYMBOL  : unit:MilliGM-HR-PER-M3-L - calculated from factors: mg·h/(m³·L), actual: (mg/m³)/(l/h)
+  #
+  #  ──┬ unit:MilliGM-HR-PER-M3-L symbol: (mg/m³)/(l/h) (correct: mg·h/(m³·L))
+  #    ├──┬ unit:MilliGM symbol: mg
+  #    │  └─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├─── unit:M^-3 symbol: m
+  #    └──┬ unit:L^-1 symbol: L
+  #       └──┬ unit:DeciM3 symbol: dm³
+  #          └──┬ unit:DeciM^3 symbol: dm
+  #             └─── unit:M symbol: m
+unit:MilliGM-HR-PER-M3-L qudt:symbol "mg·h/(m³·L)" .
+
+  # WRONG SYMBOL  : unit:MilliGM-HR-PER-M6 - calculated from factors: mg·h/m⁶, actual: (mg/m³)/(m³/h)
+  #
+  #  ──┬ unit:MilliGM-HR-PER-M6 symbol: (mg/m³)/(m³/h) (correct: mg·h/m⁶)
+  #    ├──┬ unit:MilliGM symbol: mg
+  #    │  └─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    └─── unit:M^-6 symbol: m
+unit:MilliGM-HR-PER-M6 qudt:symbol "mg·h/m⁶" .
+
+  # WRONG SYMBOL  : unit:MilliGM-MIN-PER-L-CentiM3 - calculated from factors: mg·min/(L·cm³), actual: (mg/l)/(cm³/min)
+  #
+  #  ──┬ unit:MilliGM-MIN-PER-L-CentiM3 symbol: (mg/l)/(cm³/min) (correct: mg·min/(L·cm³))
+  #    ├──┬ unit:MilliGM symbol: mg
+  #    │  └─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └──┬ unit:CentiM^-3 symbol: cm
+  #       └─── unit:M symbol: m
+unit:MilliGM-MIN-PER-L-CentiM3 qudt:symbol "mg·min/(L·cm³)" .
+
+  # WRONG SYMBOL  : unit:MilliGM-MIN-PER-L-M3 - calculated from factors: mg·min/(L·m³), actual: (mg/l)/(m³/min)
+  #
+  #  ──┬ unit:MilliGM-MIN-PER-L-M3 symbol: (mg/l)/(m³/min) (correct: mg·min/(L·m³))
+  #    ├──┬ unit:MilliGM symbol: mg
+  #    │  └─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └─── unit:M^-3 symbol: m
+unit:MilliGM-MIN-PER-L-M3 qudt:symbol "mg·min/(L·m³)" .
+
+  # WRONG SYMBOL  : unit:MilliGM-MIN-PER-L2 - calculated from factors: mg·min/L², actual: (mg/l)/(l/min)
+  #
+  #  ──┬ unit:MilliGM-MIN-PER-L2 symbol: (mg/l)/(l/min) (correct: mg·min/L²)
+  #    ├──┬ unit:MilliGM symbol: mg
+  #    │  └─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    └──┬ unit:L^-2 symbol: L
+  #       └──┬ unit:DeciM3 symbol: dm³
+  #          └──┬ unit:DeciM^3 symbol: dm
+  #             └─── unit:M symbol: m
+unit:MilliGM-MIN-PER-L2 qudt:symbol "mg·min/L²" .
+
+  # WRONG SYMBOL  : unit:MilliGM-MIN-PER-M3-CentiM3 - calculated from factors: mg·min/(m³·cm³), actual: (mg/m³)/(cm³/min)
+  #
+  #  ──┬ unit:MilliGM-MIN-PER-M3-CentiM3 symbol: (mg/m³)/(cm³/min) (correct: mg·min/(m³·cm³))
+  #    ├──┬ unit:MilliGM symbol: mg
+  #    │  └─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    ├─── unit:M^-3 symbol: m
+  #    └──┬ unit:CentiM^-3 symbol: cm
+  #       └─── unit:M symbol: m
+unit:MilliGM-MIN-PER-M3-CentiM3 qudt:symbol "mg·min/(m³·cm³)" .
+
+  # WRONG SYMBOL  : unit:MilliGM-MIN-PER-M3-L - calculated from factors: mg·min/(m³·L), actual: (mg/m³)/(l/min)
+  #
+  #  ──┬ unit:MilliGM-MIN-PER-M3-L symbol: (mg/m³)/(l/min) (correct: mg·min/(m³·L))
+  #    ├──┬ unit:MilliGM symbol: mg
+  #    │  └─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    ├─── unit:M^-3 symbol: m
+  #    └──┬ unit:L^-1 symbol: L
+  #       └──┬ unit:DeciM3 symbol: dm³
+  #          └──┬ unit:DeciM^3 symbol: dm
+  #             └─── unit:M symbol: m
+unit:MilliGM-MIN-PER-M3-L qudt:symbol "mg·min/(m³·L)" .
+
+  # WRONG SYMBOL  : unit:MilliGM-MIN-PER-M6 - calculated from factors: mg·min/m⁶, actual: (mg/m³)/(m³/min)
+  #
+  #  ──┬ unit:MilliGM-MIN-PER-M6 symbol: (mg/m³)/(m³/min) (correct: mg·min/m⁶)
+  #    ├──┬ unit:MilliGM symbol: mg
+  #    │  └─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    └─── unit:M^-6 symbol: m
+unit:MilliGM-MIN-PER-M6 qudt:symbol "mg·min/m⁶" .
+
+  # WRONG SYMBOL  : unit:MilliGM-PER-DAY - calculated from factors: mg/d, actual: mg/day
+  #
+  #  ──┬ unit:MilliGM-PER-DAY symbol: mg/day (correct: mg/d)
+  #    ├──┬ unit:MilliGM symbol: mg
+  #    │  └─── unit:GM symbol: g
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:MilliGM-PER-DAY qudt:symbol "mg/d" .
+
+  # WRONG SYMBOL  : unit:MilliGM-PER-GM-HR - calculated from factors: mg/(g·h), actual: mg/gm/h
+  #
+  #  ──┬ unit:MilliGM-PER-GM-HR symbol: mg/gm/h (correct: mg/(g·h))
+  #    ├──┬ unit:MilliGM symbol: mg
+  #    │  └─── unit:GM symbol: g
+  #    ├─── unit:GM^-1 symbol: g
+  #    └──┬ unit:HR^-1 symbol: h
+  #       └─── unit:SEC symbol: s
+unit:MilliGM-PER-GM-HR qudt:symbol "mg/(g·h)" .
+
+  # WRONG SYMBOL  : unit:MilliGM-PER-KiloGM-DAY - calculated from factors: mg/(kg·d), actual: mg/kg/day
+  #
+  #  ──┬ unit:MilliGM-PER-KiloGM-DAY symbol: mg/kg/day (correct: mg/(kg·d))
+  #    ├──┬ unit:MilliGM symbol: mg
+  #    │  └─── unit:GM symbol: g
+  #    ├──┬ unit:KiloGM^-1 symbol: kg
+  #    │  └─── unit:GM symbol: g
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:MilliGM-PER-KiloGM-DAY qudt:symbol "mg/(kg·d)" .
+
+  # WRONG SYMBOL  : unit:MilliGM-PER-L-CentiPOISE - calculated from factors: mg/(L·cP), actual: (mg/l)/cP
+  #
+  #  ──┬ unit:MilliGM-PER-L-CentiPOISE symbol: (mg/l)/cP (correct: mg/(L·cP))
+  #    ├──┬ unit:MilliGM symbol: mg
+  #    │  └─── unit:GM symbol: g
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └──┬ unit:CentiPOISE^-1 symbol: cP
+  #       └──┬ unit:POISE symbol: P
+  #          └──┬ unit:KiloGM-PER-M-SEC symbol: kg/(m·s)
+  #             ├──┬ unit:KiloGM symbol: kg
+  #             │  └─── unit:GM symbol: g
+  #             ├─── unit:M^-1 symbol: m
+  #             └─── unit:SEC^-1 symbol: s
+unit:MilliGM-PER-L-CentiPOISE qudt:symbol "mg/(L·cP)" .
+
+  # WRONG SYMBOL  : unit:MilliGM-PER-L-MilliPA-SEC - calculated from factors: mg/(L·mPa·s), actual: (mg/l)/(mPa·s)
+  #
+  #  ──┬ unit:MilliGM-PER-L-MilliPA-SEC symbol: (mg/l)/(mPa·s) (correct: mg/(L·mPa·s))
+  #    ├──┬ unit:MilliGM symbol: mg
+  #    │  └─── unit:GM symbol: g
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    ├──┬ unit:MilliPA^-1 symbol: mPa
+  #    │  └──┬ unit:PA symbol: Pa
+  #    │     ├─── unit:M^-2 symbol: m
+  #    │     └──┬ unit:N symbol: N
+  #    │        ├──┬ unit:KiloGM symbol: kg
+  #    │        │  └─── unit:GM symbol: g
+  #    │        ├─── unit:M symbol: m
+  #    │        └─── unit:SEC^-2 symbol: s
+  #    └─── unit:SEC^-1 symbol: s
+unit:MilliGM-PER-L-MilliPA-SEC qudt:symbol "mg/(L·mPa·s)" .
+
+  # WRONG SYMBOL  : unit:MilliGM-PER-L-PA-SEC - calculated from factors: mg/(L·Pa·s), actual: (mg/l)/(Pa·s)
+  #
+  #  ──┬ unit:MilliGM-PER-L-PA-SEC symbol: (mg/l)/(Pa·s) (correct: mg/(L·Pa·s))
+  #    ├──┬ unit:MilliGM symbol: mg
+  #    │  └─── unit:GM symbol: g
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    ├──┬ unit:PA^-1 symbol: Pa
+  #    │  ├─── unit:M^-2 symbol: m
+  #    │  └──┬ unit:N symbol: N
+  #    │     ├──┬ unit:KiloGM symbol: kg
+  #    │     │  └─── unit:GM symbol: g
+  #    │     ├─── unit:M symbol: m
+  #    │     └─── unit:SEC^-2 symbol: s
+  #    └─── unit:SEC^-1 symbol: s
+unit:MilliGM-PER-L-PA-SEC qudt:symbol "mg/(L·Pa·s)" .
+
+  # WRONG SYMBOL  : unit:MilliGM-PER-L-POISE - calculated from factors: mg/(L·P), actual: (mg/l)/P
+  #
+  #  ──┬ unit:MilliGM-PER-L-POISE symbol: (mg/l)/P (correct: mg/(L·P))
+  #    ├──┬ unit:MilliGM symbol: mg
+  #    │  └─── unit:GM symbol: g
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └──┬ unit:POISE^-1 symbol: P
+  #       └──┬ unit:KiloGM-PER-M-SEC symbol: kg/(m·s)
+  #          ├──┬ unit:KiloGM symbol: kg
+  #          │  └─── unit:GM symbol: g
+  #          ├─── unit:M^-1 symbol: m
+  #          └─── unit:SEC^-1 symbol: s
+unit:MilliGM-PER-L-POISE qudt:symbol "mg/(L·P)" .
+
+  # WRONG SYMBOL  : unit:MilliGM-PER-M2-DAY - calculated from factors: mg/(m²·d), actual: mg/(m²·day)
+  #
+  #  ──┬ unit:MilliGM-PER-M2-DAY symbol: mg/(m²·day) (correct: mg/(m²·d))
+  #    ├──┬ unit:MilliGM symbol: mg
+  #    │  └─── unit:GM symbol: g
+  #    ├─── unit:M^-2 symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:MilliGM-PER-M2-DAY qudt:symbol "mg/(m²·d)" .
+
+  # WRONG SYMBOL  : unit:MilliGM-PER-M3-CentiPOISE - calculated from factors: mg/(m³·cP), actual: (mg/m³)/cP
+  #
+  #  ──┬ unit:MilliGM-PER-M3-CentiPOISE symbol: (mg/m³)/cP (correct: mg/(m³·cP))
+  #    ├──┬ unit:MilliGM symbol: mg
+  #    │  └─── unit:GM symbol: g
+  #    ├─── unit:M^-3 symbol: m
+  #    └──┬ unit:CentiPOISE^-1 symbol: cP
+  #       └──┬ unit:POISE symbol: P
+  #          └──┬ unit:KiloGM-PER-M-SEC symbol: kg/(m·s)
+  #             ├──┬ unit:KiloGM symbol: kg
+  #             │  └─── unit:GM symbol: g
+  #             ├─── unit:M^-1 symbol: m
+  #             └─── unit:SEC^-1 symbol: s
+unit:MilliGM-PER-M3-CentiPOISE qudt:symbol "mg/(m³·cP)" .
+
+  # WRONG SYMBOL  : unit:MilliGM-PER-M3-DAY - calculated from factors: mg/(m³·d), actual: mg/(m³·day)
+  #
+  #  ──┬ unit:MilliGM-PER-M3-DAY symbol: mg/(m³·day) (correct: mg/(m³·d))
+  #    ├──┬ unit:MilliGM symbol: mg
+  #    │  └─── unit:GM symbol: g
+  #    ├─── unit:M^-3 symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:MilliGM-PER-M3-DAY qudt:symbol "mg/(m³·d)" .
+
+  # WRONG SYMBOL  : unit:MilliGM-PER-M3-MilliPA-SEC - calculated from factors: mg/(m³·mPa·s), actual: (mg/m³)/(mPa·s)
+  #
+  #  ──┬ unit:MilliGM-PER-M3-MilliPA-SEC symbol: (mg/m³)/(mPa·s) (correct: mg/(m³·mPa·s))
+  #    ├──┬ unit:MilliGM symbol: mg
+  #    │  └─── unit:GM symbol: g
+  #    ├─── unit:M^-3 symbol: m
+  #    ├──┬ unit:MilliPA^-1 symbol: mPa
+  #    │  └──┬ unit:PA symbol: Pa
+  #    │     ├─── unit:M^-2 symbol: m
+  #    │     └──┬ unit:N symbol: N
+  #    │        ├──┬ unit:KiloGM symbol: kg
+  #    │        │  └─── unit:GM symbol: g
+  #    │        ├─── unit:M symbol: m
+  #    │        └─── unit:SEC^-2 symbol: s
+  #    └─── unit:SEC^-1 symbol: s
+unit:MilliGM-PER-M3-MilliPA-SEC qudt:symbol "mg/(m³·mPa·s)" .
+
+  # WRONG SYMBOL  : unit:MilliGM-PER-M3-PA-SEC - calculated from factors: mg/(m³·Pa·s), actual: (mg/m³)/(Pa·s)
+  #
+  #  ──┬ unit:MilliGM-PER-M3-PA-SEC symbol: (mg/m³)/(Pa·s) (correct: mg/(m³·Pa·s))
+  #    ├──┬ unit:MilliGM symbol: mg
+  #    │  └─── unit:GM symbol: g
+  #    ├─── unit:M^-3 symbol: m
+  #    ├──┬ unit:PA^-1 symbol: Pa
+  #    │  ├─── unit:M^-2 symbol: m
+  #    │  └──┬ unit:N symbol: N
+  #    │     ├──┬ unit:KiloGM symbol: kg
+  #    │     │  └─── unit:GM symbol: g
+  #    │     ├─── unit:M symbol: m
+  #    │     └─── unit:SEC^-2 symbol: s
+  #    └─── unit:SEC^-1 symbol: s
+unit:MilliGM-PER-M3-PA-SEC qudt:symbol "mg/(m³·Pa·s)" .
+
+  # WRONG SYMBOL  : unit:MilliGM-PER-M3-POISE - calculated from factors: mg/(m³·P), actual: (mg/m³)/P
+  #
+  #  ──┬ unit:MilliGM-PER-M3-POISE symbol: (mg/m³)/P (correct: mg/(m³·P))
+  #    ├──┬ unit:MilliGM symbol: mg
+  #    │  └─── unit:GM symbol: g
+  #    ├─── unit:M^-3 symbol: m
+  #    └──┬ unit:POISE^-1 symbol: P
+  #       └──┬ unit:KiloGM-PER-M-SEC symbol: kg/(m·s)
+  #          ├──┬ unit:KiloGM symbol: kg
+  #          │  └─── unit:GM symbol: g
+  #          ├─── unit:M^-1 symbol: m
+  #          └─── unit:SEC^-1 symbol: s
+unit:MilliGM-PER-M3-POISE qudt:symbol "mg/(m³·P)" .
+
+  # WRONG SYMBOL  : unit:MilliGM-SEC-PER-L-CentiM3 - calculated from factors: mg·s/(L·cm³), actual: (mg/l)/(cm³/s)
+  #
+  #  ──┬ unit:MilliGM-SEC-PER-L-CentiM3 symbol: (mg/l)/(cm³/s) (correct: mg·s/(L·cm³))
+  #    ├──┬ unit:MilliGM symbol: mg
+  #    │  └─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └──┬ unit:CentiM^-3 symbol: cm
+  #       └─── unit:M symbol: m
+unit:MilliGM-SEC-PER-L-CentiM3 qudt:symbol "mg·s/(L·cm³)" .
+
+  # WRONG SYMBOL  : unit:MilliGM-SEC-PER-L-M3 - calculated from factors: mg·s/(L·m³), actual: (mg/l)/(m³/s)
+  #
+  #  ──┬ unit:MilliGM-SEC-PER-L-M3 symbol: (mg/l)/(m³/s) (correct: mg·s/(L·m³))
+  #    ├──┬ unit:MilliGM symbol: mg
+  #    │  └─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └─── unit:M^-3 symbol: m
+unit:MilliGM-SEC-PER-L-M3 qudt:symbol "mg·s/(L·m³)" .
+
+  # WRONG SYMBOL  : unit:MilliGM-SEC-PER-L2 - calculated from factors: mg·s/L², actual: (mg/l)/(l/s)
+  #
+  #  ──┬ unit:MilliGM-SEC-PER-L2 symbol: (mg/l)/(l/s) (correct: mg·s/L²)
+  #    ├──┬ unit:MilliGM symbol: mg
+  #    │  └─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    └──┬ unit:L^-2 symbol: L
+  #       └──┬ unit:DeciM3 symbol: dm³
+  #          └──┬ unit:DeciM^3 symbol: dm
+  #             └─── unit:M symbol: m
+unit:MilliGM-SEC-PER-L2 qudt:symbol "mg·s/L²" .
+
+  # WRONG SYMBOL  : unit:MilliGM-SEC-PER-M3-CentiM3 - calculated from factors: mg·s/(m³·cm³), actual: (mg/m³)/(cm³/s)
+  #
+  #  ──┬ unit:MilliGM-SEC-PER-M3-CentiM3 symbol: (mg/m³)/(cm³/s) (correct: mg·s/(m³·cm³))
+  #    ├──┬ unit:MilliGM symbol: mg
+  #    │  └─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    ├─── unit:M^-3 symbol: m
+  #    └──┬ unit:CentiM^-3 symbol: cm
+  #       └─── unit:M symbol: m
+unit:MilliGM-SEC-PER-M3-CentiM3 qudt:symbol "mg·s/(m³·cm³)" .
+
+  # WRONG SYMBOL  : unit:MilliGM-SEC-PER-M3-L - calculated from factors: mg·s/(m³·L), actual: (mg/m³)/(l/s)
+  #
+  #  ──┬ unit:MilliGM-SEC-PER-M3-L symbol: (mg/m³)/(l/s) (correct: mg·s/(m³·L))
+  #    ├──┬ unit:MilliGM symbol: mg
+  #    │  └─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    ├─── unit:M^-3 symbol: m
+  #    └──┬ unit:L^-1 symbol: L
+  #       └──┬ unit:DeciM3 symbol: dm³
+  #          └──┬ unit:DeciM^3 symbol: dm
+  #             └─── unit:M symbol: m
+unit:MilliGM-SEC-PER-M3-L qudt:symbol "mg·s/(m³·L)" .
+
+  # WRONG SYMBOL  : unit:MilliGM-SEC-PER-M6 - calculated from factors: mg·s/m⁶, actual: (mg/m³)/(m³/s)
+  #
+  #  ──┬ unit:MilliGM-SEC-PER-M6 symbol: (mg/m³)/(m³/s) (correct: mg·s/m⁶)
+  #    ├──┬ unit:MilliGM symbol: mg
+  #    │  └─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    └─── unit:M^-6 symbol: m
+unit:MilliGM-SEC-PER-M6 qudt:symbol "mg·s/m⁶" .
+
+  # WRONG SYMBOL  : unit:MilliL-PER-BAR - calculated from factors: mL/bar, actual: ml/bar
+  #
+  #  ──┬ unit:MilliL-PER-BAR symbol: ml/bar (correct: mL/bar)
+  #    ├──┬ unit:MilliL symbol: mL
+  #    │  └──┬ unit:L symbol: L
+  #    │     └──┬ unit:DeciM3 symbol: dm³
+  #    │        └──┬ unit:DeciM^3 symbol: dm
+  #    │           └─── unit:M symbol: m
+  #    └──┬ unit:BAR^-1 symbol: bar
+  #       └──┬ unit:PA symbol: Pa
+  #          ├─── unit:M^-2 symbol: m
+  #          └──┬ unit:N symbol: N
+  #             ├──┬ unit:KiloGM symbol: kg
+  #             │  └─── unit:GM symbol: g
+  #             ├─── unit:M symbol: m
+  #             └─── unit:SEC^-2 symbol: s
+unit:MilliL-PER-BAR qudt:symbol "mL/bar" .
+
+  # WRONG SYMBOL  : unit:MilliL-PER-DAY - calculated from factors: mL/d, actual: mL/day
+  #
+  #  ──┬ unit:MilliL-PER-DAY symbol: mL/day (correct: mL/d)
+  #    ├──┬ unit:MilliL symbol: mL
+  #    │  └──┬ unit:L symbol: L
+  #    │     └──┬ unit:DeciM3 symbol: dm³
+  #    │        └──┬ unit:DeciM^3 symbol: dm
+  #    │           └─── unit:M symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:MilliL-PER-DAY qudt:symbol "mL/d" .
+
+  # WRONG SYMBOL  : unit:MilliL-PER-DAY-BAR - calculated from factors: mL/(d·bar), actual: ml/(d·bar)
+  #
+  #  ──┬ unit:MilliL-PER-DAY-BAR symbol: ml/(d·bar) (correct: mL/(d·bar))
+  #    ├──┬ unit:MilliL symbol: mL
+  #    │  └──┬ unit:L symbol: L
+  #    │     └──┬ unit:DeciM3 symbol: dm³
+  #    │        └──┬ unit:DeciM^3 symbol: dm
+  #    │           └─── unit:M symbol: m
+  #    ├──┬ unit:DAY^-1 symbol: d
+  #    │  └─── unit:SEC symbol: s
+  #    └──┬ unit:BAR^-1 symbol: bar
+  #       └──┬ unit:PA symbol: Pa
+  #          ├─── unit:M^-2 symbol: m
+  #          └──┬ unit:N symbol: N
+  #             ├──┬ unit:KiloGM symbol: kg
+  #             │  └─── unit:GM symbol: g
+  #             ├─── unit:M symbol: m
+  #             └─── unit:SEC^-2 symbol: s
+unit:MilliL-PER-DAY-BAR qudt:symbol "mL/(d·bar)" .
+
+  # WRONG SYMBOL  : unit:MilliL-PER-DAY-K - calculated from factors: mL/(d·K), actual: ml/(d·K)
+  #
+  #  ──┬ unit:MilliL-PER-DAY-K symbol: ml/(d·K) (correct: mL/(d·K))
+  #    ├──┬ unit:MilliL symbol: mL
+  #    │  └──┬ unit:L symbol: L
+  #    │     └──┬ unit:DeciM3 symbol: dm³
+  #    │        └──┬ unit:DeciM^3 symbol: dm
+  #    │           └─── unit:M symbol: m
+  #    ├──┬ unit:DAY^-1 symbol: d
+  #    │  └─── unit:SEC symbol: s
+  #    └─── unit:K^-1 symbol: K
+unit:MilliL-PER-DAY-K qudt:symbol "mL/(d·K)" .
+
+  # WRONG SYMBOL  : unit:MilliL-PER-HR-BAR - calculated from factors: mL/(h·bar), actual: ml/(h·bar)
+  #
+  #  ──┬ unit:MilliL-PER-HR-BAR symbol: ml/(h·bar) (correct: mL/(h·bar))
+  #    ├──┬ unit:MilliL symbol: mL
+  #    │  └──┬ unit:L symbol: L
+  #    │     └──┬ unit:DeciM3 symbol: dm³
+  #    │        └──┬ unit:DeciM^3 symbol: dm
+  #    │           └─── unit:M symbol: m
+  #    ├──┬ unit:HR^-1 symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    └──┬ unit:BAR^-1 symbol: bar
+  #       └──┬ unit:PA symbol: Pa
+  #          ├─── unit:M^-2 symbol: m
+  #          └──┬ unit:N symbol: N
+  #             ├──┬ unit:KiloGM symbol: kg
+  #             │  └─── unit:GM symbol: g
+  #             ├─── unit:M symbol: m
+  #             └─── unit:SEC^-2 symbol: s
+unit:MilliL-PER-HR-BAR qudt:symbol "mL/(h·bar)" .
+
+  # WRONG SYMBOL  : unit:MilliL-PER-HR-K - calculated from factors: mL/(h·K), actual: ml/(h·K)
+  #
+  #  ──┬ unit:MilliL-PER-HR-K symbol: ml/(h·K) (correct: mL/(h·K))
+  #    ├──┬ unit:MilliL symbol: mL
+  #    │  └──┬ unit:L symbol: L
+  #    │     └──┬ unit:DeciM3 symbol: dm³
+  #    │        └──┬ unit:DeciM^3 symbol: dm
+  #    │           └─── unit:M symbol: m
+  #    ├──┬ unit:HR^-1 symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    └─── unit:K^-1 symbol: K
+unit:MilliL-PER-HR-K qudt:symbol "mL/(h·K)" .
+
+  # WRONG SYMBOL  : unit:MilliL-PER-M2-DAY - calculated from factors: mL/(m²·d), actual: mL/(m²·day)
+  #
+  #  ──┬ unit:MilliL-PER-M2-DAY symbol: mL/(m²·day) (correct: mL/(m²·d))
+  #    ├──┬ unit:MilliL symbol: mL
+  #    │  └──┬ unit:L symbol: L
+  #    │     └──┬ unit:DeciM3 symbol: dm³
+  #    │        └──┬ unit:DeciM^3 symbol: dm
+  #    │           └─── unit:M symbol: m
+  #    ├─── unit:M^-2 symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:MilliL-PER-M2-DAY qudt:symbol "mL/(m²·d)" .
+
+  # WRONG SYMBOL  : unit:MilliL-PER-MIN-BAR - calculated from factors: mL/(min·bar), actual: ml/(min·bar)
+  #
+  #  ──┬ unit:MilliL-PER-MIN-BAR symbol: ml/(min·bar) (correct: mL/(min·bar))
+  #    ├──┬ unit:MilliL symbol: mL
+  #    │  └──┬ unit:L symbol: L
+  #    │     └──┬ unit:DeciM3 symbol: dm³
+  #    │        └──┬ unit:DeciM^3 symbol: dm
+  #    │           └─── unit:M symbol: m
+  #    ├──┬ unit:MIN^-1 symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    └──┬ unit:BAR^-1 symbol: bar
+  #       └──┬ unit:PA symbol: Pa
+  #          ├─── unit:M^-2 symbol: m
+  #          └──┬ unit:N symbol: N
+  #             ├──┬ unit:KiloGM symbol: kg
+  #             │  └─── unit:GM symbol: g
+  #             ├─── unit:M symbol: m
+  #             └─── unit:SEC^-2 symbol: s
+unit:MilliL-PER-MIN-BAR qudt:symbol "mL/(min·bar)" .
+
+  # WRONG SYMBOL  : unit:MilliL-PER-MIN-K - calculated from factors: mL/(min·K), actual: ml/(min·K)
+  #
+  #  ──┬ unit:MilliL-PER-MIN-K symbol: ml/(min·K) (correct: mL/(min·K))
+  #    ├──┬ unit:MilliL symbol: mL
+  #    │  └──┬ unit:L symbol: L
+  #    │     └──┬ unit:DeciM3 symbol: dm³
+  #    │        └──┬ unit:DeciM^3 symbol: dm
+  #    │           └─── unit:M symbol: m
+  #    ├──┬ unit:MIN^-1 symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    └─── unit:K^-1 symbol: K
+unit:MilliL-PER-MIN-K qudt:symbol "mL/(min·K)" .
+
+  # WRONG SYMBOL  : unit:MilliL-PER-SEC-BAR - calculated from factors: mL/(s·bar), actual: ml/(s·bar)
+  #
+  #  ──┬ unit:MilliL-PER-SEC-BAR symbol: ml/(s·bar) (correct: mL/(s·bar))
+  #    ├──┬ unit:MilliL symbol: mL
+  #    │  └──┬ unit:L symbol: L
+  #    │     └──┬ unit:DeciM3 symbol: dm³
+  #    │        └──┬ unit:DeciM^3 symbol: dm
+  #    │           └─── unit:M symbol: m
+  #    ├─── unit:SEC^-1 symbol: s
+  #    └──┬ unit:BAR^-1 symbol: bar
+  #       └──┬ unit:PA symbol: Pa
+  #          ├─── unit:M^-2 symbol: m
+  #          └──┬ unit:N symbol: N
+  #             ├──┬ unit:KiloGM symbol: kg
+  #             │  └─── unit:GM symbol: g
+  #             ├─── unit:M symbol: m
+  #             └─── unit:SEC^-2 symbol: s
+unit:MilliL-PER-SEC-BAR qudt:symbol "mL/(s·bar)" .
+
+  # WRONG SYMBOL  : unit:MilliL-PER-SEC-K - calculated from factors: mL/(s·K), actual: ml/(s·K)
+  #
+  #  ──┬ unit:MilliL-PER-SEC-K symbol: ml/(s·K) (correct: mL/(s·K))
+  #    ├──┬ unit:MilliL symbol: mL
+  #    │  └──┬ unit:L symbol: L
+  #    │     └──┬ unit:DeciM3 symbol: dm³
+  #    │        └──┬ unit:DeciM^3 symbol: dm
+  #    │           └─── unit:M symbol: m
+  #    ├─── unit:SEC^-1 symbol: s
+  #    └─── unit:K^-1 symbol: K
+unit:MilliL-PER-SEC-K qudt:symbol "mL/(s·K)" .
+
+  # WRONG SYMBOL  : unit:MilliM-PER-DAY - calculated from factors: mm/d, actual: mm/day
+  #
+  #  ──┬ unit:MilliM-PER-DAY symbol: mm/day (correct: mm/d)
+  #    ├──┬ unit:MilliM symbol: mm
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:MilliM-PER-DAY qudt:symbol "mm/d" .
+
+  # WRONG SYMBOL  : unit:MilliMOL-PER-M2-DAY - calculated from factors: mmol/(m²·d), actual: mmol/(m²·day)
+  #
+  #  ──┬ unit:MilliMOL-PER-M2-DAY symbol: mmol/(m²·day) (correct: mmol/(m²·d))
+  #    ├──┬ unit:MilliMOL symbol: mmol
+  #    │  └─── unit:MOL symbol: mol
+  #    ├─── unit:M^-2 symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:MilliMOL-PER-M2-DAY qudt:symbol "mmol/(m²·d)" .
+
+  # WRONG SYMBOL  : unit:MilliMOL-PER-M3-DAY - calculated from factors: mmol/(m³·d), actual: mmol/(m³·day)
+  #
+  #  ──┬ unit:MilliMOL-PER-M3-DAY symbol: mmol/(m³·day) (correct: mmol/(m³·d))
+  #    ├──┬ unit:MilliMOL symbol: mmol
+  #    │  └─── unit:MOL symbol: mol
+  #    ├─── unit:M^-3 symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:MilliMOL-PER-M3-DAY qudt:symbol "mmol/(m³·d)" .
+
+  # WRONG SYMBOL  : unit:MilliN-M - calculated from factors: m·mN, actual: mN·m
+  #
+  #  ──┬ unit:MilliN-M symbol: mN·m (correct: m·mN)
+  #    ├─── unit:M symbol: m
+  #    └──┬ unit:MilliN symbol: mN
+  #       └──┬ unit:N symbol: N
+  #          ├──┬ unit:KiloGM symbol: kg
+  #          │  └─── unit:GM symbol: g
+  #          ├─── unit:M symbol: m
+  #          └─── unit:SEC^-2 symbol: s
+unit:MilliN-M qudt:symbol "m·mN" .
+
+  # WRONG SYMBOL  : unit:MilliN-M-PER-M2 - calculated from factors: m·mN/m², actual: mN·m/m²
+  #
+  #  ──┬ unit:MilliN-M-PER-M2 symbol: mN·m/m² (correct: m·mN/m²)
+  #    ├─── unit:M symbol: m
+  #    ├──┬ unit:MilliN symbol: mN
+  #    │  └──┬ unit:N symbol: N
+  #    │     ├──┬ unit:KiloGM symbol: kg
+  #    │     │  └─── unit:GM symbol: g
+  #    │     ├─── unit:M symbol: m
+  #    │     └─── unit:SEC^-2 symbol: s
+  #    └─── unit:M^-2 symbol: m
+unit:MilliN-M-PER-M2 qudt:symbol "m·mN/m²" .
+
+  # WRONG SYMBOL  : unit:MilliOHM-M - calculated from factors: m·mΩ, actual: mΩ·m
+  #
+  #  ──┬ unit:MilliOHM-M symbol: mΩ·m (correct: m·mΩ)
+  #    ├─── unit:M symbol: m
+  #    └──┬ unit:MilliOHM symbol: mΩ
+  #       └──┬ unit:OHM symbol: Ω
+  #          ├─── unit:A^-1 symbol: A
+  #          └──┬ unit:V symbol: V
+  #             ├─── unit:A^-1 symbol: A
+  #             └──┬ unit:W symbol: W
+  #                ├──┬ unit:J symbol: J
+  #                │  ├─── unit:M symbol: m
+  #                │  └──┬ unit:N symbol: N
+  #                │     ├──┬ unit:KiloGM symbol: kg
+  #                │     │  └─── unit:GM symbol: g
+  #                │     ├─── unit:M symbol: m
+  #                │     └─── unit:SEC^-2 symbol: s
+  #                └─── unit:SEC^-1 symbol: s
+unit:MilliOHM-M qudt:symbol "m·mΩ" .
+
+  # WRONG SYMBOL  : unit:MilliOHM-PER-BAR - calculated from factors: mΩ/bar, actual: mΩ/bar
+  #
+  #  ──┬ unit:MilliOHM-PER-BAR symbol: mΩ/bar (correct: mΩ/bar)
+  #    ├──┬ unit:MilliOHM symbol: mΩ
+  #    │  └──┬ unit:OHM symbol: Ω
+  #    │     ├─── unit:A^-1 symbol: A
+  #    │     └──┬ unit:V symbol: V
+  #    │        ├─── unit:A^-1 symbol: A
+  #    │        └──┬ unit:W symbol: W
+  #    │           ├──┬ unit:J symbol: J
+  #    │           │  ├─── unit:M symbol: m
+  #    │           │  └──┬ unit:N symbol: N
+  #    │           │     ├──┬ unit:KiloGM symbol: kg
+  #    │           │     │  └─── unit:GM symbol: g
+  #    │           │     ├─── unit:M symbol: m
+  #    │           │     └─── unit:SEC^-2 symbol: s
+  #    │           └─── unit:SEC^-1 symbol: s
+  #    └──┬ unit:BAR^-1 symbol: bar
+  #       └──┬ unit:PA symbol: Pa
+  #          ├─── unit:M^-2 symbol: m
+  #          └──┬ unit:N symbol: N
+  #             ├──┬ unit:KiloGM symbol: kg
+  #             │  └─── unit:GM symbol: g
+  #             ├─── unit:M symbol: m
+  #             └─── unit:SEC^-2 symbol: s
+unit:MilliOHM-PER-BAR qudt:symbol "mΩ/bar" .
+
+  # WRONG SYMBOL  : unit:MilliOHM-PER-K - calculated from factors: mΩ/K, actual: mΩ/K
+  #
+  #  ──┬ unit:MilliOHM-PER-K symbol: mΩ/K (correct: mΩ/K)
+  #    ├──┬ unit:MilliOHM symbol: mΩ
+  #    │  └──┬ unit:OHM symbol: Ω
+  #    │     ├─── unit:A^-1 symbol: A
+  #    │     └──┬ unit:V symbol: V
+  #    │        ├─── unit:A^-1 symbol: A
+  #    │        └──┬ unit:W symbol: W
+  #    │           ├──┬ unit:J symbol: J
+  #    │           │  ├─── unit:M symbol: m
+  #    │           │  └──┬ unit:N symbol: N
+  #    │           │     ├──┬ unit:KiloGM symbol: kg
+  #    │           │     │  └─── unit:GM symbol: g
+  #    │           │     ├─── unit:M symbol: m
+  #    │           │     └─── unit:SEC^-2 symbol: s
+  #    │           └─── unit:SEC^-1 symbol: s
+  #    └─── unit:K^-1 symbol: K
+unit:MilliOHM-PER-K qudt:symbol "mΩ/K" .
+
+  # WRONG SYMBOL  : unit:MilliOHM-PER-M - calculated from factors: mΩ/m, actual: mΩ/m
+  #
+  #  ──┬ unit:MilliOHM-PER-M symbol: mΩ/m (correct: mΩ/m)
+  #    ├──┬ unit:MilliOHM symbol: mΩ
+  #    │  └──┬ unit:OHM symbol: Ω
+  #    │     ├─── unit:A^-1 symbol: A
+  #    │     └──┬ unit:V symbol: V
+  #    │        ├─── unit:A^-1 symbol: A
+  #    │        └──┬ unit:W symbol: W
+  #    │           ├──┬ unit:J symbol: J
+  #    │           │  ├─── unit:M symbol: m
+  #    │           │  └──┬ unit:N symbol: N
+  #    │           │     ├──┬ unit:KiloGM symbol: kg
+  #    │           │     │  └─── unit:GM symbol: g
+  #    │           │     ├─── unit:M symbol: m
+  #    │           │     └─── unit:SEC^-2 symbol: s
+  #    │           └─── unit:SEC^-1 symbol: s
+  #    └─── unit:M^-1 symbol: m
+unit:MilliOHM-PER-M qudt:symbol "mΩ/m" .
+
+  # WRONG SYMBOL  : unit:MilliW-PER-CentiM2-MicroM-SR - calculated from factors: mW/(cm²·μm·sr), actual: mW/(cm²·µm·sr)
+  #
+  #  ──┬ unit:MilliW-PER-CentiM2-MicroM-SR symbol: mW/(cm²·µm·sr) (correct: mW/(cm²·μm·sr))
+  #    ├──┬ unit:MilliW symbol: mW
+  #    │  └──┬ unit:W symbol: W
+  #    │     ├──┬ unit:J symbol: J
+  #    │     │  ├─── unit:M symbol: m
+  #    │     │  └──┬ unit:N symbol: N
+  #    │     │     ├──┬ unit:KiloGM symbol: kg
+  #    │     │     │  └─── unit:GM symbol: g
+  #    │     │     ├─── unit:M symbol: m
+  #    │     │     └─── unit:SEC^-2 symbol: s
+  #    │     └─── unit:SEC^-1 symbol: s
+  #    ├──┬ unit:CentiM^-2 symbol: cm
+  #    │  └─── unit:M symbol: m
+  #    ├──┬ unit:MicroM^-1 symbol: μm
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:SR^-1 symbol: sr
+  #       ├─── unit:M^-2 symbol: m
+  #       └─── unit:M^2 symbol: m
+unit:MilliW-PER-CentiM2-MicroM-SR qudt:symbol "mW/(cm²·μm·sr)" .
+
+  # WRONG SYMBOL  : unit:MilliW-PER-M2-NanoM-SR - calculated from factors: mW/(m²·nm·sr), actual: mW/(cm·nm·sr)
+  #
+  #  ──┬ unit:MilliW-PER-M2-NanoM-SR symbol: mW/(cm·nm·sr) (correct: mW/(m²·nm·sr))
+  #    ├──┬ unit:MilliW symbol: mW
+  #    │  └──┬ unit:W symbol: W
+  #    │     ├──┬ unit:J symbol: J
+  #    │     │  ├─── unit:M symbol: m
+  #    │     │  └──┬ unit:N symbol: N
+  #    │     │     ├──┬ unit:KiloGM symbol: kg
+  #    │     │     │  └─── unit:GM symbol: g
+  #    │     │     ├─── unit:M symbol: m
+  #    │     │     └─── unit:SEC^-2 symbol: s
+  #    │     └─── unit:SEC^-1 symbol: s
+  #    ├─── unit:M^-2 symbol: m
+  #    ├──┬ unit:NanoM^-1 symbol: nm
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:SR^-1 symbol: sr
+  #       ├─── unit:M^-2 symbol: m
+  #       └─── unit:M^2 symbol: m
+unit:MilliW-PER-M2-NanoM-SR qudt:symbol "mW/(m²·nm·sr)" .
+
+  # WRONG SYMBOL  : unit:NUM-PER-KiloGM - calculated from factors: #/kg, actual: /kg
+  #
+  #  ──┬ unit:NUM-PER-KiloGM symbol: /kg (correct: #/kg)
+  #    ├─── unit:NUM symbol: #
+  #    └──┬ unit:KiloGM^-1 symbol: kg
+  #       └─── unit:GM symbol: g
+unit:NUM-PER-KiloGM qudt:symbol "#/kg" .
+
+  # WRONG SYMBOL  : unit:NUM-PER-M2-DAY - calculated from factors: #/(m²·d), actual: #/(m²·day)
+  #
+  #  ──┬ unit:NUM-PER-M2-DAY symbol: #/(m²·day) (correct: #/(m²·d))
+  #    ├─── unit:NUM symbol: #
+  #    ├─── unit:M^-2 symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:NUM-PER-M2-DAY qudt:symbol "#/(m²·d)" .
+
+  # WRONG SYMBOL  : unit:NUM-PER-MicroL - calculated from factors: #/μL, actual: #/µL
+  #
+  #  ──┬ unit:NUM-PER-MicroL symbol: #/µL (correct: #/μL)
+  #    ├─── unit:NUM symbol: #
+  #    └──┬ unit:MicroL^-1 symbol: μL
+  #       └──┬ unit:L symbol: L
+  #          └──┬ unit:DeciM3 symbol: dm³
+  #             └──┬ unit:DeciM^3 symbol: dm
+  #                └─── unit:M symbol: m
+unit:NUM-PER-MicroL qudt:symbol "#/μL" .
+
+  # WRONG SYMBOL  : unit:NanoGM-PER-CentiM2-DAY - calculated from factors: ng/(cm²·d), actual: ng/(cm²·day)
+  #
+  #  ──┬ unit:NanoGM-PER-CentiM2-DAY symbol: ng/(cm²·day) (correct: ng/(cm²·d))
+  #    ├──┬ unit:NanoGM symbol: ng
+  #    │  └─── unit:GM symbol: g
+  #    ├──┬ unit:CentiM^-2 symbol: cm
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:NanoGM-PER-CentiM2-DAY qudt:symbol "ng/(cm²·d)" .
+
+  # WRONG SYMBOL  : unit:NanoGM-PER-DAY - calculated from factors: ng/d, actual: ng/day
+  #
+  #  ──┬ unit:NanoGM-PER-DAY symbol: ng/day (correct: ng/d)
+  #    ├──┬ unit:NanoGM symbol: ng
+  #    │  └─── unit:GM symbol: g
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:NanoGM-PER-DAY qudt:symbol "ng/d" .
+
+  # WRONG SYMBOL  : unit:NanoGM-PER-KiloGM - calculated from factors: ng/kg, actual: ng/Kg
+  #
+  #  ──┬ unit:NanoGM-PER-KiloGM symbol: ng/Kg (correct: ng/kg)
+  #    ├──┬ unit:NanoGM symbol: ng
+  #    │  └─── unit:GM symbol: g
+  #    └──┬ unit:KiloGM^-1 symbol: kg
+  #       └─── unit:GM symbol: g
+unit:NanoGM-PER-KiloGM qudt:symbol "ng/kg" .
+
+  # WRONG SYMBOL  : unit:NanoGM-PER-M2-PA-SEC - calculated from factors: ng/(m²·Pa·s), actual: kg/(m²·s·Pa)
+  #
+  #  ──┬ unit:NanoGM-PER-M2-PA-SEC symbol: kg/(m²·s·Pa) (correct: ng/(m²·Pa·s))
+  #    ├──┬ unit:NanoGM symbol: ng
+  #    │  └─── unit:GM symbol: g
+  #    ├─── unit:M^-2 symbol: m
+  #    ├──┬ unit:PA^-1 symbol: Pa
+  #    │  ├─── unit:M^-2 symbol: m
+  #    │  └──┬ unit:N symbol: N
+  #    │     ├──┬ unit:KiloGM symbol: kg
+  #    │     │  └─── unit:GM symbol: g
+  #    │     ├─── unit:M symbol: m
+  #    │     └─── unit:SEC^-2 symbol: s
+  #    └─── unit:SEC^-1 symbol: s
+unit:NanoGM-PER-M2-PA-SEC qudt:symbol "ng/(m²·Pa·s)" .
+
+  # WRONG SYMBOL  : unit:NanoGM-PER-MicroL - calculated from factors: ng/μL, actual: ng/µL
+  #
+  #  ──┬ unit:NanoGM-PER-MicroL symbol: ng/µL (correct: ng/μL)
+  #    ├──┬ unit:NanoGM symbol: ng
+  #    │  └─── unit:GM symbol: g
+  #    └──┬ unit:MicroL^-1 symbol: μL
+  #       └──┬ unit:L symbol: L
+  #          └──┬ unit:DeciM3 symbol: dm³
+  #             └──┬ unit:DeciM^3 symbol: dm
+  #                └─── unit:M symbol: m
+unit:NanoGM-PER-MicroL qudt:symbol "ng/μL" .
+
+  # WRONG SYMBOL  : unit:NanoMOL-PER-GM-HR - calculated from factors: nmol/(g·h), actual: nmol/(g.h)
+  #
+  #  ──┬ unit:NanoMOL-PER-GM-HR symbol: nmol/(g.h) (correct: nmol/(g·h))
+  #    ├──┬ unit:NanoMOL symbol: nmol
+  #    │  └─── unit:MOL symbol: mol
+  #    ├─── unit:GM^-1 symbol: g
+  #    └──┬ unit:HR^-1 symbol: h
+  #       └─── unit:SEC symbol: s
+unit:NanoMOL-PER-GM-HR qudt:symbol "nmol/(g·h)" .
+
+  # WRONG SYMBOL  : unit:NanoMOL-PER-L-DAY - calculated from factors: nmol/(L·d), actual: nmol/(L·day)
+  #
+  #  ──┬ unit:NanoMOL-PER-L-DAY symbol: nmol/(L·day) (correct: nmol/(L·d))
+  #    ├──┬ unit:NanoMOL symbol: nmol
+  #    │  └─── unit:MOL symbol: mol
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:NanoMOL-PER-L-DAY qudt:symbol "nmol/(L·d)" .
+
+  # WRONG SYMBOL  : unit:NanoMOL-PER-M2-DAY - calculated from factors: nmol/(m²·d), actual: nmol/(m²·day)
+  #
+  #  ──┬ unit:NanoMOL-PER-M2-DAY symbol: nmol/(m²·day) (correct: nmol/(m²·d))
+  #    ├──┬ unit:NanoMOL symbol: nmol
+  #    │  └─── unit:MOL symbol: mol
+  #    ├─── unit:M^-2 symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:NanoMOL-PER-M2-DAY qudt:symbol "nmol/(m²·d)" .
+
+  # WRONG SYMBOL  : unit:NanoMOL-PER-MicroGM-HR - calculated from factors: nmol/(μg·h), actual: nmol/(µg·h)
+  #
+  #  ──┬ unit:NanoMOL-PER-MicroGM-HR symbol: nmol/(µg·h) (correct: nmol/(μg·h))
+  #    ├──┬ unit:NanoMOL symbol: nmol
+  #    │  └─── unit:MOL symbol: mol
+  #    ├──┬ unit:MicroGM^-1 symbol: μg
+  #    │  └─── unit:GM symbol: g
+  #    └──┬ unit:HR^-1 symbol: h
+  #       └─── unit:SEC symbol: s
+unit:NanoMOL-PER-MicroGM-HR qudt:symbol "nmol/(μg·h)" .
+
+  # WRONG SYMBOL  : unit:NanoMOL-PER-MicroMOL - calculated from factors: nmol/μmol, actual: nmol/µmol
+  #
+  #  ──┬ unit:NanoMOL-PER-MicroMOL symbol: nmol/µmol (correct: nmol/μmol)
+  #    ├──┬ unit:NanoMOL symbol: nmol
+  #    │  └─── unit:MOL symbol: mol
+  #    └──┬ unit:MicroMOL^-1 symbol: μmol
+  #       └─── unit:MOL symbol: mol
+unit:NanoMOL-PER-MicroMOL qudt:symbol "nmol/μmol" .
+
+  # WRONG SYMBOL  : unit:NanoMOL-PER-MicroMOL-DAY - calculated from factors: nmol/(μmol·d), actual: nmol/(µmol·day)
+  #
+  #  ──┬ unit:NanoMOL-PER-MicroMOL-DAY symbol: nmol/(µmol·day) (correct: nmol/(μmol·d))
+  #    ├──┬ unit:NanoMOL symbol: nmol
+  #    │  └─── unit:MOL symbol: mol
+  #    ├──┬ unit:MicroMOL^-1 symbol: μmol
+  #    │  └─── unit:MOL symbol: mol
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:NanoMOL-PER-MicroMOL-DAY qudt:symbol "nmol/(μmol·d)" .
+
+  # WRONG SYMBOL  : unit:OHM-KiloM - calculated from factors: Ω·km, actual: Ω·km
+  #
+  #  ──┬ unit:OHM-KiloM symbol: Ω·km (correct: Ω·km)
+  #    ├──┬ unit:OHM symbol: Ω
+  #    │  ├─── unit:A^-1 symbol: A
+  #    │  └──┬ unit:V symbol: V
+  #    │     ├─── unit:A^-1 symbol: A
+  #    │     └──┬ unit:W symbol: W
+  #    │        ├──┬ unit:J symbol: J
+  #    │        │  ├─── unit:M symbol: m
+  #    │        │  └──┬ unit:N symbol: N
+  #    │        │     ├──┬ unit:KiloGM symbol: kg
+  #    │        │     │  └─── unit:GM symbol: g
+  #    │        │     ├─── unit:M symbol: m
+  #    │        │     └─── unit:SEC^-2 symbol: s
+  #    │        └─── unit:SEC^-1 symbol: s
+  #    └──┬ unit:KiloM symbol: km
+  #       └─── unit:M symbol: m
+unit:OHM-KiloM qudt:symbol "Ω·km" .
+
+  # WRONG SYMBOL  : unit:OHM-PER-BAR - calculated from factors: Ω/bar, actual: Ω/bar
+  #
+  #  ──┬ unit:OHM-PER-BAR symbol: Ω/bar (correct: Ω/bar)
+  #    ├──┬ unit:OHM symbol: Ω
+  #    │  ├─── unit:A^-1 symbol: A
+  #    │  └──┬ unit:V symbol: V
+  #    │     ├─── unit:A^-1 symbol: A
+  #    │     └──┬ unit:W symbol: W
+  #    │        ├──┬ unit:J symbol: J
+  #    │        │  ├─── unit:M symbol: m
+  #    │        │  └──┬ unit:N symbol: N
+  #    │        │     ├──┬ unit:KiloGM symbol: kg
+  #    │        │     │  └─── unit:GM symbol: g
+  #    │        │     ├─── unit:M symbol: m
+  #    │        │     └─── unit:SEC^-2 symbol: s
+  #    │        └─── unit:SEC^-1 symbol: s
+  #    └──┬ unit:BAR^-1 symbol: bar
+  #       └──┬ unit:PA symbol: Pa
+  #          ├─── unit:M^-2 symbol: m
+  #          └──┬ unit:N symbol: N
+  #             ├──┬ unit:KiloGM symbol: kg
+  #             │  └─── unit:GM symbol: g
+  #             ├─── unit:M symbol: m
+  #             └─── unit:SEC^-2 symbol: s
+unit:OHM-PER-BAR qudt:symbol "Ω/bar" .
+
+  # WRONG SYMBOL  : unit:OHM-PER-K - calculated from factors: Ω/K, actual: Ω/K
+  #
+  #  ──┬ unit:OHM-PER-K symbol: Ω/K (correct: Ω/K)
+  #    ├──┬ unit:OHM symbol: Ω
+  #    │  ├─── unit:A^-1 symbol: A
+  #    │  └──┬ unit:V symbol: V
+  #    │     ├─── unit:A^-1 symbol: A
+  #    │     └──┬ unit:W symbol: W
+  #    │        ├──┬ unit:J symbol: J
+  #    │        │  ├─── unit:M symbol: m
+  #    │        │  └──┬ unit:N symbol: N
+  #    │        │     ├──┬ unit:KiloGM symbol: kg
+  #    │        │     │  └─── unit:GM symbol: g
+  #    │        │     ├─── unit:M symbol: m
+  #    │        │     └─── unit:SEC^-2 symbol: s
+  #    │        └─── unit:SEC^-1 symbol: s
+  #    └─── unit:K^-1 symbol: K
+unit:OHM-PER-K qudt:symbol "Ω/K" .
+
+  # WRONG SYMBOL  : unit:OHM-PER-KiloM - calculated from factors: Ω/km, actual: Ω/km
+  #
+  #  ──┬ unit:OHM-PER-KiloM symbol: Ω/km (correct: Ω/km)
+  #    ├──┬ unit:OHM symbol: Ω
+  #    │  ├─── unit:A^-1 symbol: A
+  #    │  └──┬ unit:V symbol: V
+  #    │     ├─── unit:A^-1 symbol: A
+  #    │     └──┬ unit:W symbol: W
+  #    │        ├──┬ unit:J symbol: J
+  #    │        │  ├─── unit:M symbol: m
+  #    │        │  └──┬ unit:N symbol: N
+  #    │        │     ├──┬ unit:KiloGM symbol: kg
+  #    │        │     │  └─── unit:GM symbol: g
+  #    │        │     ├─── unit:M symbol: m
+  #    │        │     └─── unit:SEC^-2 symbol: s
+  #    │        └─── unit:SEC^-1 symbol: s
+  #    └──┬ unit:KiloM^-1 symbol: km
+  #       └─── unit:M symbol: m
+unit:OHM-PER-KiloM qudt:symbol "Ω/km" .
+
+  # WRONG SYMBOL  : unit:OHM-PER-M - calculated from factors: Ω/m, actual: Ω/m
+  #
+  #  ──┬ unit:OHM-PER-M symbol: Ω/m (correct: Ω/m)
+  #    ├──┬ unit:OHM symbol: Ω
+  #    │  ├─── unit:A^-1 symbol: A
+  #    │  └──┬ unit:V symbol: V
+  #    │     ├─── unit:A^-1 symbol: A
+  #    │     └──┬ unit:W symbol: W
+  #    │        ├──┬ unit:J symbol: J
+  #    │        │  ├─── unit:M symbol: m
+  #    │        │  └──┬ unit:N symbol: N
+  #    │        │     ├──┬ unit:KiloGM symbol: kg
+  #    │        │     │  └─── unit:GM symbol: g
+  #    │        │     ├─── unit:M symbol: m
+  #    │        │     └─── unit:SEC^-2 symbol: s
+  #    │        └─── unit:SEC^-1 symbol: s
+  #    └─── unit:M^-1 symbol: m
+unit:OHM-PER-M qudt:symbol "Ω/m" .
+
+  # WRONG SYMBOL  : unit:OHM-PER-MI - calculated from factors: Ω/mi, actual: Ω/mi
+  #
+  #  ──┬ unit:OHM-PER-MI symbol: Ω/mi (correct: Ω/mi)
+  #    ├──┬ unit:OHM symbol: Ω
+  #    │  ├─── unit:A^-1 symbol: A
+  #    │  └──┬ unit:V symbol: V
+  #    │     ├─── unit:A^-1 symbol: A
+  #    │     └──┬ unit:W symbol: W
+  #    │        ├──┬ unit:J symbol: J
+  #    │        │  ├─── unit:M symbol: m
+  #    │        │  └──┬ unit:N symbol: N
+  #    │        │     ├──┬ unit:KiloGM symbol: kg
+  #    │        │     │  └─── unit:GM symbol: g
+  #    │        │     ├─── unit:M symbol: m
+  #    │        │     └─── unit:SEC^-2 symbol: s
+  #    │        └─── unit:SEC^-1 symbol: s
+  #    └──┬ unit:MI^-1 symbol: mi
+  #       └─── unit:M symbol: m
+unit:OHM-PER-MI qudt:symbol "Ω/mi" .
+
+  # WRONG SYMBOL  : unit:ONE-PER-ONE - calculated from factors: one/one, actual: /1
+  #
+  #  ──┬ unit:ONE-PER-ONE symbol: /1 (correct: one/one)
+  #    ├─── unit:ONE symbol: one
+  #    └─── unit:ONE^-1 symbol: one
+unit:ONE-PER-ONE qudt:symbol "one/one" .
+
+  # WRONG SYMBOL  : unit:OZ-FT-HR-PER-IN3-LB - calculated from factors: oz·ft·h/(in³·lbm), actual: (oz/in³)/(lb/(ft·h))
+  #
+  #  ──┬ unit:OZ-FT-HR-PER-IN3-LB symbol: (oz/in³)/(lb/(ft·h)) (correct: oz·ft·h/(in³·lbm))
+  #    ├──┬ unit:OZ symbol: oz
+  #    │  └──┬ unit:LB symbol: lbm
+  #    │     └──┬ unit:KiloGM symbol: kg
+  #    │        └─── unit:GM symbol: g
+  #    ├──┬ unit:FT symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:LB^-1 symbol: lbm
+  #       └──┬ unit:KiloGM symbol: kg
+  #          └─── unit:GM symbol: g
+unit:OZ-FT-HR-PER-IN3-LB qudt:symbol "oz·ft·h/(in³·lbm)" .
+
+  # WRONG SYMBOL  : unit:OZ-FT-SEC-PER-IN3-LB - calculated from factors: oz·ft·s/(in³·lbm), actual: (oz/in³)/(lb/(ft·s))
+  #
+  #  ──┬ unit:OZ-FT-SEC-PER-IN3-LB symbol: (oz/in³)/(lb/(ft·s)) (correct: oz·ft·s/(in³·lbm))
+  #    ├──┬ unit:OZ symbol: oz
+  #    │  └──┬ unit:LB symbol: lbm
+  #    │     └──┬ unit:KiloGM symbol: kg
+  #    │        └─── unit:GM symbol: g
+  #    ├──┬ unit:FT symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    ├─── unit:SEC symbol: s
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:LB^-1 symbol: lbm
+  #       └──┬ unit:KiloGM symbol: kg
+  #          └─── unit:GM symbol: g
+unit:OZ-FT-SEC-PER-IN3-LB qudt:symbol "oz·ft·s/(in³·lbm)" .
+
+  # WRONG SYMBOL  : unit:OZ-FT2-PER-IN3-LB_F-SEC - calculated from factors: oz·ft²/(in³·lbf·s), actual: (oz/in³)/(lbf·s/ft²)
+  #
+  #  ──┬ unit:OZ-FT2-PER-IN3-LB_F-SEC symbol: (oz/in³)/(lbf·s/ft²) (correct: oz·ft²/(in³·lbf·s))
+  #    ├──┬ unit:OZ symbol: oz
+  #    │  └──┬ unit:LB symbol: lbm
+  #    │     └──┬ unit:KiloGM symbol: kg
+  #    │        └─── unit:GM symbol: g
+  #    ├──┬ unit:FT^2 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    ├──┬ unit:LB_F^-1 symbol: lbf
+  #    │  ├──┬ unit:FT symbol: ft
+  #    │  │  └──┬ unit:IN symbol: in
+  #    │  │     └─── unit:M symbol: m
+  #    │  ├─── unit:SEC^-2 symbol: s
+  #    │  └──┬ unit:SLUG symbol: slug
+  #    │     └──┬ unit:LB symbol: lbm
+  #    │        └──┬ unit:KiloGM symbol: kg
+  #    │           └─── unit:GM symbol: g
+  #    └─── unit:SEC^-1 symbol: s
+unit:OZ-FT2-PER-IN3-LB_F-SEC qudt:symbol "oz·ft²/(in³·lbf·s)" .
+
+  # WRONG SYMBOL  : unit:OZ-HR-PER-IN3-FT3 - calculated from factors: oz·h/(in³·ft³), actual: (oz/in³)/(ft³/h)
+  #
+  #  ──┬ unit:OZ-HR-PER-IN3-FT3 symbol: (oz/in³)/(ft³/h) (correct: oz·h/(in³·ft³))
+  #    ├──┬ unit:OZ symbol: oz
+  #    │  └──┬ unit:LB symbol: lbm
+  #    │     └──┬ unit:KiloGM symbol: kg
+  #    │        └─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:FT^-3 symbol: ft
+  #       └──┬ unit:IN symbol: in
+  #          └─── unit:M symbol: m
+unit:OZ-HR-PER-IN3-FT3 qudt:symbol "oz·h/(in³·ft³)" .
+
+  # WRONG SYMBOL  : unit:OZ-HR-PER-IN3-GAL_UK - calculated from factors: oz·h/(in³·gal{UK}), actual: (oz/in³)/(gal (UK)/h)
+  #
+  #  ──┬ unit:OZ-HR-PER-IN3-GAL_UK symbol: (oz/in³)/(gal (UK)/h) (correct: oz·h/(in³·gal{UK}))
+  #    ├──┬ unit:OZ symbol: oz
+  #    │  └──┬ unit:LB symbol: lbm
+  #    │     └──┬ unit:KiloGM symbol: kg
+  #    │        └─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:GAL_UK^-1 symbol: gal{UK}
+  #       └──┬ unit:L symbol: L
+  #          └──┬ unit:DeciM3 symbol: dm³
+  #             └──┬ unit:DeciM^3 symbol: dm
+  #                └─── unit:M symbol: m
+unit:OZ-HR-PER-IN3-GAL_UK qudt:symbol "oz·h/(in³·gal{UK})" .
+
+  # WRONG SYMBOL  : unit:OZ-HR-PER-IN3-GAL_US - calculated from factors: oz·h/(in³·gal{US}), actual: (oz/in³)/(gal (US)/h)
+  #
+  #  ──┬ unit:OZ-HR-PER-IN3-GAL_US symbol: (oz/in³)/(gal (US)/h) (correct: oz·h/(in³·gal{US}))
+  #    ├──┬ unit:OZ symbol: oz
+  #    │  └──┬ unit:LB symbol: lbm
+  #    │     └──┬ unit:KiloGM symbol: kg
+  #    │        └─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:GAL_US^-1 symbol: gal{US}
+  #       └──┬ unit:IN^3 symbol: in
+  #          └─── unit:M symbol: m
+unit:OZ-HR-PER-IN3-GAL_US qudt:symbol "oz·h/(in³·gal{US})" .
+
+  # WRONG SYMBOL  : unit:OZ-HR-PER-IN3-YD3 - calculated from factors: oz·h/(in³·yd³), actual: (oz/in³)/(yd³/h)
+  #
+  #  ──┬ unit:OZ-HR-PER-IN3-YD3 symbol: (oz/in³)/(yd³/h) (correct: oz·h/(in³·yd³))
+  #    ├──┬ unit:OZ symbol: oz
+  #    │  └──┬ unit:LB symbol: lbm
+  #    │     └──┬ unit:KiloGM symbol: kg
+  #    │        └─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:YD^-3 symbol: yd
+  #       └──┬ unit:FT symbol: ft
+  #          └──┬ unit:IN symbol: in
+  #             └─── unit:M symbol: m
+unit:OZ-HR-PER-IN3-YD3 qudt:symbol "oz·h/(in³·yd³)" .
+
+  # WRONG SYMBOL  : unit:OZ-HR-PER-IN6 - calculated from factors: oz·h/in⁶, actual: (oz/in³)/(in³/h)
+  #
+  #  ──┬ unit:OZ-HR-PER-IN6 symbol: (oz/in³)/(in³/h) (correct: oz·h/in⁶)
+  #    ├──┬ unit:OZ symbol: oz
+  #    │  └──┬ unit:LB symbol: lbm
+  #    │     └──┬ unit:KiloGM symbol: kg
+  #    │        └─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    └──┬ unit:IN^-6 symbol: in
+  #       └─── unit:M symbol: m
+unit:OZ-HR-PER-IN6 qudt:symbol "oz·h/in⁶" .
+
+  # WRONG SYMBOL  : unit:OZ-IN2-PER-IN3-LB_F-SEC - calculated from factors: oz·in²/(in³·lbf·s), actual: (oz/in³)/(lbf·s/in²)
+  #
+  #  ──┬ unit:OZ-IN2-PER-IN3-LB_F-SEC symbol: (oz/in³)/(lbf·s/in²) (correct: oz·in²/(in³·lbf·s))
+  #    ├──┬ unit:OZ symbol: oz
+  #    │  └──┬ unit:LB symbol: lbm
+  #    │     └──┬ unit:KiloGM symbol: kg
+  #    │        └─── unit:GM symbol: g
+  #    ├──┬ unit:IN^2 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    ├──┬ unit:LB_F^-1 symbol: lbf
+  #    │  ├──┬ unit:FT symbol: ft
+  #    │  │  └──┬ unit:IN symbol: in
+  #    │  │     └─── unit:M symbol: m
+  #    │  ├─── unit:SEC^-2 symbol: s
+  #    │  └──┬ unit:SLUG symbol: slug
+  #    │     └──┬ unit:LB symbol: lbm
+  #    │        └──┬ unit:KiloGM symbol: kg
+  #    │           └─── unit:GM symbol: g
+  #    └─── unit:SEC^-1 symbol: s
+unit:OZ-IN2-PER-IN3-LB_F-SEC qudt:symbol "oz·in²/(in³·lbf·s)" .
+
+  # WRONG SYMBOL  : unit:OZ-MIN-PER-IN3-FT3 - calculated from factors: oz·min/(in³·ft³), actual: (oz/in³)/(ft³/min)
+  #
+  #  ──┬ unit:OZ-MIN-PER-IN3-FT3 symbol: (oz/in³)/(ft³/min) (correct: oz·min/(in³·ft³))
+  #    ├──┬ unit:OZ symbol: oz
+  #    │  └──┬ unit:LB symbol: lbm
+  #    │     └──┬ unit:KiloGM symbol: kg
+  #    │        └─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:FT^-3 symbol: ft
+  #       └──┬ unit:IN symbol: in
+  #          └─── unit:M symbol: m
+unit:OZ-MIN-PER-IN3-FT3 qudt:symbol "oz·min/(in³·ft³)" .
+
+  # WRONG SYMBOL  : unit:OZ-MIN-PER-IN3-GAL_UK - calculated from factors: oz·min/(in³·gal{UK}), actual: oz·min/(in³·gal (UK))
+  #
+  #  ──┬ unit:OZ-MIN-PER-IN3-GAL_UK symbol: oz·min/(in³·gal (UK)) (correct: oz·min/(in³·gal{UK}))
+  #    ├──┬ unit:OZ symbol: oz
+  #    │  └──┬ unit:LB symbol: lbm
+  #    │     └──┬ unit:KiloGM symbol: kg
+  #    │        └─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:GAL_UK^-1 symbol: gal{UK}
+  #       └──┬ unit:L symbol: L
+  #          └──┬ unit:DeciM3 symbol: dm³
+  #             └──┬ unit:DeciM^3 symbol: dm
+  #                └─── unit:M symbol: m
+unit:OZ-MIN-PER-IN3-GAL_UK qudt:symbol "oz·min/(in³·gal{UK})" .
+
+  # WRONG SYMBOL  : unit:OZ-MIN-PER-IN3-GAL_US - calculated from factors: oz·min/(in³·gal{US}), actual: (oz/in³)/(gal (US)/min)
+  #
+  #  ──┬ unit:OZ-MIN-PER-IN3-GAL_US symbol: (oz/in³)/(gal (US)/min) (correct: oz·min/(in³·gal{US}))
+  #    ├──┬ unit:OZ symbol: oz
+  #    │  └──┬ unit:LB symbol: lbm
+  #    │     └──┬ unit:KiloGM symbol: kg
+  #    │        └─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:GAL_US^-1 symbol: gal{US}
+  #       └──┬ unit:IN^3 symbol: in
+  #          └─── unit:M symbol: m
+unit:OZ-MIN-PER-IN3-GAL_US qudt:symbol "oz·min/(in³·gal{US})" .
+
+  # WRONG SYMBOL  : unit:OZ-MIN-PER-IN3-YD3 - calculated from factors: oz·min/(in³·yd³), actual: (oz/in³)/(yd³/min)
+  #
+  #  ──┬ unit:OZ-MIN-PER-IN3-YD3 symbol: (oz/in³)/(yd³/min) (correct: oz·min/(in³·yd³))
+  #    ├──┬ unit:OZ symbol: oz
+  #    │  └──┬ unit:LB symbol: lbm
+  #    │     └──┬ unit:KiloGM symbol: kg
+  #    │        └─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:YD^-3 symbol: yd
+  #       └──┬ unit:FT symbol: ft
+  #          └──┬ unit:IN symbol: in
+  #             └─── unit:M symbol: m
+unit:OZ-MIN-PER-IN3-YD3 qudt:symbol "oz·min/(in³·yd³)" .
+
+  # WRONG SYMBOL  : unit:OZ-MIN-PER-IN6 - calculated from factors: oz·min/in⁶, actual: (oz/in³)/(in³/min)
+  #
+  #  ──┬ unit:OZ-MIN-PER-IN6 symbol: (oz/in³)/(in³/min) (correct: oz·min/in⁶)
+  #    ├──┬ unit:OZ symbol: oz
+  #    │  └──┬ unit:LB symbol: lbm
+  #    │     └──┬ unit:KiloGM symbol: kg
+  #    │        └─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    └──┬ unit:IN^-6 symbol: in
+  #       └─── unit:M symbol: m
+unit:OZ-MIN-PER-IN6 qudt:symbol "oz·min/in⁶" .
+
+  # WRONG SYMBOL  : unit:OZ-PER-DAY - calculated from factors: oz/d, actual: oz/day
+  #
+  #  ──┬ unit:OZ-PER-DAY symbol: oz/day (correct: oz/d)
+  #    ├──┬ unit:OZ symbol: oz
+  #    │  └──┬ unit:LB symbol: lbm
+  #    │     └──┬ unit:KiloGM symbol: kg
+  #    │        └─── unit:GM symbol: g
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:OZ-PER-DAY qudt:symbol "oz/d" .
+
+  # WRONG SYMBOL  : unit:OZ-PER-FT2 - calculated from factors: oz/ft², actual: oz/ft²{US}
+  #
+  #  ──┬ unit:OZ-PER-FT2 symbol: oz/ft²{US} (correct: oz/ft²)
+  #    ├──┬ unit:OZ symbol: oz
+  #    │  └──┬ unit:LB symbol: lbm
+  #    │     └──┬ unit:KiloGM symbol: kg
+  #    │        └─── unit:GM symbol: g
+  #    └──┬ unit:FT^-2 symbol: ft
+  #       └──┬ unit:IN symbol: in
+  #          └─── unit:M symbol: m
+unit:OZ-PER-FT2 qudt:symbol "oz/ft²" .
+
+  # WRONG SYMBOL  : unit:OZ-PER-YD2 - calculated from factors: oz/yd², actual: oz/yd³{US}
+  #
+  #  ──┬ unit:OZ-PER-YD2 symbol: oz/yd³{US} (correct: oz/yd²)
+  #    ├──┬ unit:OZ symbol: oz
+  #    │  └──┬ unit:LB symbol: lbm
+  #    │     └──┬ unit:KiloGM symbol: kg
+  #    │        └─── unit:GM symbol: g
+  #    └──┬ unit:YD^-2 symbol: yd
+  #       └──┬ unit:FT symbol: ft
+  #          └──┬ unit:IN symbol: in
+  #             └─── unit:M symbol: m
+unit:OZ-PER-YD2 qudt:symbol "oz/yd²" .
+
+  # WRONG SYMBOL  : unit:OZ-SEC-PER-IN3-FT3 - calculated from factors: oz·s/(in³·ft³), actual: (oz/in³)/(ft³/s)
+  #
+  #  ──┬ unit:OZ-SEC-PER-IN3-FT3 symbol: (oz/in³)/(ft³/s) (correct: oz·s/(in³·ft³))
+  #    ├──┬ unit:OZ symbol: oz
+  #    │  └──┬ unit:LB symbol: lbm
+  #    │     └──┬ unit:KiloGM symbol: kg
+  #    │        └─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:FT^-3 symbol: ft
+  #       └──┬ unit:IN symbol: in
+  #          └─── unit:M symbol: m
+unit:OZ-SEC-PER-IN3-FT3 qudt:symbol "oz·s/(in³·ft³)" .
+
+  # WRONG SYMBOL  : unit:OZ-SEC-PER-IN3-GAL_UK - calculated from factors: oz·s/(in³·gal{UK}), actual: (oz/in³)/(gal (UK)/s)
+  #
+  #  ──┬ unit:OZ-SEC-PER-IN3-GAL_UK symbol: (oz/in³)/(gal (UK)/s) (correct: oz·s/(in³·gal{UK}))
+  #    ├──┬ unit:OZ symbol: oz
+  #    │  └──┬ unit:LB symbol: lbm
+  #    │     └──┬ unit:KiloGM symbol: kg
+  #    │        └─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:GAL_UK^-1 symbol: gal{UK}
+  #       └──┬ unit:L symbol: L
+  #          └──┬ unit:DeciM3 symbol: dm³
+  #             └──┬ unit:DeciM^3 symbol: dm
+  #                └─── unit:M symbol: m
+unit:OZ-SEC-PER-IN3-GAL_UK qudt:symbol "oz·s/(in³·gal{UK})" .
+
+  # WRONG SYMBOL  : unit:OZ-SEC-PER-IN3-GAL_US - calculated from factors: oz·s/(in³·gal{US}), actual: (oz/in³)/(gal (US)/s)
+  #
+  #  ──┬ unit:OZ-SEC-PER-IN3-GAL_US symbol: (oz/in³)/(gal (US)/s) (correct: oz·s/(in³·gal{US}))
+  #    ├──┬ unit:OZ symbol: oz
+  #    │  └──┬ unit:LB symbol: lbm
+  #    │     └──┬ unit:KiloGM symbol: kg
+  #    │        └─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:GAL_US^-1 symbol: gal{US}
+  #       └──┬ unit:IN^3 symbol: in
+  #          └─── unit:M symbol: m
+unit:OZ-SEC-PER-IN3-GAL_US qudt:symbol "oz·s/(in³·gal{US})" .
+
+  # WRONG SYMBOL  : unit:OZ-SEC-PER-IN3-YD3 - calculated from factors: oz·s/(in³·yd³), actual: (oz/in³)/(yd³/s)
+  #
+  #  ──┬ unit:OZ-SEC-PER-IN3-YD3 symbol: (oz/in³)/(yd³/s) (correct: oz·s/(in³·yd³))
+  #    ├──┬ unit:OZ symbol: oz
+  #    │  └──┬ unit:LB symbol: lbm
+  #    │     └──┬ unit:KiloGM symbol: kg
+  #    │        └─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:YD^-3 symbol: yd
+  #       └──┬ unit:FT symbol: ft
+  #          └──┬ unit:IN symbol: in
+  #             └─── unit:M symbol: m
+unit:OZ-SEC-PER-IN3-YD3 qudt:symbol "oz·s/(in³·yd³)" .
+
+  # WRONG SYMBOL  : unit:OZ-SEC-PER-IN6 - calculated from factors: oz·s/in⁶, actual: (oz/in³)/(in³/s)
+  #
+  #  ──┬ unit:OZ-SEC-PER-IN6 symbol: (oz/in³)/(in³/s) (correct: oz·s/in⁶)
+  #    ├──┬ unit:OZ symbol: oz
+  #    │  └──┬ unit:LB symbol: lbm
+  #    │     └──┬ unit:KiloGM symbol: kg
+  #    │        └─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    └──┬ unit:IN^-6 symbol: in
+  #       └─── unit:M symbol: m
+unit:OZ-SEC-PER-IN6 qudt:symbol "oz·s/in⁶" .
+
+  # WRONG SYMBOL  : unit:OZ_VOL_UK-PER-DAY - calculated from factors: oz{UK}/d, actual: oz{UK}/day
+  #
+  #  ──┬ unit:OZ_VOL_UK-PER-DAY symbol: oz{UK}/day (correct: oz{UK}/d)
+  #    ├──┬ unit:OZ_VOL_UK symbol: oz{UK}
+  #    │  └──┬ unit:M3 symbol: m³
+  #    │     └─── unit:M^3 symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:OZ_VOL_UK-PER-DAY qudt:symbol "oz{UK}/d" .
+
+  # WRONG SYMBOL  : unit:OZ_VOL_US-PER-DAY - calculated from factors: fl oz{US}/d, actual: fl oz{US}/day
+  #
+  #  ──┬ unit:OZ_VOL_US-PER-DAY symbol: fl oz{US}/day (correct: fl oz{US}/d)
+  #    ├──┬ unit:OZ_VOL_US symbol: fl oz{US}
+  #    │  └──┬ unit:M3 symbol: m³
+  #    │     └─── unit:M^3 symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:OZ_VOL_US-PER-DAY qudt:symbol "fl oz{US}/d" .
+
+  # WRONG SYMBOL  : unit:PA-M2-PER-KiloGM - calculated from factors: Pa·m²/kg, actual: Pa/(kg/m²)
+  #
+  #  ──┬ unit:PA-M2-PER-KiloGM symbol: Pa/(kg/m²) (correct: Pa·m²/kg)
+  #    ├──┬ unit:PA symbol: Pa
+  #    │  ├─── unit:M^-2 symbol: m
+  #    │  └──┬ unit:N symbol: N
+  #    │     ├──┬ unit:KiloGM symbol: kg
+  #    │     │  └─── unit:GM symbol: g
+  #    │     ├─── unit:M symbol: m
+  #    │     └─── unit:SEC^-2 symbol: s
+  #    ├─── unit:M^2 symbol: m
+  #    └──┬ unit:KiloGM^-1 symbol: kg
+  #       └─── unit:GM symbol: g
+unit:PA-M2-PER-KiloGM qudt:symbol "Pa·m²/kg" .
+
+  # WRONG SYMBOL  : unit:PA-SEC-PER-L - calculated from factors: Pa·s/L, actual: Pa·s/l
+  #
+  #  ──┬ unit:PA-SEC-PER-L symbol: Pa·s/l (correct: Pa·s/L)
+  #    ├──┬ unit:PA symbol: Pa
+  #    │  ├─── unit:M^-2 symbol: m
+  #    │  └──┬ unit:N symbol: N
+  #    │     ├──┬ unit:KiloGM symbol: kg
+  #    │     │  └─── unit:GM symbol: g
+  #    │     ├─── unit:M symbol: m
+  #    │     └─── unit:SEC^-2 symbol: s
+  #    ├─── unit:SEC symbol: s
+  #    └──┬ unit:L^-1 symbol: L
+  #       └──┬ unit:DeciM3 symbol: dm³
+  #          └──┬ unit:DeciM^3 symbol: dm
+  #             └─── unit:M symbol: m
+unit:PA-SEC-PER-L qudt:symbol "Pa·s/L" .
+
+  # WRONG SYMBOL  : unit:PDL-SEC-PER-FT2 - calculated from factors: pdl·s/ft², actual: pdl/ft²)·s
+  #
+  #  ──┬ unit:PDL-SEC-PER-FT2 symbol: pdl/ft²)·s (correct: pdl·s/ft²)
+  #    ├──┬ unit:PDL symbol: pdl
+  #    │  └──┬ unit:N symbol: N
+  #    │     ├──┬ unit:KiloGM symbol: kg
+  #    │     │  └─── unit:GM symbol: g
+  #    │     ├─── unit:M symbol: m
+  #    │     └─── unit:SEC^-2 symbol: s
+  #    ├─── unit:SEC symbol: s
+  #    └──┬ unit:FT^-2 symbol: ft
+  #       └──┬ unit:IN symbol: in
+  #          └─── unit:M symbol: m
+unit:PDL-SEC-PER-FT2 qudt:symbol "pdl·s/ft²" .
+
+  # WRONG SYMBOL  : unit:PER-DAY - calculated from factors: /d, actual: /day
+  #
+  #  ──┬ unit:PER-DAY symbol: /day (correct: /d)
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:PER-DAY qudt:symbol "/d" .
+
+  # WRONG SYMBOL  : unit:PER-DEG_F - calculated from factors: /°F, actual: °F⁻¹
+  #
+  #  ──┬ unit:PER-DEG_F symbol: °F⁻¹ (correct: /°F)
+  #    └──┬ unit:DEG_F^-1 symbol: °F
+  #       └─── unit:K symbol: K
+unit:PER-DEG_F qudt:symbol "/°F" .
+
+  # WRONG SYMBOL  : unit:PER-IN - calculated from factors: /in, actual: in⁻¹
+  #
+  #  ──┬ unit:PER-IN symbol: in⁻¹ (correct: /in)
+  #    └──┬ unit:IN^-1 symbol: in
+  #       └─── unit:M symbol: m
+unit:PER-IN qudt:symbol "/in" .
+
+  # WRONG SYMBOL  : unit:PER-J - calculated from factors: /J, actual: J⁻¹
+  #
+  #  ──┬ unit:PER-J symbol: J⁻¹ (correct: /J)
+  #    └──┬ unit:J^-1 symbol: J
+  #       ├─── unit:M symbol: m
+  #       └──┬ unit:N symbol: N
+  #          ├──┬ unit:KiloGM symbol: kg
+  #          │  └─── unit:GM symbol: g
+  #          ├─── unit:M symbol: m
+  #          └─── unit:SEC^-2 symbol: s
+unit:PER-J qudt:symbol "/J" .
+
+  # WRONG SYMBOL  : unit:PER-KiloGM - calculated from factors: /kg, actual: kg⁻¹
+  #
+  #  ──┬ unit:PER-KiloGM symbol: kg⁻¹ (correct: /kg)
+  #    └──┬ unit:KiloGM^-1 symbol: kg
+  #       └─── unit:GM symbol: g
+unit:PER-KiloGM qudt:symbol "/kg" .
+
+  # WRONG SYMBOL  : unit:PER-LB - calculated from factors: /lbm, actual: lb⁻¹
+  #
+  #  ──┬ unit:PER-LB symbol: lb⁻¹ (correct: /lbm)
+  #    └──┬ unit:LB^-1 symbol: lbm
+  #       └──┬ unit:KiloGM symbol: kg
+  #          └─── unit:GM symbol: g
+unit:PER-LB qudt:symbol "/lbm" .
+
+  # WRONG SYMBOL  : unit:PER-M3 - calculated from factors: /m³, actual: m⁻³
+  #
+  #  ──┬ unit:PER-M3 symbol: m⁻³ (correct: /m³)
+  #    └─── unit:M^-3 symbol: m
+unit:PER-M3 qudt:symbol "/m³" .
+
+  # WRONG SYMBOL  : unit:PER-MicroM - calculated from factors: /μm, actual: /µm
+  #
+  #  ──┬ unit:PER-MicroM symbol: /µm (correct: /μm)
+  #    └──┬ unit:MicroM^-1 symbol: μm
+  #       └─── unit:M symbol: m
+unit:PER-MicroM qudt:symbol "/μm" .
+
+  # WRONG SYMBOL  : unit:PER-MicroMOL-L - calculated from factors: /(μmol·L), actual: /(µmol·L)
+  #
+  #  ──┬ unit:PER-MicroMOL-L symbol: /(µmol·L) (correct: /(μmol·L))
+  #    ├──┬ unit:MicroMOL^-1 symbol: μmol
+  #    │  └─── unit:MOL symbol: mol
+  #    └──┬ unit:L^-1 symbol: L
+  #       └──┬ unit:DeciM3 symbol: dm³
+  #          └──┬ unit:DeciM^3 symbol: dm
+  #             └─── unit:M symbol: m
+unit:PER-MicroMOL-L qudt:symbol "/(μmol·L)" .
+
+  # WRONG SYMBOL  : unit:PER-MilliGM - calculated from factors: /mg, actual: mg⁻¹
+  #
+  #  ──┬ unit:PER-MilliGM symbol: mg⁻¹ (correct: /mg)
+  #    └──┬ unit:MilliGM^-1 symbol: mg
+  #       └─── unit:GM symbol: g
+unit:PER-MilliGM qudt:symbol "/mg" .
+
+  # WRONG SYMBOL  : unit:PER-OZ - calculated from factors: /oz, actual: oz⁻¹
+  #
+  #  ──┬ unit:PER-OZ symbol: oz⁻¹ (correct: /oz)
+  #    └──┬ unit:OZ^-1 symbol: oz
+  #       └──┬ unit:LB symbol: lbm
+  #          └──┬ unit:KiloGM symbol: kg
+  #             └─── unit:GM symbol: g
+unit:PER-OZ qudt:symbol "/oz" .
+
+  # WRONG SYMBOL  : unit:PER-PA - calculated from factors: /Pa, actual: Pa⁻¹
+  #
+  #  ──┬ unit:PER-PA symbol: Pa⁻¹ (correct: /Pa)
+  #    └──┬ unit:PA^-1 symbol: Pa
+  #       ├─── unit:M^-2 symbol: m
+  #       └──┬ unit:N symbol: N
+  #          ├──┬ unit:KiloGM symbol: kg
+  #          │  └─── unit:GM symbol: g
+  #          ├─── unit:M symbol: m
+  #          └─── unit:SEC^-2 symbol: s
+unit:PER-PA qudt:symbol "/Pa" .
+
+  # WRONG SYMBOL  : unit:PER-PlanckMass2 - calculated from factors: /planckmass², actual: /mₚ²
+  #
+  #  ──┬ unit:PER-PlanckMass2 symbol: /mₚ² (correct: /planckmass²)
+  #    └──┬ unit:PlanckMass^-2 symbol: planckmass
+  #       └──┬ unit:KiloGM symbol: kg
+  #          └─── unit:GM symbol: g
+unit:PER-PlanckMass2 qudt:symbol "/planckmass²" .
+
+  # WRONG SYMBOL  : unit:PER-RAD - calculated from factors: /rad, actual: rad⁻¹
+  #
+  #  ──┬ unit:PER-RAD symbol: rad⁻¹ (correct: /rad)
+  #    └──┬ unit:RAD^-1 symbol: rad
+  #       ├─── unit:M^-1 symbol: m
+  #       └─── unit:M symbol: m
+unit:PER-RAD qudt:symbol "/rad" .
+
+  # WRONG SYMBOL  : unit:PER-SEC-M2 - calculated from factors: /(s·m²), actual: s⁻¹·m⁻²
+  #
+  #  ──┬ unit:PER-SEC-M2 symbol: s⁻¹·m⁻² (correct: /(s·m²))
+  #    ├─── unit:SEC^-1 symbol: s
+  #    └─── unit:M^-2 symbol: m
+unit:PER-SEC-M2 qudt:symbol "/(s·m²)" .
+
+  # WRONG SYMBOL  : unit:PER-SEC-M3 - calculated from factors: /(s·m³), actual: s⁻¹·m⁻³
+  #
+  #  ──┬ unit:PER-SEC-M3 symbol: s⁻¹·m⁻³ (correct: /(s·m³))
+  #    ├─── unit:SEC^-1 symbol: s
+  #    └─── unit:M^-3 symbol: m
+unit:PER-SEC-M3 qudt:symbol "/(s·m³)" .
+
+  # WRONG SYMBOL  : unit:PER-SEC-SR - calculated from factors: /(s·sr), actual: /s·sr
+  #
+  #  ──┬ unit:PER-SEC-SR symbol: /s·sr (correct: /(s·sr))
+  #    ├─── unit:SEC^-1 symbol: s
+  #    └──┬ unit:SR^-1 symbol: sr
+  #       ├─── unit:M^-2 symbol: m
+  #       └─── unit:M^2 symbol: m
+unit:PER-SEC-SR qudt:symbol "/(s·sr)" .
+
+  # WRONG SYMBOL  : unit:PER-SEC-SR-M2 - calculated from factors: /(s·sr·m²), actual: s⁻¹·sr⁻¹·m⁻²
+  #
+  #  ──┬ unit:PER-SEC-SR-M2 symbol: s⁻¹·sr⁻¹·m⁻² (correct: /(s·sr·m²))
+  #    ├─── unit:SEC^-1 symbol: s
+  #    ├──┬ unit:SR^-1 symbol: sr
+  #    │  ├─── unit:M^-2 symbol: m
+  #    │  └─── unit:M^2 symbol: m
+  #    └─── unit:M^-2 symbol: m
+unit:PER-SEC-SR-M2 qudt:symbol "/(s·sr·m²)" .
+
+  # WRONG SYMBOL  : unit:PER-TON - calculated from factors: /tn, actual: st⁻¹
+  #
+  #  ──┬ unit:PER-TON symbol: st⁻¹ (correct: /tn)
+  #    └──┬ unit:TON^-1 symbol: tn
+  #       └──┬ unit:KiloGM symbol: kg
+  #          └─── unit:GM symbol: g
+unit:PER-TON qudt:symbol "/tn" .
+
+  # WRONG SYMBOL  : unit:PER-TONNE - calculated from factors: /t, actual: t⁻¹
+  #
+  #  ──┬ unit:PER-TONNE symbol: t⁻¹ (correct: /t)
+  #    └──┬ unit:TONNE^-1 symbol: t
+  #       └──┬ unit:KiloGM symbol: kg
+  #          └─── unit:GM symbol: g
+unit:PER-TONNE qudt:symbol "/t" .
+
+  # WRONG SYMBOL  : unit:PER-V - calculated from factors: /V, actual: V⁻¹
+  #
+  #  ──┬ unit:PER-V symbol: V⁻¹ (correct: /V)
+  #    └──┬ unit:V^-1 symbol: V
+  #       ├─── unit:A^-1 symbol: A
+  #       └──┬ unit:W symbol: W
+  #          ├──┬ unit:J symbol: J
+  #          │  ├─── unit:M symbol: m
+  #          │  └──┬ unit:N symbol: N
+  #          │     ├──┬ unit:KiloGM symbol: kg
+  #          │     │  └─── unit:GM symbol: g
+  #          │     ├─── unit:M symbol: m
+  #          │     └─── unit:SEC^-2 symbol: s
+  #          └─── unit:SEC^-1 symbol: s
+unit:PER-V qudt:symbol "/V" .
+
+  # WRONG SYMBOL  : unit:PER-V-A-SEC - calculated from factors: /(V·A·s), actual: /VAs
+  #
+  #  ──┬ unit:PER-V-A-SEC symbol: /VAs (correct: /(V·A·s))
+  #    ├──┬ unit:V^-1 symbol: V
+  #    │  ├─── unit:A^-1 symbol: A
+  #    │  └──┬ unit:W symbol: W
+  #    │     ├──┬ unit:J symbol: J
+  #    │     │  ├─── unit:M symbol: m
+  #    │     │  └──┬ unit:N symbol: N
+  #    │     │     ├──┬ unit:KiloGM symbol: kg
+  #    │     │     │  └─── unit:GM symbol: g
+  #    │     │     ├─── unit:M symbol: m
+  #    │     │     └─── unit:SEC^-2 symbol: s
+  #    │     └─── unit:SEC^-1 symbol: s
+  #    ├─── unit:A^-1 symbol: A
+  #    └─── unit:SEC^-1 symbol: s
+unit:PER-V-A-SEC qudt:symbol "/(V·A·s)" .
+
+  # WRONG SYMBOL  : unit:PERCENT-FT-HR-PER-LB - calculated from factors: ft·h·%/lbm, actual: %/(lb/(ft·h))
+  #
+  #  ──┬ unit:PERCENT-FT-HR-PER-LB symbol: %/(lb/(ft·h)) (correct: ft·h·%/lbm)
+  #    ├──┬ unit:FT symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:LB^-1 symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    └─── unit:PERCENT symbol: %
+unit:PERCENT-FT-HR-PER-LB qudt:symbol "ft·h·%/lbm" .
+
+  # WRONG SYMBOL  : unit:PERCENT-FT-SEC-PER-LB - calculated from factors: ft·%·s/lbm, actual: %/(lb/(ft·s))
+  #
+  #  ──┬ unit:PERCENT-FT-SEC-PER-LB symbol: %/(lb/(ft·s)) (correct: ft·%·s/lbm)
+  #    ├──┬ unit:FT symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    ├──┬ unit:LB^-1 symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├─── unit:PERCENT symbol: %
+  #    └─── unit:SEC symbol: s
+unit:PERCENT-FT-SEC-PER-LB qudt:symbol "ft·%·s/lbm" .
+
+  # WRONG SYMBOL  : unit:PERCENT-FT2-PER-LB_F-SEC - calculated from factors: ft²·%/(lbf·s), actual: %/(lbf·s/ft²)
+  #
+  #  ──┬ unit:PERCENT-FT2-PER-LB_F-SEC symbol: %/(lbf·s/ft²) (correct: ft²·%/(lbf·s))
+  #    ├──┬ unit:FT^2 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    ├──┬ unit:LB_F^-1 symbol: lbf
+  #    │  ├──┬ unit:FT symbol: ft
+  #    │  │  └──┬ unit:IN symbol: in
+  #    │  │     └─── unit:M symbol: m
+  #    │  ├─── unit:SEC^-2 symbol: s
+  #    │  └──┬ unit:SLUG symbol: slug
+  #    │     └──┬ unit:LB symbol: lbm
+  #    │        └──┬ unit:KiloGM symbol: kg
+  #    │           └─── unit:GM symbol: g
+  #    ├─── unit:PERCENT symbol: %
+  #    └─── unit:SEC^-1 symbol: s
+unit:PERCENT-FT2-PER-LB_F-SEC qudt:symbol "ft²·%/(lbf·s)" .
+
+  # WRONG SYMBOL  : unit:PERCENT-HR-PER-CentiM3 - calculated from factors: h·%/cm³, actual: %/(cm³/h)
+  #
+  #  ──┬ unit:PERCENT-HR-PER-CentiM3 symbol: %/(cm³/h) (correct: h·%/cm³)
+  #    ├──┬ unit:CentiM^-3 symbol: cm
+  #    │  └─── unit:M symbol: m
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    └─── unit:PERCENT symbol: %
+unit:PERCENT-HR-PER-CentiM3 qudt:symbol "h·%/cm³" .
+
+  # WRONG SYMBOL  : unit:PERCENT-HR-PER-FT3 - calculated from factors: h·%/ft³, actual: %/(ft³/h)
+  #
+  #  ──┬ unit:PERCENT-HR-PER-FT3 symbol: %/(ft³/h) (correct: h·%/ft³)
+  #    ├──┬ unit:FT^-3 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    └─── unit:PERCENT symbol: %
+unit:PERCENT-HR-PER-FT3 qudt:symbol "h·%/ft³" .
+
+  # WRONG SYMBOL  : unit:PERCENT-HR-PER-GAL_UK - calculated from factors: h·%/gal{UK}, actual: %/(gal (UK)/h)
+  #
+  #  ──┬ unit:PERCENT-HR-PER-GAL_UK symbol: %/(gal (UK)/h) (correct: h·%/gal{UK})
+  #    ├──┬ unit:GAL_UK^-1 symbol: gal{UK}
+  #    │  └──┬ unit:L symbol: L
+  #    │     └──┬ unit:DeciM3 symbol: dm³
+  #    │        └──┬ unit:DeciM^3 symbol: dm
+  #    │           └─── unit:M symbol: m
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    └─── unit:PERCENT symbol: %
+unit:PERCENT-HR-PER-GAL_UK qudt:symbol "h·%/gal{UK}" .
+
+  # WRONG SYMBOL  : unit:PERCENT-HR-PER-GAL_US - calculated from factors: h·%/gal{US}, actual: %/(gal (US)/h)
+  #
+  #  ──┬ unit:PERCENT-HR-PER-GAL_US symbol: %/(gal (US)/h) (correct: h·%/gal{US})
+  #    ├──┬ unit:GAL_US^-1 symbol: gal{US}
+  #    │  └──┬ unit:IN^3 symbol: in
+  #    │     └─── unit:M symbol: m
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    └─── unit:PERCENT symbol: %
+unit:PERCENT-HR-PER-GAL_US qudt:symbol "h·%/gal{US}" .
+
+  # WRONG SYMBOL  : unit:PERCENT-HR-PER-IN3 - calculated from factors: h·%/in³, actual: %/(in³/h)
+  #
+  #  ──┬ unit:PERCENT-HR-PER-IN3 symbol: %/(in³/h) (correct: h·%/in³)
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └─── unit:PERCENT symbol: %
+unit:PERCENT-HR-PER-IN3 qudt:symbol "h·%/in³" .
+
+  # WRONG SYMBOL  : unit:PERCENT-HR-PER-L - calculated from factors: h·%/L, actual: %/(l/h)
+  #
+  #  ──┬ unit:PERCENT-HR-PER-L symbol: %/(l/h) (correct: h·%/L)
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └─── unit:PERCENT symbol: %
+unit:PERCENT-HR-PER-L qudt:symbol "h·%/L" .
+
+  # WRONG SYMBOL  : unit:PERCENT-HR-PER-M3 - calculated from factors: h·%/m³, actual: %/(m³/h)
+  #
+  #  ──┬ unit:PERCENT-HR-PER-M3 symbol: %/(m³/h) (correct: h·%/m³)
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├─── unit:M^-3 symbol: m
+  #    └─── unit:PERCENT symbol: %
+unit:PERCENT-HR-PER-M3 qudt:symbol "h·%/m³" .
+
+  # WRONG SYMBOL  : unit:PERCENT-HR-PER-YD3 - calculated from factors: h·%/yd³, actual: %/(yd³/h)
+  #
+  #  ──┬ unit:PERCENT-HR-PER-YD3 symbol: %/(yd³/h) (correct: h·%/yd³)
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├─── unit:PERCENT symbol: %
+  #    └──┬ unit:YD^-3 symbol: yd
+  #       └──┬ unit:FT symbol: ft
+  #          └──┬ unit:IN symbol: in
+  #             └─── unit:M symbol: m
+unit:PERCENT-HR-PER-YD3 qudt:symbol "h·%/yd³" .
+
+  # WRONG SYMBOL  : unit:PERCENT-IN2-PER-LB_F-SEC - calculated from factors: in²·%/(lbf·s), actual: %/(lbf·s/in²)
+  #
+  #  ──┬ unit:PERCENT-IN2-PER-LB_F-SEC symbol: %/(lbf·s/in²) (correct: in²·%/(lbf·s))
+  #    ├──┬ unit:IN^2 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    ├──┬ unit:LB_F^-1 symbol: lbf
+  #    │  ├──┬ unit:FT symbol: ft
+  #    │  │  └──┬ unit:IN symbol: in
+  #    │  │     └─── unit:M symbol: m
+  #    │  ├─── unit:SEC^-2 symbol: s
+  #    │  └──┬ unit:SLUG symbol: slug
+  #    │     └──┬ unit:LB symbol: lbm
+  #    │        └──┬ unit:KiloGM symbol: kg
+  #    │           └─── unit:GM symbol: g
+  #    ├─── unit:PERCENT symbol: %
+  #    └─── unit:SEC^-1 symbol: s
+unit:PERCENT-IN2-PER-LB_F-SEC qudt:symbol "in²·%/(lbf·s)" .
+
+  # WRONG SYMBOL  : unit:PERCENT-MIN-PER-CentiM3 - calculated from factors: min·%/cm³, actual: %/(cm³/min)
+  #
+  #  ──┬ unit:PERCENT-MIN-PER-CentiM3 symbol: %/(cm³/min) (correct: min·%/cm³)
+  #    ├──┬ unit:CentiM^-3 symbol: cm
+  #    │  └─── unit:M symbol: m
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    └─── unit:PERCENT symbol: %
+unit:PERCENT-MIN-PER-CentiM3 qudt:symbol "min·%/cm³" .
+
+  # WRONG SYMBOL  : unit:PERCENT-MIN-PER-FT3 - calculated from factors: min·%/ft³, actual: %/(ft³/min)
+  #
+  #  ──┬ unit:PERCENT-MIN-PER-FT3 symbol: %/(ft³/min) (correct: min·%/ft³)
+  #    ├──┬ unit:FT^-3 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    └─── unit:PERCENT symbol: %
+unit:PERCENT-MIN-PER-FT3 qudt:symbol "min·%/ft³" .
+
+  # WRONG SYMBOL  : unit:PERCENT-MIN-PER-GAL_UK - calculated from factors: min·%/gal{UK}, actual: %/(gal (UK)/min)
+  #
+  #  ──┬ unit:PERCENT-MIN-PER-GAL_UK symbol: %/(gal (UK)/min) (correct: min·%/gal{UK})
+  #    ├──┬ unit:GAL_UK^-1 symbol: gal{UK}
+  #    │  └──┬ unit:L symbol: L
+  #    │     └──┬ unit:DeciM3 symbol: dm³
+  #    │        └──┬ unit:DeciM^3 symbol: dm
+  #    │           └─── unit:M symbol: m
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    └─── unit:PERCENT symbol: %
+unit:PERCENT-MIN-PER-GAL_UK qudt:symbol "min·%/gal{UK}" .
+
+  # WRONG SYMBOL  : unit:PERCENT-MIN-PER-GAL_US - calculated from factors: min·%/gal{US}, actual: %/(gal (US)/min)
+  #
+  #  ──┬ unit:PERCENT-MIN-PER-GAL_US symbol: %/(gal (US)/min) (correct: min·%/gal{US})
+  #    ├──┬ unit:GAL_US^-1 symbol: gal{US}
+  #    │  └──┬ unit:IN^3 symbol: in
+  #    │     └─── unit:M symbol: m
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    └─── unit:PERCENT symbol: %
+unit:PERCENT-MIN-PER-GAL_US qudt:symbol "min·%/gal{US}" .
+
+  # WRONG SYMBOL  : unit:PERCENT-MIN-PER-IN3 - calculated from factors: min·%/in³, actual: %/(in³/min)
+  #
+  #  ──┬ unit:PERCENT-MIN-PER-IN3 symbol: %/(in³/min) (correct: min·%/in³)
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    └─── unit:PERCENT symbol: %
+unit:PERCENT-MIN-PER-IN3 qudt:symbol "min·%/in³" .
+
+  # WRONG SYMBOL  : unit:PERCENT-MIN-PER-L - calculated from factors: min·%/L, actual: %/(l/min)
+  #
+  #  ──┬ unit:PERCENT-MIN-PER-L symbol: %/(l/min) (correct: min·%/L)
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    └─── unit:PERCENT symbol: %
+unit:PERCENT-MIN-PER-L qudt:symbol "min·%/L" .
+
+  # WRONG SYMBOL  : unit:PERCENT-MIN-PER-M3 - calculated from factors: min·%/m³, actual: %/(m³/min)
+  #
+  #  ──┬ unit:PERCENT-MIN-PER-M3 symbol: %/(m³/min) (correct: min·%/m³)
+  #    ├─── unit:M^-3 symbol: m
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    └─── unit:PERCENT symbol: %
+unit:PERCENT-MIN-PER-M3 qudt:symbol "min·%/m³" .
+
+  # WRONG SYMBOL  : unit:PERCENT-MIN-PER-YD3 - calculated from factors: min·%/yd³, actual: %/(yd³/min)
+  #
+  #  ──┬ unit:PERCENT-MIN-PER-YD3 symbol: %/(yd³/min) (correct: min·%/yd³)
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    ├─── unit:PERCENT symbol: %
+  #    └──┬ unit:YD^-3 symbol: yd
+  #       └──┬ unit:FT symbol: ft
+  #          └──┬ unit:IN symbol: in
+  #             └─── unit:M symbol: m
+unit:PERCENT-MIN-PER-YD3 qudt:symbol "min·%/yd³" .
+
+  # WRONG SYMBOL  : unit:PERCENT-PER-DAY - calculated from factors: %/d, actual: %/day
+  #
+  #  ──┬ unit:PERCENT-PER-DAY symbol: %/day (correct: %/d)
+  #    ├──┬ unit:DAY^-1 symbol: d
+  #    │  └─── unit:SEC symbol: s
+  #    └─── unit:PERCENT symbol: %
+unit:PERCENT-PER-DAY qudt:symbol "%/d" .
+
+  # WRONG SYMBOL  : unit:PERCENT-PER-OHM - calculated from factors: %/Ω, actual: %/Ω
+  #
+  #  ──┬ unit:PERCENT-PER-OHM symbol: %/Ω (correct: %/Ω)
+  #    ├──┬ unit:OHM^-1 symbol: Ω
+  #    │  ├─── unit:A^-1 symbol: A
+  #    │  └──┬ unit:V symbol: V
+  #    │     ├─── unit:A^-1 symbol: A
+  #    │     └──┬ unit:W symbol: W
+  #    │        ├──┬ unit:J symbol: J
+  #    │        │  ├─── unit:M symbol: m
+  #    │        │  └──┬ unit:N symbol: N
+  #    │        │     ├──┬ unit:KiloGM symbol: kg
+  #    │        │     │  └─── unit:GM symbol: g
+  #    │        │     ├─── unit:M symbol: m
+  #    │        │     └─── unit:SEC^-2 symbol: s
+  #    │        └─── unit:SEC^-1 symbol: s
+  #    └─── unit:PERCENT symbol: %
+unit:PERCENT-PER-OHM qudt:symbol "%/Ω" .
+
+  # WRONG SYMBOL  : unit:PERCENT-SEC-PER-CentiM3 - calculated from factors: %·s/cm³, actual: %/(cm³/s)
+  #
+  #  ──┬ unit:PERCENT-SEC-PER-CentiM3 symbol: %/(cm³/s) (correct: %·s/cm³)
+  #    ├──┬ unit:CentiM^-3 symbol: cm
+  #    │  └─── unit:M symbol: m
+  #    ├─── unit:PERCENT symbol: %
+  #    └─── unit:SEC symbol: s
+unit:PERCENT-SEC-PER-CentiM3 qudt:symbol "%·s/cm³" .
+
+  # WRONG SYMBOL  : unit:PERCENT-SEC-PER-FT3 - calculated from factors: %·s/ft³, actual: %/(ft³/s)
+  #
+  #  ──┬ unit:PERCENT-SEC-PER-FT3 symbol: %/(ft³/s) (correct: %·s/ft³)
+  #    ├──┬ unit:FT^-3 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    ├─── unit:PERCENT symbol: %
+  #    └─── unit:SEC symbol: s
+unit:PERCENT-SEC-PER-FT3 qudt:symbol "%·s/ft³" .
+
+  # WRONG SYMBOL  : unit:PERCENT-SEC-PER-GAL_UK - calculated from factors: %·s/gal{UK}, actual: %/(gal (UK)/s)
+  #
+  #  ──┬ unit:PERCENT-SEC-PER-GAL_UK symbol: %/(gal (UK)/s) (correct: %·s/gal{UK})
+  #    ├──┬ unit:GAL_UK^-1 symbol: gal{UK}
+  #    │  └──┬ unit:L symbol: L
+  #    │     └──┬ unit:DeciM3 symbol: dm³
+  #    │        └──┬ unit:DeciM^3 symbol: dm
+  #    │           └─── unit:M symbol: m
+  #    ├─── unit:PERCENT symbol: %
+  #    └─── unit:SEC symbol: s
+unit:PERCENT-SEC-PER-GAL_UK qudt:symbol "%·s/gal{UK}" .
+
+  # WRONG SYMBOL  : unit:PERCENT-SEC-PER-GAL_US - calculated from factors: %·s/gal{US}, actual: %/(gal (US)/s)
+  #
+  #  ──┬ unit:PERCENT-SEC-PER-GAL_US symbol: %/(gal (US)/s) (correct: %·s/gal{US})
+  #    ├──┬ unit:GAL_US^-1 symbol: gal{US}
+  #    │  └──┬ unit:IN^3 symbol: in
+  #    │     └─── unit:M symbol: m
+  #    ├─── unit:PERCENT symbol: %
+  #    └─── unit:SEC symbol: s
+unit:PERCENT-SEC-PER-GAL_US qudt:symbol "%·s/gal{US}" .
+
+  # WRONG SYMBOL  : unit:PERCENT-SEC-PER-IN3 - calculated from factors: %·s/in³, actual: %/(in³/s)
+  #
+  #  ──┬ unit:PERCENT-SEC-PER-IN3 symbol: %/(in³/s) (correct: %·s/in³)
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    ├─── unit:PERCENT symbol: %
+  #    └─── unit:SEC symbol: s
+unit:PERCENT-SEC-PER-IN3 qudt:symbol "%·s/in³" .
+
+  # WRONG SYMBOL  : unit:PERCENT-SEC-PER-L - calculated from factors: %·s/L, actual: %/(l/s)
+  #
+  #  ──┬ unit:PERCENT-SEC-PER-L symbol: %/(l/s) (correct: %·s/L)
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    ├─── unit:PERCENT symbol: %
+  #    └─── unit:SEC symbol: s
+unit:PERCENT-SEC-PER-L qudt:symbol "%·s/L" .
+
+  # WRONG SYMBOL  : unit:PERCENT-SEC-PER-M3 - calculated from factors: %·s/m³, actual: %/(m³/s)
+  #
+  #  ──┬ unit:PERCENT-SEC-PER-M3 symbol: %/(m³/s) (correct: %·s/m³)
+  #    ├─── unit:M^-3 symbol: m
+  #    ├─── unit:PERCENT symbol: %
+  #    └─── unit:SEC symbol: s
+unit:PERCENT-SEC-PER-M3 qudt:symbol "%·s/m³" .
+
+  # WRONG SYMBOL  : unit:PERCENT-SEC-PER-YD3 - calculated from factors: %·s/yd³, actual: %/(yd³/s)
+  #
+  #  ──┬ unit:PERCENT-SEC-PER-YD3 symbol: %/(yd³/s) (correct: %·s/yd³)
+  #    ├─── unit:PERCENT symbol: %
+  #    ├─── unit:SEC symbol: s
+  #    └──┬ unit:YD^-3 symbol: yd
+  #       └──┬ unit:FT symbol: ft
+  #          └──┬ unit:IN symbol: in
+  #             └─── unit:M symbol: m
+unit:PERCENT-SEC-PER-YD3 qudt:symbol "%·s/yd³" .
+
+  # WRONG SYMBOL  : unit:PINT_UK-PER-DAY - calculated from factors: pt{UK}/d, actual: pt{UK}/day
+  #
+  #  ──┬ unit:PINT_UK-PER-DAY symbol: pt{UK}/day (correct: pt{UK}/d)
+  #    ├──┬ unit:PINT_UK symbol: pt{UK}
+  #    │  └──┬ unit:QT_UK symbol: qt{UK}
+  #    │     └──┬ unit:GAL_UK symbol: gal{UK}
+  #    │        └──┬ unit:L symbol: L
+  #    │           └──┬ unit:DeciM3 symbol: dm³
+  #    │              └──┬ unit:DeciM^3 symbol: dm
+  #    │                 └─── unit:M symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:PINT_UK-PER-DAY qudt:symbol "pt{UK}/d" .
+
+  # WRONG SYMBOL  : unit:PINT_US-PER-DAY - calculated from factors: pt{US}/d, actual: pt{US}/day
+  #
+  #  ──┬ unit:PINT_US-PER-DAY symbol: pt{US}/day (correct: pt{US}/d)
+  #    ├──┬ unit:PINT_US symbol: pt{US}
+  #    │  └──┬ unit:QT_US symbol: qt{US liq}
+  #    │     └──┬ unit:GAL_US symbol: gal{US}
+  #    │        └──┬ unit:IN^3 symbol: in
+  #    │           └─── unit:M symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:PINT_US-PER-DAY qudt:symbol "pt{US}/d" .
+
+  # WRONG SYMBOL  : unit:PK_UK-PER-DAY - calculated from factors: peck{UK}/d, actual: peck{UK}/day
+  #
+  #  ──┬ unit:PK_UK-PER-DAY symbol: peck{UK}/day (correct: peck{UK}/d)
+  #    ├──┬ unit:PK_UK symbol: peck{UK}
+  #    │  └──┬ unit:M3 symbol: m³
+  #    │     └─── unit:M^3 symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:PK_UK-PER-DAY qudt:symbol "peck{UK}/d" .
+
+  # WRONG SYMBOL  : unit:PK_US_DRY-PER-DAY - calculated from factors: peck{US Dry}/d, actual: peck{US Dry}/day
+  #
+  #  ──┬ unit:PK_US_DRY-PER-DAY symbol: peck{US Dry}/day (correct: peck{US Dry}/d)
+  #    ├──┬ unit:PK_US_DRY symbol: peck{US Dry}
+  #    │  └──┬ unit:M3 symbol: m³
+  #    │     └─── unit:M^3 symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:PK_US_DRY-PER-DAY qudt:symbol "peck{US Dry}/d" .
+
+  # WRONG SYMBOL  : unit:PicoA-PER-MicroMOL-L - calculated from factors: pA/(μmol·L), actual: pA/(µmol·L)
+  #
+  #  ──┬ unit:PicoA-PER-MicroMOL-L symbol: pA/(µmol·L) (correct: pA/(μmol·L))
+  #    ├──┬ unit:PicoA symbol: pA
+  #    │  └─── unit:A symbol: A
+  #    ├──┬ unit:MicroMOL^-1 symbol: μmol
+  #    │  └─── unit:MOL symbol: mol
+  #    └──┬ unit:L^-1 symbol: L
+  #       └──┬ unit:DeciM3 symbol: dm³
+  #          └──┬ unit:DeciM^3 symbol: dm
+  #             └─── unit:M symbol: m
+unit:PicoA-PER-MicroMOL-L qudt:symbol "pA/(μmol·L)" .
+
+  # WRONG SYMBOL  : unit:PicoMOL-PER-L-DAY - calculated from factors: pmol/(L·d), actual: pmol/(L·day)
+  #
+  #  ──┬ unit:PicoMOL-PER-L-DAY symbol: pmol/(L·day) (correct: pmol/(L·d))
+  #    ├──┬ unit:PicoMOL symbol: pmol
+  #    │  └─── unit:MOL symbol: mol
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:PicoMOL-PER-L-DAY qudt:symbol "pmol/(L·d)" .
+
+  # WRONG SYMBOL  : unit:PicoMOL-PER-M2-DAY - calculated from factors: pmol/(m²·d), actual: pmol/(m²·day)
+  #
+  #  ──┬ unit:PicoMOL-PER-M2-DAY symbol: pmol/(m²·day) (correct: pmol/(m²·d))
+  #    ├──┬ unit:PicoMOL symbol: pmol
+  #    │  └─── unit:MOL symbol: mol
+  #    ├─── unit:M^-2 symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:PicoMOL-PER-M2-DAY qudt:symbol "pmol/(m²·d)" .
+
+  # WRONG SYMBOL  : unit:QT_UK-PER-DAY - calculated from factors: qt{UK}/d, actual: qt{UK}/day
+  #
+  #  ──┬ unit:QT_UK-PER-DAY symbol: qt{UK}/day (correct: qt{UK}/d)
+  #    ├──┬ unit:QT_UK symbol: qt{UK}
+  #    │  └──┬ unit:GAL_UK symbol: gal{UK}
+  #    │     └──┬ unit:L symbol: L
+  #    │        └──┬ unit:DeciM3 symbol: dm³
+  #    │           └──┬ unit:DeciM^3 symbol: dm
+  #    │              └─── unit:M symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:QT_UK-PER-DAY qudt:symbol "qt{UK}/d" .
+
+  # WRONG SYMBOL  : unit:QT_US-PER-DAY - calculated from factors: qt{US liq}/d, actual: qt/day
+  #
+  #  ──┬ unit:QT_US-PER-DAY symbol: qt/day (correct: qt{US liq}/d)
+  #    ├──┬ unit:QT_US symbol: qt{US liq}
+  #    │  └──┬ unit:GAL_US symbol: gal{US}
+  #    │     └──┬ unit:IN^3 symbol: in
+  #    │        └─── unit:M symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:QT_US-PER-DAY qudt:symbol "qt{US liq}/d" .
+
+  # WRONG SYMBOL  : unit:QT_US-PER-HR - calculated from factors: qt{US liq}/h, actual: qt/h
+  #
+  #  ──┬ unit:QT_US-PER-HR symbol: qt/h (correct: qt{US liq}/h)
+  #    ├──┬ unit:QT_US symbol: qt{US liq}
+  #    │  └──┬ unit:GAL_US symbol: gal{US}
+  #    │     └──┬ unit:IN^3 symbol: in
+  #    │        └─── unit:M symbol: m
+  #    └──┬ unit:HR^-1 symbol: h
+  #       └─── unit:SEC symbol: s
+unit:QT_US-PER-HR qudt:symbol "qt{US liq}/h" .
+
+  # WRONG SYMBOL  : unit:QT_US-PER-MIN - calculated from factors: qt{US liq}/min, actual: qt/min
+  #
+  #  ──┬ unit:QT_US-PER-MIN symbol: qt/min (correct: qt{US liq}/min)
+  #    ├──┬ unit:QT_US symbol: qt{US liq}
+  #    │  └──┬ unit:GAL_US symbol: gal{US}
+  #    │     └──┬ unit:IN^3 symbol: in
+  #    │        └─── unit:M symbol: m
+  #    └──┬ unit:MIN^-1 symbol: min
+  #       └─── unit:SEC symbol: s
+unit:QT_US-PER-MIN qudt:symbol "qt{US liq}/min" .
+
+  # WRONG SYMBOL  : unit:QT_US-PER-SEC - calculated from factors: qt{US liq}/s, actual: qt/s
+  #
+  #  ──┬ unit:QT_US-PER-SEC symbol: qt/s (correct: qt{US liq}/s)
+  #    ├──┬ unit:QT_US symbol: qt{US liq}
+  #    │  └──┬ unit:GAL_US symbol: gal{US}
+  #    │     └──┬ unit:IN^3 symbol: in
+  #    │        └─── unit:M symbol: m
+  #    └─── unit:SEC^-1 symbol: s
+unit:QT_US-PER-SEC qudt:symbol "qt{US liq}/s" .
+
+  # WRONG SYMBOL  : unit:REV-PER-MIN-SEC - calculated from factors: rev/(min·s), actual: rev/min/s
+  #
+  #  ──┬ unit:REV-PER-MIN-SEC symbol: rev/min/s (correct: rev/(min·s))
+  #    ├─── unit:REV symbol: rev
+  #    ├──┬ unit:MIN^-1 symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    └─── unit:SEC^-1 symbol: s
+unit:REV-PER-MIN-SEC qudt:symbol "rev/(min·s)" .
+
+  # WRONG SYMBOL  : unit:SCF-PER-HR - calculated from factors: scf/h, actual: scfh
+  #
+  #  ──┬ unit:SCF-PER-HR symbol: scfh (correct: scf/h)
+  #    ├─── unit:SCF symbol: scf
+  #    └──┬ unit:HR^-1 symbol: h
+  #       └─── unit:SEC symbol: s
+unit:SCF-PER-HR qudt:symbol "scf/h" .
+
+  # WRONG SYMBOL  : unit:SCF-PER-MIN - calculated from factors: scf/min, actual: scfm
+  #
+  #  ──┬ unit:SCF-PER-MIN symbol: scfm (correct: scf/min)
+  #    ├─── unit:SCF symbol: scf
+  #    └──┬ unit:MIN^-1 symbol: min
+  #       └─── unit:SEC symbol: s
+unit:SCF-PER-MIN qudt:symbol "scf/min" .
+
+  # WRONG SYMBOL  : unit:SCM-PER-HR - calculated from factors: scm/h, actual: scmh
+  #
+  #  ──┬ unit:SCM-PER-HR symbol: scmh (correct: scm/h)
+  #    ├─── unit:SCM symbol: scm
+  #    └──┬ unit:HR^-1 symbol: h
+  #       └─── unit:SEC symbol: s
+unit:SCM-PER-HR qudt:symbol "scm/h" .
+
+  # WRONG SYMBOL  : unit:SCM-PER-MIN - calculated from factors: scm/min, actual: scmm
+  #
+  #  ──┬ unit:SCM-PER-MIN symbol: scmm (correct: scm/min)
+  #    ├─── unit:SCM symbol: scm
+  #    └──┬ unit:MIN^-1 symbol: min
+  #       └─── unit:SEC symbol: s
+unit:SCM-PER-MIN qudt:symbol "scm/min" .
+
+  # WRONG SYMBOL  : unit:SEC-PER-FT2 - calculated from factors: s/ft², actual: (lb/ft³)/(lb/(ft·s)
+  #
+  #  ──┬ unit:SEC-PER-FT2 symbol: (lb/ft³)/(lb/(ft·s) (correct: s/ft²)
+  #    ├─── unit:SEC symbol: s
+  #    └──┬ unit:FT^-2 symbol: ft
+  #       └──┬ unit:IN symbol: in
+  #          └─── unit:M symbol: m
+unit:SEC-PER-FT2 qudt:symbol "s/ft²" .
+
+  # WRONG SYMBOL  : unit:SLUG-PER-DAY - calculated from factors: slug/d, actual: slug/day
+  #
+  #  ──┬ unit:SLUG-PER-DAY symbol: slug/day (correct: slug/d)
+  #    ├──┬ unit:SLUG symbol: slug
+  #    │  └──┬ unit:LB symbol: lbm
+  #    │     └──┬ unit:KiloGM symbol: kg
+  #    │        └─── unit:GM symbol: g
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:SLUG-PER-DAY qudt:symbol "slug/d" .
+
+  # WRONG SYMBOL  : unit:TONNE-PER-DAY - calculated from factors: t/d, actual: t/day
+  #
+  #  ──┬ unit:TONNE-PER-DAY symbol: t/day (correct: t/d)
+  #    ├──┬ unit:TONNE symbol: t
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:TONNE-PER-DAY qudt:symbol "t/d" .
+
+  # WRONG SYMBOL  : unit:TONNE-PER-YR - calculated from factors: t/a, actual: t/y
+  #
+  #  ──┬ unit:TONNE-PER-YR symbol: t/y (correct: t/a)
+  #    ├──┬ unit:TONNE symbol: t
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    └──┬ unit:YR^-1 symbol: a
+  #       └─── unit:SEC symbol: s
+unit:TONNE-PER-YR qudt:symbol "t/a" .
+
+  # WRONG SYMBOL  : unit:TON_Metric-PER-DAY - calculated from factors: t/d, actual: t/day
+  #
+  #  ──┬ unit:TON_Metric-PER-DAY symbol: t/day (correct: t/d)
+  #    ├──┬ unit:TON_Metric symbol: t
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:TON_Metric-PER-DAY qudt:symbol "t/d" .
+
+  # WRONG SYMBOL  : unit:TON_UK-PER-DAY - calculated from factors: ton{UK}/d, actual: ton{UK}/day
+  #
+  #  ──┬ unit:TON_UK-PER-DAY symbol: ton{UK}/day (correct: ton{UK}/d)
+  #    ├──┬ unit:TON_UK symbol: ton{UK}
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:TON_UK-PER-DAY qudt:symbol "ton{UK}/d" .
+
+  # WRONG SYMBOL  : unit:TON_US-PER-DAY - calculated from factors: ton{US}/d, actual: ton{US}/day
+  #
+  #  ──┬ unit:TON_US-PER-DAY symbol: ton{US}/day (correct: ton{US}/d)
+  #    ├──┬ unit:TON_US symbol: ton{US}
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:TON_US-PER-DAY qudt:symbol "ton{US}/d" .
+
+  # WRONG SYMBOL  : unit:V-IN2-PER-LB_F - calculated from factors: V·in²/lbf, actual: V/psi
+  #
+  #  ──┬ unit:V-IN2-PER-LB_F symbol: V/psi (correct: V·in²/lbf)
+  #    ├──┬ unit:V symbol: V
+  #    │  ├─── unit:A^-1 symbol: A
+  #    │  └──┬ unit:W symbol: W
+  #    │     ├──┬ unit:J symbol: J
+  #    │     │  ├─── unit:M symbol: m
+  #    │     │  └──┬ unit:N symbol: N
+  #    │     │     ├──┬ unit:KiloGM symbol: kg
+  #    │     │     │  └─── unit:GM symbol: g
+  #    │     │     ├─── unit:M symbol: m
+  #    │     │     └─── unit:SEC^-2 symbol: s
+  #    │     └─── unit:SEC^-1 symbol: s
+  #    ├──┬ unit:IN^2 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:LB_F^-1 symbol: lbf
+  #       ├──┬ unit:FT symbol: ft
+  #       │  └──┬ unit:IN symbol: in
+  #       │     └─── unit:M symbol: m
+  #       ├─── unit:SEC^-2 symbol: s
+  #       └──┬ unit:SLUG symbol: slug
+  #          └──┬ unit:LB symbol: lbm
+  #             └──┬ unit:KiloGM symbol: kg
+  #                └─── unit:GM symbol: g
+unit:V-IN2-PER-LB_F qudt:symbol "V·in²/lbf" .
+
+  # WRONG SYMBOL  : unit:V-PER-L-MIN - calculated from factors: V/(L·min), actual: V/(l·min)
+  #
+  #  ──┬ unit:V-PER-L-MIN symbol: V/(l·min) (correct: V/(L·min))
+  #    ├──┬ unit:V symbol: V
+  #    │  ├─── unit:A^-1 symbol: A
+  #    │  └──┬ unit:W symbol: W
+  #    │     ├──┬ unit:J symbol: J
+  #    │     │  ├─── unit:M symbol: m
+  #    │     │  └──┬ unit:N symbol: N
+  #    │     │     ├──┬ unit:KiloGM symbol: kg
+  #    │     │     │  └─── unit:GM symbol: g
+  #    │     │     ├─── unit:M symbol: m
+  #    │     │     └─── unit:SEC^-2 symbol: s
+  #    │     └─── unit:SEC^-1 symbol: s
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └──┬ unit:MIN^-1 symbol: min
+  #       └─── unit:SEC symbol: s
+unit:V-PER-L-MIN qudt:symbol "V/(L·min)" .
+
+  # WRONG SYMBOL  : unit:W-HR-PER-L - calculated from factors: W·h/L, actual: W·h/l
+  #
+  #  ──┬ unit:W-HR-PER-L symbol: W·h/l (correct: W·h/L)
+  #    ├──┬ unit:W symbol: W
+  #    │  ├──┬ unit:J symbol: J
+  #    │  │  ├─── unit:M symbol: m
+  #    │  │  └──┬ unit:N symbol: N
+  #    │  │     ├──┬ unit:KiloGM symbol: kg
+  #    │  │     │  └─── unit:GM symbol: g
+  #    │  │     ├─── unit:M symbol: m
+  #    │  │     └─── unit:SEC^-2 symbol: s
+  #    │  └─── unit:SEC^-1 symbol: s
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    └──┬ unit:L^-1 symbol: L
+  #       └──┬ unit:DeciM3 symbol: dm³
+  #          └──┬ unit:DeciM^3 symbol: dm
+  #             └─── unit:M symbol: m
+unit:W-HR-PER-L qudt:symbol "W·h/L" .
+
+  # WRONG SYMBOL  : unit:YD2 - calculated from factors: yd², actual: sqyd
+  #
+  #  ──┬ unit:YD2 symbol: sqyd (correct: yd²)
+  #    └──┬ unit:YD^2 symbol: yd
+  #       └──┬ unit:FT symbol: ft
+  #          └──┬ unit:IN symbol: in
+  #             └─── unit:M symbol: m
+unit:YD2 qudt:symbol "yd²" .
+
+  # WRONG SYMBOL  : unit:YD3-PER-DAY - calculated from factors: yd³/d, actual: yd³/day
+  #
+  #  ──┬ unit:YD3-PER-DAY symbol: yd³/day (correct: yd³/d)
+  #    ├──┬ unit:YD^3 symbol: yd
+  #    │  └──┬ unit:FT symbol: ft
+  #    │     └──┬ unit:IN symbol: in
+  #    │        └─── unit:M symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:YD3-PER-DAY qudt:symbol "yd³/d" .
+
+  # WRONG SYMBOL  : unit:A-PER-A-HR - calculated from factors: A/(A·h), actual: A/A·h
+  #
+  #  ──┬ unit:A-PER-A-HR symbol: A/A·h (correct: A/(A·h))
+  #    ├─── unit:A symbol: A
+  #    ├─── unit:A^-1 symbol: A
+  #    └──┬ unit:HR^-1 symbol: h
+  #       └─── unit:SEC symbol: s
+unit:A-PER-A-HR qudt:symbol "A/(A·h)" .
+
+  # WRONG SYMBOL  : unit:AC-FT_US - calculated from factors: acre·ft{US Survey}, actual: acre-ft (US survey)
+  #
+  #  ──┬ unit:AC-FT_US symbol: acre-ft (US survey) (correct: acre·ft{US Survey})
+  #    ├──┬ unit:AC symbol: acre
+  #    │  └──┬ unit:M2 symbol: m²
+  #    │     └─── unit:M^2 symbol: m
+  #    └──┬ unit:FT_US symbol: ft{US Survey}
+  #       └─── unit:M symbol: m
+unit:AC-FT_US qudt:symbol "acre·ft{US Survey}" .
+
+  # WRONG SYMBOL  : unit:ATM-PER-M - calculated from factors: atm/m, actual: Atm/m
+  #
+  #  ──┬ unit:ATM-PER-M symbol: Atm/m (correct: atm/m)
+  #    ├──┬ unit:ATM symbol: atm
+  #    │  └──┬ unit:PA symbol: Pa
+  #    │     ├─── unit:M^-2 symbol: m
+  #    │     └──┬ unit:N symbol: N
+  #    │        ├──┬ unit:KiloGM symbol: kg
+  #    │        │  └─── unit:GM symbol: g
+  #    │        ├─── unit:M symbol: m
+  #    │        └─── unit:SEC^-2 symbol: s
+  #    └─── unit:M^-1 symbol: m
+unit:ATM-PER-M qudt:symbol "atm/m" .
+
+  # WRONG SYMBOL  : unit:BBL_UK_PET-PER-DAY - calculated from factors: bbl{UK petroleum}/d, actual: bbl{UK petroleum}/day
+  #
+  #  ──┬ unit:BBL_UK_PET-PER-DAY symbol: bbl{UK petroleum}/day (correct: bbl{UK petroleum}/d)
+  #    ├──┬ unit:BBL_UK_PET symbol: bbl{UK petroleum}
+  #    │  └──┬ unit:M3 symbol: m³
+  #    │     └─── unit:M^3 symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:BBL_UK_PET-PER-DAY qudt:symbol "bbl{UK petroleum}/d" .
+
+  # WRONG SYMBOL  : unit:BBL_US-PER-DAY - calculated from factors: bbl{US petroleum}/d, actual: bbl{US petroleum}/day
+  #
+  #  ──┬ unit:BBL_US-PER-DAY symbol: bbl{US petroleum}/day (correct: bbl{US petroleum}/d)
+  #    ├──┬ unit:BBL_US symbol: bbl{US petroleum}
+  #    │  └──┬ unit:M3 symbol: m³
+  #    │     └─── unit:M^3 symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:BBL_US-PER-DAY qudt:symbol "bbl{US petroleum}/d" .
+
+  # WRONG SYMBOL  : unit:BIT-PER-M - calculated from factors: b/m, actual: bit/m
+  #
+  #  ──┬ unit:BIT-PER-M symbol: bit/m (correct: b/m)
+  #    ├─── unit:BIT symbol: b
+  #    └─── unit:M^-1 symbol: m
+unit:BIT-PER-M qudt:symbol "b/m" .
+
+  # WRONG SYMBOL  : unit:BIT-PER-M2 - calculated from factors: b/m², actual: bit/m²
+  #
+  #  ──┬ unit:BIT-PER-M2 symbol: bit/m² (correct: b/m²)
+  #    ├─── unit:BIT symbol: b
+  #    └─── unit:M^-2 symbol: m
+unit:BIT-PER-M2 qudt:symbol "b/m²" .
+
+  # WRONG SYMBOL  : unit:BTU_IT-PER-FT2-HR - calculated from factors: Btu{IT}/(ft²·h), actual: BtuIT/(ft²·h)
+  #
+  #  ──┬ unit:BTU_IT-PER-FT2-HR symbol: BtuIT/(ft²·h) (correct: Btu{IT}/(ft²·h))
+  #    ├──┬ unit:BTU_IT symbol: Btu{IT}
+  #    │  └──┬ unit:J symbol: J
+  #    │     ├─── unit:M symbol: m
+  #    │     └──┬ unit:N symbol: N
+  #    │        ├──┬ unit:KiloGM symbol: kg
+  #    │        │  └─── unit:GM symbol: g
+  #    │        ├─── unit:M symbol: m
+  #    │        └─── unit:SEC^-2 symbol: s
+  #    ├──┬ unit:FT^-2 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:HR^-1 symbol: h
+  #       └─── unit:SEC symbol: s
+unit:BTU_IT-PER-FT2-HR qudt:symbol "Btu{IT}/(ft²·h)" .
+
+  # WRONG SYMBOL  : unit:BTU_IT-PER-FT2-SEC - calculated from factors: Btu{IT}/(ft²·s), actual: BtuIT/(ft²·s)
+  #
+  #  ──┬ unit:BTU_IT-PER-FT2-SEC symbol: BtuIT/(ft²·s) (correct: Btu{IT}/(ft²·s))
+  #    ├──┬ unit:BTU_IT symbol: Btu{IT}
+  #    │  └──┬ unit:J symbol: J
+  #    │     ├─── unit:M symbol: m
+  #    │     └──┬ unit:N symbol: N
+  #    │        ├──┬ unit:KiloGM symbol: kg
+  #    │        │  └─── unit:GM symbol: g
+  #    │        ├─── unit:M symbol: m
+  #    │        └─── unit:SEC^-2 symbol: s
+  #    ├──┬ unit:FT^-2 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └─── unit:SEC^-1 symbol: s
+unit:BTU_IT-PER-FT2-SEC qudt:symbol "Btu{IT}/(ft²·s)" .
+
+  # WRONG SYMBOL  : unit:BTU_IT-PER-HR-FT2-DEG_F - calculated from factors: Btu{IT}/(h·ft²·°F), actual: BtuIT/(h·ft²·°F)
+  #
+  #  ──┬ unit:BTU_IT-PER-HR-FT2-DEG_F symbol: BtuIT/(h·ft²·°F) (correct: Btu{IT}/(h·ft²·°F))
+  #    ├──┬ unit:BTU_IT symbol: Btu{IT}
+  #    │  └──┬ unit:J symbol: J
+  #    │     ├─── unit:M symbol: m
+  #    │     └──┬ unit:N symbol: N
+  #    │        ├──┬ unit:KiloGM symbol: kg
+  #    │        │  └─── unit:GM symbol: g
+  #    │        ├─── unit:M symbol: m
+  #    │        └─── unit:SEC^-2 symbol: s
+  #    ├──┬ unit:HR^-1 symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:FT^-2 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:DEG_F^-1 symbol: °F
+  #       └─── unit:K symbol: K
+unit:BTU_IT-PER-HR-FT2-DEG_F qudt:symbol "Btu{IT}/(h·ft²·°F)" .
+
+  # WRONG SYMBOL  : unit:BTU_IT-PER-IN2-SEC - calculated from factors: Btu{IT}/(in²·s), actual: BtuIT/(in²·s)
+  #
+  #  ──┬ unit:BTU_IT-PER-IN2-SEC symbol: BtuIT/(in²·s) (correct: Btu{IT}/(in²·s))
+  #    ├──┬ unit:BTU_IT symbol: Btu{IT}
+  #    │  └──┬ unit:J symbol: J
+  #    │     ├─── unit:M symbol: m
+  #    │     └──┬ unit:N symbol: N
+  #    │        ├──┬ unit:KiloGM symbol: kg
+  #    │        │  └─── unit:GM symbol: g
+  #    │        ├─── unit:M symbol: m
+  #    │        └─── unit:SEC^-2 symbol: s
+  #    ├──┬ unit:IN^-2 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └─── unit:SEC^-1 symbol: s
+unit:BTU_IT-PER-IN2-SEC qudt:symbol "Btu{IT}/(in²·s)" .
+
+  # WRONG SYMBOL  : unit:BTU_IT-PER-LB - calculated from factors: Btu{IT}/lbm, actual: Btu{IT}/lb
+  #
+  #  ──┬ unit:BTU_IT-PER-LB symbol: Btu{IT}/lb (correct: Btu{IT}/lbm)
+  #    ├──┬ unit:BTU_IT symbol: Btu{IT}
+  #    │  └──┬ unit:J symbol: J
+  #    │     ├─── unit:M symbol: m
+  #    │     └──┬ unit:N symbol: N
+  #    │        ├──┬ unit:KiloGM symbol: kg
+  #    │        │  └─── unit:GM symbol: g
+  #    │        ├─── unit:M symbol: m
+  #    │        └─── unit:SEC^-2 symbol: s
+  #    └──┬ unit:LB^-1 symbol: lbm
+  #       └──┬ unit:KiloGM symbol: kg
+  #          └─── unit:GM symbol: g
+unit:BTU_IT-PER-LB qudt:symbol "Btu{IT}/lbm" .
+
+  # WRONG SYMBOL  : unit:BTU_IT-PER-MOL_LB - calculated from factors: Btu{IT}/lb-mol, actual: Btu{IT}/(mol-lb)
+  #
+  #  ──┬ unit:BTU_IT-PER-MOL_LB symbol: Btu{IT}/(mol-lb) (correct: Btu{IT}/lb-mol)
+  #    ├──┬ unit:BTU_IT symbol: Btu{IT}
+  #    │  └──┬ unit:J symbol: J
+  #    │     ├─── unit:M symbol: m
+  #    │     └──┬ unit:N symbol: N
+  #    │        ├──┬ unit:KiloGM symbol: kg
+  #    │        │  └─── unit:GM symbol: g
+  #    │        ├─── unit:M symbol: m
+  #    │        └─── unit:SEC^-2 symbol: s
+  #    └──┬ unit:MOL_LB^-1 symbol: lb-mol
+  #       └─── unit:MOL symbol: mol
+unit:BTU_IT-PER-MOL_LB qudt:symbol "Btu{IT}/lb-mol" .
+
+  # WRONG SYMBOL  : unit:BTU_IT-PER-SEC-FT2-DEG_F - calculated from factors: Btu{IT}/(s·ft²·°F), actual: BtuIT/(s·ft²·°F)
+  #
+  #  ──┬ unit:BTU_IT-PER-SEC-FT2-DEG_F symbol: BtuIT/(s·ft²·°F) (correct: Btu{IT}/(s·ft²·°F))
+  #    ├──┬ unit:BTU_IT symbol: Btu{IT}
+  #    │  └──┬ unit:J symbol: J
+  #    │     ├─── unit:M symbol: m
+  #    │     └──┬ unit:N symbol: N
+  #    │        ├──┬ unit:KiloGM symbol: kg
+  #    │        │  └─── unit:GM symbol: g
+  #    │        ├─── unit:M symbol: m
+  #    │        └─── unit:SEC^-2 symbol: s
+  #    ├─── unit:SEC^-1 symbol: s
+  #    ├──┬ unit:FT^-2 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:DEG_F^-1 symbol: °F
+  #       └─── unit:K symbol: K
+unit:BTU_IT-PER-SEC-FT2-DEG_F qudt:symbol "Btu{IT}/(s·ft²·°F)" .
+
+  # WRONG SYMBOL  : unit:BTU_TH-PER-DEG_F - calculated from factors: Btu{th}/°F, actual: Btuth/°F
+  #
+  #  ──┬ unit:BTU_TH-PER-DEG_F symbol: Btuth/°F (correct: Btu{th}/°F)
+  #    ├──┬ unit:BTU_TH symbol: Btu{th}
+  #    │  └──┬ unit:J symbol: J
+  #    │     ├─── unit:M symbol: m
+  #    │     └──┬ unit:N symbol: N
+  #    │        ├──┬ unit:KiloGM symbol: kg
+  #    │        │  └─── unit:GM symbol: g
+  #    │        ├─── unit:M symbol: m
+  #    │        └─── unit:SEC^-2 symbol: s
+  #    └──┬ unit:DEG_F^-1 symbol: °F
+  #       └─── unit:K symbol: K
+unit:BTU_TH-PER-DEG_F qudt:symbol "Btu{th}/°F" .
+
+  # WRONG SYMBOL  : unit:BTU_TH-PER-DEG_R - calculated from factors: Btu{th}/°R, actual: Btuth/°R
+  #
+  #  ──┬ unit:BTU_TH-PER-DEG_R symbol: Btuth/°R (correct: Btu{th}/°R)
+  #    ├──┬ unit:BTU_TH symbol: Btu{th}
+  #    │  └──┬ unit:J symbol: J
+  #    │     ├─── unit:M symbol: m
+  #    │     └──┬ unit:N symbol: N
+  #    │        ├──┬ unit:KiloGM symbol: kg
+  #    │        │  └─── unit:GM symbol: g
+  #    │        ├─── unit:M symbol: m
+  #    │        └─── unit:SEC^-2 symbol: s
+  #    └──┬ unit:DEG_R^-1 symbol: °R
+  #       └─── unit:K symbol: K
+unit:BTU_TH-PER-DEG_R qudt:symbol "Btu{th}/°R" .
+
+  # WRONG SYMBOL  : unit:BTU_TH-PER-FT2 - calculated from factors: Btu{th}/ft², actual: Btuth/ft²
+  #
+  #  ──┬ unit:BTU_TH-PER-FT2 symbol: Btuth/ft² (correct: Btu{th}/ft²)
+  #    ├──┬ unit:BTU_TH symbol: Btu{th}
+  #    │  └──┬ unit:J symbol: J
+  #    │     ├─── unit:M symbol: m
+  #    │     └──┬ unit:N symbol: N
+  #    │        ├──┬ unit:KiloGM symbol: kg
+  #    │        │  └─── unit:GM symbol: g
+  #    │        ├─── unit:M symbol: m
+  #    │        └─── unit:SEC^-2 symbol: s
+  #    └──┬ unit:FT^-2 symbol: ft
+  #       └──┬ unit:IN symbol: in
+  #          └─── unit:M symbol: m
+unit:BTU_TH-PER-FT2 qudt:symbol "Btu{th}/ft²" .
+
+  # WRONG SYMBOL  : unit:BTU_TH-PER-FT2-HR - calculated from factors: Btu{th}/(ft²·h), actual: Btuth/(ft²·h)
+  #
+  #  ──┬ unit:BTU_TH-PER-FT2-HR symbol: Btuth/(ft²·h) (correct: Btu{th}/(ft²·h))
+  #    ├──┬ unit:BTU_TH symbol: Btu{th}
+  #    │  └──┬ unit:J symbol: J
+  #    │     ├─── unit:M symbol: m
+  #    │     └──┬ unit:N symbol: N
+  #    │        ├──┬ unit:KiloGM symbol: kg
+  #    │        │  └─── unit:GM symbol: g
+  #    │        ├─── unit:M symbol: m
+  #    │        └─── unit:SEC^-2 symbol: s
+  #    ├──┬ unit:FT^-2 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:HR^-1 symbol: h
+  #       └─── unit:SEC symbol: s
+unit:BTU_TH-PER-FT2-HR qudt:symbol "Btu{th}/(ft²·h)" .
+
+  # WRONG SYMBOL  : unit:BTU_TH-PER-FT2-MIN - calculated from factors: Btu{th}/(ft²·min), actual: Btuth/(ft²·min)
+  #
+  #  ──┬ unit:BTU_TH-PER-FT2-MIN symbol: Btuth/(ft²·min) (correct: Btu{th}/(ft²·min))
+  #    ├──┬ unit:BTU_TH symbol: Btu{th}
+  #    │  └──┬ unit:J symbol: J
+  #    │     ├─── unit:M symbol: m
+  #    │     └──┬ unit:N symbol: N
+  #    │        ├──┬ unit:KiloGM symbol: kg
+  #    │        │  └─── unit:GM symbol: g
+  #    │        ├─── unit:M symbol: m
+  #    │        └─── unit:SEC^-2 symbol: s
+  #    ├──┬ unit:FT^-2 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:MIN^-1 symbol: min
+  #       └─── unit:SEC symbol: s
+unit:BTU_TH-PER-FT2-MIN qudt:symbol "Btu{th}/(ft²·min)" .
+
+  # WRONG SYMBOL  : unit:BTU_TH-PER-FT2-SEC - calculated from factors: Btu{th}/(ft²·s), actual: Btuth/(ft²·s)
+  #
+  #  ──┬ unit:BTU_TH-PER-FT2-SEC symbol: Btuth/(ft²·s) (correct: Btu{th}/(ft²·s))
+  #    ├──┬ unit:BTU_TH symbol: Btu{th}
+  #    │  └──┬ unit:J symbol: J
+  #    │     ├─── unit:M symbol: m
+  #    │     └──┬ unit:N symbol: N
+  #    │        ├──┬ unit:KiloGM symbol: kg
+  #    │        │  └─── unit:GM symbol: g
+  #    │        ├─── unit:M symbol: m
+  #    │        └─── unit:SEC^-2 symbol: s
+  #    ├──┬ unit:FT^-2 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └─── unit:SEC^-1 symbol: s
+unit:BTU_TH-PER-FT2-SEC qudt:symbol "Btu{th}/(ft²·s)" .
+
+  # WRONG SYMBOL  : unit:BTU_TH-PER-HR-FT2-DEG_F - calculated from factors: Btu{th}/(h·ft²·°F), actual: Btuth/(h·ft²·°F)
+  #
+  #  ──┬ unit:BTU_TH-PER-HR-FT2-DEG_F symbol: Btuth/(h·ft²·°F) (correct: Btu{th}/(h·ft²·°F))
+  #    ├──┬ unit:BTU_TH symbol: Btu{th}
+  #    │  └──┬ unit:J symbol: J
+  #    │     ├─── unit:M symbol: m
+  #    │     └──┬ unit:N symbol: N
+  #    │        ├──┬ unit:KiloGM symbol: kg
+  #    │        │  └─── unit:GM symbol: g
+  #    │        ├─── unit:M symbol: m
+  #    │        └─── unit:SEC^-2 symbol: s
+  #    ├──┬ unit:HR^-1 symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:FT^-2 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:DEG_F^-1 symbol: °F
+  #       └─── unit:K symbol: K
+unit:BTU_TH-PER-HR-FT2-DEG_F qudt:symbol "Btu{th}/(h·ft²·°F)" .
+
+  # WRONG SYMBOL  : unit:BTU_TH-PER-LB-DEG_R - calculated from factors: Btu{th}/(lbm·°R), actual: Btuth/°R)/lb
+  #
+  #  ──┬ unit:BTU_TH-PER-LB-DEG_R symbol: Btuth/°R)/lb (correct: Btu{th}/(lbm·°R))
+  #    ├──┬ unit:BTU_TH symbol: Btu{th}
+  #    │  └──┬ unit:J symbol: J
+  #    │     ├─── unit:M symbol: m
+  #    │     └──┬ unit:N symbol: N
+  #    │        ├──┬ unit:KiloGM symbol: kg
+  #    │        │  └─── unit:GM symbol: g
+  #    │        ├─── unit:M symbol: m
+  #    │        └─── unit:SEC^-2 symbol: s
+  #    ├──┬ unit:LB^-1 symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    └──┬ unit:DEG_R^-1 symbol: °R
+  #       └─── unit:K symbol: K
+unit:BTU_TH-PER-LB-DEG_R qudt:symbol "Btu{th}/(lbm·°R)" .
+
+  # WRONG SYMBOL  : unit:BTU_TH-PER-SEC-FT2-DEG_F - calculated from factors: Btu{th}/(s·ft²·°F), actual: Btuth/(s·ft²·°F)
+  #
+  #  ──┬ unit:BTU_TH-PER-SEC-FT2-DEG_F symbol: Btuth/(s·ft²·°F) (correct: Btu{th}/(s·ft²·°F))
+  #    ├──┬ unit:BTU_TH symbol: Btu{th}
+  #    │  └──┬ unit:J symbol: J
+  #    │     ├─── unit:M symbol: m
+  #    │     └──┬ unit:N symbol: N
+  #    │        ├──┬ unit:KiloGM symbol: kg
+  #    │        │  └─── unit:GM symbol: g
+  #    │        ├─── unit:M symbol: m
+  #    │        └─── unit:SEC^-2 symbol: s
+  #    ├─── unit:SEC^-1 symbol: s
+  #    ├──┬ unit:FT^-2 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:DEG_F^-1 symbol: °F
+  #       └─── unit:K symbol: K
+unit:BTU_TH-PER-SEC-FT2-DEG_F qudt:symbol "Btu{th}/(s·ft²·°F)" .
+
+  # WRONG SYMBOL  : unit:BU_UK-PER-DAY - calculated from factors: bsh{UK}/d, actual: bsh{UK}/day
+  #
+  #  ──┬ unit:BU_UK-PER-DAY symbol: bsh{UK}/day (correct: bsh{UK}/d)
+  #    ├──┬ unit:BU_UK symbol: bsh{UK}
+  #    │  └──┬ unit:M3 symbol: m³
+  #    │     └─── unit:M^3 symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:BU_UK-PER-DAY qudt:symbol "bsh{UK}/d" .
+
+  # WRONG SYMBOL  : unit:BU_US - calculated from factors: in³, actual: bsh{US}
+  #
+  #  ──┬ unit:BU_US symbol: bsh{US} (correct: in³)
+  #    └──┬ unit:IN^3 symbol: in
+  #       └─── unit:M symbol: m
+unit:BU_US qudt:symbol "in³" .
+
+  # WRONG SYMBOL  : unit:BYTE-PER-SEC - calculated from factors: B/s, actual: byte/s
+  #
+  #  ──┬ unit:BYTE-PER-SEC symbol: byte/s (correct: B/s)
+  #    ├─── unit:BYTE symbol: B
+  #    └─── unit:SEC^-1 symbol: s
+unit:BYTE-PER-SEC qudt:symbol "B/s" .
+
+  # WRONG SYMBOL  : unit:CAL_TH-PER-CentiM2 - calculated from factors: cal/cm², actual: calth/cm²
+  #
+  #  ──┬ unit:CAL_TH-PER-CentiM2 symbol: calth/cm² (correct: cal/cm²)
+  #    ├──┬ unit:CAL_TH symbol: cal
+  #    │  └──┬ unit:J symbol: J
+  #    │     ├─── unit:M symbol: m
+  #    │     └──┬ unit:N symbol: N
+  #    │        ├──┬ unit:KiloGM symbol: kg
+  #    │        │  └─── unit:GM symbol: g
+  #    │        ├─── unit:M symbol: m
+  #    │        └─── unit:SEC^-2 symbol: s
+  #    └──┬ unit:CentiM^-2 symbol: cm
+  #       └─── unit:M symbol: m
+unit:CAL_TH-PER-CentiM2 qudt:symbol "cal/cm²" .
+
+  # WRONG SYMBOL  : unit:CAL_TH-PER-CentiM2-MIN - calculated from factors: cal/(cm²·min), actual: calth/(cm²·min)
+  #
+  #  ──┬ unit:CAL_TH-PER-CentiM2-MIN symbol: calth/(cm²·min) (correct: cal/(cm²·min))
+  #    ├──┬ unit:CAL_TH symbol: cal
+  #    │  └──┬ unit:J symbol: J
+  #    │     ├─── unit:M symbol: m
+  #    │     └──┬ unit:N symbol: N
+  #    │        ├──┬ unit:KiloGM symbol: kg
+  #    │        │  └─── unit:GM symbol: g
+  #    │        ├─── unit:M symbol: m
+  #    │        └─── unit:SEC^-2 symbol: s
+  #    ├──┬ unit:CentiM^-2 symbol: cm
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:MIN^-1 symbol: min
+  #       └─── unit:SEC symbol: s
+unit:CAL_TH-PER-CentiM2-MIN qudt:symbol "cal/(cm²·min)" .
+
+  # WRONG SYMBOL  : unit:CAL_TH-PER-CentiM2-SEC - calculated from factors: cal/(cm²·s), actual: calth/(cm²·s)
+  #
+  #  ──┬ unit:CAL_TH-PER-CentiM2-SEC symbol: calth/(cm²·s) (correct: cal/(cm²·s))
+  #    ├──┬ unit:CAL_TH symbol: cal
+  #    │  └──┬ unit:J symbol: J
+  #    │     ├─── unit:M symbol: m
+  #    │     └──┬ unit:N symbol: N
+  #    │        ├──┬ unit:KiloGM symbol: kg
+  #    │        │  └─── unit:GM symbol: g
+  #    │        ├─── unit:M symbol: m
+  #    │        └─── unit:SEC^-2 symbol: s
+  #    ├──┬ unit:CentiM^-2 symbol: cm
+  #    │  └─── unit:M symbol: m
+  #    └─── unit:SEC^-1 symbol: s
+unit:CAL_TH-PER-CentiM2-SEC qudt:symbol "cal/(cm²·s)" .
+
+  # WRONG SYMBOL  : unit:CAL_TH-PER-CentiM3-K - calculated from factors: cal/(cm³·K), actual: cal{th}/(cm³·K)
+  #
+  #  ──┬ unit:CAL_TH-PER-CentiM3-K symbol: cal{th}/(cm³·K) (correct: cal/(cm³·K))
+  #    ├──┬ unit:CAL_TH symbol: cal
+  #    │  └──┬ unit:J symbol: J
+  #    │     ├─── unit:M symbol: m
+  #    │     └──┬ unit:N symbol: N
+  #    │        ├──┬ unit:KiloGM symbol: kg
+  #    │        │  └─── unit:GM symbol: g
+  #    │        ├─── unit:M symbol: m
+  #    │        └─── unit:SEC^-2 symbol: s
+  #    ├──┬ unit:CentiM^-3 symbol: cm
+  #    │  └─── unit:M symbol: m
+  #    └─── unit:K^-1 symbol: K
+unit:CAL_TH-PER-CentiM3-K qudt:symbol "cal/(cm³·K)" .
+
+  # WRONG SYMBOL  : unit:CentiM-PER-KiloYR - calculated from factors: cm/1000 a, actual: cm/(1000 a)
+  #
+  #  ──┬ unit:CentiM-PER-KiloYR symbol: cm/(1000 a) (correct: cm/1000 a)
+  #    ├──┬ unit:CentiM symbol: cm
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:KiloYR^-1 symbol: 1000 a
+  #       └──┬ unit:YR symbol: a
+  #          └─── unit:SEC symbol: s
+unit:CentiM-PER-KiloYR qudt:symbol "cm/1000 a" .
+
+  # WRONG SYMBOL  : unit:CentiM3-PER-DAY - calculated from factors: cm³/d, actual: cm³/day
+  #
+  #  ──┬ unit:CentiM3-PER-DAY symbol: cm³/day (correct: cm³/d)
+  #    ├──┬ unit:CentiM^3 symbol: cm
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:CentiM3-PER-DAY qudt:symbol "cm³/d" .
+
+  # WRONG SYMBOL  : unit:DEG_F-HR-PER-BTU_TH - calculated from factors: °F·h/Btu{th}, actual: °F/(Btuth/h)
+  #
+  #  ──┬ unit:DEG_F-HR-PER-BTU_TH symbol: °F/(Btuth/h) (correct: °F·h/Btu{th})
+  #    ├──┬ unit:DEG_F symbol: °F
+  #    │  └─── unit:K symbol: K
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    └──┬ unit:BTU_TH^-1 symbol: Btu{th}
+  #       └──┬ unit:J symbol: J
+  #          ├─── unit:M symbol: m
+  #          └──┬ unit:N symbol: N
+  #             ├──┬ unit:KiloGM symbol: kg
+  #             │  └─── unit:GM symbol: g
+  #             ├─── unit:M symbol: m
+  #             └─── unit:SEC^-2 symbol: s
+unit:DEG_F-HR-PER-BTU_TH qudt:symbol "°F·h/Btu{th}" .
+
+  # WRONG SYMBOL  : unit:DeciB-MilliW-PER-MegaHZ - calculated from factors: dB·mW/MHz, actual: dB·mW/Mhz
+  #
+  #  ──┬ unit:DeciB-MilliW-PER-MegaHZ symbol: dB·mW/Mhz (correct: dB·mW/MHz)
+  #    ├──┬ unit:DeciB symbol: dB
+  #    │  └─── unit:B symbol: B
+  #    ├──┬ unit:MilliW symbol: mW
+  #    │  └──┬ unit:W symbol: W
+  #    │     ├──┬ unit:J symbol: J
+  #    │     │  ├─── unit:M symbol: m
+  #    │     │  └──┬ unit:N symbol: N
+  #    │     │     ├──┬ unit:KiloGM symbol: kg
+  #    │     │     │  └─── unit:GM symbol: g
+  #    │     │     ├─── unit:M symbol: m
+  #    │     │     └─── unit:SEC^-2 symbol: s
+  #    │     └─── unit:SEC^-1 symbol: s
+  #    └──┬ unit:MegaHZ^-1 symbol: MHz
+  #       └──┬ unit:HZ symbol: Hz
+  #          └─── unit:SEC^-1 symbol: s
+unit:DeciB-MilliW-PER-MegaHZ qudt:symbol "dB·mW/MHz" .
+
+  # WRONG SYMBOL  : unit:DeciB-W - calculated from factors: dB·W, actual: dBW
+  #
+  #  ──┬ unit:DeciB-W symbol: dBW (correct: dB·W)
+  #    ├──┬ unit:DeciB symbol: dB
+  #    │  └─── unit:B symbol: B
+  #    └──┬ unit:W symbol: W
+  #       ├──┬ unit:J symbol: J
+  #       │  ├─── unit:M symbol: m
+  #       │  └──┬ unit:N symbol: N
+  #       │     ├──┬ unit:KiloGM symbol: kg
+  #       │     │  └─── unit:GM symbol: g
+  #       │     ├─── unit:M symbol: m
+  #       │     └─── unit:SEC^-2 symbol: s
+  #       └─── unit:SEC^-1 symbol: s
+unit:DeciB-W qudt:symbol "dB·W" .
+
+  # WRONG SYMBOL  : unit:DeciM3-PER-DAY - calculated from factors: dm³/d, actual: dm³/day
+  #
+  #  ──┬ unit:DeciM3-PER-DAY symbol: dm³/day (correct: dm³/d)
+  #    ├──┬ unit:DeciM^3 symbol: dm
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:DeciM3-PER-DAY qudt:symbol "dm³/d" .
+
+  # WRONG SYMBOL  : unit:FT-HR-PER-GAL_UK - calculated from factors: ft·h/gal{UK}, actual: lb/(gal (UK))/(lb/(ft·h))
+  #
+  #  ──┬ unit:FT-HR-PER-GAL_UK symbol: lb/(gal (UK))/(lb/(ft·h)) (correct: ft·h/gal{UK})
+  #    ├──┬ unit:FT symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    └──┬ unit:GAL_UK^-1 symbol: gal{UK}
+  #       └──┬ unit:L symbol: L
+  #          └──┬ unit:DeciM3 symbol: dm³
+  #             └──┬ unit:DeciM^3 symbol: dm
+  #                └─── unit:M symbol: m
+unit:FT-HR-PER-GAL_UK qudt:symbol "ft·h/gal{UK}" .
+
+  # WRONG SYMBOL  : unit:FT-HR-PER-GAL_US - calculated from factors: ft·h/gal{US}, actual: lb/(gal (US))/(lb/(ft·h))
+  #
+  #  ──┬ unit:FT-HR-PER-GAL_US symbol: lb/(gal (US))/(lb/(ft·h)) (correct: ft·h/gal{US})
+  #    ├──┬ unit:FT symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    └──┬ unit:GAL_US^-1 symbol: gal{US}
+  #       └──┬ unit:IN^3 symbol: in
+  #          └─── unit:M symbol: m
+unit:FT-HR-PER-GAL_US qudt:symbol "ft·h/gal{US}" .
+
+  # WRONG SYMBOL  : unit:FT-HR-PER-IN3 - calculated from factors: ft·h/in³, actual: (lb/in³)/(lb/(ft·h))
+  #
+  #  ──┬ unit:FT-HR-PER-IN3 symbol: (lb/in³)/(lb/(ft·h)) (correct: ft·h/in³)
+  #    ├──┬ unit:FT symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    └──┬ unit:IN^-3 symbol: in
+  #       └─── unit:M symbol: m
+unit:FT-HR-PER-IN3 qudt:symbol "ft·h/in³" .
+
+  # WRONG SYMBOL  : unit:FT-PER-DAY - calculated from factors: ft/d, actual: ft/day
+  #
+  #  ──┬ unit:FT-PER-DAY symbol: ft/day (correct: ft/d)
+  #    ├──┬ unit:FT symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:FT-PER-DAY qudt:symbol "ft/d" .
+
+  # WRONG SYMBOL  : unit:FT-SEC-PER-GAL_UK - calculated from factors: ft·s/gal{UK}, actual: lb/(gal (UK))/(lb/(ft·s))
+  #
+  #  ──┬ unit:FT-SEC-PER-GAL_UK symbol: lb/(gal (UK))/(lb/(ft·s)) (correct: ft·s/gal{UK})
+  #    ├──┬ unit:FT symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    ├─── unit:SEC symbol: s
+  #    └──┬ unit:GAL_UK^-1 symbol: gal{UK}
+  #       └──┬ unit:L symbol: L
+  #          └──┬ unit:DeciM3 symbol: dm³
+  #             └──┬ unit:DeciM^3 symbol: dm
+  #                └─── unit:M symbol: m
+unit:FT-SEC-PER-GAL_UK qudt:symbol "ft·s/gal{UK}" .
+
+  # WRONG SYMBOL  : unit:FT-SEC-PER-GAL_US - calculated from factors: ft·s/gal{US}, actual: lb/(gal (US))/(lb/(ft·s))
+  #
+  #  ──┬ unit:FT-SEC-PER-GAL_US symbol: lb/(gal (US))/(lb/(ft·s)) (correct: ft·s/gal{US})
+  #    ├──┬ unit:FT symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    ├─── unit:SEC symbol: s
+  #    └──┬ unit:GAL_US^-1 symbol: gal{US}
+  #       └──┬ unit:IN^3 symbol: in
+  #          └─── unit:M symbol: m
+unit:FT-SEC-PER-GAL_US qudt:symbol "ft·s/gal{US}" .
+
+  # WRONG SYMBOL  : unit:FT-SEC-PER-IN3 - calculated from factors: ft·s/in³, actual: (lb/in³)/(lb/(ft·s))
+  #
+  #  ──┬ unit:FT-SEC-PER-IN3 symbol: (lb/in³)/(lb/(ft·s)) (correct: ft·s/in³)
+  #    ├──┬ unit:FT symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    ├─── unit:SEC symbol: s
+  #    └──┬ unit:IN^-3 symbol: in
+  #       └─── unit:M symbol: m
+unit:FT-SEC-PER-IN3 qudt:symbol "ft·s/in³" .
+
+  # WRONG SYMBOL  : unit:FT3-PER-DAY - calculated from factors: ft³/d, actual: ft³/day
+  #
+  #  ──┬ unit:FT3-PER-DAY symbol: ft³/day (correct: ft³/d)
+  #    ├──┬ unit:FT^3 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:FT3-PER-DAY qudt:symbol "ft³/d" .
+
+  # WRONG SYMBOL  : unit:GAL_UK-PER-DAY - calculated from factors: gal{UK}/d, actual: gal{UK}/day
+  #
+  #  ──┬ unit:GAL_UK-PER-DAY symbol: gal{UK}/day (correct: gal{UK}/d)
+  #    ├──┬ unit:GAL_UK symbol: gal{UK}
+  #    │  └──┬ unit:L symbol: L
+  #    │     └──┬ unit:DeciM3 symbol: dm³
+  #    │        └──┬ unit:DeciM^3 symbol: dm
+  #    │           └─── unit:M symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:GAL_UK-PER-DAY qudt:symbol "gal{UK}/d" .
+
+  # WRONG SYMBOL  : unit:GAL_US - calculated from factors: in³, actual: gal{US}
+  #
+  #  ──┬ unit:GAL_US symbol: gal{US} (correct: in³)
+  #    └──┬ unit:IN^3 symbol: in
+  #       └─── unit:M symbol: m
+unit:GAL_US qudt:symbol "in³" .
+
+  # WRONG SYMBOL  : unit:GAL_US-PER-DAY - calculated from factors: gal{US}/d, actual: gal{US}/day
+  #
+  #  ──┬ unit:GAL_US-PER-DAY symbol: gal{US}/day (correct: gal{US}/d)
+  #    ├──┬ unit:GAL_US symbol: gal{US}
+  #    │  └──┬ unit:IN^3 symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:GAL_US-PER-DAY qudt:symbol "gal{US}/d" .
+
+  # WRONG SYMBOL  : unit:GI_UK-PER-DAY - calculated from factors: gill{UK}/d, actual: gill{UK}/day
+  #
+  #  ──┬ unit:GI_UK-PER-DAY symbol: gill{UK}/day (correct: gill{UK}/d)
+  #    ├──┬ unit:GI_UK symbol: gill{UK}
+  #    │  └──┬ unit:M3 symbol: m³
+  #    │     └─── unit:M^3 symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:GI_UK-PER-DAY qudt:symbol "gill{UK}/d" .
+
+  # WRONG SYMBOL  : unit:GI_US-PER-DAY - calculated from factors: gill{US}/d, actual: gill{US}/day
+  #
+  #  ──┬ unit:GI_US-PER-DAY symbol: gill{US}/day (correct: gill{US}/d)
+  #    ├──┬ unit:GI_US symbol: gill{US}
+  #    │  └──┬ unit:M3 symbol: m³
+  #    │     └─── unit:M^3 symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:GI_US-PER-DAY qudt:symbol "gill{US}/d" .
+
+  # WRONG SYMBOL  : unit:GM-CentiM-PER-SEC - calculated from factors: g·cm/s, actual: g·(cm/s)
+  #
+  #  ──┬ unit:GM-CentiM-PER-SEC symbol: g·(cm/s) (correct: g·cm/s)
+  #    ├─── unit:GM symbol: g
+  #    ├──┬ unit:CentiM symbol: cm
+  #    │  └─── unit:M symbol: m
+  #    └─── unit:SEC^-1 symbol: s
+unit:GM-CentiM-PER-SEC qudt:symbol "g·cm/s" .
+
+  # WRONG SYMBOL  : unit:GM-HR-PER-L-CentiM3 - calculated from factors: g·h/(L·cm³), actual: (g/l)/(cm³/h)
+  #
+  #  ──┬ unit:GM-HR-PER-L-CentiM3 symbol: (g/l)/(cm³/h) (correct: g·h/(L·cm³))
+  #    ├─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └──┬ unit:CentiM^-3 symbol: cm
+  #       └─── unit:M symbol: m
+unit:GM-HR-PER-L-CentiM3 qudt:symbol "g·h/(L·cm³)" .
+
+  # WRONG SYMBOL  : unit:GM-HR-PER-L-M3 - calculated from factors: g·h/(L·m³), actual: (g/l)/(m³/h)
+  #
+  #  ──┬ unit:GM-HR-PER-L-M3 symbol: (g/l)/(m³/h) (correct: g·h/(L·m³))
+  #    ├─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └─── unit:M^-3 symbol: m
+unit:GM-HR-PER-L-M3 qudt:symbol "g·h/(L·m³)" .
+
+  # WRONG SYMBOL  : unit:GM-HR-PER-L2 - calculated from factors: g·h/L², actual: (g/l)/(l/h)
+  #
+  #  ──┬ unit:GM-HR-PER-L2 symbol: (g/l)/(l/h) (correct: g·h/L²)
+  #    ├─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    └──┬ unit:L^-2 symbol: L
+  #       └──┬ unit:DeciM3 symbol: dm³
+  #          └──┬ unit:DeciM^3 symbol: dm
+  #             └─── unit:M symbol: m
+unit:GM-HR-PER-L2 qudt:symbol "g·h/L²" .
+
+  # WRONG SYMBOL  : unit:GM-HR-PER-M3-CentiM3 - calculated from factors: g·h/(m³·cm³), actual: (g/m³)/(cm³/h)
+  #
+  #  ──┬ unit:GM-HR-PER-M3-CentiM3 symbol: (g/m³)/(cm³/h) (correct: g·h/(m³·cm³))
+  #    ├─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├─── unit:M^-3 symbol: m
+  #    └──┬ unit:CentiM^-3 symbol: cm
+  #       └─── unit:M symbol: m
+unit:GM-HR-PER-M3-CentiM3 qudt:symbol "g·h/(m³·cm³)" .
+
+  # WRONG SYMBOL  : unit:GM-HR-PER-M3-L - calculated from factors: g·h/(m³·L), actual: (g/m³)/(l/h)
+  #
+  #  ──┬ unit:GM-HR-PER-M3-L symbol: (g/m³)/(l/h) (correct: g·h/(m³·L))
+  #    ├─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├─── unit:M^-3 symbol: m
+  #    └──┬ unit:L^-1 symbol: L
+  #       └──┬ unit:DeciM3 symbol: dm³
+  #          └──┬ unit:DeciM^3 symbol: dm
+  #             └─── unit:M symbol: m
+unit:GM-HR-PER-M3-L qudt:symbol "g·h/(m³·L)" .
+
+  # WRONG SYMBOL  : unit:GM-HR-PER-M6 - calculated from factors: g·h/m⁶, actual: (g/m³)/(m³/h)
+  #
+  #  ──┬ unit:GM-HR-PER-M6 symbol: (g/m³)/(m³/h) (correct: g·h/m⁶)
+  #    ├─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    └─── unit:M^-6 symbol: m
+unit:GM-HR-PER-M6 qudt:symbol "g·h/m⁶" .
+
+  # WRONG SYMBOL  : unit:GM-MIN-PER-L-CentiM3 - calculated from factors: g·min/(L·cm³), actual: (g/l)/(cm³/min)
+  #
+  #  ──┬ unit:GM-MIN-PER-L-CentiM3 symbol: (g/l)/(cm³/min) (correct: g·min/(L·cm³))
+  #    ├─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └──┬ unit:CentiM^-3 symbol: cm
+  #       └─── unit:M symbol: m
+unit:GM-MIN-PER-L-CentiM3 qudt:symbol "g·min/(L·cm³)" .
+
+  # WRONG SYMBOL  : unit:GM-MIN-PER-L-M3 - calculated from factors: g·min/(L·m³), actual: (g/l)/(m³/min)
+  #
+  #  ──┬ unit:GM-MIN-PER-L-M3 symbol: (g/l)/(m³/min) (correct: g·min/(L·m³))
+  #    ├─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └─── unit:M^-3 symbol: m
+unit:GM-MIN-PER-L-M3 qudt:symbol "g·min/(L·m³)" .
+
+  # WRONG SYMBOL  : unit:GM-MIN-PER-L2 - calculated from factors: g·min/L², actual: (g/l)/(l/min)
+  #
+  #  ──┬ unit:GM-MIN-PER-L2 symbol: (g/l)/(l/min) (correct: g·min/L²)
+  #    ├─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    └──┬ unit:L^-2 symbol: L
+  #       └──┬ unit:DeciM3 symbol: dm³
+  #          └──┬ unit:DeciM^3 symbol: dm
+  #             └─── unit:M symbol: m
+unit:GM-MIN-PER-L2 qudt:symbol "g·min/L²" .
+
+  # WRONG SYMBOL  : unit:GM-MIN-PER-M3-CentiM3 - calculated from factors: g·min/(m³·cm³), actual: (g/m³)/(cm³/min)
+  #
+  #  ──┬ unit:GM-MIN-PER-M3-CentiM3 symbol: (g/m³)/(cm³/min) (correct: g·min/(m³·cm³))
+  #    ├─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    ├─── unit:M^-3 symbol: m
+  #    └──┬ unit:CentiM^-3 symbol: cm
+  #       └─── unit:M symbol: m
+unit:GM-MIN-PER-M3-CentiM3 qudt:symbol "g·min/(m³·cm³)" .
+
+  # WRONG SYMBOL  : unit:GM-MIN-PER-M3-L - calculated from factors: g·min/(m³·L), actual: (g/m³)/(l/min)
+  #
+  #  ──┬ unit:GM-MIN-PER-M3-L symbol: (g/m³)/(l/min) (correct: g·min/(m³·L))
+  #    ├─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    ├─── unit:M^-3 symbol: m
+  #    └──┬ unit:L^-1 symbol: L
+  #       └──┬ unit:DeciM3 symbol: dm³
+  #          └──┬ unit:DeciM^3 symbol: dm
+  #             └─── unit:M symbol: m
+unit:GM-MIN-PER-M3-L qudt:symbol "g·min/(m³·L)" .
+
+  # WRONG SYMBOL  : unit:GM-MIN-PER-M6 - calculated from factors: g·min/m⁶, actual: (g/m³)/(m³/min)
+  #
+  #  ──┬ unit:GM-MIN-PER-M6 symbol: (g/m³)/(m³/min) (correct: g·min/m⁶)
+  #    ├─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    └─── unit:M^-6 symbol: m
+unit:GM-MIN-PER-M6 qudt:symbol "g·min/m⁶" .
+
+  # WRONG SYMBOL  : unit:GM-PER-DAY - calculated from factors: g/d, actual: g/day
+  #
+  #  ──┬ unit:GM-PER-DAY symbol: g/day (correct: g/d)
+  #    ├─── unit:GM symbol: g
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:GM-PER-DAY qudt:symbol "g/d" .
+
+  # WRONG SYMBOL  : unit:GM-PER-L-BAR - calculated from factors: g/(L·bar), actual: g/(l·bar)
+  #
+  #  ──┬ unit:GM-PER-L-BAR symbol: g/(l·bar) (correct: g/(L·bar))
+  #    ├─── unit:GM symbol: g
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └──┬ unit:BAR^-1 symbol: bar
+  #       └──┬ unit:PA symbol: Pa
+  #          ├─── unit:M^-2 symbol: m
+  #          └──┬ unit:N symbol: N
+  #             ├──┬ unit:KiloGM symbol: kg
+  #             │  └─── unit:GM symbol: g
+  #             ├─── unit:M symbol: m
+  #             └─── unit:SEC^-2 symbol: s
+unit:GM-PER-L-BAR qudt:symbol "g/(L·bar)" .
+
+  # WRONG SYMBOL  : unit:GM-PER-L-CentiPOISE - calculated from factors: g/(L·cP), actual: (g/l)/cP
+  #
+  #  ──┬ unit:GM-PER-L-CentiPOISE symbol: (g/l)/cP (correct: g/(L·cP))
+  #    ├─── unit:GM symbol: g
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └──┬ unit:CentiPOISE^-1 symbol: cP
+  #       └──┬ unit:POISE symbol: P
+  #          └──┬ unit:KiloGM-PER-M-SEC symbol: kg/(m·s)
+  #             ├──┬ unit:KiloGM symbol: kg
+  #             │  └─── unit:GM symbol: g
+  #             ├─── unit:M^-1 symbol: m
+  #             └─── unit:SEC^-1 symbol: s
+unit:GM-PER-L-CentiPOISE qudt:symbol "g/(L·cP)" .
+
+  # WRONG SYMBOL  : unit:GM-PER-L-K - calculated from factors: g/(L·K), actual: g/(l·K)
+  #
+  #  ──┬ unit:GM-PER-L-K symbol: g/(l·K) (correct: g/(L·K))
+  #    ├─── unit:GM symbol: g
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └─── unit:K^-1 symbol: K
+unit:GM-PER-L-K qudt:symbol "g/(L·K)" .
+
+  # WRONG SYMBOL  : unit:GM-PER-L-MilliPA-SEC - calculated from factors: g/(L·mPa·s), actual: (g/l)/(mPa·s)
+  #
+  #  ──┬ unit:GM-PER-L-MilliPA-SEC symbol: (g/l)/(mPa·s) (correct: g/(L·mPa·s))
+  #    ├─── unit:GM symbol: g
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    ├──┬ unit:MilliPA^-1 symbol: mPa
+  #    │  └──┬ unit:PA symbol: Pa
+  #    │     ├─── unit:M^-2 symbol: m
+  #    │     └──┬ unit:N symbol: N
+  #    │        ├──┬ unit:KiloGM symbol: kg
+  #    │        │  └─── unit:GM symbol: g
+  #    │        ├─── unit:M symbol: m
+  #    │        └─── unit:SEC^-2 symbol: s
+  #    └─── unit:SEC^-1 symbol: s
+unit:GM-PER-L-MilliPA-SEC qudt:symbol "g/(L·mPa·s)" .
+
+  # WRONG SYMBOL  : unit:GM-PER-L-PA-SEC - calculated from factors: g/(L·Pa·s), actual: (g/l)/(Pa·s)
+  #
+  #  ──┬ unit:GM-PER-L-PA-SEC symbol: (g/l)/(Pa·s) (correct: g/(L·Pa·s))
+  #    ├─── unit:GM symbol: g
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    ├──┬ unit:PA^-1 symbol: Pa
+  #    │  ├─── unit:M^-2 symbol: m
+  #    │  └──┬ unit:N symbol: N
+  #    │     ├──┬ unit:KiloGM symbol: kg
+  #    │     │  └─── unit:GM symbol: g
+  #    │     ├─── unit:M symbol: m
+  #    │     └─── unit:SEC^-2 symbol: s
+  #    └─── unit:SEC^-1 symbol: s
+unit:GM-PER-L-PA-SEC qudt:symbol "g/(L·Pa·s)" .
+
+  # WRONG SYMBOL  : unit:GM-PER-L-POISE - calculated from factors: g/(L·P), actual: (g/l)/P
+  #
+  #  ──┬ unit:GM-PER-L-POISE symbol: (g/l)/P (correct: g/(L·P))
+  #    ├─── unit:GM symbol: g
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └──┬ unit:POISE^-1 symbol: P
+  #       └──┬ unit:KiloGM-PER-M-SEC symbol: kg/(m·s)
+  #          ├──┬ unit:KiloGM symbol: kg
+  #          │  └─── unit:GM symbol: g
+  #          ├─── unit:M^-1 symbol: m
+  #          └─── unit:SEC^-1 symbol: s
+unit:GM-PER-L-POISE qudt:symbol "g/(L·P)" .
+
+  # WRONG SYMBOL  : unit:GM-PER-M2-DAY - calculated from factors: g/(m²·d), actual: g/(m²·day)
+  #
+  #  ──┬ unit:GM-PER-M2-DAY symbol: g/(m²·day) (correct: g/(m²·d))
+  #    ├─── unit:GM symbol: g
+  #    ├─── unit:M^-2 symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:GM-PER-M2-DAY qudt:symbol "g/(m²·d)" .
+
+  # WRONG SYMBOL  : unit:GM-PER-M2-HR - calculated from factors: g/(m²·h), actual: g/m²·hr
+  #
+  #  ──┬ unit:GM-PER-M2-HR symbol: g/m²·hr (correct: g/(m²·h))
+  #    ├─── unit:GM symbol: g
+  #    ├─── unit:M^-2 symbol: m
+  #    └──┬ unit:HR^-1 symbol: h
+  #       └─── unit:SEC symbol: s
+unit:GM-PER-M2-HR qudt:symbol "g/(m²·h)" .
+
+  # WRONG SYMBOL  : unit:GM-PER-M2-YR - calculated from factors: g/(m²·a), actual: g/m²·yr
+  #
+  #  ──┬ unit:GM-PER-M2-YR symbol: g/m²·yr (correct: g/(m²·a))
+  #    ├─── unit:GM symbol: g
+  #    ├─── unit:M^-2 symbol: m
+  #    └──┬ unit:YR^-1 symbol: a
+  #       └─── unit:SEC symbol: s
+unit:GM-PER-M2-YR qudt:symbol "g/(m²·a)" .
+
+  # WRONG SYMBOL  : unit:GM-PER-M3-PA-SEC - calculated from factors: g/(m³·Pa·s), actual: g/(m³Pa·s)
+  #
+  #  ──┬ unit:GM-PER-M3-PA-SEC symbol: g/(m³Pa·s) (correct: g/(m³·Pa·s))
+  #    ├─── unit:GM symbol: g
+  #    ├─── unit:M^-3 symbol: m
+  #    ├──┬ unit:PA^-1 symbol: Pa
+  #    │  ├─── unit:M^-2 symbol: m
+  #    │  └──┬ unit:N symbol: N
+  #    │     ├──┬ unit:KiloGM symbol: kg
+  #    │     │  └─── unit:GM symbol: g
+  #    │     ├─── unit:M symbol: m
+  #    │     └─── unit:SEC^-2 symbol: s
+  #    └─── unit:SEC^-1 symbol: s
+unit:GM-PER-M3-PA-SEC qudt:symbol "g/(m³·Pa·s)" .
+
+  # WRONG SYMBOL  : unit:GM-PER-M3-POISE - calculated from factors: g/(m³·P), actual: (g/m³)/P
+  #
+  #  ──┬ unit:GM-PER-M3-POISE symbol: (g/m³)/P (correct: g/(m³·P))
+  #    ├─── unit:GM symbol: g
+  #    ├─── unit:M^-3 symbol: m
+  #    └──┬ unit:POISE^-1 symbol: P
+  #       └──┬ unit:KiloGM-PER-M-SEC symbol: kg/(m·s)
+  #          ├──┬ unit:KiloGM symbol: kg
+  #          │  └─── unit:GM symbol: g
+  #          ├─── unit:M^-1 symbol: m
+  #          └─── unit:SEC^-1 symbol: s
+unit:GM-PER-M3-POISE qudt:symbol "g/(m³·P)" .
+
+  # WRONG SYMBOL  : unit:GM-PER-MilliL-BAR - calculated from factors: g/(mL·bar), actual: g/(ml·bar)
+  #
+  #  ──┬ unit:GM-PER-MilliL-BAR symbol: g/(ml·bar) (correct: g/(mL·bar))
+  #    ├─── unit:GM symbol: g
+  #    ├──┬ unit:MilliL^-1 symbol: mL
+  #    │  └──┬ unit:L symbol: L
+  #    │     └──┬ unit:DeciM3 symbol: dm³
+  #    │        └──┬ unit:DeciM^3 symbol: dm
+  #    │           └─── unit:M symbol: m
+  #    └──┬ unit:BAR^-1 symbol: bar
+  #       └──┬ unit:PA symbol: Pa
+  #          ├─── unit:M^-2 symbol: m
+  #          └──┬ unit:N symbol: N
+  #             ├──┬ unit:KiloGM symbol: kg
+  #             │  └─── unit:GM symbol: g
+  #             ├─── unit:M symbol: m
+  #             └─── unit:SEC^-2 symbol: s
+unit:GM-PER-MilliL-BAR qudt:symbol "g/(mL·bar)" .
+
+  # WRONG SYMBOL  : unit:GM-PER-MilliL-K - calculated from factors: g/(mL·K), actual: g/(ml·K)
+  #
+  #  ──┬ unit:GM-PER-MilliL-K symbol: g/(ml·K) (correct: g/(mL·K))
+  #    ├─── unit:GM symbol: g
+  #    ├──┬ unit:MilliL^-1 symbol: mL
+  #    │  └──┬ unit:L symbol: L
+  #    │     └──┬ unit:DeciM3 symbol: dm³
+  #    │        └──┬ unit:DeciM^3 symbol: dm
+  #    │           └─── unit:M symbol: m
+  #    └─── unit:K^-1 symbol: K
+unit:GM-PER-MilliL-K qudt:symbol "g/(mL·K)" .
+
+  # WRONG SYMBOL  : unit:GM-SEC-PER-L-CentiM3 - calculated from factors: g·s/(L·cm³), actual: (g/l)/(cm³/s)
+  #
+  #  ──┬ unit:GM-SEC-PER-L-CentiM3 symbol: (g/l)/(cm³/s) (correct: g·s/(L·cm³))
+  #    ├─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └──┬ unit:CentiM^-3 symbol: cm
+  #       └─── unit:M symbol: m
+unit:GM-SEC-PER-L-CentiM3 qudt:symbol "g·s/(L·cm³)" .
+
+  # WRONG SYMBOL  : unit:GM-SEC-PER-L-M3 - calculated from factors: g·s/(L·m³), actual: (g/l)/(m³/s)
+  #
+  #  ──┬ unit:GM-SEC-PER-L-M3 symbol: (g/l)/(m³/s) (correct: g·s/(L·m³))
+  #    ├─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └─── unit:M^-3 symbol: m
+unit:GM-SEC-PER-L-M3 qudt:symbol "g·s/(L·m³)" .
+
+  # WRONG SYMBOL  : unit:GM-SEC-PER-L2 - calculated from factors: g·s/L², actual: (g/l)/(l/s)
+  #
+  #  ──┬ unit:GM-SEC-PER-L2 symbol: (g/l)/(l/s) (correct: g·s/L²)
+  #    ├─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    └──┬ unit:L^-2 symbol: L
+  #       └──┬ unit:DeciM3 symbol: dm³
+  #          └──┬ unit:DeciM^3 symbol: dm
+  #             └─── unit:M symbol: m
+unit:GM-SEC-PER-L2 qudt:symbol "g·s/L²" .
+
+  # WRONG SYMBOL  : unit:GM-SEC-PER-M3-CentiM3 - calculated from factors: g·s/(m³·cm³), actual: (g/m³)/(cm³/s)
+  #
+  #  ──┬ unit:GM-SEC-PER-M3-CentiM3 symbol: (g/m³)/(cm³/s) (correct: g·s/(m³·cm³))
+  #    ├─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    ├─── unit:M^-3 symbol: m
+  #    └──┬ unit:CentiM^-3 symbol: cm
+  #       └─── unit:M symbol: m
+unit:GM-SEC-PER-M3-CentiM3 qudt:symbol "g·s/(m³·cm³)" .
+
+  # WRONG SYMBOL  : unit:GM-SEC-PER-M3-L - calculated from factors: g·s/(m³·L), actual: (g/m³)/(l/s)
+  #
+  #  ──┬ unit:GM-SEC-PER-M3-L symbol: (g/m³)/(l/s) (correct: g·s/(m³·L))
+  #    ├─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    ├─── unit:M^-3 symbol: m
+  #    └──┬ unit:L^-1 symbol: L
+  #       └──┬ unit:DeciM3 symbol: dm³
+  #          └──┬ unit:DeciM^3 symbol: dm
+  #             └─── unit:M symbol: m
+unit:GM-SEC-PER-M3-L qudt:symbol "g·s/(m³·L)" .
+
+  # WRONG SYMBOL  : unit:GM-SEC-PER-M6 - calculated from factors: g·s/m⁶, actual: (g/m³)/(m³/s)
+  #
+  #  ──┬ unit:GM-SEC-PER-M6 symbol: (g/m³)/(m³/s) (correct: g·s/m⁶)
+  #    ├─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    └─── unit:M^-6 symbol: m
+unit:GM-SEC-PER-M6 qudt:symbol "g·s/m⁶" .
+
+  # WRONG SYMBOL  : unit:GigaBIT-PER-SEC - calculated from factors: Gbit/s, actual: Gbps
+  #
+  #  ──┬ unit:GigaBIT-PER-SEC symbol: Gbps (correct: Gbit/s)
+  #    ├──┬ unit:GigaBIT symbol: Gbit
+  #    │  └─── unit:BIT symbol: b
+  #    └─── unit:SEC^-1 symbol: s
+unit:GigaBIT-PER-SEC qudt:symbol "Gbit/s" .
+
+  # WRONG SYMBOL  : unit:GigaBYTE-PER-SEC - calculated from factors: GB/s, actual: Gbyte/s
+  #
+  #  ──┬ unit:GigaBYTE-PER-SEC symbol: Gbyte/s (correct: GB/s)
+  #    ├──┬ unit:GigaBYTE symbol: GB
+  #    │  └─── unit:BYTE symbol: B
+  #    └─── unit:SEC^-1 symbol: s
+unit:GigaBYTE-PER-SEC qudt:symbol "GB/s" .
+
+  # WRONG SYMBOL  : unit:GigaOHM-M - calculated from factors: GΩ·m, actual: GΩ·m
+  #
+  #  ──┬ unit:GigaOHM-M symbol: GΩ·m (correct: GΩ·m)
+  #    ├──┬ unit:GigaOHM symbol: GΩ
+  #    │  └──┬ unit:OHM symbol: Ω
+  #    │     ├─── unit:A^-1 symbol: A
+  #    │     └──┬ unit:V symbol: V
+  #    │        ├─── unit:A^-1 symbol: A
+  #    │        └──┬ unit:W symbol: W
+  #    │           ├──┬ unit:J symbol: J
+  #    │           │  ├─── unit:M symbol: m
+  #    │           │  └──┬ unit:N symbol: N
+  #    │           │     ├──┬ unit:KiloGM symbol: kg
+  #    │           │     │  └─── unit:GM symbol: g
+  #    │           │     ├─── unit:M symbol: m
+  #    │           │     └─── unit:SEC^-2 symbol: s
+  #    │           └─── unit:SEC^-1 symbol: s
+  #    └─── unit:M symbol: m
+unit:GigaOHM-M qudt:symbol "GΩ·m" .
+
+  # WRONG SYMBOL  : unit:GigaOHM-PER-M - calculated from factors: GΩ/m, actual: GΩ/m
+  #
+  #  ──┬ unit:GigaOHM-PER-M symbol: GΩ/m (correct: GΩ/m)
+  #    ├──┬ unit:GigaOHM symbol: GΩ
+  #    │  └──┬ unit:OHM symbol: Ω
+  #    │     ├─── unit:A^-1 symbol: A
+  #    │     └──┬ unit:V symbol: V
+  #    │        ├─── unit:A^-1 symbol: A
+  #    │        └──┬ unit:W symbol: W
+  #    │           ├──┬ unit:J symbol: J
+  #    │           │  ├─── unit:M symbol: m
+  #    │           │  └──┬ unit:N symbol: N
+  #    │           │     ├──┬ unit:KiloGM symbol: kg
+  #    │           │     │  └─── unit:GM symbol: g
+  #    │           │     ├─── unit:M symbol: m
+  #    │           │     └─── unit:SEC^-2 symbol: s
+  #    │           └─── unit:SEC^-1 symbol: s
+  #    └─── unit:M^-1 symbol: m
+unit:GigaOHM-PER-M qudt:symbol "GΩ/m" .
+
+  # WRONG SYMBOL  : unit:HR-PER-FT2 - calculated from factors: h/ft², actual: (lb/ft³)/(lb/(ft·h)
+  #
+  #  ──┬ unit:HR-PER-FT2 symbol: (lb/ft³)/(lb/(ft·h) (correct: h/ft²)
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    └──┬ unit:FT^-2 symbol: ft
+  #       └──┬ unit:IN symbol: in
+  #          └─── unit:M symbol: m
+unit:HR-PER-FT2 qudt:symbol "h/ft²" .
+
+  # WRONG SYMBOL  : unit:IN-PER-YR - calculated from factors: in/a, actual: in/y
+  #
+  #  ──┬ unit:IN-PER-YR symbol: in/y (correct: in/a)
+  #    ├──┬ unit:IN symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:YR^-1 symbol: a
+  #       └─── unit:SEC symbol: s
+unit:IN-PER-YR qudt:symbol "in/a" .
+
+  # WRONG SYMBOL  : unit:J-PER-CentiM2-DAY - calculated from factors: J/(cm²·d), actual: J/(cm²·day)
+  #
+  #  ──┬ unit:J-PER-CentiM2-DAY symbol: J/(cm²·day) (correct: J/(cm²·d))
+  #    ├──┬ unit:J symbol: J
+  #    │  ├─── unit:M symbol: m
+  #    │  └──┬ unit:N symbol: N
+  #    │     ├──┬ unit:KiloGM symbol: kg
+  #    │     │  └─── unit:GM symbol: g
+  #    │     ├─── unit:M symbol: m
+  #    │     └─── unit:SEC^-2 symbol: s
+  #    ├──┬ unit:CentiM^-2 symbol: cm
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:J-PER-CentiM2-DAY qudt:symbol "J/(cm²·d)" .
+
+  # WRONG SYMBOL  : unit:J-PER-KiloGM-K - calculated from factors: J/(K·kg), actual: J/(kg·K)
+  #
+  #  ──┬ unit:J-PER-KiloGM-K symbol: J/(kg·K) (correct: J/(K·kg))
+  #    ├──┬ unit:J symbol: J
+  #    │  ├─── unit:M symbol: m
+  #    │  └──┬ unit:N symbol: N
+  #    │     ├──┬ unit:KiloGM symbol: kg
+  #    │     │  └─── unit:GM symbol: g
+  #    │     ├─── unit:M symbol: m
+  #    │     └─── unit:SEC^-2 symbol: s
+  #    ├─── unit:K^-1 symbol: K
+  #    └──┬ unit:KiloGM^-1 symbol: kg
+  #       └─── unit:GM symbol: g
+unit:J-PER-KiloGM-K qudt:symbol "J/(K·kg)" .
+
+  # WRONG SYMBOL  : unit:J-PER-KiloGM-K-M3 - calculated from factors: J/(K·kg·m³), actual: J/(kg·K·m³)
+  #
+  #  ──┬ unit:J-PER-KiloGM-K-M3 symbol: J/(kg·K·m³) (correct: J/(K·kg·m³))
+  #    ├──┬ unit:J symbol: J
+  #    │  ├─── unit:M symbol: m
+  #    │  └──┬ unit:N symbol: N
+  #    │     ├──┬ unit:KiloGM symbol: kg
+  #    │     │  └─── unit:GM symbol: g
+  #    │     ├─── unit:M symbol: m
+  #    │     └─── unit:SEC^-2 symbol: s
+  #    ├─── unit:K^-1 symbol: K
+  #    ├──┬ unit:KiloGM^-1 symbol: kg
+  #    │  └─── unit:GM symbol: g
+  #    └─── unit:M^-3 symbol: m
+unit:J-PER-KiloGM-K-M3 qudt:symbol "J/(K·kg·m³)" .
+
+  # WRONG SYMBOL  : unit:J-PER-KiloGM-K-PA - calculated from factors: J/(K·kg·Pa), actual: J/(kg·K·Pa)
+  #
+  #  ──┬ unit:J-PER-KiloGM-K-PA symbol: J/(kg·K·Pa) (correct: J/(K·kg·Pa))
+  #    ├──┬ unit:J symbol: J
+  #    │  ├─── unit:M symbol: m
+  #    │  └──┬ unit:N symbol: N
+  #    │     ├──┬ unit:KiloGM symbol: kg
+  #    │     │  └─── unit:GM symbol: g
+  #    │     ├─── unit:M symbol: m
+  #    │     └─── unit:SEC^-2 symbol: s
+  #    ├─── unit:K^-1 symbol: K
+  #    ├──┬ unit:KiloGM^-1 symbol: kg
+  #    │  └─── unit:GM symbol: g
+  #    └──┬ unit:PA^-1 symbol: Pa
+  #       ├─── unit:M^-2 symbol: m
+  #       └──┬ unit:N symbol: N
+  #          ├──┬ unit:KiloGM symbol: kg
+  #          │  └─── unit:GM symbol: g
+  #          ├─── unit:M symbol: m
+  #          └─── unit:SEC^-2 symbol: s
+unit:J-PER-KiloGM-K-PA qudt:symbol "J/(K·kg·Pa)" .
+
+  # WRONG SYMBOL  : unit:K-DAY - calculated from factors: K·d, actual: K·day
+  #
+  #  ──┬ unit:K-DAY symbol: K·day (correct: K·d)
+  #    ├─── unit:K symbol: K
+  #    └──┬ unit:DAY symbol: d
+  #       └─── unit:SEC symbol: s
+unit:K-DAY qudt:symbol "K·d" .
+
+  # WRONG SYMBOL  : unit:KAT-PER-MicroL - calculated from factors: kat/μL, actual: kat/µL
+  #
+  #  ──┬ unit:KAT-PER-MicroL symbol: kat/µL (correct: kat/μL)
+  #    ├──┬ unit:KAT symbol: kat
+  #    │  ├─── unit:MOL symbol: mol
+  #    │  └─── unit:SEC^-1 symbol: s
+  #    └──┬ unit:MicroL^-1 symbol: μL
+  #       └──┬ unit:L symbol: L
+  #          └──┬ unit:DeciM3 symbol: dm³
+  #             └──┬ unit:DeciM^3 symbol: dm
+  #                └─── unit:M symbol: m
+unit:KAT-PER-MicroL qudt:symbol "kat/μL" .
+
+  # WRONG SYMBOL  : unit:KiloBIT-PER-SEC - calculated from factors: kbit/s, actual: kbps
+  #
+  #  ──┬ unit:KiloBIT-PER-SEC symbol: kbps (correct: kbit/s)
+  #    ├──┬ unit:KiloBIT symbol: kbit
+  #    │  └─── unit:BIT symbol: b
+  #    └─── unit:SEC^-1 symbol: s
+unit:KiloBIT-PER-SEC qudt:symbol "kbit/s" .
+
+  # WRONG SYMBOL  : unit:KiloCAL_IT-PER-GM-K - calculated from factors: kcal{IT}/(g·K), actual: kcalIT/(g·K)
+  #
+  #  ──┬ unit:KiloCAL_IT-PER-GM-K symbol: kcalIT/(g·K) (correct: kcal{IT}/(g·K))
+  #    ├──┬ unit:KiloCAL_IT symbol: kcal{IT}
+  #    │  └──┬ unit:CAL_IT symbol: cal{IT}
+  #    │     └──┬ unit:J symbol: J
+  #    │        ├─── unit:M symbol: m
+  #    │        └──┬ unit:N symbol: N
+  #    │           ├──┬ unit:KiloGM symbol: kg
+  #    │           │  └─── unit:GM symbol: g
+  #    │           ├─── unit:M symbol: m
+  #    │           └─── unit:SEC^-2 symbol: s
+  #    ├─── unit:GM^-1 symbol: g
+  #    └─── unit:K^-1 symbol: K
+unit:KiloCAL_IT-PER-GM-K qudt:symbol "kcal{IT}/(g·K)" .
+
+  # WRONG SYMBOL  : unit:KiloCAL_TH-PER-HR - calculated from factors: kcal/h, actual: kcal{th}/h
+  #
+  #  ──┬ unit:KiloCAL_TH-PER-HR symbol: kcal{th}/h (correct: kcal/h)
+  #    ├──┬ unit:KiloCAL_TH symbol: kcal
+  #    │  └──┬ unit:CAL_TH symbol: cal
+  #    │     └──┬ unit:J symbol: J
+  #    │        ├─── unit:M symbol: m
+  #    │        └──┬ unit:N symbol: N
+  #    │           ├──┬ unit:KiloGM symbol: kg
+  #    │           │  └─── unit:GM symbol: g
+  #    │           ├─── unit:M symbol: m
+  #    │           └─── unit:SEC^-2 symbol: s
+  #    └──┬ unit:HR^-1 symbol: h
+  #       └─── unit:SEC symbol: s
+unit:KiloCAL_TH-PER-HR qudt:symbol "kcal/h" .
+
+  # WRONG SYMBOL  : unit:KiloCAL_TH-PER-MIN - calculated from factors: kcal/min, actual: kcal{th}/min
+  #
+  #  ──┬ unit:KiloCAL_TH-PER-MIN symbol: kcal{th}/min (correct: kcal/min)
+  #    ├──┬ unit:KiloCAL_TH symbol: kcal
+  #    │  └──┬ unit:CAL_TH symbol: cal
+  #    │     └──┬ unit:J symbol: J
+  #    │        ├─── unit:M symbol: m
+  #    │        └──┬ unit:N symbol: N
+  #    │           ├──┬ unit:KiloGM symbol: kg
+  #    │           │  └─── unit:GM symbol: g
+  #    │           ├─── unit:M symbol: m
+  #    │           └─── unit:SEC^-2 symbol: s
+  #    └──┬ unit:MIN^-1 symbol: min
+  #       └─── unit:SEC symbol: s
+unit:KiloCAL_TH-PER-MIN qudt:symbol "kcal/min" .
+
+  # WRONG SYMBOL  : unit:KiloCAL_TH-PER-SEC - calculated from factors: kcal/s, actual: kcal{th}/s
+  #
+  #  ──┬ unit:KiloCAL_TH-PER-SEC symbol: kcal{th}/s (correct: kcal/s)
+  #    ├──┬ unit:KiloCAL_TH symbol: kcal
+  #    │  └──┬ unit:CAL_TH symbol: cal
+  #    │     └──┬ unit:J symbol: J
+  #    │        ├─── unit:M symbol: m
+  #    │        └──┬ unit:N symbol: N
+  #    │           ├──┬ unit:KiloGM symbol: kg
+  #    │           │  └─── unit:GM symbol: g
+  #    │           ├─── unit:M symbol: m
+  #    │           └─── unit:SEC^-2 symbol: s
+  #    └─── unit:SEC^-1 symbol: s
+unit:KiloCAL_TH-PER-SEC qudt:symbol "kcal/s" .
+
+  # WRONG SYMBOL  : unit:KiloEV-PER-MicroM - calculated from factors: keV/μm, actual: keV/µm
+  #
+  #  ──┬ unit:KiloEV-PER-MicroM symbol: keV/µm (correct: keV/μm)
+  #    ├──┬ unit:KiloEV symbol: keV
+  #    │  └──┬ unit:EV symbol: eV
+  #    │     └──┬ unit:J symbol: J
+  #    │        ├─── unit:M symbol: m
+  #    │        └──┬ unit:N symbol: N
+  #    │           ├──┬ unit:KiloGM symbol: kg
+  #    │           │  └─── unit:GM symbol: g
+  #    │           ├─── unit:M symbol: m
+  #    │           └─── unit:SEC^-2 symbol: s
+  #    └──┬ unit:MicroM^-1 symbol: μm
+  #       └─── unit:M symbol: m
+unit:KiloEV-PER-MicroM qudt:symbol "keV/μm" .
+
+  # WRONG SYMBOL  : unit:KiloGM-CentiM-PER-SEC - calculated from factors: kg·cm/s, actual: kg·(cm/s)
+  #
+  #  ──┬ unit:KiloGM-CentiM-PER-SEC symbol: kg·(cm/s) (correct: kg·cm/s)
+  #    ├──┬ unit:KiloGM symbol: kg
+  #    │  └─── unit:GM symbol: g
+  #    ├──┬ unit:CentiM symbol: cm
+  #    │  └─── unit:M symbol: m
+  #    └─── unit:SEC^-1 symbol: s
+unit:KiloGM-CentiM-PER-SEC qudt:symbol "kg·cm/s" .
+
+  # WRONG SYMBOL  : unit:KiloGM-K - calculated from factors: K·kg, actual: kg·K
+  #
+  #  ──┬ unit:KiloGM-K symbol: kg·K (correct: K·kg)
+  #    ├─── unit:K symbol: K
+  #    └──┬ unit:KiloGM symbol: kg
+  #       └─── unit:GM symbol: g
+unit:KiloGM-K qudt:symbol "K·kg" .
+
+  # WRONG SYMBOL  : unit:KiloGM-PER-DAY - calculated from factors: kg/d, actual: kg/day
+  #
+  #  ──┬ unit:KiloGM-PER-DAY symbol: kg/day (correct: kg/d)
+  #    ├──┬ unit:KiloGM symbol: kg
+  #    │  └─── unit:GM symbol: g
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:KiloGM-PER-DAY qudt:symbol "kg/d" .
+
+  # WRONG SYMBOL  : unit:KiloGM-PER-HA-YR - calculated from factors: kg/(ha·a), actual: kg/ha/year
+  #
+  #  ──┬ unit:KiloGM-PER-HA-YR symbol: kg/ha/year (correct: kg/(ha·a))
+  #    ├──┬ unit:KiloGM symbol: kg
+  #    │  └─── unit:GM symbol: g
+  #    ├──┬ unit:HA^-1 symbol: ha
+  #    │  └──┬ unit:M2 symbol: m²
+  #    │     └─── unit:M^2 symbol: m
+  #    └──┬ unit:YR^-1 symbol: a
+  #       └─── unit:SEC symbol: s
+unit:KiloGM-PER-HA-YR qudt:symbol "kg/(ha·a)" .
+
+  # WRONG SYMBOL  : unit:KiloGM-PER-L-BAR - calculated from factors: kg/(L·bar), actual: kg/(l·bar)
+  #
+  #  ──┬ unit:KiloGM-PER-L-BAR symbol: kg/(l·bar) (correct: kg/(L·bar))
+  #    ├──┬ unit:KiloGM symbol: kg
+  #    │  └─── unit:GM symbol: g
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └──┬ unit:BAR^-1 symbol: bar
+  #       └──┬ unit:PA symbol: Pa
+  #          ├─── unit:M^-2 symbol: m
+  #          └──┬ unit:N symbol: N
+  #             ├──┬ unit:KiloGM symbol: kg
+  #             │  └─── unit:GM symbol: g
+  #             ├─── unit:M symbol: m
+  #             └─── unit:SEC^-2 symbol: s
+unit:KiloGM-PER-L-BAR qudt:symbol "kg/(L·bar)" .
+
+  # WRONG SYMBOL  : unit:KiloGM-PER-L-K - calculated from factors: kg/(L·K), actual: kg/(l·K)
+  #
+  #  ──┬ unit:KiloGM-PER-L-K symbol: kg/(l·K) (correct: kg/(L·K))
+  #    ├──┬ unit:KiloGM symbol: kg
+  #    │  └─── unit:GM symbol: g
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └─── unit:K^-1 symbol: K
+unit:KiloGM-PER-L-K qudt:symbol "kg/(L·K)" .
+
+  # WRONG SYMBOL  : unit:KiloJ-PER-KiloGM-K - calculated from factors: kJ/(K·kg), actual: kJ/(kg·K)
+  #
+  #  ──┬ unit:KiloJ-PER-KiloGM-K symbol: kJ/(kg·K) (correct: kJ/(K·kg))
+  #    ├──┬ unit:KiloJ symbol: kJ
+  #    │  └──┬ unit:J symbol: J
+  #    │     ├─── unit:M symbol: m
+  #    │     └──┬ unit:N symbol: N
+  #    │        ├──┬ unit:KiloGM symbol: kg
+  #    │        │  └─── unit:GM symbol: g
+  #    │        ├─── unit:M symbol: m
+  #    │        └─── unit:SEC^-2 symbol: s
+  #    ├─── unit:K^-1 symbol: K
+  #    └──┬ unit:KiloGM^-1 symbol: kg
+  #       └─── unit:GM symbol: g
+unit:KiloJ-PER-KiloGM-K qudt:symbol "kJ/(K·kg)" .
+
+  # WRONG SYMBOL  : unit:KiloM-PER-DAY - calculated from factors: km/d, actual: km/day
+  #
+  #  ──┬ unit:KiloM-PER-DAY symbol: km/day (correct: km/d)
+  #    ├──┬ unit:KiloM symbol: km
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:KiloM-PER-DAY qudt:symbol "km/d" .
+
+  # WRONG SYMBOL  : unit:KiloOHM-M - calculated from factors: kΩ·m, actual: kΩ·m
+  #
+  #  ──┬ unit:KiloOHM-M symbol: kΩ·m (correct: kΩ·m)
+  #    ├──┬ unit:KiloOHM symbol: kΩ
+  #    │  └──┬ unit:OHM symbol: Ω
+  #    │     ├─── unit:A^-1 symbol: A
+  #    │     └──┬ unit:V symbol: V
+  #    │        ├─── unit:A^-1 symbol: A
+  #    │        └──┬ unit:W symbol: W
+  #    │           ├──┬ unit:J symbol: J
+  #    │           │  ├─── unit:M symbol: m
+  #    │           │  └──┬ unit:N symbol: N
+  #    │           │     ├──┬ unit:KiloGM symbol: kg
+  #    │           │     │  └─── unit:GM symbol: g
+  #    │           │     ├─── unit:M symbol: m
+  #    │           │     └─── unit:SEC^-2 symbol: s
+  #    │           └─── unit:SEC^-1 symbol: s
+  #    └─── unit:M symbol: m
+unit:KiloOHM-M qudt:symbol "kΩ·m" .
+
+  # WRONG SYMBOL  : unit:KiloOHM-PER-BAR - calculated from factors: kΩ/bar, actual: kΩ/bar
+  #
+  #  ──┬ unit:KiloOHM-PER-BAR symbol: kΩ/bar (correct: kΩ/bar)
+  #    ├──┬ unit:KiloOHM symbol: kΩ
+  #    │  └──┬ unit:OHM symbol: Ω
+  #    │     ├─── unit:A^-1 symbol: A
+  #    │     └──┬ unit:V symbol: V
+  #    │        ├─── unit:A^-1 symbol: A
+  #    │        └──┬ unit:W symbol: W
+  #    │           ├──┬ unit:J symbol: J
+  #    │           │  ├─── unit:M symbol: m
+  #    │           │  └──┬ unit:N symbol: N
+  #    │           │     ├──┬ unit:KiloGM symbol: kg
+  #    │           │     │  └─── unit:GM symbol: g
+  #    │           │     ├─── unit:M symbol: m
+  #    │           │     └─── unit:SEC^-2 symbol: s
+  #    │           └─── unit:SEC^-1 symbol: s
+  #    └──┬ unit:BAR^-1 symbol: bar
+  #       └──┬ unit:PA symbol: Pa
+  #          ├─── unit:M^-2 symbol: m
+  #          └──┬ unit:N symbol: N
+  #             ├──┬ unit:KiloGM symbol: kg
+  #             │  └─── unit:GM symbol: g
+  #             ├─── unit:M symbol: m
+  #             └─── unit:SEC^-2 symbol: s
+unit:KiloOHM-PER-BAR qudt:symbol "kΩ/bar" .
+
+  # WRONG SYMBOL  : unit:KiloOHM-PER-K - calculated from factors: kΩ/K, actual: kΩ/K
+  #
+  #  ──┬ unit:KiloOHM-PER-K symbol: kΩ/K (correct: kΩ/K)
+  #    ├──┬ unit:KiloOHM symbol: kΩ
+  #    │  └──┬ unit:OHM symbol: Ω
+  #    │     ├─── unit:A^-1 symbol: A
+  #    │     └──┬ unit:V symbol: V
+  #    │        ├─── unit:A^-1 symbol: A
+  #    │        └──┬ unit:W symbol: W
+  #    │           ├──┬ unit:J symbol: J
+  #    │           │  ├─── unit:M symbol: m
+  #    │           │  └──┬ unit:N symbol: N
+  #    │           │     ├──┬ unit:KiloGM symbol: kg
+  #    │           │     │  └─── unit:GM symbol: g
+  #    │           │     ├─── unit:M symbol: m
+  #    │           │     └─── unit:SEC^-2 symbol: s
+  #    │           └─── unit:SEC^-1 symbol: s
+  #    └─── unit:K^-1 symbol: K
+unit:KiloOHM-PER-K qudt:symbol "kΩ/K" .
+
+  # WRONG SYMBOL  : unit:KiloOHM-PER-M - calculated from factors: kΩ/m, actual: kΩ/m
+  #
+  #  ──┬ unit:KiloOHM-PER-M symbol: kΩ/m (correct: kΩ/m)
+  #    ├──┬ unit:KiloOHM symbol: kΩ
+  #    │  └──┬ unit:OHM symbol: Ω
+  #    │     ├─── unit:A^-1 symbol: A
+  #    │     └──┬ unit:V symbol: V
+  #    │        ├─── unit:A^-1 symbol: A
+  #    │        └──┬ unit:W symbol: W
+  #    │           ├──┬ unit:J symbol: J
+  #    │           │  ├─── unit:M symbol: m
+  #    │           │  └──┬ unit:N symbol: N
+  #    │           │     ├──┬ unit:KiloGM symbol: kg
+  #    │           │     │  └─── unit:GM symbol: g
+  #    │           │     ├─── unit:M symbol: m
+  #    │           │     └─── unit:SEC^-2 symbol: s
+  #    │           └─── unit:SEC^-1 symbol: s
+  #    └─── unit:M^-1 symbol: m
+unit:KiloOHM-PER-M qudt:symbol "kΩ/m" .
+
+  # WRONG SYMBOL  : unit:KiloTONNE-PER-YR - calculated from factors: kt/a, actual: kt/yr
+  #
+  #  ──┬ unit:KiloTONNE-PER-YR symbol: kt/yr (correct: kt/a)
+  #    ├──┬ unit:KiloTONNE symbol: kt
+  #    │  └──┬ unit:TONNE symbol: t
+  #    │     └──┬ unit:KiloGM symbol: kg
+  #    │        └─── unit:GM symbol: g
+  #    └──┬ unit:YR^-1 symbol: a
+  #       └─── unit:SEC symbol: s
+unit:KiloTONNE-PER-YR qudt:symbol "kt/a" .
+
+  # WRONG SYMBOL  : unit:KiloW-PER-M2 - calculated from factors: kW/m², actual: kW/m2
+  #
+  #  ──┬ unit:KiloW-PER-M2 symbol: kW/m2 (correct: kW/m²)
+  #    ├──┬ unit:KiloW symbol: kW
+  #    │  └──┬ unit:W symbol: W
+  #    │     ├──┬ unit:J symbol: J
+  #    │     │  ├─── unit:M symbol: m
+  #    │     │  └──┬ unit:N symbol: N
+  #    │     │     ├──┬ unit:KiloGM symbol: kg
+  #    │     │     │  └─── unit:GM symbol: g
+  #    │     │     ├─── unit:M symbol: m
+  #    │     │     └─── unit:SEC^-2 symbol: s
+  #    │     └─── unit:SEC^-1 symbol: s
+  #    └─── unit:M^-2 symbol: m
+unit:KiloW-PER-M2 qudt:symbol "kW/m²" .
+
+  # WRONG SYMBOL  : unit:L-PER-BAR - calculated from factors: L/bar, actual: l/bar
+  #
+  #  ──┬ unit:L-PER-BAR symbol: l/bar (correct: L/bar)
+  #    ├──┬ unit:L symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └──┬ unit:BAR^-1 symbol: bar
+  #       └──┬ unit:PA symbol: Pa
+  #          ├─── unit:M^-2 symbol: m
+  #          └──┬ unit:N symbol: N
+  #             ├──┬ unit:KiloGM symbol: kg
+  #             │  └─── unit:GM symbol: g
+  #             ├─── unit:M symbol: m
+  #             └─── unit:SEC^-2 symbol: s
+unit:L-PER-BAR qudt:symbol "L/bar" .
+
+  # WRONG SYMBOL  : unit:L-PER-DAY - calculated from factors: L/d, actual: L/day
+  #
+  #  ──┬ unit:L-PER-DAY symbol: L/day (correct: L/d)
+  #    ├──┬ unit:L symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:L-PER-DAY qudt:symbol "L/d" .
+
+  # WRONG SYMBOL  : unit:L-PER-DAY-BAR - calculated from factors: L/(d·bar), actual: l/(d·bar)
+  #
+  #  ──┬ unit:L-PER-DAY-BAR symbol: l/(d·bar) (correct: L/(d·bar))
+  #    ├──┬ unit:L symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    ├──┬ unit:DAY^-1 symbol: d
+  #    │  └─── unit:SEC symbol: s
+  #    └──┬ unit:BAR^-1 symbol: bar
+  #       └──┬ unit:PA symbol: Pa
+  #          ├─── unit:M^-2 symbol: m
+  #          └──┬ unit:N symbol: N
+  #             ├──┬ unit:KiloGM symbol: kg
+  #             │  └─── unit:GM symbol: g
+  #             ├─── unit:M symbol: m
+  #             └─── unit:SEC^-2 symbol: s
+unit:L-PER-DAY-BAR qudt:symbol "L/(d·bar)" .
+
+  # WRONG SYMBOL  : unit:L-PER-DAY-K - calculated from factors: L/(d·K), actual: l/(d·K)
+  #
+  #  ──┬ unit:L-PER-DAY-K symbol: l/(d·K) (correct: L/(d·K))
+  #    ├──┬ unit:L symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    ├──┬ unit:DAY^-1 symbol: d
+  #    │  └─── unit:SEC symbol: s
+  #    └─── unit:K^-1 symbol: K
+unit:L-PER-DAY-K qudt:symbol "L/(d·K)" .
+
+  # WRONG SYMBOL  : unit:L-PER-HR-BAR - calculated from factors: L/(h·bar), actual: l/(h·bar)
+  #
+  #  ──┬ unit:L-PER-HR-BAR symbol: l/(h·bar) (correct: L/(h·bar))
+  #    ├──┬ unit:L symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    ├──┬ unit:HR^-1 symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    └──┬ unit:BAR^-1 symbol: bar
+  #       └──┬ unit:PA symbol: Pa
+  #          ├─── unit:M^-2 symbol: m
+  #          └──┬ unit:N symbol: N
+  #             ├──┬ unit:KiloGM symbol: kg
+  #             │  └─── unit:GM symbol: g
+  #             ├─── unit:M symbol: m
+  #             └─── unit:SEC^-2 symbol: s
+unit:L-PER-HR-BAR qudt:symbol "L/(h·bar)" .
+
+  # WRONG SYMBOL  : unit:L-PER-HR-K - calculated from factors: L/(h·K), actual: l/(h·K)
+  #
+  #  ──┬ unit:L-PER-HR-K symbol: l/(h·K) (correct: L/(h·K))
+  #    ├──┬ unit:L symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    ├──┬ unit:HR^-1 symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    └─── unit:K^-1 symbol: K
+unit:L-PER-HR-K qudt:symbol "L/(h·K)" .
+
+  # WRONG SYMBOL  : unit:L-PER-MIN-BAR - calculated from factors: L/(min·bar), actual: l/(min·bar)
+  #
+  #  ──┬ unit:L-PER-MIN-BAR symbol: l/(min·bar) (correct: L/(min·bar))
+  #    ├──┬ unit:L symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    ├──┬ unit:MIN^-1 symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    └──┬ unit:BAR^-1 symbol: bar
+  #       └──┬ unit:PA symbol: Pa
+  #          ├─── unit:M^-2 symbol: m
+  #          └──┬ unit:N symbol: N
+  #             ├──┬ unit:KiloGM symbol: kg
+  #             │  └─── unit:GM symbol: g
+  #             ├─── unit:M symbol: m
+  #             └─── unit:SEC^-2 symbol: s
+unit:L-PER-MIN-BAR qudt:symbol "L/(min·bar)" .
+
+  # WRONG SYMBOL  : unit:L-PER-MIN-K - calculated from factors: L/(min·K), actual: l/(min·K)
+  #
+  #  ──┬ unit:L-PER-MIN-K symbol: l/(min·K) (correct: L/(min·K))
+  #    ├──┬ unit:L symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    ├──┬ unit:MIN^-1 symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    └─── unit:K^-1 symbol: K
+unit:L-PER-MIN-K qudt:symbol "L/(min·K)" .
+
+  # WRONG SYMBOL  : unit:L-PER-MOL-SEC - calculated from factors: L/(mol·s), actual: l/(mol·s)
+  #
+  #  ──┬ unit:L-PER-MOL-SEC symbol: l/(mol·s) (correct: L/(mol·s))
+  #    ├──┬ unit:L symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    ├─── unit:MOL^-1 symbol: mol
+  #    └─── unit:SEC^-1 symbol: s
+unit:L-PER-MOL-SEC qudt:symbol "L/(mol·s)" .
+
+  # WRONG SYMBOL  : unit:L-PER-MicroMOL - calculated from factors: L/μmol, actual: L/µmol
+  #
+  #  ──┬ unit:L-PER-MicroMOL symbol: L/µmol (correct: L/μmol)
+  #    ├──┬ unit:L symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └──┬ unit:MicroMOL^-1 symbol: μmol
+  #       └─── unit:MOL symbol: mol
+unit:L-PER-MicroMOL qudt:symbol "L/μmol" .
+
+  # WRONG SYMBOL  : unit:L-PER-SEC-BAR - calculated from factors: L/(s·bar), actual: l/(s·bar)
+  #
+  #  ──┬ unit:L-PER-SEC-BAR symbol: l/(s·bar) (correct: L/(s·bar))
+  #    ├──┬ unit:L symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    ├─── unit:SEC^-1 symbol: s
+  #    └──┬ unit:BAR^-1 symbol: bar
+  #       └──┬ unit:PA symbol: Pa
+  #          ├─── unit:M^-2 symbol: m
+  #          └──┬ unit:N symbol: N
+  #             ├──┬ unit:KiloGM symbol: kg
+  #             │  └─── unit:GM symbol: g
+  #             ├─── unit:M symbol: m
+  #             └─── unit:SEC^-2 symbol: s
+unit:L-PER-SEC-BAR qudt:symbol "L/(s·bar)" .
+
+  # WRONG SYMBOL  : unit:L-PER-SEC-K - calculated from factors: L/(s·K), actual: l/(s·K)
+  #
+  #  ──┬ unit:L-PER-SEC-K symbol: l/(s·K) (correct: L/(s·K))
+  #    ├──┬ unit:L symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    ├─── unit:SEC^-1 symbol: s
+  #    └─── unit:K^-1 symbol: K
+unit:L-PER-SEC-K qudt:symbol "L/(s·K)" .
+
+  # WRONG SYMBOL  : unit:LB-FT-PER-SEC - calculated from factors: lbm·ft/s, actual: lb·(ft/s)
+  #
+  #  ──┬ unit:LB-FT-PER-SEC symbol: lb·(ft/s) (correct: lbm·ft/s)
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:FT symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └─── unit:SEC^-1 symbol: s
+unit:LB-FT-PER-SEC qudt:symbol "lbm·ft/s" .
+
+  # WRONG SYMBOL  : unit:LB-FT2-PER-GAL_UK-LB_F-SEC - calculated from factors: lbm·ft²/(gal{UK}·lbf·s), actual: lb/(gal (UK))/(lbf·s/ft²)
+  #
+  #  ──┬ unit:LB-FT2-PER-GAL_UK-LB_F-SEC symbol: lb/(gal (UK))/(lbf·s/ft²) (correct: lbm·ft²/(gal{UK}·lbf·s))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:FT^2 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    ├──┬ unit:GAL_UK^-1 symbol: gal{UK}
+  #    │  └──┬ unit:L symbol: L
+  #    │     └──┬ unit:DeciM3 symbol: dm³
+  #    │        └──┬ unit:DeciM^3 symbol: dm
+  #    │           └─── unit:M symbol: m
+  #    ├──┬ unit:LB_F^-1 symbol: lbf
+  #    │  ├──┬ unit:FT symbol: ft
+  #    │  │  └──┬ unit:IN symbol: in
+  #    │  │     └─── unit:M symbol: m
+  #    │  ├─── unit:SEC^-2 symbol: s
+  #    │  └──┬ unit:SLUG symbol: slug
+  #    │     └──┬ unit:LB symbol: lbm
+  #    │        └──┬ unit:KiloGM symbol: kg
+  #    │           └─── unit:GM symbol: g
+  #    └─── unit:SEC^-1 symbol: s
+unit:LB-FT2-PER-GAL_UK-LB_F-SEC qudt:symbol "lbm·ft²/(gal{UK}·lbf·s)" .
+
+  # WRONG SYMBOL  : unit:LB-FT2-PER-GAL_US-LB_F-SEC - calculated from factors: lbm·ft²/(gal{US}·lbf·s), actual: lb/(gal (US))/(lbf·s/ft²)
+  #
+  #  ──┬ unit:LB-FT2-PER-GAL_US-LB_F-SEC symbol: lb/(gal (US))/(lbf·s/ft²) (correct: lbm·ft²/(gal{US}·lbf·s))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:FT^2 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    ├──┬ unit:GAL_US^-1 symbol: gal{US}
+  #    │  └──┬ unit:IN^3 symbol: in
+  #    │     └─── unit:M symbol: m
+  #    ├──┬ unit:LB_F^-1 symbol: lbf
+  #    │  ├──┬ unit:FT symbol: ft
+  #    │  │  └──┬ unit:IN symbol: in
+  #    │  │     └─── unit:M symbol: m
+  #    │  ├─── unit:SEC^-2 symbol: s
+  #    │  └──┬ unit:SLUG symbol: slug
+  #    │     └──┬ unit:LB symbol: lbm
+  #    │        └──┬ unit:KiloGM symbol: kg
+  #    │           └─── unit:GM symbol: g
+  #    └─── unit:SEC^-1 symbol: s
+unit:LB-FT2-PER-GAL_US-LB_F-SEC qudt:symbol "lbm·ft²/(gal{US}·lbf·s)" .
+
+  # WRONG SYMBOL  : unit:LB-FT2-PER-IN3-LB_F-SEC - calculated from factors: lbm·ft²/(in³·lbf·s), actual: (lb/in³)/(lbf·s/ft²)
+  #
+  #  ──┬ unit:LB-FT2-PER-IN3-LB_F-SEC symbol: (lb/in³)/(lbf·s/ft²) (correct: lbm·ft²/(in³·lbf·s))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:FT^2 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    ├──┬ unit:LB_F^-1 symbol: lbf
+  #    │  ├──┬ unit:FT symbol: ft
+  #    │  │  └──┬ unit:IN symbol: in
+  #    │  │     └─── unit:M symbol: m
+  #    │  ├─── unit:SEC^-2 symbol: s
+  #    │  └──┬ unit:SLUG symbol: slug
+  #    │     └──┬ unit:LB symbol: lbm
+  #    │        └──┬ unit:KiloGM symbol: kg
+  #    │           └─── unit:GM symbol: g
+  #    └─── unit:SEC^-1 symbol: s
+unit:LB-FT2-PER-IN3-LB_F-SEC qudt:symbol "lbm·ft²/(in³·lbf·s)" .
+
+  # WRONG SYMBOL  : unit:LB-HR-PER-FT3-GAL_UK - calculated from factors: lbm·h/(ft³·gal{UK}), actual: (lb/ft³)/(gal (UK)/h)
+  #
+  #  ──┬ unit:LB-HR-PER-FT3-GAL_UK symbol: (lb/ft³)/(gal (UK)/h) (correct: lbm·h/(ft³·gal{UK}))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:FT^-3 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:GAL_UK^-1 symbol: gal{UK}
+  #       └──┬ unit:L symbol: L
+  #          └──┬ unit:DeciM3 symbol: dm³
+  #             └──┬ unit:DeciM^3 symbol: dm
+  #                └─── unit:M symbol: m
+unit:LB-HR-PER-FT3-GAL_UK qudt:symbol "lbm·h/(ft³·gal{UK})" .
+
+  # WRONG SYMBOL  : unit:LB-HR-PER-FT3-GAL_US - calculated from factors: lbm·h/(ft³·gal{US}), actual: (lb/ft³)/(gal (US)/h)
+  #
+  #  ──┬ unit:LB-HR-PER-FT3-GAL_US symbol: (lb/ft³)/(gal (US)/h) (correct: lbm·h/(ft³·gal{US}))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:FT^-3 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:GAL_US^-1 symbol: gal{US}
+  #       └──┬ unit:IN^3 symbol: in
+  #          └─── unit:M symbol: m
+unit:LB-HR-PER-FT3-GAL_US qudt:symbol "lbm·h/(ft³·gal{US})" .
+
+  # WRONG SYMBOL  : unit:LB-HR-PER-FT3-IN3 - calculated from factors: lbm·h/(ft³·in³), actual: (lb/ft³)/(in³/h)
+  #
+  #  ──┬ unit:LB-HR-PER-FT3-IN3 symbol: (lb/ft³)/(in³/h) (correct: lbm·h/(ft³·in³))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:FT^-3 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:IN^-3 symbol: in
+  #       └─── unit:M symbol: m
+unit:LB-HR-PER-FT3-IN3 qudt:symbol "lbm·h/(ft³·in³)" .
+
+  # WRONG SYMBOL  : unit:LB-HR-PER-FT3-YD3 - calculated from factors: lbm·h/(ft³·yd³), actual: (lb/ft³)/(yd³/h)
+  #
+  #  ──┬ unit:LB-HR-PER-FT3-YD3 symbol: (lb/ft³)/(yd³/h) (correct: lbm·h/(ft³·yd³))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:FT^-3 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:YD^-3 symbol: yd
+  #       └──┬ unit:FT symbol: ft
+  #          └──┬ unit:IN symbol: in
+  #             └─── unit:M symbol: m
+unit:LB-HR-PER-FT3-YD3 qudt:symbol "lbm·h/(ft³·yd³)" .
+
+  # WRONG SYMBOL  : unit:LB-HR-PER-FT6 - calculated from factors: lbm·h/ft⁶, actual: (lb/ft³)/(ft³/h)
+  #
+  #  ──┬ unit:LB-HR-PER-FT6 symbol: (lb/ft³)/(ft³/h) (correct: lbm·h/ft⁶)
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    └──┬ unit:FT^-6 symbol: ft
+  #       └──┬ unit:IN symbol: in
+  #          └─── unit:M symbol: m
+unit:LB-HR-PER-FT6 qudt:symbol "lbm·h/ft⁶" .
+
+  # WRONG SYMBOL  : unit:LB-HR-PER-GAL_UK-FT3 - calculated from factors: lbm·h/(gal{UK}·ft³), actual: lb/(gal (UK))/(ft³/h)
+  #
+  #  ──┬ unit:LB-HR-PER-GAL_UK-FT3 symbol: lb/(gal (UK))/(ft³/h) (correct: lbm·h/(gal{UK}·ft³))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:GAL_UK^-1 symbol: gal{UK}
+  #    │  └──┬ unit:L symbol: L
+  #    │     └──┬ unit:DeciM3 symbol: dm³
+  #    │        └──┬ unit:DeciM^3 symbol: dm
+  #    │           └─── unit:M symbol: m
+  #    └──┬ unit:FT^-3 symbol: ft
+  #       └──┬ unit:IN symbol: in
+  #          └─── unit:M symbol: m
+unit:LB-HR-PER-GAL_UK-FT3 qudt:symbol "lbm·h/(gal{UK}·ft³)" .
+
+  # WRONG SYMBOL  : unit:LB-HR-PER-GAL_UK-IN3 - calculated from factors: lbm·h/(gal{UK}·in³), actual: lb/(gal (UK))/(in³/h)
+  #
+  #  ──┬ unit:LB-HR-PER-GAL_UK-IN3 symbol: lb/(gal (UK))/(in³/h) (correct: lbm·h/(gal{UK}·in³))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:GAL_UK^-1 symbol: gal{UK}
+  #    │  └──┬ unit:L symbol: L
+  #    │     └──┬ unit:DeciM3 symbol: dm³
+  #    │        └──┬ unit:DeciM^3 symbol: dm
+  #    │           └─── unit:M symbol: m
+  #    └──┬ unit:IN^-3 symbol: in
+  #       └─── unit:M symbol: m
+unit:LB-HR-PER-GAL_UK-IN3 qudt:symbol "lbm·h/(gal{UK}·in³)" .
+
+  # WRONG SYMBOL  : unit:LB-HR-PER-GAL_UK-YD3 - calculated from factors: lbm·h/(gal{UK}·yd³), actual: lb/(gal (UK))/(yd³/h)
+  #
+  #  ──┬ unit:LB-HR-PER-GAL_UK-YD3 symbol: lb/(gal (UK))/(yd³/h) (correct: lbm·h/(gal{UK}·yd³))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:GAL_UK^-1 symbol: gal{UK}
+  #    │  └──┬ unit:L symbol: L
+  #    │     └──┬ unit:DeciM3 symbol: dm³
+  #    │        └──┬ unit:DeciM^3 symbol: dm
+  #    │           └─── unit:M symbol: m
+  #    └──┬ unit:YD^-3 symbol: yd
+  #       └──┬ unit:FT symbol: ft
+  #          └──┬ unit:IN symbol: in
+  #             └─── unit:M symbol: m
+unit:LB-HR-PER-GAL_UK-YD3 qudt:symbol "lbm·h/(gal{UK}·yd³)" .
+
+  # WRONG SYMBOL  : unit:LB-HR-PER-GAL_US-FT3 - calculated from factors: lbm·h/(gal{US}·ft³), actual: lb/(gal (US))/(ft³/h)
+  #
+  #  ──┬ unit:LB-HR-PER-GAL_US-FT3 symbol: lb/(gal (US))/(ft³/h) (correct: lbm·h/(gal{US}·ft³))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:GAL_US^-1 symbol: gal{US}
+  #    │  └──┬ unit:IN^3 symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:FT^-3 symbol: ft
+  #       └──┬ unit:IN symbol: in
+  #          └─── unit:M symbol: m
+unit:LB-HR-PER-GAL_US-FT3 qudt:symbol "lbm·h/(gal{US}·ft³)" .
+
+  # WRONG SYMBOL  : unit:LB-HR-PER-GAL_US-IN3 - calculated from factors: lbm·h/(gal{US}·in³), actual: lb/(gal (US))/(in³/h)
+  #
+  #  ──┬ unit:LB-HR-PER-GAL_US-IN3 symbol: lb/(gal (US))/(in³/h) (correct: lbm·h/(gal{US}·in³))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:GAL_US^-1 symbol: gal{US}
+  #    │  └──┬ unit:IN^3 symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:IN^-3 symbol: in
+  #       └─── unit:M symbol: m
+unit:LB-HR-PER-GAL_US-IN3 qudt:symbol "lbm·h/(gal{US}·in³)" .
+
+  # WRONG SYMBOL  : unit:LB-HR-PER-GAL_US-YD3 - calculated from factors: lbm·h/(gal{US}·yd³), actual: lb/(gal (US))/(yd³/h)
+  #
+  #  ──┬ unit:LB-HR-PER-GAL_US-YD3 symbol: lb/(gal (US))/(yd³/h) (correct: lbm·h/(gal{US}·yd³))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:GAL_US^-1 symbol: gal{US}
+  #    │  └──┬ unit:IN^3 symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:YD^-3 symbol: yd
+  #       └──┬ unit:FT symbol: ft
+  #          └──┬ unit:IN symbol: in
+  #             └─── unit:M symbol: m
+unit:LB-HR-PER-GAL_US-YD3 qudt:symbol "lbm·h/(gal{US}·yd³)" .
+
+  # WRONG SYMBOL  : unit:LB-HR-PER-GAL_US2 - calculated from factors: lbm·h/gal{US}², actual: lb/(gal (US))/(gal (US)/h)
+  #
+  #  ──┬ unit:LB-HR-PER-GAL_US2 symbol: lb/(gal (US))/(gal (US)/h) (correct: lbm·h/gal{US}²)
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    └──┬ unit:GAL_US^-2 symbol: gal{US}
+  #       └──┬ unit:IN^3 symbol: in
+  #          └─── unit:M symbol: m
+unit:LB-HR-PER-GAL_US2 qudt:symbol "lbm·h/gal{US}²" .
+
+  # WRONG SYMBOL  : unit:LB-HR-PER-IN3-FT3 - calculated from factors: lbm·h/(in³·ft³), actual: (lb/in³)/(ft³/h)
+  #
+  #  ──┬ unit:LB-HR-PER-IN3-FT3 symbol: (lb/in³)/(ft³/h) (correct: lbm·h/(in³·ft³))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:FT^-3 symbol: ft
+  #       └──┬ unit:IN symbol: in
+  #          └─── unit:M symbol: m
+unit:LB-HR-PER-IN3-FT3 qudt:symbol "lbm·h/(in³·ft³)" .
+
+  # WRONG SYMBOL  : unit:LB-HR-PER-IN3-GAL_UK - calculated from factors: lbm·h/(in³·gal{UK}), actual: (lb/in³)/(gal (UK)/h)
+  #
+  #  ──┬ unit:LB-HR-PER-IN3-GAL_UK symbol: (lb/in³)/(gal (UK)/h) (correct: lbm·h/(in³·gal{UK}))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:GAL_UK^-1 symbol: gal{UK}
+  #       └──┬ unit:L symbol: L
+  #          └──┬ unit:DeciM3 symbol: dm³
+  #             └──┬ unit:DeciM^3 symbol: dm
+  #                └─── unit:M symbol: m
+unit:LB-HR-PER-IN3-GAL_UK qudt:symbol "lbm·h/(in³·gal{UK})" .
+
+  # WRONG SYMBOL  : unit:LB-HR-PER-IN3-GAL_US - calculated from factors: lbm·h/(in³·gal{US}), actual: (lb/in³)/(gal (US)/h)
+  #
+  #  ──┬ unit:LB-HR-PER-IN3-GAL_US symbol: (lb/in³)/(gal (US)/h) (correct: lbm·h/(in³·gal{US}))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:GAL_US^-1 symbol: gal{US}
+  #       └──┬ unit:IN^3 symbol: in
+  #          └─── unit:M symbol: m
+unit:LB-HR-PER-IN3-GAL_US qudt:symbol "lbm·h/(in³·gal{US})" .
+
+  # WRONG SYMBOL  : unit:LB-HR-PER-IN3-YD3 - calculated from factors: lbm·h/(in³·yd³), actual: (lb/in³)/(yd³/h)
+  #
+  #  ──┬ unit:LB-HR-PER-IN3-YD3 symbol: (lb/in³)/(yd³/h) (correct: lbm·h/(in³·yd³))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:YD^-3 symbol: yd
+  #       └──┬ unit:FT symbol: ft
+  #          └──┬ unit:IN symbol: in
+  #             └─── unit:M symbol: m
+unit:LB-HR-PER-IN3-YD3 qudt:symbol "lbm·h/(in³·yd³)" .
+
+  # WRONG SYMBOL  : unit:LB-HR-PER-IN6 - calculated from factors: lbm·h/in⁶, actual: (lb/in³)/(in³/h)
+  #
+  #  ──┬ unit:LB-HR-PER-IN6 symbol: (lb/in³)/(in³/h) (correct: lbm·h/in⁶)
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    └──┬ unit:IN^-6 symbol: in
+  #       └─── unit:M symbol: m
+unit:LB-HR-PER-IN6 qudt:symbol "lbm·h/in⁶" .
+
+  # WRONG SYMBOL  : unit:LB-IN-PER-SEC - calculated from factors: lbm·in/s, actual: lb·(in/s)
+  #
+  #  ──┬ unit:LB-IN-PER-SEC symbol: lb·(in/s) (correct: lbm·in/s)
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:IN symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └─── unit:SEC^-1 symbol: s
+unit:LB-IN-PER-SEC qudt:symbol "lbm·in/s" .
+
+  # WRONG SYMBOL  : unit:LB-IN2-PER-FT3-LB_F-SEC - calculated from factors: lbm·in²/(ft³·lbf·s), actual: (lb/ft³)/(lbf·s/in²)
+  #
+  #  ──┬ unit:LB-IN2-PER-FT3-LB_F-SEC symbol: (lb/ft³)/(lbf·s/in²) (correct: lbm·in²/(ft³·lbf·s))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:IN^2 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    ├──┬ unit:FT^-3 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    ├──┬ unit:LB_F^-1 symbol: lbf
+  #    │  ├──┬ unit:FT symbol: ft
+  #    │  │  └──┬ unit:IN symbol: in
+  #    │  │     └─── unit:M symbol: m
+  #    │  ├─── unit:SEC^-2 symbol: s
+  #    │  └──┬ unit:SLUG symbol: slug
+  #    │     └──┬ unit:LB symbol: lbm
+  #    │        └──┬ unit:KiloGM symbol: kg
+  #    │           └─── unit:GM symbol: g
+  #    └─── unit:SEC^-1 symbol: s
+unit:LB-IN2-PER-FT3-LB_F-SEC qudt:symbol "lbm·in²/(ft³·lbf·s)" .
+
+  # WRONG SYMBOL  : unit:LB-IN2-PER-GAL_UK-LB_F-SEC - calculated from factors: lbm·in²/(gal{UK}·lbf·s), actual: lb/(gal (UK))/(lbf·s/in²)
+  #
+  #  ──┬ unit:LB-IN2-PER-GAL_UK-LB_F-SEC symbol: lb/(gal (UK))/(lbf·s/in²) (correct: lbm·in²/(gal{UK}·lbf·s))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:IN^2 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    ├──┬ unit:GAL_UK^-1 symbol: gal{UK}
+  #    │  └──┬ unit:L symbol: L
+  #    │     └──┬ unit:DeciM3 symbol: dm³
+  #    │        └──┬ unit:DeciM^3 symbol: dm
+  #    │           └─── unit:M symbol: m
+  #    ├──┬ unit:LB_F^-1 symbol: lbf
+  #    │  ├──┬ unit:FT symbol: ft
+  #    │  │  └──┬ unit:IN symbol: in
+  #    │  │     └─── unit:M symbol: m
+  #    │  ├─── unit:SEC^-2 symbol: s
+  #    │  └──┬ unit:SLUG symbol: slug
+  #    │     └──┬ unit:LB symbol: lbm
+  #    │        └──┬ unit:KiloGM symbol: kg
+  #    │           └─── unit:GM symbol: g
+  #    └─── unit:SEC^-1 symbol: s
+unit:LB-IN2-PER-GAL_UK-LB_F-SEC qudt:symbol "lbm·in²/(gal{UK}·lbf·s)" .
+
+  # WRONG SYMBOL  : unit:LB-IN2-PER-GAL_US-LB_F-SEC - calculated from factors: lbm·in²/(gal{US}·lbf·s), actual: lb/(gal (US))/(lbf·s/in²)
+  #
+  #  ──┬ unit:LB-IN2-PER-GAL_US-LB_F-SEC symbol: lb/(gal (US))/(lbf·s/in²) (correct: lbm·in²/(gal{US}·lbf·s))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:IN^2 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    ├──┬ unit:GAL_US^-1 symbol: gal{US}
+  #    │  └──┬ unit:IN^3 symbol: in
+  #    │     └─── unit:M symbol: m
+  #    ├──┬ unit:LB_F^-1 symbol: lbf
+  #    │  ├──┬ unit:FT symbol: ft
+  #    │  │  └──┬ unit:IN symbol: in
+  #    │  │     └─── unit:M symbol: m
+  #    │  ├─── unit:SEC^-2 symbol: s
+  #    │  └──┬ unit:SLUG symbol: slug
+  #    │     └──┬ unit:LB symbol: lbm
+  #    │        └──┬ unit:KiloGM symbol: kg
+  #    │           └─── unit:GM symbol: g
+  #    └─── unit:SEC^-1 symbol: s
+unit:LB-IN2-PER-GAL_US-LB_F-SEC qudt:symbol "lbm·in²/(gal{US}·lbf·s)" .
+
+  # WRONG SYMBOL  : unit:LB-IN2-PER-IN3-LB_F-SEC - calculated from factors: lbm·in²/(in³·lbf·s), actual: (lb/in³)/(lbf·s/in²)
+  #
+  #  ──┬ unit:LB-IN2-PER-IN3-LB_F-SEC symbol: (lb/in³)/(lbf·s/in²) (correct: lbm·in²/(in³·lbf·s))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:IN^2 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    ├──┬ unit:LB_F^-1 symbol: lbf
+  #    │  ├──┬ unit:FT symbol: ft
+  #    │  │  └──┬ unit:IN symbol: in
+  #    │  │     └─── unit:M symbol: m
+  #    │  ├─── unit:SEC^-2 symbol: s
+  #    │  └──┬ unit:SLUG symbol: slug
+  #    │     └──┬ unit:LB symbol: lbm
+  #    │        └──┬ unit:KiloGM symbol: kg
+  #    │           └─── unit:GM symbol: g
+  #    └─── unit:SEC^-1 symbol: s
+unit:LB-IN2-PER-IN3-LB_F-SEC qudt:symbol "lbm·in²/(in³·lbf·s)" .
+
+  # WRONG SYMBOL  : unit:LB-MIN-PER-FT3-GAL_UK - calculated from factors: lbm·min/(ft³·gal{UK}), actual: lb·min/(ft³·gal (UK))
+  #
+  #  ──┬ unit:LB-MIN-PER-FT3-GAL_UK symbol: lb·min/(ft³·gal (UK)) (correct: lbm·min/(ft³·gal{UK}))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:FT^-3 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:GAL_UK^-1 symbol: gal{UK}
+  #       └──┬ unit:L symbol: L
+  #          └──┬ unit:DeciM3 symbol: dm³
+  #             └──┬ unit:DeciM^3 symbol: dm
+  #                └─── unit:M symbol: m
+unit:LB-MIN-PER-FT3-GAL_UK qudt:symbol "lbm·min/(ft³·gal{UK})" .
+
+  # WRONG SYMBOL  : unit:LB-MIN-PER-FT3-GAL_US - calculated from factors: lbm·min/(ft³·gal{US}), actual: (lb/ft³)/(gal (US)/min)
+  #
+  #  ──┬ unit:LB-MIN-PER-FT3-GAL_US symbol: (lb/ft³)/(gal (US)/min) (correct: lbm·min/(ft³·gal{US}))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:FT^-3 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:GAL_US^-1 symbol: gal{US}
+  #       └──┬ unit:IN^3 symbol: in
+  #          └─── unit:M symbol: m
+unit:LB-MIN-PER-FT3-GAL_US qudt:symbol "lbm·min/(ft³·gal{US})" .
+
+  # WRONG SYMBOL  : unit:LB-MIN-PER-FT3-IN3 - calculated from factors: lbm·min/(ft³·in³), actual: (lb/ft³)/(in³/min)
+  #
+  #  ──┬ unit:LB-MIN-PER-FT3-IN3 symbol: (lb/ft³)/(in³/min) (correct: lbm·min/(ft³·in³))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:FT^-3 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:IN^-3 symbol: in
+  #       └─── unit:M symbol: m
+unit:LB-MIN-PER-FT3-IN3 qudt:symbol "lbm·min/(ft³·in³)" .
+
+  # WRONG SYMBOL  : unit:LB-MIN-PER-FT3-YD3 - calculated from factors: lbm·min/(ft³·yd³), actual: (lb/ft³)/(yd³/min)
+  #
+  #  ──┬ unit:LB-MIN-PER-FT3-YD3 symbol: (lb/ft³)/(yd³/min) (correct: lbm·min/(ft³·yd³))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:FT^-3 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:YD^-3 symbol: yd
+  #       └──┬ unit:FT symbol: ft
+  #          └──┬ unit:IN symbol: in
+  #             └─── unit:M symbol: m
+unit:LB-MIN-PER-FT3-YD3 qudt:symbol "lbm·min/(ft³·yd³)" .
+
+  # WRONG SYMBOL  : unit:LB-MIN-PER-FT6 - calculated from factors: lbm·min/ft⁶, actual: (lb/ft³)/(ft³/min)
+  #
+  #  ──┬ unit:LB-MIN-PER-FT6 symbol: (lb/ft³)/(ft³/min) (correct: lbm·min/ft⁶)
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    └──┬ unit:FT^-6 symbol: ft
+  #       └──┬ unit:IN symbol: in
+  #          └─── unit:M symbol: m
+unit:LB-MIN-PER-FT6 qudt:symbol "lbm·min/ft⁶" .
+
+  # WRONG SYMBOL  : unit:LB-MIN-PER-GAL_UK-FT3 - calculated from factors: lbm·min/(gal{UK}·ft³), actual: lb/(gal (UK))/(ft³/min)
+  #
+  #  ──┬ unit:LB-MIN-PER-GAL_UK-FT3 symbol: lb/(gal (UK))/(ft³/min) (correct: lbm·min/(gal{UK}·ft³))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:GAL_UK^-1 symbol: gal{UK}
+  #    │  └──┬ unit:L symbol: L
+  #    │     └──┬ unit:DeciM3 symbol: dm³
+  #    │        └──┬ unit:DeciM^3 symbol: dm
+  #    │           └─── unit:M symbol: m
+  #    └──┬ unit:FT^-3 symbol: ft
+  #       └──┬ unit:IN symbol: in
+  #          └─── unit:M symbol: m
+unit:LB-MIN-PER-GAL_UK-FT3 qudt:symbol "lbm·min/(gal{UK}·ft³)" .
+
+  # WRONG SYMBOL  : unit:LB-MIN-PER-GAL_UK-IN3 - calculated from factors: lbm·min/(gal{UK}·in³), actual: lb/(gal (UK))/(in³/min)
+  #
+  #  ──┬ unit:LB-MIN-PER-GAL_UK-IN3 symbol: lb/(gal (UK))/(in³/min) (correct: lbm·min/(gal{UK}·in³))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:GAL_UK^-1 symbol: gal{UK}
+  #    │  └──┬ unit:L symbol: L
+  #    │     └──┬ unit:DeciM3 symbol: dm³
+  #    │        └──┬ unit:DeciM^3 symbol: dm
+  #    │           └─── unit:M symbol: m
+  #    └──┬ unit:IN^-3 symbol: in
+  #       └─── unit:M symbol: m
+unit:LB-MIN-PER-GAL_UK-IN3 qudt:symbol "lbm·min/(gal{UK}·in³)" .
+
+  # WRONG SYMBOL  : unit:LB-MIN-PER-GAL_UK-YD3 - calculated from factors: lbm·min/(gal{UK}·yd³), actual: lb/(gal (UK))/(yd³/min)
+  #
+  #  ──┬ unit:LB-MIN-PER-GAL_UK-YD3 symbol: lb/(gal (UK))/(yd³/min) (correct: lbm·min/(gal{UK}·yd³))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:GAL_UK^-1 symbol: gal{UK}
+  #    │  └──┬ unit:L symbol: L
+  #    │     └──┬ unit:DeciM3 symbol: dm³
+  #    │        └──┬ unit:DeciM^3 symbol: dm
+  #    │           └─── unit:M symbol: m
+  #    └──┬ unit:YD^-3 symbol: yd
+  #       └──┬ unit:FT symbol: ft
+  #          └──┬ unit:IN symbol: in
+  #             └─── unit:M symbol: m
+unit:LB-MIN-PER-GAL_UK-YD3 qudt:symbol "lbm·min/(gal{UK}·yd³)" .
+
+  # WRONG SYMBOL  : unit:LB-MIN-PER-GAL_UK2 - calculated from factors: lbm·min/gal{UK}², actual: lb/(gal (UK))/(gal (UK)/min)
+  #
+  #  ──┬ unit:LB-MIN-PER-GAL_UK2 symbol: lb/(gal (UK))/(gal (UK)/min) (correct: lbm·min/gal{UK}²)
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    └──┬ unit:GAL_UK^-2 symbol: gal{UK}
+  #       └──┬ unit:L symbol: L
+  #          └──┬ unit:DeciM3 symbol: dm³
+  #             └──┬ unit:DeciM^3 symbol: dm
+  #                └─── unit:M symbol: m
+unit:LB-MIN-PER-GAL_UK2 qudt:symbol "lbm·min/gal{UK}²" .
+
+  # WRONG SYMBOL  : unit:LB-MIN-PER-GAL_US-FT3 - calculated from factors: lbm·min/(gal{US}·ft³), actual: lb/(gal (US))/(ft³/min)
+  #
+  #  ──┬ unit:LB-MIN-PER-GAL_US-FT3 symbol: lb/(gal (US))/(ft³/min) (correct: lbm·min/(gal{US}·ft³))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:GAL_US^-1 symbol: gal{US}
+  #    │  └──┬ unit:IN^3 symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:FT^-3 symbol: ft
+  #       └──┬ unit:IN symbol: in
+  #          └─── unit:M symbol: m
+unit:LB-MIN-PER-GAL_US-FT3 qudt:symbol "lbm·min/(gal{US}·ft³)" .
+
+  # WRONG SYMBOL  : unit:LB-MIN-PER-GAL_US-IN3 - calculated from factors: lbm·min/(gal{US}·in³), actual: lb/(gal (US))/(in³/min)
+  #
+  #  ──┬ unit:LB-MIN-PER-GAL_US-IN3 symbol: lb/(gal (US))/(in³/min) (correct: lbm·min/(gal{US}·in³))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:GAL_US^-1 symbol: gal{US}
+  #    │  └──┬ unit:IN^3 symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:IN^-3 symbol: in
+  #       └─── unit:M symbol: m
+unit:LB-MIN-PER-GAL_US-IN3 qudt:symbol "lbm·min/(gal{US}·in³)" .
+
+  # WRONG SYMBOL  : unit:LB-MIN-PER-GAL_US-YD3 - calculated from factors: lbm·min/(gal{US}·yd³), actual: lb/(gal (US))/(yd³/min)
+  #
+  #  ──┬ unit:LB-MIN-PER-GAL_US-YD3 symbol: lb/(gal (US))/(yd³/min) (correct: lbm·min/(gal{US}·yd³))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:GAL_US^-1 symbol: gal{US}
+  #    │  └──┬ unit:IN^3 symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:YD^-3 symbol: yd
+  #       └──┬ unit:FT symbol: ft
+  #          └──┬ unit:IN symbol: in
+  #             └─── unit:M symbol: m
+unit:LB-MIN-PER-GAL_US-YD3 qudt:symbol "lbm·min/(gal{US}·yd³)" .
+
+  # WRONG SYMBOL  : unit:LB-MIN-PER-GAL_US2 - calculated from factors: lbm·min/gal{US}², actual: lb/(gal (US))/(gal (US)/min)
+  #
+  #  ──┬ unit:LB-MIN-PER-GAL_US2 symbol: lb/(gal (US))/(gal (US)/min) (correct: lbm·min/gal{US}²)
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    └──┬ unit:GAL_US^-2 symbol: gal{US}
+  #       └──┬ unit:IN^3 symbol: in
+  #          └─── unit:M symbol: m
+unit:LB-MIN-PER-GAL_US2 qudt:symbol "lbm·min/gal{US}²" .
+
+  # WRONG SYMBOL  : unit:LB-MIN-PER-IN3-FT3 - calculated from factors: lbm·min/(in³·ft³), actual: (lb/in³)/(ft³/min)
+  #
+  #  ──┬ unit:LB-MIN-PER-IN3-FT3 symbol: (lb/in³)/(ft³/min) (correct: lbm·min/(in³·ft³))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:FT^-3 symbol: ft
+  #       └──┬ unit:IN symbol: in
+  #          └─── unit:M symbol: m
+unit:LB-MIN-PER-IN3-FT3 qudt:symbol "lbm·min/(in³·ft³)" .
+
+  # WRONG SYMBOL  : unit:LB-MIN-PER-IN3-GAL_UK - calculated from factors: lbm·min/(in³·gal{UK}), actual: lb·min/(in³·gal (UK))
+  #
+  #  ──┬ unit:LB-MIN-PER-IN3-GAL_UK symbol: lb·min/(in³·gal (UK)) (correct: lbm·min/(in³·gal{UK}))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:GAL_UK^-1 symbol: gal{UK}
+  #       └──┬ unit:L symbol: L
+  #          └──┬ unit:DeciM3 symbol: dm³
+  #             └──┬ unit:DeciM^3 symbol: dm
+  #                └─── unit:M symbol: m
+unit:LB-MIN-PER-IN3-GAL_UK qudt:symbol "lbm·min/(in³·gal{UK})" .
+
+  # WRONG SYMBOL  : unit:LB-MIN-PER-IN3-GAL_US - calculated from factors: lbm·min/(in³·gal{US}), actual: (lb/in³)/(gal (US)/min)
+  #
+  #  ──┬ unit:LB-MIN-PER-IN3-GAL_US symbol: (lb/in³)/(gal (US)/min) (correct: lbm·min/(in³·gal{US}))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:GAL_US^-1 symbol: gal{US}
+  #       └──┬ unit:IN^3 symbol: in
+  #          └─── unit:M symbol: m
+unit:LB-MIN-PER-IN3-GAL_US qudt:symbol "lbm·min/(in³·gal{US})" .
+
+  # WRONG SYMBOL  : unit:LB-MIN-PER-IN3-YD3 - calculated from factors: lbm·min/(in³·yd³), actual: (lb/in³)/(yd³/min)
+  #
+  #  ──┬ unit:LB-MIN-PER-IN3-YD3 symbol: (lb/in³)/(yd³/min) (correct: lbm·min/(in³·yd³))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:YD^-3 symbol: yd
+  #       └──┬ unit:FT symbol: ft
+  #          └──┬ unit:IN symbol: in
+  #             └─── unit:M symbol: m
+unit:LB-MIN-PER-IN3-YD3 qudt:symbol "lbm·min/(in³·yd³)" .
+
+  # WRONG SYMBOL  : unit:LB-MIN-PER-IN6 - calculated from factors: lbm·min/in⁶, actual: (lb/in³)/(in³/min)
+  #
+  #  ──┬ unit:LB-MIN-PER-IN6 symbol: (lb/in³)/(in³/min) (correct: lbm·min/in⁶)
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    └──┬ unit:IN^-6 symbol: in
+  #       └─── unit:M symbol: m
+unit:LB-MIN-PER-IN6 qudt:symbol "lbm·min/in⁶" .
+
+  # WRONG SYMBOL  : unit:LB-PER-AC - calculated from factors: lbm/acre, actual: lb/acre
+  #
+  #  ──┬ unit:LB-PER-AC symbol: lb/acre (correct: lbm/acre)
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    └──┬ unit:AC^-1 symbol: acre
+  #       └──┬ unit:M2 symbol: m²
+  #          └─── unit:M^2 symbol: m
+unit:LB-PER-AC qudt:symbol "lbm/acre" .
+
+  # WRONG SYMBOL  : unit:LB-PER-DAY - calculated from factors: lbm/d, actual: lbm/day
+  #
+  #  ──┬ unit:LB-PER-DAY symbol: lbm/day (correct: lbm/d)
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:LB-PER-DAY qudt:symbol "lbm/d" .
+
+  # WRONG SYMBOL  : unit:LB-PER-DEG_F - calculated from factors: lbm/°F, actual: lb/°F
+  #
+  #  ──┬ unit:LB-PER-DEG_F symbol: lb/°F (correct: lbm/°F)
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    └──┬ unit:DEG_F^-1 symbol: °F
+  #       └─── unit:K symbol: K
+unit:LB-PER-DEG_F qudt:symbol "lbm/°F" .
+
+  # WRONG SYMBOL  : unit:LB-PER-FT - calculated from factors: lbm/ft, actual: lb/ft
+  #
+  #  ──┬ unit:LB-PER-FT symbol: lb/ft (correct: lbm/ft)
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    └──┬ unit:FT^-1 symbol: ft
+  #       └──┬ unit:IN symbol: in
+  #          └─── unit:M symbol: m
+unit:LB-PER-FT qudt:symbol "lbm/ft" .
+
+  # WRONG SYMBOL  : unit:LB-PER-FT-DAY - calculated from factors: lbm/(ft·d), actual: lb/(ft·d)
+  #
+  #  ──┬ unit:LB-PER-FT-DAY symbol: lb/(ft·d) (correct: lbm/(ft·d))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:FT^-1 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:LB-PER-FT-DAY qudt:symbol "lbm/(ft·d)" .
+
+  # WRONG SYMBOL  : unit:LB-PER-FT-LB_F-SEC - calculated from factors: lbm/(ft·lbf·s), actual: (lb/ft³)/(lbf·s/ft²)
+  #
+  #  ──┬ unit:LB-PER-FT-LB_F-SEC symbol: (lb/ft³)/(lbf·s/ft²) (correct: lbm/(ft·lbf·s))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:FT^-1 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    ├──┬ unit:LB_F^-1 symbol: lbf
+  #    │  ├──┬ unit:FT symbol: ft
+  #    │  │  └──┬ unit:IN symbol: in
+  #    │  │     └─── unit:M symbol: m
+  #    │  ├─── unit:SEC^-2 symbol: s
+  #    │  └──┬ unit:SLUG symbol: slug
+  #    │     └──┬ unit:LB symbol: lbm
+  #    │        └──┬ unit:KiloGM symbol: kg
+  #    │           └─── unit:GM symbol: g
+  #    └─── unit:SEC^-1 symbol: s
+unit:LB-PER-FT-LB_F-SEC qudt:symbol "lbm/(ft·lbf·s)" .
+
+  # WRONG SYMBOL  : unit:LB-PER-FT-MIN - calculated from factors: lbm/(ft·min), actual: lb/(ft·min)
+  #
+  #  ──┬ unit:LB-PER-FT-MIN symbol: lb/(ft·min) (correct: lbm/(ft·min))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:FT^-1 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:MIN^-1 symbol: min
+  #       └─── unit:SEC symbol: s
+unit:LB-PER-FT-MIN qudt:symbol "lbm/(ft·min)" .
+
+  # WRONG SYMBOL  : unit:LB-PER-FT3-DEG_F - calculated from factors: lbm/(ft³·°F), actual: lb/(ft³·°F)
+  #
+  #  ──┬ unit:LB-PER-FT3-DEG_F symbol: lb/(ft³·°F) (correct: lbm/(ft³·°F))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:FT^-3 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:DEG_F^-1 symbol: °F
+  #       └─── unit:K symbol: K
+unit:LB-PER-FT3-DEG_F qudt:symbol "lbm/(ft³·°F)" .
+
+  # WRONG SYMBOL  : unit:LB-PER-FT3-PSI - calculated from factors: lbm/(ft³·psi), actual: lb/(ft³·psi)
+  #
+  #  ──┬ unit:LB-PER-FT3-PSI symbol: lb/(ft³·psi) (correct: lbm/(ft³·psi))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:FT^-3 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:PSI^-1 symbol: psi
+  #       ├──┬ unit:IN^-2 symbol: in
+  #       │  └─── unit:M symbol: m
+  #       └──┬ unit:LB_F symbol: lbf
+  #          ├──┬ unit:FT symbol: ft
+  #          │  └──┬ unit:IN symbol: in
+  #          │     └─── unit:M symbol: m
+  #          ├─── unit:SEC^-2 symbol: s
+  #          └──┬ unit:SLUG symbol: slug
+  #             └──┬ unit:LB symbol: lbm
+  #                └──┬ unit:KiloGM symbol: kg
+  #                   └─── unit:GM symbol: g
+unit:LB-PER-FT3-PSI qudt:symbol "lbm/(ft³·psi)" .
+
+  # WRONG SYMBOL  : unit:LB-PER-HR-DEG_F - calculated from factors: lbm/(h·°F), actual: lb/(h·°F)
+  #
+  #  ──┬ unit:LB-PER-HR-DEG_F symbol: lb/(h·°F) (correct: lbm/(h·°F))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:HR^-1 symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    └──┬ unit:DEG_F^-1 symbol: °F
+  #       └─── unit:K symbol: K
+unit:LB-PER-HR-DEG_F qudt:symbol "lbm/(h·°F)" .
+
+  # WRONG SYMBOL  : unit:LB-PER-HR-PSI - calculated from factors: lbm/(h·psi), actual: lb/(h·psi)
+  #
+  #  ──┬ unit:LB-PER-HR-PSI symbol: lb/(h·psi) (correct: lbm/(h·psi))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:HR^-1 symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    └──┬ unit:PSI^-1 symbol: psi
+  #       ├──┬ unit:IN^-2 symbol: in
+  #       │  └─── unit:M symbol: m
+  #       └──┬ unit:LB_F symbol: lbf
+  #          ├──┬ unit:FT symbol: ft
+  #          │  └──┬ unit:IN symbol: in
+  #          │     └─── unit:M symbol: m
+  #          ├─── unit:SEC^-2 symbol: s
+  #          └──┬ unit:SLUG symbol: slug
+  #             └──┬ unit:LB symbol: lbm
+  #                └──┬ unit:KiloGM symbol: kg
+  #                   └─── unit:GM symbol: g
+unit:LB-PER-HR-PSI qudt:symbol "lbm/(h·psi)" .
+
+  # WRONG SYMBOL  : unit:LB-PER-IN3-DEG_F - calculated from factors: lbm/(in³·°F), actual: lb/(in³·°F)
+  #
+  #  ──┬ unit:LB-PER-IN3-DEG_F symbol: lb/(in³·°F) (correct: lbm/(in³·°F))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:DEG_F^-1 symbol: °F
+  #       └─── unit:K symbol: K
+unit:LB-PER-IN3-DEG_F qudt:symbol "lbm/(in³·°F)" .
+
+  # WRONG SYMBOL  : unit:LB-PER-IN3-PSI - calculated from factors: lbm/(in³·psi), actual: lb/(in³·psi)
+  #
+  #  ──┬ unit:LB-PER-IN3-PSI symbol: lb/(in³·psi) (correct: lbm/(in³·psi))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:PSI^-1 symbol: psi
+  #       ├──┬ unit:IN^-2 symbol: in
+  #       │  └─── unit:M symbol: m
+  #       └──┬ unit:LB_F symbol: lbf
+  #          ├──┬ unit:FT symbol: ft
+  #          │  └──┬ unit:IN symbol: in
+  #          │     └─── unit:M symbol: m
+  #          ├─── unit:SEC^-2 symbol: s
+  #          └──┬ unit:SLUG symbol: slug
+  #             └──┬ unit:LB symbol: lbm
+  #                └──┬ unit:KiloGM symbol: kg
+  #                   └─── unit:GM symbol: g
+unit:LB-PER-IN3-PSI qudt:symbol "lbm/(in³·psi)" .
+
+  # WRONG SYMBOL  : unit:LB-PER-LB - calculated from factors: lbm/lbm, actual: lb/lb
+  #
+  #  ──┬ unit:LB-PER-LB symbol: lb/lb (correct: lbm/lbm)
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    └──┬ unit:LB^-1 symbol: lbm
+  #       └──┬ unit:KiloGM symbol: kg
+  #          └─── unit:GM symbol: g
+unit:LB-PER-LB qudt:symbol "lbm/lbm" .
+
+  # WRONG SYMBOL  : unit:LB-PER-MIN-DEG_F - calculated from factors: lbm/(min·°F), actual: lb/(min·°F)
+  #
+  #  ──┬ unit:LB-PER-MIN-DEG_F symbol: lb/(min·°F) (correct: lbm/(min·°F))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:MIN^-1 symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    └──┬ unit:DEG_F^-1 symbol: °F
+  #       └─── unit:K symbol: K
+unit:LB-PER-MIN-DEG_F qudt:symbol "lbm/(min·°F)" .
+
+  # WRONG SYMBOL  : unit:LB-PER-MIN-PSI - calculated from factors: lbm/(min·psi), actual: lb/(min·psi)
+  #
+  #  ──┬ unit:LB-PER-MIN-PSI symbol: lb/(min·psi) (correct: lbm/(min·psi))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├──┬ unit:MIN^-1 symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    └──┬ unit:PSI^-1 symbol: psi
+  #       ├──┬ unit:IN^-2 symbol: in
+  #       │  └─── unit:M symbol: m
+  #       └──┬ unit:LB_F symbol: lbf
+  #          ├──┬ unit:FT symbol: ft
+  #          │  └──┬ unit:IN symbol: in
+  #          │     └─── unit:M symbol: m
+  #          ├─── unit:SEC^-2 symbol: s
+  #          └──┬ unit:SLUG symbol: slug
+  #             └──┬ unit:LB symbol: lbm
+  #                └──┬ unit:KiloGM symbol: kg
+  #                   └─── unit:GM symbol: g
+unit:LB-PER-MIN-PSI qudt:symbol "lbm/(min·psi)" .
+
+  # WRONG SYMBOL  : unit:LB-PER-PSI - calculated from factors: lbm/psi, actual: lb/psi
+  #
+  #  ──┬ unit:LB-PER-PSI symbol: lb/psi (correct: lbm/psi)
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    └──┬ unit:PSI^-1 symbol: psi
+  #       ├──┬ unit:IN^-2 symbol: in
+  #       │  └─── unit:M symbol: m
+  #       └──┬ unit:LB_F symbol: lbf
+  #          ├──┬ unit:FT symbol: ft
+  #          │  └──┬ unit:IN symbol: in
+  #          │     └─── unit:M symbol: m
+  #          ├─── unit:SEC^-2 symbol: s
+  #          └──┬ unit:SLUG symbol: slug
+  #             └──┬ unit:LB symbol: lbm
+  #                └──┬ unit:KiloGM symbol: kg
+  #                   └─── unit:GM symbol: g
+unit:LB-PER-PSI qudt:symbol "lbm/psi" .
+
+  # WRONG SYMBOL  : unit:LB-PER-SEC-DEG_F - calculated from factors: lbm/(s·°F), actual: lb/(s·°F)
+  #
+  #  ──┬ unit:LB-PER-SEC-DEG_F symbol: lb/(s·°F) (correct: lbm/(s·°F))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├─── unit:SEC^-1 symbol: s
+  #    └──┬ unit:DEG_F^-1 symbol: °F
+  #       └─── unit:K symbol: K
+unit:LB-PER-SEC-DEG_F qudt:symbol "lbm/(s·°F)" .
+
+  # WRONG SYMBOL  : unit:LB-PER-SEC-PSI - calculated from factors: lbm/(s·psi), actual: lb/(s·psi)
+  #
+  #  ──┬ unit:LB-PER-SEC-PSI symbol: lb/(s·psi) (correct: lbm/(s·psi))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├─── unit:SEC^-1 symbol: s
+  #    └──┬ unit:PSI^-1 symbol: psi
+  #       ├──┬ unit:IN^-2 symbol: in
+  #       │  └─── unit:M symbol: m
+  #       └──┬ unit:LB_F symbol: lbf
+  #          ├──┬ unit:FT symbol: ft
+  #          │  └──┬ unit:IN symbol: in
+  #          │     └─── unit:M symbol: m
+  #          ├─── unit:SEC^-2 symbol: s
+  #          └──┬ unit:SLUG symbol: slug
+  #             └──┬ unit:LB symbol: lbm
+  #                └──┬ unit:KiloGM symbol: kg
+  #                   └─── unit:GM symbol: g
+unit:LB-PER-SEC-PSI qudt:symbol "lbm/(s·psi)" .
+
+  # WRONG SYMBOL  : unit:LB-PER-YD - calculated from factors: lbm/yd, actual: lb/yd
+  #
+  #  ──┬ unit:LB-PER-YD symbol: lb/yd (correct: lbm/yd)
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    └──┬ unit:YD^-1 symbol: yd
+  #       └──┬ unit:FT symbol: ft
+  #          └──┬ unit:IN symbol: in
+  #             └─── unit:M symbol: m
+unit:LB-PER-YD qudt:symbol "lbm/yd" .
+
+  # WRONG SYMBOL  : unit:LB-PER-YD2 - calculated from factors: lbm/yd², actual: lb/yd²
+  #
+  #  ──┬ unit:LB-PER-YD2 symbol: lb/yd² (correct: lbm/yd²)
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    └──┬ unit:YD^-2 symbol: yd
+  #       └──┬ unit:FT symbol: ft
+  #          └──┬ unit:IN symbol: in
+  #             └─── unit:M symbol: m
+unit:LB-PER-YD2 qudt:symbol "lbm/yd²" .
+
+  # WRONG SYMBOL  : unit:LB-SEC-PER-FT3-GAL_UK - calculated from factors: lbm·s/(ft³·gal{UK}), actual: (lb/ft³)/(gal (UK)/s)
+  #
+  #  ──┬ unit:LB-SEC-PER-FT3-GAL_UK symbol: (lb/ft³)/(gal (UK)/s) (correct: lbm·s/(ft³·gal{UK}))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    ├──┬ unit:FT^-3 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:GAL_UK^-1 symbol: gal{UK}
+  #       └──┬ unit:L symbol: L
+  #          └──┬ unit:DeciM3 symbol: dm³
+  #             └──┬ unit:DeciM^3 symbol: dm
+  #                └─── unit:M symbol: m
+unit:LB-SEC-PER-FT3-GAL_UK qudt:symbol "lbm·s/(ft³·gal{UK})" .
+
+  # WRONG SYMBOL  : unit:LB-SEC-PER-FT3-GAL_US - calculated from factors: lbm·s/(ft³·gal{US}), actual: (lb/ft³)/(gal (US)/s)
+  #
+  #  ──┬ unit:LB-SEC-PER-FT3-GAL_US symbol: (lb/ft³)/(gal (US)/s) (correct: lbm·s/(ft³·gal{US}))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    ├──┬ unit:FT^-3 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:GAL_US^-1 symbol: gal{US}
+  #       └──┬ unit:IN^3 symbol: in
+  #          └─── unit:M symbol: m
+unit:LB-SEC-PER-FT3-GAL_US qudt:symbol "lbm·s/(ft³·gal{US})" .
+
+  # WRONG SYMBOL  : unit:LB-SEC-PER-FT3-IN3 - calculated from factors: lbm·s/(ft³·in³), actual: (lb/ft³)/(in³/s)
+  #
+  #  ──┬ unit:LB-SEC-PER-FT3-IN3 symbol: (lb/ft³)/(in³/s) (correct: lbm·s/(ft³·in³))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    ├──┬ unit:FT^-3 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:IN^-3 symbol: in
+  #       └─── unit:M symbol: m
+unit:LB-SEC-PER-FT3-IN3 qudt:symbol "lbm·s/(ft³·in³)" .
+
+  # WRONG SYMBOL  : unit:LB-SEC-PER-FT3-YD3 - calculated from factors: lbm·s/(ft³·yd³), actual: (lb/ft³)/(yd³/s)
+  #
+  #  ──┬ unit:LB-SEC-PER-FT3-YD3 symbol: (lb/ft³)/(yd³/s) (correct: lbm·s/(ft³·yd³))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    ├──┬ unit:FT^-3 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:YD^-3 symbol: yd
+  #       └──┬ unit:FT symbol: ft
+  #          └──┬ unit:IN symbol: in
+  #             └─── unit:M symbol: m
+unit:LB-SEC-PER-FT3-YD3 qudt:symbol "lbm·s/(ft³·yd³)" .
+
+  # WRONG SYMBOL  : unit:LB-SEC-PER-FT6 - calculated from factors: lbm·s/ft⁶, actual: (lb/ft³)/(ft³/s)
+  #
+  #  ──┬ unit:LB-SEC-PER-FT6 symbol: (lb/ft³)/(ft³/s) (correct: lbm·s/ft⁶)
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    └──┬ unit:FT^-6 symbol: ft
+  #       └──┬ unit:IN symbol: in
+  #          └─── unit:M symbol: m
+unit:LB-SEC-PER-FT6 qudt:symbol "lbm·s/ft⁶" .
+
+  # WRONG SYMBOL  : unit:LB-SEC-PER-GAL_UK-FT3 - calculated from factors: lbm·s/(gal{UK}·ft³), actual: (lb/(gal (UK))/(ft³/s)
+  #
+  #  ──┬ unit:LB-SEC-PER-GAL_UK-FT3 symbol: (lb/(gal (UK))/(ft³/s) (correct: lbm·s/(gal{UK}·ft³))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    ├──┬ unit:GAL_UK^-1 symbol: gal{UK}
+  #    │  └──┬ unit:L symbol: L
+  #    │     └──┬ unit:DeciM3 symbol: dm³
+  #    │        └──┬ unit:DeciM^3 symbol: dm
+  #    │           └─── unit:M symbol: m
+  #    └──┬ unit:FT^-3 symbol: ft
+  #       └──┬ unit:IN symbol: in
+  #          └─── unit:M symbol: m
+unit:LB-SEC-PER-GAL_UK-FT3 qudt:symbol "lbm·s/(gal{UK}·ft³)" .
+
+  # WRONG SYMBOL  : unit:LB-SEC-PER-GAL_UK-IN3 - calculated from factors: lbm·s/(gal{UK}·in³), actual: (lb/(gal (UK))/(in³/s)
+  #
+  #  ──┬ unit:LB-SEC-PER-GAL_UK-IN3 symbol: (lb/(gal (UK))/(in³/s) (correct: lbm·s/(gal{UK}·in³))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    ├──┬ unit:GAL_UK^-1 symbol: gal{UK}
+  #    │  └──┬ unit:L symbol: L
+  #    │     └──┬ unit:DeciM3 symbol: dm³
+  #    │        └──┬ unit:DeciM^3 symbol: dm
+  #    │           └─── unit:M symbol: m
+  #    └──┬ unit:IN^-3 symbol: in
+  #       └─── unit:M symbol: m
+unit:LB-SEC-PER-GAL_UK-IN3 qudt:symbol "lbm·s/(gal{UK}·in³)" .
+
+  # WRONG SYMBOL  : unit:LB-SEC-PER-GAL_UK-YD3 - calculated from factors: lbm·s/(gal{UK}·yd³), actual: (lb/(gal (UK))/(yd³/s)
+  #
+  #  ──┬ unit:LB-SEC-PER-GAL_UK-YD3 symbol: (lb/(gal (UK))/(yd³/s) (correct: lbm·s/(gal{UK}·yd³))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    ├──┬ unit:GAL_UK^-1 symbol: gal{UK}
+  #    │  └──┬ unit:L symbol: L
+  #    │     └──┬ unit:DeciM3 symbol: dm³
+  #    │        └──┬ unit:DeciM^3 symbol: dm
+  #    │           └─── unit:M symbol: m
+  #    └──┬ unit:YD^-3 symbol: yd
+  #       └──┬ unit:FT symbol: ft
+  #          └──┬ unit:IN symbol: in
+  #             └─── unit:M symbol: m
+unit:LB-SEC-PER-GAL_UK-YD3 qudt:symbol "lbm·s/(gal{UK}·yd³)" .
+
+  # WRONG SYMBOL  : unit:LB-SEC-PER-GAL_UK2 - calculated from factors: lbm·s/gal{UK}², actual: (lb/(gal (UK))/(gal (UK)/s)
+  #
+  #  ──┬ unit:LB-SEC-PER-GAL_UK2 symbol: (lb/(gal (UK))/(gal (UK)/s) (correct: lbm·s/gal{UK}²)
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    └──┬ unit:GAL_UK^-2 symbol: gal{UK}
+  #       └──┬ unit:L symbol: L
+  #          └──┬ unit:DeciM3 symbol: dm³
+  #             └──┬ unit:DeciM^3 symbol: dm
+  #                └─── unit:M symbol: m
+unit:LB-SEC-PER-GAL_UK2 qudt:symbol "lbm·s/gal{UK}²" .
+
+  # WRONG SYMBOL  : unit:LB-SEC-PER-GAL_US-FT3 - calculated from factors: lbm·s/(gal{US}·ft³), actual: lb/(gal (US))/(ft³/s)
+  #
+  #  ──┬ unit:LB-SEC-PER-GAL_US-FT3 symbol: lb/(gal (US))/(ft³/s) (correct: lbm·s/(gal{US}·ft³))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    ├──┬ unit:GAL_US^-1 symbol: gal{US}
+  #    │  └──┬ unit:IN^3 symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:FT^-3 symbol: ft
+  #       └──┬ unit:IN symbol: in
+  #          └─── unit:M symbol: m
+unit:LB-SEC-PER-GAL_US-FT3 qudt:symbol "lbm·s/(gal{US}·ft³)" .
+
+  # WRONG SYMBOL  : unit:LB-SEC-PER-GAL_US-IN3 - calculated from factors: lbm·s/(gal{US}·in³), actual: lb/(gal (US))/(in³/s)
+  #
+  #  ──┬ unit:LB-SEC-PER-GAL_US-IN3 symbol: lb/(gal (US))/(in³/s) (correct: lbm·s/(gal{US}·in³))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    ├──┬ unit:GAL_US^-1 symbol: gal{US}
+  #    │  └──┬ unit:IN^3 symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:IN^-3 symbol: in
+  #       └─── unit:M symbol: m
+unit:LB-SEC-PER-GAL_US-IN3 qudt:symbol "lbm·s/(gal{US}·in³)" .
+
+  # WRONG SYMBOL  : unit:LB-SEC-PER-GAL_US-YD3 - calculated from factors: lbm·s/(gal{US}·yd³), actual: (lb/(gal (US))/(yd³/s)
+  #
+  #  ──┬ unit:LB-SEC-PER-GAL_US-YD3 symbol: (lb/(gal (US))/(yd³/s) (correct: lbm·s/(gal{US}·yd³))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    ├──┬ unit:GAL_US^-1 symbol: gal{US}
+  #    │  └──┬ unit:IN^3 symbol: in
+  #    │     └─── unit:M symbol: m
+  #    └──┬ unit:YD^-3 symbol: yd
+  #       └──┬ unit:FT symbol: ft
+  #          └──┬ unit:IN symbol: in
+  #             └─── unit:M symbol: m
+unit:LB-SEC-PER-GAL_US-YD3 qudt:symbol "lbm·s/(gal{US}·yd³)" .
+
+  # WRONG SYMBOL  : unit:LB-SEC-PER-GAL_US2 - calculated from factors: lbm·s/gal{US}², actual: (lb/(gal (US))/(gal (US)/s)
+  #
+  #  ──┬ unit:LB-SEC-PER-GAL_US2 symbol: (lb/(gal (US))/(gal (US)/s) (correct: lbm·s/gal{US}²)
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    └──┬ unit:GAL_US^-2 symbol: gal{US}
+  #       └──┬ unit:IN^3 symbol: in
+  #          └─── unit:M symbol: m
+unit:LB-SEC-PER-GAL_US2 qudt:symbol "lbm·s/gal{US}²" .
+
+  # WRONG SYMBOL  : unit:LB-SEC-PER-IN3-FT3 - calculated from factors: lbm·s/(in³·ft³), actual: (lb/in³)/(ft³/s)
+  #
+  #  ──┬ unit:LB-SEC-PER-IN3-FT3 symbol: (lb/in³)/(ft³/s) (correct: lbm·s/(in³·ft³))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:FT^-3 symbol: ft
+  #       └──┬ unit:IN symbol: in
+  #          └─── unit:M symbol: m
+unit:LB-SEC-PER-IN3-FT3 qudt:symbol "lbm·s/(in³·ft³)" .
+
+  # WRONG SYMBOL  : unit:LB-SEC-PER-IN3-GAL_UK - calculated from factors: lbm·s/(in³·gal{UK}), actual: (lb/in³)/(gal (UK)/s)
+  #
+  #  ──┬ unit:LB-SEC-PER-IN3-GAL_UK symbol: (lb/in³)/(gal (UK)/s) (correct: lbm·s/(in³·gal{UK}))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:GAL_UK^-1 symbol: gal{UK}
+  #       └──┬ unit:L symbol: L
+  #          └──┬ unit:DeciM3 symbol: dm³
+  #             └──┬ unit:DeciM^3 symbol: dm
+  #                └─── unit:M symbol: m
+unit:LB-SEC-PER-IN3-GAL_UK qudt:symbol "lbm·s/(in³·gal{UK})" .
+
+  # WRONG SYMBOL  : unit:LB-SEC-PER-IN3-GAL_US - calculated from factors: lbm·s/(in³·gal{US}), actual: (lb/in³)/(gal (US)/s)
+  #
+  #  ──┬ unit:LB-SEC-PER-IN3-GAL_US symbol: (lb/in³)/(gal (US)/s) (correct: lbm·s/(in³·gal{US}))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:GAL_US^-1 symbol: gal{US}
+  #       └──┬ unit:IN^3 symbol: in
+  #          └─── unit:M symbol: m
+unit:LB-SEC-PER-IN3-GAL_US qudt:symbol "lbm·s/(in³·gal{US})" .
+
+  # WRONG SYMBOL  : unit:LB-SEC-PER-IN3-YD3 - calculated from factors: lbm·s/(in³·yd³), actual: (lb/in³)/(yd³/s)
+  #
+  #  ──┬ unit:LB-SEC-PER-IN3-YD3 symbol: (lb/in³)/(yd³/s) (correct: lbm·s/(in³·yd³))
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:YD^-3 symbol: yd
+  #       └──┬ unit:FT symbol: ft
+  #          └──┬ unit:IN symbol: in
+  #             └─── unit:M symbol: m
+unit:LB-SEC-PER-IN3-YD3 qudt:symbol "lbm·s/(in³·yd³)" .
+
+  # WRONG SYMBOL  : unit:LB-SEC-PER-IN6 - calculated from factors: lbm·s/in⁶, actual: (lb/in³)/(in³/s
+  #
+  #  ──┬ unit:LB-SEC-PER-IN6 symbol: (lb/in³)/(in³/s (correct: lbm·s/in⁶)
+  #    ├──┬ unit:LB symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    └──┬ unit:IN^-6 symbol: in
+  #       └─── unit:M symbol: m
+unit:LB-SEC-PER-IN6 qudt:symbol "lbm·s/in⁶" .
+
+  # WRONG SYMBOL  : unit:M-PER-DAY - calculated from factors: m/d, actual: m/day
+  #
+  #  ──┬ unit:M-PER-DAY symbol: m/day (correct: m/d)
+  #    ├─── unit:M symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:M-PER-DAY qudt:symbol "m/d" .
+
+  # WRONG SYMBOL  : unit:M-PER-M2 - calculated from factors: m/m², actual: m/m2
+  #
+  #  ──┬ unit:M-PER-M2 symbol: m/m2 (correct: m/m²)
+  #    ├─── unit:M symbol: m
+  #    └─── unit:M^-2 symbol: m
+unit:M-PER-M2 qudt:symbol "m/m²" .
+
+  # WRONG SYMBOL  : unit:M3-PER-DAY - calculated from factors: m³/d, actual: m³/day
+  #
+  #  ──┬ unit:M3-PER-DAY symbol: m³/day (correct: m³/d)
+  #    ├─── unit:M^3 symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:M3-PER-DAY qudt:symbol "m³/d" .
+
+  # WRONG SYMBOL  : unit:MI_US2 - calculated from factors: mi{US}², actual: mi² {US}
+  #
+  #  ──┬ unit:MI_US2 symbol: mi² {US} (correct: mi{US}²)
+  #    └──┬ unit:MI_US^2 symbol: mi{US}
+  #       └─── unit:M symbol: m
+unit:MI_US2 qudt:symbol "mi{US}²" .
+
+  # WRONG SYMBOL  : unit:MOL-PER-KiloGM-K - calculated from factors: mol/(K·kg), actual: mol/(kg·K)
+  #
+  #  ──┬ unit:MOL-PER-KiloGM-K symbol: mol/(kg·K) (correct: mol/(K·kg))
+  #    ├─── unit:MOL symbol: mol
+  #    ├─── unit:K^-1 symbol: K
+  #    └──┬ unit:KiloGM^-1 symbol: kg
+  #       └─── unit:GM symbol: g
+unit:MOL-PER-KiloGM-K qudt:symbol "mol/(K·kg)" .
+
+  # WRONG SYMBOL  : unit:MOL-PER-L-BAR - calculated from factors: mol/(L·bar), actual: mol/(l·bar)
+  #
+  #  ──┬ unit:MOL-PER-L-BAR symbol: mol/(l·bar) (correct: mol/(L·bar))
+  #    ├─── unit:MOL symbol: mol
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └──┬ unit:BAR^-1 symbol: bar
+  #       └──┬ unit:PA symbol: Pa
+  #          ├─── unit:M^-2 symbol: m
+  #          └──┬ unit:N symbol: N
+  #             ├──┬ unit:KiloGM symbol: kg
+  #             │  └─── unit:GM symbol: g
+  #             ├─── unit:M symbol: m
+  #             └─── unit:SEC^-2 symbol: s
+unit:MOL-PER-L-BAR qudt:symbol "mol/(L·bar)" .
+
+  # WRONG SYMBOL  : unit:MOL-PER-L-K - calculated from factors: mol/(L·K), actual: mol/(l·K)
+  #
+  #  ──┬ unit:MOL-PER-L-K symbol: mol/(l·K) (correct: mol/(L·K))
+  #    ├─── unit:MOL symbol: mol
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └─── unit:K^-1 symbol: K
+unit:MOL-PER-L-K qudt:symbol "mol/(L·K)" .
+
+  # WRONG SYMBOL  : unit:MOL-PER-M2-DAY - calculated from factors: mol/(m²·d), actual: mol/(m²·day)
+  #
+  #  ──┬ unit:MOL-PER-M2-DAY symbol: mol/(m²·day) (correct: mol/(m²·d))
+  #    ├─── unit:MOL symbol: mol
+  #    ├─── unit:M^-2 symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:MOL-PER-M2-DAY qudt:symbol "mol/(m²·d)" .
+
+  # WRONG SYMBOL  : unit:MOL-PER-M2-SEC-M - calculated from factors: mol/(m²·m·s), actual: mol/(m²·s·m)
+  #
+  #  ──┬ unit:MOL-PER-M2-SEC-M symbol: mol/(m²·s·m) (correct: mol/(m²·m·s))
+  #    ├─── unit:MOL symbol: mol
+  #    ├─── unit:M^-2 symbol: m
+  #    ├─── unit:M^-1 symbol: m
+  #    └─── unit:SEC^-1 symbol: s
+unit:MOL-PER-M2-SEC-M qudt:symbol "mol/(m²·m·s)" .
+
+  # WRONG SYMBOL  : unit:MOL-PER-M2-SEC-M-SR - calculated from factors: mol/(m²·m·s·sr), actual: mol/(m²·s·m·sr)
+  #
+  #  ──┬ unit:MOL-PER-M2-SEC-M-SR symbol: mol/(m²·s·m·sr) (correct: mol/(m²·m·s·sr))
+  #    ├─── unit:MOL symbol: mol
+  #    ├─── unit:M^-2 symbol: m
+  #    ├─── unit:M^-1 symbol: m
+  #    ├─── unit:SEC^-1 symbol: s
+  #    └──┬ unit:SR^-1 symbol: sr
+  #       ├─── unit:M^-2 symbol: m
+  #       └─── unit:M^2 symbol: m
+unit:MOL-PER-M2-SEC-M-SR qudt:symbol "mol/(m²·m·s·sr)" .
+
+  # WRONG SYMBOL  : unit:MegaBIT-PER-SEC - calculated from factors: Mbit/s, actual: mbps
+  #
+  #  ──┬ unit:MegaBIT-PER-SEC symbol: mbps (correct: Mbit/s)
+  #    ├──┬ unit:MegaBIT symbol: Mbit
+  #    │  └─── unit:BIT symbol: b
+  #    └─── unit:SEC^-1 symbol: s
+unit:MegaBIT-PER-SEC qudt:symbol "Mbit/s" .
+
+  # WRONG SYMBOL  : unit:MegaBYTE-PER-SEC - calculated from factors: MB/s, actual: Mbyte/s
+  #
+  #  ──┬ unit:MegaBYTE-PER-SEC symbol: Mbyte/s (correct: MB/s)
+  #    ├──┬ unit:MegaBYTE symbol: MB
+  #    │  └─── unit:BYTE symbol: B
+  #    └─── unit:SEC^-1 symbol: s
+unit:MegaBYTE-PER-SEC qudt:symbol "MB/s" .
+
+  # WRONG SYMBOL  : unit:MegaGM-PER-HA-YR - calculated from factors: Mg/(ha·a), actual: Mg/(ha·yr)
+  #
+  #  ──┬ unit:MegaGM-PER-HA-YR symbol: Mg/(ha·yr) (correct: Mg/(ha·a))
+  #    ├──┬ unit:MegaGM symbol: Mg
+  #    │  └─── unit:GM symbol: g
+  #    ├──┬ unit:HA^-1 symbol: ha
+  #    │  └──┬ unit:M2 symbol: m²
+  #    │     └─── unit:M^2 symbol: m
+  #    └──┬ unit:YR^-1 symbol: a
+  #       └─── unit:SEC symbol: s
+unit:MegaGM-PER-HA-YR qudt:symbol "Mg/(ha·a)" .
+
+  # WRONG SYMBOL  : unit:MegaHZ-M - calculated from factors: m·MHz, actual: MHz·m
+  #
+  #  ──┬ unit:MegaHZ-M symbol: MHz·m (correct: m·MHz)
+  #    ├─── unit:M symbol: m
+  #    └──┬ unit:MegaHZ symbol: MHz
+  #       └──┬ unit:HZ symbol: Hz
+  #          └─── unit:SEC^-1 symbol: s
+unit:MegaHZ-M qudt:symbol "m·MHz" .
+
+  # WRONG SYMBOL  : unit:MegaN-M - calculated from factors: m·MN, actual: MN·m
+  #
+  #  ──┬ unit:MegaN-M symbol: MN·m (correct: m·MN)
+  #    ├─── unit:M symbol: m
+  #    └──┬ unit:MegaN symbol: MN
+  #       └──┬ unit:N symbol: N
+  #          ├──┬ unit:KiloGM symbol: kg
+  #          │  └─── unit:GM symbol: g
+  #          ├─── unit:M symbol: m
+  #          └─── unit:SEC^-2 symbol: s
+unit:MegaN-M qudt:symbol "m·MN" .
+
+  # WRONG SYMBOL  : unit:MegaN-M-PER-M2 - calculated from factors: m·MN/m², actual: MN·m/m²
+  #
+  #  ──┬ unit:MegaN-M-PER-M2 symbol: MN·m/m² (correct: m·MN/m²)
+  #    ├─── unit:M symbol: m
+  #    ├──┬ unit:MegaN symbol: MN
+  #    │  └──┬ unit:N symbol: N
+  #    │     ├──┬ unit:KiloGM symbol: kg
+  #    │     │  └─── unit:GM symbol: g
+  #    │     ├─── unit:M symbol: m
+  #    │     └─── unit:SEC^-2 symbol: s
+  #    └─── unit:M^-2 symbol: m
+unit:MegaN-M-PER-M2 qudt:symbol "m·MN/m²" .
+
+  # WRONG SYMBOL  : unit:MegaOHM-M - calculated from factors: m·MΩ, actual: MΩ·m
+  #
+  #  ──┬ unit:MegaOHM-M symbol: MΩ·m (correct: m·MΩ)
+  #    ├─── unit:M symbol: m
+  #    └──┬ unit:MegaOHM symbol: MΩ
+  #       └──┬ unit:OHM symbol: Ω
+  #          ├─── unit:A^-1 symbol: A
+  #          └──┬ unit:V symbol: V
+  #             ├─── unit:A^-1 symbol: A
+  #             └──┬ unit:W symbol: W
+  #                ├──┬ unit:J symbol: J
+  #                │  ├─── unit:M symbol: m
+  #                │  └──┬ unit:N symbol: N
+  #                │     ├──┬ unit:KiloGM symbol: kg
+  #                │     │  └─── unit:GM symbol: g
+  #                │     ├─── unit:M symbol: m
+  #                │     └─── unit:SEC^-2 symbol: s
+  #                └─── unit:SEC^-1 symbol: s
+unit:MegaOHM-M qudt:symbol "m·MΩ" .
+
+  # WRONG SYMBOL  : unit:MegaOHM-PER-BAR - calculated from factors: MΩ/bar, actual: MΩ/bar
+  #
+  #  ──┬ unit:MegaOHM-PER-BAR symbol: MΩ/bar (correct: MΩ/bar)
+  #    ├──┬ unit:MegaOHM symbol: MΩ
+  #    │  └──┬ unit:OHM symbol: Ω
+  #    │     ├─── unit:A^-1 symbol: A
+  #    │     └──┬ unit:V symbol: V
+  #    │        ├─── unit:A^-1 symbol: A
+  #    │        └──┬ unit:W symbol: W
+  #    │           ├──┬ unit:J symbol: J
+  #    │           │  ├─── unit:M symbol: m
+  #    │           │  └──┬ unit:N symbol: N
+  #    │           │     ├──┬ unit:KiloGM symbol: kg
+  #    │           │     │  └─── unit:GM symbol: g
+  #    │           │     ├─── unit:M symbol: m
+  #    │           │     └─── unit:SEC^-2 symbol: s
+  #    │           └─── unit:SEC^-1 symbol: s
+  #    └──┬ unit:BAR^-1 symbol: bar
+  #       └──┬ unit:PA symbol: Pa
+  #          ├─── unit:M^-2 symbol: m
+  #          └──┬ unit:N symbol: N
+  #             ├──┬ unit:KiloGM symbol: kg
+  #             │  └─── unit:GM symbol: g
+  #             ├─── unit:M symbol: m
+  #             └─── unit:SEC^-2 symbol: s
+unit:MegaOHM-PER-BAR qudt:symbol "MΩ/bar" .
+
+  # WRONG SYMBOL  : unit:MegaOHM-PER-K - calculated from factors: MΩ/K, actual: MΩ/K
+  #
+  #  ──┬ unit:MegaOHM-PER-K symbol: MΩ/K (correct: MΩ/K)
+  #    ├──┬ unit:MegaOHM symbol: MΩ
+  #    │  └──┬ unit:OHM symbol: Ω
+  #    │     ├─── unit:A^-1 symbol: A
+  #    │     └──┬ unit:V symbol: V
+  #    │        ├─── unit:A^-1 symbol: A
+  #    │        └──┬ unit:W symbol: W
+  #    │           ├──┬ unit:J symbol: J
+  #    │           │  ├─── unit:M symbol: m
+  #    │           │  └──┬ unit:N symbol: N
+  #    │           │     ├──┬ unit:KiloGM symbol: kg
+  #    │           │     │  └─── unit:GM symbol: g
+  #    │           │     ├─── unit:M symbol: m
+  #    │           │     └─── unit:SEC^-2 symbol: s
+  #    │           └─── unit:SEC^-1 symbol: s
+  #    └─── unit:K^-1 symbol: K
+unit:MegaOHM-PER-K qudt:symbol "MΩ/K" .
+
+  # WRONG SYMBOL  : unit:MegaOHM-PER-KiloM - calculated from factors: MΩ/km, actual: MΩ/km
+  #
+  #  ──┬ unit:MegaOHM-PER-KiloM symbol: MΩ/km (correct: MΩ/km)
+  #    ├──┬ unit:MegaOHM symbol: MΩ
+  #    │  └──┬ unit:OHM symbol: Ω
+  #    │     ├─── unit:A^-1 symbol: A
+  #    │     └──┬ unit:V symbol: V
+  #    │        ├─── unit:A^-1 symbol: A
+  #    │        └──┬ unit:W symbol: W
+  #    │           ├──┬ unit:J symbol: J
+  #    │           │  ├─── unit:M symbol: m
+  #    │           │  └──┬ unit:N symbol: N
+  #    │           │     ├──┬ unit:KiloGM symbol: kg
+  #    │           │     │  └─── unit:GM symbol: g
+  #    │           │     ├─── unit:M symbol: m
+  #    │           │     └─── unit:SEC^-2 symbol: s
+  #    │           └─── unit:SEC^-1 symbol: s
+  #    └──┬ unit:KiloM^-1 symbol: km
+  #       └─── unit:M symbol: m
+unit:MegaOHM-PER-KiloM qudt:symbol "MΩ/km" .
+
+  # WRONG SYMBOL  : unit:MegaOHM-PER-M - calculated from factors: MΩ/m, actual: MΩ/m
+  #
+  #  ──┬ unit:MegaOHM-PER-M symbol: MΩ/m (correct: MΩ/m)
+  #    ├──┬ unit:MegaOHM symbol: MΩ
+  #    │  └──┬ unit:OHM symbol: Ω
+  #    │     ├─── unit:A^-1 symbol: A
+  #    │     └──┬ unit:V symbol: V
+  #    │        ├─── unit:A^-1 symbol: A
+  #    │        └──┬ unit:W symbol: W
+  #    │           ├──┬ unit:J symbol: J
+  #    │           │  ├─── unit:M symbol: m
+  #    │           │  └──┬ unit:N symbol: N
+  #    │           │     ├──┬ unit:KiloGM symbol: kg
+  #    │           │     │  └─── unit:GM symbol: g
+  #    │           │     ├─── unit:M symbol: m
+  #    │           │     └─── unit:SEC^-2 symbol: s
+  #    │           └─── unit:SEC^-1 symbol: s
+  #    └─── unit:M^-1 symbol: m
+unit:MegaOHM-PER-M qudt:symbol "MΩ/m" .
+
+  # WRONG SYMBOL  : unit:MicroA-PER-K - calculated from factors: μA/K, actual: µA/K
+  #
+  #  ──┬ unit:MicroA-PER-K symbol: µA/K (correct: μA/K)
+  #    ├──┬ unit:MicroA symbol: μA
+  #    │  └─── unit:A symbol: A
+  #    └─── unit:K^-1 symbol: K
+unit:MicroA-PER-K qudt:symbol "μA/K" .
+
+  # WRONG SYMBOL  : unit:MicroC-PER-M2 - calculated from factors: μC/m², actual: µC/m²
+  #
+  #  ──┬ unit:MicroC-PER-M2 symbol: µC/m² (correct: μC/m²)
+  #    ├──┬ unit:MicroC symbol: μC
+  #    │  └──┬ unit:C symbol: C
+  #    │     ├─── unit:A symbol: A
+  #    │     └─── unit:SEC symbol: s
+  #    └─── unit:M^-2 symbol: m
+unit:MicroC-PER-M2 qudt:symbol "μC/m²" .
+
+  # WRONG SYMBOL  : unit:MicroC-PER-M3 - calculated from factors: μC/m³, actual: µC/m³
+  #
+  #  ──┬ unit:MicroC-PER-M3 symbol: µC/m³ (correct: μC/m³)
+  #    ├──┬ unit:MicroC symbol: μC
+  #    │  └──┬ unit:C symbol: C
+  #    │     ├─── unit:A symbol: A
+  #    │     └─── unit:SEC symbol: s
+  #    └─── unit:M^-3 symbol: m
+unit:MicroC-PER-M3 qudt:symbol "μC/m³" .
+
+  # WRONG SYMBOL  : unit:MicroFARAD-PER-KiloM - calculated from factors: μF/km, actual: µF/km
+  #
+  #  ──┬ unit:MicroFARAD-PER-KiloM symbol: µF/km (correct: μF/km)
+  #    ├──┬ unit:MicroFARAD symbol: μF
+  #    │  └──┬ unit:FARAD symbol: F
+  #    │     ├──┬ unit:C symbol: C
+  #    │     │  ├─── unit:A symbol: A
+  #    │     │  └─── unit:SEC symbol: s
+  #    │     └──┬ unit:V^-1 symbol: V
+  #    │        ├─── unit:A^-1 symbol: A
+  #    │        └──┬ unit:W symbol: W
+  #    │           ├──┬ unit:J symbol: J
+  #    │           │  ├─── unit:M symbol: m
+  #    │           │  └──┬ unit:N symbol: N
+  #    │           │     ├──┬ unit:KiloGM symbol: kg
+  #    │           │     │  └─── unit:GM symbol: g
+  #    │           │     ├─── unit:M symbol: m
+  #    │           │     └─── unit:SEC^-2 symbol: s
+  #    │           └─── unit:SEC^-1 symbol: s
+  #    └──┬ unit:KiloM^-1 symbol: km
+  #       └─── unit:M symbol: m
+unit:MicroFARAD-PER-KiloM qudt:symbol "μF/km" .
+
+  # WRONG SYMBOL  : unit:MicroFARAD-PER-M - calculated from factors: μF/m, actual: µF/m
+  #
+  #  ──┬ unit:MicroFARAD-PER-M symbol: µF/m (correct: μF/m)
+  #    ├──┬ unit:MicroFARAD symbol: μF
+  #    │  └──┬ unit:FARAD symbol: F
+  #    │     ├──┬ unit:C symbol: C
+  #    │     │  ├─── unit:A symbol: A
+  #    │     │  └─── unit:SEC symbol: s
+  #    │     └──┬ unit:V^-1 symbol: V
+  #    │        ├─── unit:A^-1 symbol: A
+  #    │        └──┬ unit:W symbol: W
+  #    │           ├──┬ unit:J symbol: J
+  #    │           │  ├─── unit:M symbol: m
+  #    │           │  └──┬ unit:N symbol: N
+  #    │           │     ├──┬ unit:KiloGM symbol: kg
+  #    │           │     │  └─── unit:GM symbol: g
+  #    │           │     ├─── unit:M symbol: m
+  #    │           │     └─── unit:SEC^-2 symbol: s
+  #    │           └─── unit:SEC^-1 symbol: s
+  #    └─── unit:M^-1 symbol: m
+unit:MicroFARAD-PER-M qudt:symbol "μF/m" .
+
+  # WRONG SYMBOL  : unit:MicroGM-PER-CentiM2 - calculated from factors: μg/cm², actual: µG/cm²
+  #
+  #  ──┬ unit:MicroGM-PER-CentiM2 symbol: µG/cm² (correct: μg/cm²)
+  #    ├──┬ unit:MicroGM symbol: μg
+  #    │  └─── unit:GM symbol: g
+  #    └──┬ unit:CentiM^-2 symbol: cm
+  #       └─── unit:M symbol: m
+unit:MicroGM-PER-CentiM2 qudt:symbol "μg/cm²" .
+
+  # WRONG SYMBOL  : unit:MicroGM-PER-GM-DAY - calculated from factors: μg/(g·d), actual: ug/g/day
+  #
+  #  ──┬ unit:MicroGM-PER-GM-DAY symbol: ug/g/day (correct: μg/(g·d))
+  #    ├──┬ unit:MicroGM symbol: μg
+  #    │  └─── unit:GM symbol: g
+  #    ├─── unit:GM^-1 symbol: g
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:MicroGM-PER-GM-DAY qudt:symbol "μg/(g·d)" .
+
+  # WRONG SYMBOL  : unit:MicroGM-PER-M2-DAY - calculated from factors: μg/(m²·d), actual: μg/(m²·day)
+  #
+  #  ──┬ unit:MicroGM-PER-M2-DAY symbol: μg/(m²·day) (correct: μg/(m²·d))
+  #    ├──┬ unit:MicroGM symbol: μg
+  #    │  └─── unit:GM symbol: g
+  #    ├─── unit:M^-2 symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:MicroGM-PER-M2-DAY qudt:symbol "μg/(m²·d)" .
+
+  # WRONG SYMBOL  : unit:MicroGM-PER-M3-BAR - calculated from factors: μg/(m³·bar), actual: µg/(m³·bar)
+  #
+  #  ──┬ unit:MicroGM-PER-M3-BAR symbol: µg/(m³·bar) (correct: μg/(m³·bar))
+  #    ├──┬ unit:MicroGM symbol: μg
+  #    │  └─── unit:GM symbol: g
+  #    ├─── unit:M^-3 symbol: m
+  #    └──┬ unit:BAR^-1 symbol: bar
+  #       └──┬ unit:PA symbol: Pa
+  #          ├─── unit:M^-2 symbol: m
+  #          └──┬ unit:N symbol: N
+  #             ├──┬ unit:KiloGM symbol: kg
+  #             │  └─── unit:GM symbol: g
+  #             ├─── unit:M symbol: m
+  #             └─── unit:SEC^-2 symbol: s
+unit:MicroGM-PER-M3-BAR qudt:symbol "μg/(m³·bar)" .
+
+  # WRONG SYMBOL  : unit:MicroGM-PER-M3-K - calculated from factors: μg/(m³·K), actual: µg/(m³·K)
+  #
+  #  ──┬ unit:MicroGM-PER-M3-K symbol: µg/(m³·K) (correct: μg/(m³·K))
+  #    ├──┬ unit:MicroGM symbol: μg
+  #    │  └─── unit:GM symbol: g
+  #    ├─── unit:M^-3 symbol: m
+  #    └─── unit:K^-1 symbol: K
+unit:MicroGM-PER-M3-K qudt:symbol "μg/(m³·K)" .
+
+  # WRONG SYMBOL  : unit:MicroGM-PER-MilliGM - calculated from factors: μg/mg, actual: ug/mg
+  #
+  #  ──┬ unit:MicroGM-PER-MilliGM symbol: ug/mg (correct: μg/mg)
+  #    ├──┬ unit:MicroGM symbol: μg
+  #    │  └─── unit:GM symbol: g
+  #    └──┬ unit:MilliGM^-1 symbol: mg
+  #       └─── unit:GM symbol: g
+unit:MicroGM-PER-MilliGM qudt:symbol "μg/mg" .
+
+  # WRONG SYMBOL  : unit:MicroGRAY-PER-HR - calculated from factors: μGy/h, actual: µGy/h
+  #
+  #  ──┬ unit:MicroGRAY-PER-HR symbol: µGy/h (correct: μGy/h)
+  #    ├──┬ unit:MicroGRAY symbol: μGy
+  #    │  └──┬ unit:GRAY symbol: Gy
+  #    │     ├──┬ unit:J symbol: J
+  #    │     │  ├─── unit:M symbol: m
+  #    │     │  └──┬ unit:N symbol: N
+  #    │     │     ├──┬ unit:KiloGM symbol: kg
+  #    │     │     │  └─── unit:GM symbol: g
+  #    │     │     ├─── unit:M symbol: m
+  #    │     │     └─── unit:SEC^-2 symbol: s
+  #    │     └──┬ unit:KiloGM^-1 symbol: kg
+  #    │        └─── unit:GM symbol: g
+  #    └──┬ unit:HR^-1 symbol: h
+  #       └─── unit:SEC symbol: s
+unit:MicroGRAY-PER-HR qudt:symbol "μGy/h" .
+
+  # WRONG SYMBOL  : unit:MicroGRAY-PER-MIN - calculated from factors: μGy/min, actual: µGy/min
+  #
+  #  ──┬ unit:MicroGRAY-PER-MIN symbol: µGy/min (correct: μGy/min)
+  #    ├──┬ unit:MicroGRAY symbol: μGy
+  #    │  └──┬ unit:GRAY symbol: Gy
+  #    │     ├──┬ unit:J symbol: J
+  #    │     │  ├─── unit:M symbol: m
+  #    │     │  └──┬ unit:N symbol: N
+  #    │     │     ├──┬ unit:KiloGM symbol: kg
+  #    │     │     │  └─── unit:GM symbol: g
+  #    │     │     ├─── unit:M symbol: m
+  #    │     │     └─── unit:SEC^-2 symbol: s
+  #    │     └──┬ unit:KiloGM^-1 symbol: kg
+  #    │        └─── unit:GM symbol: g
+  #    └──┬ unit:MIN^-1 symbol: min
+  #       └─── unit:SEC symbol: s
+unit:MicroGRAY-PER-MIN qudt:symbol "μGy/min" .
+
+  # WRONG SYMBOL  : unit:MicroGRAY-PER-SEC - calculated from factors: μGy/s, actual: µGy/s
+  #
+  #  ──┬ unit:MicroGRAY-PER-SEC symbol: µGy/s (correct: μGy/s)
+  #    ├──┬ unit:MicroGRAY symbol: μGy
+  #    │  └──┬ unit:GRAY symbol: Gy
+  #    │     ├──┬ unit:J symbol: J
+  #    │     │  ├─── unit:M symbol: m
+  #    │     │  └──┬ unit:N symbol: N
+  #    │     │     ├──┬ unit:KiloGM symbol: kg
+  #    │     │     │  └─── unit:GM symbol: g
+  #    │     │     ├─── unit:M symbol: m
+  #    │     │     └─── unit:SEC^-2 symbol: s
+  #    │     └──┬ unit:KiloGM^-1 symbol: kg
+  #    │        └─── unit:GM symbol: g
+  #    └─── unit:SEC^-1 symbol: s
+unit:MicroGRAY-PER-SEC qudt:symbol "μGy/s" .
+
+  # WRONG SYMBOL  : unit:MicroH-PER-KiloOHM - calculated from factors: μH/kΩ, actual: µH/kΩ
+  #
+  #  ──┬ unit:MicroH-PER-KiloOHM symbol: µH/kΩ (correct: μH/kΩ)
+  #    ├──┬ unit:MicroH symbol: μH
+  #    │  └──┬ unit:H symbol: H
+  #    │     ├─── unit:A^-1 symbol: A
+  #    │     └──┬ unit:WB symbol: Wb
+  #    │        ├─── unit:A^-1 symbol: A
+  #    │        └──┬ unit:J symbol: J
+  #    │           ├─── unit:M symbol: m
+  #    │           └──┬ unit:N symbol: N
+  #    │              ├──┬ unit:KiloGM symbol: kg
+  #    │              │  └─── unit:GM symbol: g
+  #    │              ├─── unit:M symbol: m
+  #    │              └─── unit:SEC^-2 symbol: s
+  #    └──┬ unit:KiloOHM^-1 symbol: kΩ
+  #       └──┬ unit:OHM symbol: Ω
+  #          ├─── unit:A^-1 symbol: A
+  #          └──┬ unit:V symbol: V
+  #             ├─── unit:A^-1 symbol: A
+  #             └──┬ unit:W symbol: W
+  #                ├──┬ unit:J symbol: J
+  #                │  ├─── unit:M symbol: m
+  #                │  └──┬ unit:N symbol: N
+  #                │     ├──┬ unit:KiloGM symbol: kg
+  #                │     │  └─── unit:GM symbol: g
+  #                │     ├─── unit:M symbol: m
+  #                │     └─── unit:SEC^-2 symbol: s
+  #                └─── unit:SEC^-1 symbol: s
+unit:MicroH-PER-KiloOHM qudt:symbol "μH/kΩ" .
+
+  # WRONG SYMBOL  : unit:MicroH-PER-M - calculated from factors: μH/m, actual: µH/m
+  #
+  #  ──┬ unit:MicroH-PER-M symbol: µH/m (correct: μH/m)
+  #    ├──┬ unit:MicroH symbol: μH
+  #    │  └──┬ unit:H symbol: H
+  #    │     ├─── unit:A^-1 symbol: A
+  #    │     └──┬ unit:WB symbol: Wb
+  #    │        ├─── unit:A^-1 symbol: A
+  #    │        └──┬ unit:J symbol: J
+  #    │           ├─── unit:M symbol: m
+  #    │           └──┬ unit:N symbol: N
+  #    │              ├──┬ unit:KiloGM symbol: kg
+  #    │              │  └─── unit:GM symbol: g
+  #    │              ├─── unit:M symbol: m
+  #    │              └─── unit:SEC^-2 symbol: s
+  #    └─── unit:M^-1 symbol: m
+unit:MicroH-PER-M qudt:symbol "μH/m" .
+
+  # WRONG SYMBOL  : unit:MicroH-PER-OHM - calculated from factors: μH/Ω, actual: µH/Ω
+  #
+  #  ──┬ unit:MicroH-PER-OHM symbol: µH/Ω (correct: μH/Ω)
+  #    ├──┬ unit:MicroH symbol: μH
+  #    │  └──┬ unit:H symbol: H
+  #    │     ├─── unit:A^-1 symbol: A
+  #    │     └──┬ unit:WB symbol: Wb
+  #    │        ├─── unit:A^-1 symbol: A
+  #    │        └──┬ unit:J symbol: J
+  #    │           ├─── unit:M symbol: m
+  #    │           └──┬ unit:N symbol: N
+  #    │              ├──┬ unit:KiloGM symbol: kg
+  #    │              │  └─── unit:GM symbol: g
+  #    │              ├─── unit:M symbol: m
+  #    │              └─── unit:SEC^-2 symbol: s
+  #    └──┬ unit:OHM^-1 symbol: Ω
+  #       ├─── unit:A^-1 symbol: A
+  #       └──┬ unit:V symbol: V
+  #          ├─── unit:A^-1 symbol: A
+  #          └──┬ unit:W symbol: W
+  #             ├──┬ unit:J symbol: J
+  #             │  ├─── unit:M symbol: m
+  #             │  └──┬ unit:N symbol: N
+  #             │     ├──┬ unit:KiloGM symbol: kg
+  #             │     │  └─── unit:GM symbol: g
+  #             │     ├─── unit:M symbol: m
+  #             │     └─── unit:SEC^-2 symbol: s
+  #             └─── unit:SEC^-1 symbol: s
+unit:MicroH-PER-OHM qudt:symbol "μH/Ω" .
+
+  # WRONG SYMBOL  : unit:MicroJ-PER-SEC - calculated from factors: μJ/s, actual: µJ/s
+  #
+  #  ──┬ unit:MicroJ-PER-SEC symbol: µJ/s (correct: μJ/s)
+  #    ├──┬ unit:MicroJ symbol: μJ
+  #    │  └──┬ unit:J symbol: J
+  #    │     ├─── unit:M symbol: m
+  #    │     └──┬ unit:N symbol: N
+  #    │        ├──┬ unit:KiloGM symbol: kg
+  #    │        │  └─── unit:GM symbol: g
+  #    │        ├─── unit:M symbol: m
+  #    │        └─── unit:SEC^-2 symbol: s
+  #    └─── unit:SEC^-1 symbol: s
+unit:MicroJ-PER-SEC qudt:symbol "μJ/s" .
+
+  # WRONG SYMBOL  : unit:MicroM-PER-K - calculated from factors: μm/K, actual: µm/K
+  #
+  #  ──┬ unit:MicroM-PER-K symbol: µm/K (correct: μm/K)
+  #    ├──┬ unit:MicroM symbol: μm
+  #    │  └─── unit:M symbol: m
+  #    └─── unit:K^-1 symbol: K
+unit:MicroM-PER-K qudt:symbol "μm/K" .
+
+  # WRONG SYMBOL  : unit:MicroM-PER-L-DAY - calculated from factors: μm/(L·d), actual: µm/(L·day)
+  #
+  #  ──┬ unit:MicroM-PER-L-DAY symbol: µm/(L·day) (correct: μm/(L·d))
+  #    ├──┬ unit:MicroM symbol: μm
+  #    │  └─── unit:M symbol: m
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:MicroM-PER-L-DAY qudt:symbol "μm/(L·d)" .
+
+  # WRONG SYMBOL  : unit:MicroM-PER-M - calculated from factors: μm/m, actual: µm/m
+  #
+  #  ──┬ unit:MicroM-PER-M symbol: µm/m (correct: μm/m)
+  #    ├──┬ unit:MicroM symbol: μm
+  #    │  └─── unit:M symbol: m
+  #    └─── unit:M^-1 symbol: m
+unit:MicroM-PER-M qudt:symbol "μm/m" .
+
+  # WRONG SYMBOL  : unit:MicroM-PER-MilliL - calculated from factors: μm/mL, actual: µm/mL
+  #
+  #  ──┬ unit:MicroM-PER-MilliL symbol: µm/mL (correct: μm/mL)
+  #    ├──┬ unit:MicroM symbol: μm
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:MilliL^-1 symbol: mL
+  #       └──┬ unit:L symbol: L
+  #          └──┬ unit:DeciM3 symbol: dm³
+  #             └──┬ unit:DeciM^3 symbol: dm
+  #                └─── unit:M symbol: m
+unit:MicroM-PER-MilliL qudt:symbol "μm/mL" .
+
+  # WRONG SYMBOL  : unit:MicroM-PER-N - calculated from factors: μm/N, actual: µm/N
+  #
+  #  ──┬ unit:MicroM-PER-N symbol: µm/N (correct: μm/N)
+  #    ├──┬ unit:MicroM symbol: μm
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:N^-1 symbol: N
+  #       ├──┬ unit:KiloGM symbol: kg
+  #       │  └─── unit:GM symbol: g
+  #       ├─── unit:M symbol: m
+  #       └─── unit:SEC^-2 symbol: s
+unit:MicroM-PER-N qudt:symbol "μm/N" .
+
+  # WRONG SYMBOL  : unit:MicroM3 - calculated from factors: μm³, actual: µm³
+  #
+  #  ──┬ unit:MicroM3 symbol: µm³ (correct: μm³)
+  #    └──┬ unit:MicroM^3 symbol: μm
+  #       └─── unit:M symbol: m
+unit:MicroM3 qudt:symbol "μm³" .
+
+  # WRONG SYMBOL  : unit:MicroM3-PER-M3 - calculated from factors: μm³/m³, actual: µm³/m³
+  #
+  #  ──┬ unit:MicroM3-PER-M3 symbol: µm³/m³ (correct: μm³/m³)
+  #    ├──┬ unit:MicroM^3 symbol: μm
+  #    │  └─── unit:M symbol: m
+  #    └─── unit:M^-3 symbol: m
+unit:MicroM3-PER-M3 qudt:symbol "μm³/m³" .
+
+  # WRONG SYMBOL  : unit:MicroM3-PER-MilliL - calculated from factors: μm³/mL, actual: µm³/mL
+  #
+  #  ──┬ unit:MicroM3-PER-MilliL symbol: µm³/mL (correct: μm³/mL)
+  #    ├──┬ unit:MicroM^3 symbol: μm
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:MilliL^-1 symbol: mL
+  #       └──┬ unit:L symbol: L
+  #          └──┬ unit:DeciM3 symbol: dm³
+  #             └──┬ unit:DeciM^3 symbol: dm
+  #                └─── unit:M symbol: m
+unit:MicroM3-PER-MilliL qudt:symbol "μm³/mL" .
+
+  # WRONG SYMBOL  : unit:MicroMOL-PER-GM - calculated from factors: μmol/g, actual: µmol/g
+  #
+  #  ──┬ unit:MicroMOL-PER-GM symbol: µmol/g (correct: μmol/g)
+  #    ├──┬ unit:MicroMOL symbol: μmol
+  #    │  └─── unit:MOL symbol: mol
+  #    └─── unit:GM^-1 symbol: g
+unit:MicroMOL-PER-GM qudt:symbol "μmol/g" .
+
+  # WRONG SYMBOL  : unit:MicroMOL-PER-GM-HR - calculated from factors: μmol/(g·h), actual: µmol/(g·h)
+  #
+  #  ──┬ unit:MicroMOL-PER-GM-HR symbol: µmol/(g·h) (correct: μmol/(g·h))
+  #    ├──┬ unit:MicroMOL symbol: μmol
+  #    │  └─── unit:MOL symbol: mol
+  #    ├─── unit:GM^-1 symbol: g
+  #    └──┬ unit:HR^-1 symbol: h
+  #       └─── unit:SEC symbol: s
+unit:MicroMOL-PER-GM-HR qudt:symbol "μmol/(g·h)" .
+
+  # WRONG SYMBOL  : unit:MicroMOL-PER-KiloGM - calculated from factors: μmol/kg, actual: µmol/kg
+  #
+  #  ──┬ unit:MicroMOL-PER-KiloGM symbol: µmol/kg (correct: μmol/kg)
+  #    ├──┬ unit:MicroMOL symbol: μmol
+  #    │  └─── unit:MOL symbol: mol
+  #    └──┬ unit:KiloGM^-1 symbol: kg
+  #       └─── unit:GM symbol: g
+unit:MicroMOL-PER-KiloGM qudt:symbol "μmol/kg" .
+
+  # WRONG SYMBOL  : unit:MicroMOL-PER-L - calculated from factors: μmol/L, actual: µmol/L
+  #
+  #  ──┬ unit:MicroMOL-PER-L symbol: µmol/L (correct: μmol/L)
+  #    ├──┬ unit:MicroMOL symbol: μmol
+  #    │  └─── unit:MOL symbol: mol
+  #    └──┬ unit:L^-1 symbol: L
+  #       └──┬ unit:DeciM3 symbol: dm³
+  #          └──┬ unit:DeciM^3 symbol: dm
+  #             └─── unit:M symbol: m
+unit:MicroMOL-PER-L qudt:symbol "μmol/L" .
+
+  # WRONG SYMBOL  : unit:MicroMOL-PER-L-HR - calculated from factors: μmol/(L·h), actual: µmol/(L·h)
+  #
+  #  ──┬ unit:MicroMOL-PER-L-HR symbol: µmol/(L·h) (correct: μmol/(L·h))
+  #    ├──┬ unit:MicroMOL symbol: μmol
+  #    │  └─── unit:MOL symbol: mol
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └──┬ unit:HR^-1 symbol: h
+  #       └─── unit:SEC symbol: s
+unit:MicroMOL-PER-L-HR qudt:symbol "μmol/(L·h)" .
+
+  # WRONG SYMBOL  : unit:MicroMOL-PER-M2 - calculated from factors: μmol/m², actual: µmol/m²
+  #
+  #  ──┬ unit:MicroMOL-PER-M2 symbol: µmol/m² (correct: μmol/m²)
+  #    ├──┬ unit:MicroMOL symbol: μmol
+  #    │  └─── unit:MOL symbol: mol
+  #    └─── unit:M^-2 symbol: m
+unit:MicroMOL-PER-M2 qudt:symbol "μmol/m²" .
+
+  # WRONG SYMBOL  : unit:MicroMOL-PER-M2-DAY - calculated from factors: μmol/(m²·d), actual: µmol/(m²·day)
+  #
+  #  ──┬ unit:MicroMOL-PER-M2-DAY symbol: µmol/(m²·day) (correct: μmol/(m²·d))
+  #    ├──┬ unit:MicroMOL symbol: μmol
+  #    │  └─── unit:MOL symbol: mol
+  #    ├─── unit:M^-2 symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:MicroMOL-PER-M2-DAY qudt:symbol "μmol/(m²·d)" .
+
+  # WRONG SYMBOL  : unit:MicroMOL-PER-M2-HR - calculated from factors: μmol/(m²·h), actual: µmol/(m²·h)
+  #
+  #  ──┬ unit:MicroMOL-PER-M2-HR symbol: µmol/(m²·h) (correct: μmol/(m²·h))
+  #    ├──┬ unit:MicroMOL symbol: μmol
+  #    │  └─── unit:MOL symbol: mol
+  #    ├─── unit:M^-2 symbol: m
+  #    └──┬ unit:HR^-1 symbol: h
+  #       └─── unit:SEC symbol: s
+unit:MicroMOL-PER-M2-HR qudt:symbol "μmol/(m²·h)" .
+
+  # WRONG SYMBOL  : unit:MicroMOL-PER-M2-SEC - calculated from factors: μmol/(m²·s), actual: µmol/(m²·s)
+  #
+  #  ──┬ unit:MicroMOL-PER-M2-SEC symbol: µmol/(m²·s) (correct: μmol/(m²·s))
+  #    ├──┬ unit:MicroMOL symbol: μmol
+  #    │  └─── unit:MOL symbol: mol
+  #    ├─── unit:M^-2 symbol: m
+  #    └─── unit:SEC^-1 symbol: s
+unit:MicroMOL-PER-M2-SEC qudt:symbol "μmol/(m²·s)" .
+
+  # WRONG SYMBOL  : unit:MicroMOL-PER-MOL - calculated from factors: μmol/mol, actual: µmol/mol
+  #
+  #  ──┬ unit:MicroMOL-PER-MOL symbol: µmol/mol (correct: μmol/mol)
+  #    ├──┬ unit:MicroMOL symbol: μmol
+  #    │  └─── unit:MOL symbol: mol
+  #    └─── unit:MOL^-1 symbol: mol
+unit:MicroMOL-PER-MOL qudt:symbol "μmol/mol" .
+
+  # WRONG SYMBOL  : unit:MicroMOL-PER-MicroMOL-DAY - calculated from factors: μmol/(μmol·d), actual: μmol/(µmol·day)
+  #
+  #  ──┬ unit:MicroMOL-PER-MicroMOL-DAY symbol: μmol/(µmol·day) (correct: μmol/(μmol·d))
+  #    ├──┬ unit:MicroMOL symbol: μmol
+  #    │  └─── unit:MOL symbol: mol
+  #    ├──┬ unit:MicroMOL^-1 symbol: μmol
+  #    │  └─── unit:MOL symbol: mol
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:MicroMOL-PER-MicroMOL-DAY qudt:symbol "μmol/(μmol·d)" .
+
+  # WRONG SYMBOL  : unit:MicroMOL-PER-SEC - calculated from factors: μmol/s, actual: µmol/s
+  #
+  #  ──┬ unit:MicroMOL-PER-SEC symbol: µmol/s (correct: μmol/s)
+  #    ├──┬ unit:MicroMOL symbol: μmol
+  #    │  └─── unit:MOL symbol: mol
+  #    └─── unit:SEC^-1 symbol: s
+unit:MicroMOL-PER-SEC qudt:symbol "μmol/s" .
+
+  # WRONG SYMBOL  : unit:MicroMOL2-PER-M4-SEC2 - calculated from factors: μmol²/(m⁴·s²), actual: (uM/m^2/s)^2
+  #
+  #  ──┬ unit:MicroMOL2-PER-M4-SEC2 symbol: (uM/m^2/s)^2 (correct: μmol²/(m⁴·s²))
+  #    ├──┬ unit:MicroMOL^2 symbol: μmol
+  #    │  └─── unit:MOL symbol: mol
+  #    ├─── unit:M^-4 symbol: m
+  #    └─── unit:SEC^-2 symbol: s
+unit:MicroMOL2-PER-M4-SEC2 qudt:symbol "μmol²/(m⁴·s²)" .
+
+  # WRONG SYMBOL  : unit:MicroN-M - calculated from factors: m·μN, actual: μN·m
+  #
+  #  ──┬ unit:MicroN-M symbol: μN·m (correct: m·μN)
+  #    ├─── unit:M symbol: m
+  #    └──┬ unit:MicroN symbol: μN
+  #       └──┬ unit:N symbol: N
+  #          ├──┬ unit:KiloGM symbol: kg
+  #          │  └─── unit:GM symbol: g
+  #          ├─── unit:M symbol: m
+  #          └─── unit:SEC^-2 symbol: s
+unit:MicroN-M qudt:symbol "m·μN" .
+
+  # WRONG SYMBOL  : unit:MicroN-M-PER-M2 - calculated from factors: m·μN/m², actual: µN·m/m²
+  #
+  #  ──┬ unit:MicroN-M-PER-M2 symbol: µN·m/m² (correct: m·μN/m²)
+  #    ├─── unit:M symbol: m
+  #    ├──┬ unit:MicroN symbol: μN
+  #    │  └──┬ unit:N symbol: N
+  #    │     ├──┬ unit:KiloGM symbol: kg
+  #    │     │  └─── unit:GM symbol: g
+  #    │     ├─── unit:M symbol: m
+  #    │     └─── unit:SEC^-2 symbol: s
+  #    └─── unit:M^-2 symbol: m
+unit:MicroN-M-PER-M2 qudt:symbol "m·μN/m²" .
+
+  # WRONG SYMBOL  : unit:MicroOHM-M - calculated from factors: m·μΩ, actual: µΩ·m
+  #
+  #  ──┬ unit:MicroOHM-M symbol: µΩ·m (correct: m·μΩ)
+  #    ├─── unit:M symbol: m
+  #    └──┬ unit:MicroOHM symbol: μΩ
+  #       └──┬ unit:OHM symbol: Ω
+  #          ├─── unit:A^-1 symbol: A
+  #          └──┬ unit:V symbol: V
+  #             ├─── unit:A^-1 symbol: A
+  #             └──┬ unit:W symbol: W
+  #                ├──┬ unit:J symbol: J
+  #                │  ├─── unit:M symbol: m
+  #                │  └──┬ unit:N symbol: N
+  #                │     ├──┬ unit:KiloGM symbol: kg
+  #                │     │  └─── unit:GM symbol: g
+  #                │     ├─── unit:M symbol: m
+  #                │     └─── unit:SEC^-2 symbol: s
+  #                └─── unit:SEC^-1 symbol: s
+unit:MicroOHM-M qudt:symbol "m·μΩ" .
+
+  # WRONG SYMBOL  : unit:MilliA-PER-L-MIN - calculated from factors: mA/(L·min), actual: mA/(l·min)
+  #
+  #  ──┬ unit:MilliA-PER-L-MIN symbol: mA/(l·min) (correct: mA/(L·min))
+  #    ├──┬ unit:MilliA symbol: mA
+  #    │  └─── unit:A symbol: A
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └──┬ unit:MIN^-1 symbol: min
+  #       └─── unit:SEC symbol: s
+unit:MilliA-PER-L-MIN qudt:symbol "mA/(L·min)" .
+
+  # WRONG SYMBOL  : unit:MilliBQ-PER-M2-DAY - calculated from factors: mBq/(m²·d), actual: mBq/(m²·day)
+  #
+  #  ──┬ unit:MilliBQ-PER-M2-DAY symbol: mBq/(m²·day) (correct: mBq/(m²·d))
+  #    ├──┬ unit:MilliBQ symbol: mBq
+  #    │  └──┬ unit:BQ symbol: Bq
+  #    │     └─── unit:SEC^-1 symbol: s
+  #    ├─── unit:M^-2 symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:MilliBQ-PER-M2-DAY qudt:symbol "mBq/(m²·d)" .
+
+  # WRONG SYMBOL  : unit:MilliGM-HR-PER-L-CentiM3 - calculated from factors: mg·h/(L·cm³), actual: (mg/l)/(cm³/h)
+  #
+  #  ──┬ unit:MilliGM-HR-PER-L-CentiM3 symbol: (mg/l)/(cm³/h) (correct: mg·h/(L·cm³))
+  #    ├──┬ unit:MilliGM symbol: mg
+  #    │  └─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └──┬ unit:CentiM^-3 symbol: cm
+  #       └─── unit:M symbol: m
+unit:MilliGM-HR-PER-L-CentiM3 qudt:symbol "mg·h/(L·cm³)" .
+
+  # WRONG SYMBOL  : unit:MilliGM-HR-PER-L-M3 - calculated from factors: mg·h/(L·m³), actual: (mg/l)/(m³/h)
+  #
+  #  ──┬ unit:MilliGM-HR-PER-L-M3 symbol: (mg/l)/(m³/h) (correct: mg·h/(L·m³))
+  #    ├──┬ unit:MilliGM symbol: mg
+  #    │  └─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └─── unit:M^-3 symbol: m
+unit:MilliGM-HR-PER-L-M3 qudt:symbol "mg·h/(L·m³)" .
+
+  # WRONG SYMBOL  : unit:MilliGM-HR-PER-L2 - calculated from factors: mg·h/L², actual: (mg/l)/(l/h)
+  #
+  #  ──┬ unit:MilliGM-HR-PER-L2 symbol: (mg/l)/(l/h) (correct: mg·h/L²)
+  #    ├──┬ unit:MilliGM symbol: mg
+  #    │  └─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    └──┬ unit:L^-2 symbol: L
+  #       └──┬ unit:DeciM3 symbol: dm³
+  #          └──┬ unit:DeciM^3 symbol: dm
+  #             └─── unit:M symbol: m
+unit:MilliGM-HR-PER-L2 qudt:symbol "mg·h/L²" .
+
+  # WRONG SYMBOL  : unit:MilliGM-HR-PER-M3-CentiM3 - calculated from factors: mg·h/(m³·cm³), actual: (mg/m³)/(cm³/h)
+  #
+  #  ──┬ unit:MilliGM-HR-PER-M3-CentiM3 symbol: (mg/m³)/(cm³/h) (correct: mg·h/(m³·cm³))
+  #    ├──┬ unit:MilliGM symbol: mg
+  #    │  └─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├─── unit:M^-3 symbol: m
+  #    └──┬ unit:CentiM^-3 symbol: cm
+  #       └─── unit:M symbol: m
+unit:MilliGM-HR-PER-M3-CentiM3 qudt:symbol "mg·h/(m³·cm³)" .
+
+  # WRONG SYMBOL  : unit:MilliGM-HR-PER-M3-L - calculated from factors: mg·h/(m³·L), actual: (mg/m³)/(l/h)
+  #
+  #  ──┬ unit:MilliGM-HR-PER-M3-L symbol: (mg/m³)/(l/h) (correct: mg·h/(m³·L))
+  #    ├──┬ unit:MilliGM symbol: mg
+  #    │  └─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├─── unit:M^-3 symbol: m
+  #    └──┬ unit:L^-1 symbol: L
+  #       └──┬ unit:DeciM3 symbol: dm³
+  #          └──┬ unit:DeciM^3 symbol: dm
+  #             └─── unit:M symbol: m
+unit:MilliGM-HR-PER-M3-L qudt:symbol "mg·h/(m³·L)" .
+
+  # WRONG SYMBOL  : unit:MilliGM-HR-PER-M6 - calculated from factors: mg·h/m⁶, actual: (mg/m³)/(m³/h)
+  #
+  #  ──┬ unit:MilliGM-HR-PER-M6 symbol: (mg/m³)/(m³/h) (correct: mg·h/m⁶)
+  #    ├──┬ unit:MilliGM symbol: mg
+  #    │  └─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    └─── unit:M^-6 symbol: m
+unit:MilliGM-HR-PER-M6 qudt:symbol "mg·h/m⁶" .
+
+  # WRONG SYMBOL  : unit:MilliGM-MIN-PER-L-CentiM3 - calculated from factors: mg·min/(L·cm³), actual: (mg/l)/(cm³/min)
+  #
+  #  ──┬ unit:MilliGM-MIN-PER-L-CentiM3 symbol: (mg/l)/(cm³/min) (correct: mg·min/(L·cm³))
+  #    ├──┬ unit:MilliGM symbol: mg
+  #    │  └─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └──┬ unit:CentiM^-3 symbol: cm
+  #       └─── unit:M symbol: m
+unit:MilliGM-MIN-PER-L-CentiM3 qudt:symbol "mg·min/(L·cm³)" .
+
+  # WRONG SYMBOL  : unit:MilliGM-MIN-PER-L-M3 - calculated from factors: mg·min/(L·m³), actual: (mg/l)/(m³/min)
+  #
+  #  ──┬ unit:MilliGM-MIN-PER-L-M3 symbol: (mg/l)/(m³/min) (correct: mg·min/(L·m³))
+  #    ├──┬ unit:MilliGM symbol: mg
+  #    │  └─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └─── unit:M^-3 symbol: m
+unit:MilliGM-MIN-PER-L-M3 qudt:symbol "mg·min/(L·m³)" .
+
+  # WRONG SYMBOL  : unit:MilliGM-MIN-PER-L2 - calculated from factors: mg·min/L², actual: (mg/l)/(l/min)
+  #
+  #  ──┬ unit:MilliGM-MIN-PER-L2 symbol: (mg/l)/(l/min) (correct: mg·min/L²)
+  #    ├──┬ unit:MilliGM symbol: mg
+  #    │  └─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    └──┬ unit:L^-2 symbol: L
+  #       └──┬ unit:DeciM3 symbol: dm³
+  #          └──┬ unit:DeciM^3 symbol: dm
+  #             └─── unit:M symbol: m
+unit:MilliGM-MIN-PER-L2 qudt:symbol "mg·min/L²" .
+
+  # WRONG SYMBOL  : unit:MilliGM-MIN-PER-M3-CentiM3 - calculated from factors: mg·min/(m³·cm³), actual: (mg/m³)/(cm³/min)
+  #
+  #  ──┬ unit:MilliGM-MIN-PER-M3-CentiM3 symbol: (mg/m³)/(cm³/min) (correct: mg·min/(m³·cm³))
+  #    ├──┬ unit:MilliGM symbol: mg
+  #    │  └─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    ├─── unit:M^-3 symbol: m
+  #    └──┬ unit:CentiM^-3 symbol: cm
+  #       └─── unit:M symbol: m
+unit:MilliGM-MIN-PER-M3-CentiM3 qudt:symbol "mg·min/(m³·cm³)" .
+
+  # WRONG SYMBOL  : unit:MilliGM-MIN-PER-M3-L - calculated from factors: mg·min/(m³·L), actual: (mg/m³)/(l/min)
+  #
+  #  ──┬ unit:MilliGM-MIN-PER-M3-L symbol: (mg/m³)/(l/min) (correct: mg·min/(m³·L))
+  #    ├──┬ unit:MilliGM symbol: mg
+  #    │  └─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    ├─── unit:M^-3 symbol: m
+  #    └──┬ unit:L^-1 symbol: L
+  #       └──┬ unit:DeciM3 symbol: dm³
+  #          └──┬ unit:DeciM^3 symbol: dm
+  #             └─── unit:M symbol: m
+unit:MilliGM-MIN-PER-M3-L qudt:symbol "mg·min/(m³·L)" .
+
+  # WRONG SYMBOL  : unit:MilliGM-MIN-PER-M6 - calculated from factors: mg·min/m⁶, actual: (mg/m³)/(m³/min)
+  #
+  #  ──┬ unit:MilliGM-MIN-PER-M6 symbol: (mg/m³)/(m³/min) (correct: mg·min/m⁶)
+  #    ├──┬ unit:MilliGM symbol: mg
+  #    │  └─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    └─── unit:M^-6 symbol: m
+unit:MilliGM-MIN-PER-M6 qudt:symbol "mg·min/m⁶" .
+
+  # WRONG SYMBOL  : unit:MilliGM-PER-DAY - calculated from factors: mg/d, actual: mg/day
+  #
+  #  ──┬ unit:MilliGM-PER-DAY symbol: mg/day (correct: mg/d)
+  #    ├──┬ unit:MilliGM symbol: mg
+  #    │  └─── unit:GM symbol: g
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:MilliGM-PER-DAY qudt:symbol "mg/d" .
+
+  # WRONG SYMBOL  : unit:MilliGM-PER-GM-HR - calculated from factors: mg/(g·h), actual: mg/gm/h
+  #
+  #  ──┬ unit:MilliGM-PER-GM-HR symbol: mg/gm/h (correct: mg/(g·h))
+  #    ├──┬ unit:MilliGM symbol: mg
+  #    │  └─── unit:GM symbol: g
+  #    ├─── unit:GM^-1 symbol: g
+  #    └──┬ unit:HR^-1 symbol: h
+  #       └─── unit:SEC symbol: s
+unit:MilliGM-PER-GM-HR qudt:symbol "mg/(g·h)" .
+
+  # WRONG SYMBOL  : unit:MilliGM-PER-KiloGM-DAY - calculated from factors: mg/(kg·d), actual: mg/kg/day
+  #
+  #  ──┬ unit:MilliGM-PER-KiloGM-DAY symbol: mg/kg/day (correct: mg/(kg·d))
+  #    ├──┬ unit:MilliGM symbol: mg
+  #    │  └─── unit:GM symbol: g
+  #    ├──┬ unit:KiloGM^-1 symbol: kg
+  #    │  └─── unit:GM symbol: g
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:MilliGM-PER-KiloGM-DAY qudt:symbol "mg/(kg·d)" .
+
+  # WRONG SYMBOL  : unit:MilliGM-PER-L-CentiPOISE - calculated from factors: mg/(L·cP), actual: (mg/l)/cP
+  #
+  #  ──┬ unit:MilliGM-PER-L-CentiPOISE symbol: (mg/l)/cP (correct: mg/(L·cP))
+  #    ├──┬ unit:MilliGM symbol: mg
+  #    │  └─── unit:GM symbol: g
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └──┬ unit:CentiPOISE^-1 symbol: cP
+  #       └──┬ unit:POISE symbol: P
+  #          └──┬ unit:KiloGM-PER-M-SEC symbol: kg/(m·s)
+  #             ├──┬ unit:KiloGM symbol: kg
+  #             │  └─── unit:GM symbol: g
+  #             ├─── unit:M^-1 symbol: m
+  #             └─── unit:SEC^-1 symbol: s
+unit:MilliGM-PER-L-CentiPOISE qudt:symbol "mg/(L·cP)" .
+
+  # WRONG SYMBOL  : unit:MilliGM-PER-L-MilliPA-SEC - calculated from factors: mg/(L·mPa·s), actual: (mg/l)/(mPa·s)
+  #
+  #  ──┬ unit:MilliGM-PER-L-MilliPA-SEC symbol: (mg/l)/(mPa·s) (correct: mg/(L·mPa·s))
+  #    ├──┬ unit:MilliGM symbol: mg
+  #    │  └─── unit:GM symbol: g
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    ├──┬ unit:MilliPA^-1 symbol: mPa
+  #    │  └──┬ unit:PA symbol: Pa
+  #    │     ├─── unit:M^-2 symbol: m
+  #    │     └──┬ unit:N symbol: N
+  #    │        ├──┬ unit:KiloGM symbol: kg
+  #    │        │  └─── unit:GM symbol: g
+  #    │        ├─── unit:M symbol: m
+  #    │        └─── unit:SEC^-2 symbol: s
+  #    └─── unit:SEC^-1 symbol: s
+unit:MilliGM-PER-L-MilliPA-SEC qudt:symbol "mg/(L·mPa·s)" .
+
+  # WRONG SYMBOL  : unit:MilliGM-PER-L-PA-SEC - calculated from factors: mg/(L·Pa·s), actual: (mg/l)/(Pa·s)
+  #
+  #  ──┬ unit:MilliGM-PER-L-PA-SEC symbol: (mg/l)/(Pa·s) (correct: mg/(L·Pa·s))
+  #    ├──┬ unit:MilliGM symbol: mg
+  #    │  └─── unit:GM symbol: g
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    ├──┬ unit:PA^-1 symbol: Pa
+  #    │  ├─── unit:M^-2 symbol: m
+  #    │  └──┬ unit:N symbol: N
+  #    │     ├──┬ unit:KiloGM symbol: kg
+  #    │     │  └─── unit:GM symbol: g
+  #    │     ├─── unit:M symbol: m
+  #    │     └─── unit:SEC^-2 symbol: s
+  #    └─── unit:SEC^-1 symbol: s
+unit:MilliGM-PER-L-PA-SEC qudt:symbol "mg/(L·Pa·s)" .
+
+  # WRONG SYMBOL  : unit:MilliGM-PER-L-POISE - calculated from factors: mg/(L·P), actual: (mg/l)/P
+  #
+  #  ──┬ unit:MilliGM-PER-L-POISE symbol: (mg/l)/P (correct: mg/(L·P))
+  #    ├──┬ unit:MilliGM symbol: mg
+  #    │  └─── unit:GM symbol: g
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └──┬ unit:POISE^-1 symbol: P
+  #       └──┬ unit:KiloGM-PER-M-SEC symbol: kg/(m·s)
+  #          ├──┬ unit:KiloGM symbol: kg
+  #          │  └─── unit:GM symbol: g
+  #          ├─── unit:M^-1 symbol: m
+  #          └─── unit:SEC^-1 symbol: s
+unit:MilliGM-PER-L-POISE qudt:symbol "mg/(L·P)" .
+
+  # WRONG SYMBOL  : unit:MilliGM-PER-M2-DAY - calculated from factors: mg/(m²·d), actual: mg/(m²·day)
+  #
+  #  ──┬ unit:MilliGM-PER-M2-DAY symbol: mg/(m²·day) (correct: mg/(m²·d))
+  #    ├──┬ unit:MilliGM symbol: mg
+  #    │  └─── unit:GM symbol: g
+  #    ├─── unit:M^-2 symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:MilliGM-PER-M2-DAY qudt:symbol "mg/(m²·d)" .
+
+  # WRONG SYMBOL  : unit:MilliGM-PER-M3-CentiPOISE - calculated from factors: mg/(m³·cP), actual: (mg/m³)/cP
+  #
+  #  ──┬ unit:MilliGM-PER-M3-CentiPOISE symbol: (mg/m³)/cP (correct: mg/(m³·cP))
+  #    ├──┬ unit:MilliGM symbol: mg
+  #    │  └─── unit:GM symbol: g
+  #    ├─── unit:M^-3 symbol: m
+  #    └──┬ unit:CentiPOISE^-1 symbol: cP
+  #       └──┬ unit:POISE symbol: P
+  #          └──┬ unit:KiloGM-PER-M-SEC symbol: kg/(m·s)
+  #             ├──┬ unit:KiloGM symbol: kg
+  #             │  └─── unit:GM symbol: g
+  #             ├─── unit:M^-1 symbol: m
+  #             └─── unit:SEC^-1 symbol: s
+unit:MilliGM-PER-M3-CentiPOISE qudt:symbol "mg/(m³·cP)" .
+
+  # WRONG SYMBOL  : unit:MilliGM-PER-M3-DAY - calculated from factors: mg/(m³·d), actual: mg/(m³·day)
+  #
+  #  ──┬ unit:MilliGM-PER-M3-DAY symbol: mg/(m³·day) (correct: mg/(m³·d))
+  #    ├──┬ unit:MilliGM symbol: mg
+  #    │  └─── unit:GM symbol: g
+  #    ├─── unit:M^-3 symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:MilliGM-PER-M3-DAY qudt:symbol "mg/(m³·d)" .
+
+  # WRONG SYMBOL  : unit:MilliGM-PER-M3-MilliPA-SEC - calculated from factors: mg/(m³·mPa·s), actual: (mg/m³)/(mPa·s)
+  #
+  #  ──┬ unit:MilliGM-PER-M3-MilliPA-SEC symbol: (mg/m³)/(mPa·s) (correct: mg/(m³·mPa·s))
+  #    ├──┬ unit:MilliGM symbol: mg
+  #    │  └─── unit:GM symbol: g
+  #    ├─── unit:M^-3 symbol: m
+  #    ├──┬ unit:MilliPA^-1 symbol: mPa
+  #    │  └──┬ unit:PA symbol: Pa
+  #    │     ├─── unit:M^-2 symbol: m
+  #    │     └──┬ unit:N symbol: N
+  #    │        ├──┬ unit:KiloGM symbol: kg
+  #    │        │  └─── unit:GM symbol: g
+  #    │        ├─── unit:M symbol: m
+  #    │        └─── unit:SEC^-2 symbol: s
+  #    └─── unit:SEC^-1 symbol: s
+unit:MilliGM-PER-M3-MilliPA-SEC qudt:symbol "mg/(m³·mPa·s)" .
+
+  # WRONG SYMBOL  : unit:MilliGM-PER-M3-PA-SEC - calculated from factors: mg/(m³·Pa·s), actual: (mg/m³)/(Pa·s)
+  #
+  #  ──┬ unit:MilliGM-PER-M3-PA-SEC symbol: (mg/m³)/(Pa·s) (correct: mg/(m³·Pa·s))
+  #    ├──┬ unit:MilliGM symbol: mg
+  #    │  └─── unit:GM symbol: g
+  #    ├─── unit:M^-3 symbol: m
+  #    ├──┬ unit:PA^-1 symbol: Pa
+  #    │  ├─── unit:M^-2 symbol: m
+  #    │  └──┬ unit:N symbol: N
+  #    │     ├──┬ unit:KiloGM symbol: kg
+  #    │     │  └─── unit:GM symbol: g
+  #    │     ├─── unit:M symbol: m
+  #    │     └─── unit:SEC^-2 symbol: s
+  #    └─── unit:SEC^-1 symbol: s
+unit:MilliGM-PER-M3-PA-SEC qudt:symbol "mg/(m³·Pa·s)" .
+
+  # WRONG SYMBOL  : unit:MilliGM-PER-M3-POISE - calculated from factors: mg/(m³·P), actual: (mg/m³)/P
+  #
+  #  ──┬ unit:MilliGM-PER-M3-POISE symbol: (mg/m³)/P (correct: mg/(m³·P))
+  #    ├──┬ unit:MilliGM symbol: mg
+  #    │  └─── unit:GM symbol: g
+  #    ├─── unit:M^-3 symbol: m
+  #    └──┬ unit:POISE^-1 symbol: P
+  #       └──┬ unit:KiloGM-PER-M-SEC symbol: kg/(m·s)
+  #          ├──┬ unit:KiloGM symbol: kg
+  #          │  └─── unit:GM symbol: g
+  #          ├─── unit:M^-1 symbol: m
+  #          └─── unit:SEC^-1 symbol: s
+unit:MilliGM-PER-M3-POISE qudt:symbol "mg/(m³·P)" .
+
+  # WRONG SYMBOL  : unit:MilliGM-SEC-PER-L-CentiM3 - calculated from factors: mg·s/(L·cm³), actual: (mg/l)/(cm³/s)
+  #
+  #  ──┬ unit:MilliGM-SEC-PER-L-CentiM3 symbol: (mg/l)/(cm³/s) (correct: mg·s/(L·cm³))
+  #    ├──┬ unit:MilliGM symbol: mg
+  #    │  └─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └──┬ unit:CentiM^-3 symbol: cm
+  #       └─── unit:M symbol: m
+unit:MilliGM-SEC-PER-L-CentiM3 qudt:symbol "mg·s/(L·cm³)" .
+
+  # WRONG SYMBOL  : unit:MilliGM-SEC-PER-L-M3 - calculated from factors: mg·s/(L·m³), actual: (mg/l)/(m³/s)
+  #
+  #  ──┬ unit:MilliGM-SEC-PER-L-M3 symbol: (mg/l)/(m³/s) (correct: mg·s/(L·m³))
+  #    ├──┬ unit:MilliGM symbol: mg
+  #    │  └─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └─── unit:M^-3 symbol: m
+unit:MilliGM-SEC-PER-L-M3 qudt:symbol "mg·s/(L·m³)" .
+
+  # WRONG SYMBOL  : unit:MilliGM-SEC-PER-L2 - calculated from factors: mg·s/L², actual: (mg/l)/(l/s)
+  #
+  #  ──┬ unit:MilliGM-SEC-PER-L2 symbol: (mg/l)/(l/s) (correct: mg·s/L²)
+  #    ├──┬ unit:MilliGM symbol: mg
+  #    │  └─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    └──┬ unit:L^-2 symbol: L
+  #       └──┬ unit:DeciM3 symbol: dm³
+  #          └──┬ unit:DeciM^3 symbol: dm
+  #             └─── unit:M symbol: m
+unit:MilliGM-SEC-PER-L2 qudt:symbol "mg·s/L²" .
+
+  # WRONG SYMBOL  : unit:MilliGM-SEC-PER-M3-CentiM3 - calculated from factors: mg·s/(m³·cm³), actual: (mg/m³)/(cm³/s)
+  #
+  #  ──┬ unit:MilliGM-SEC-PER-M3-CentiM3 symbol: (mg/m³)/(cm³/s) (correct: mg·s/(m³·cm³))
+  #    ├──┬ unit:MilliGM symbol: mg
+  #    │  └─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    ├─── unit:M^-3 symbol: m
+  #    └──┬ unit:CentiM^-3 symbol: cm
+  #       └─── unit:M symbol: m
+unit:MilliGM-SEC-PER-M3-CentiM3 qudt:symbol "mg·s/(m³·cm³)" .
+
+  # WRONG SYMBOL  : unit:MilliGM-SEC-PER-M3-L - calculated from factors: mg·s/(m³·L), actual: (mg/m³)/(l/s)
+  #
+  #  ──┬ unit:MilliGM-SEC-PER-M3-L symbol: (mg/m³)/(l/s) (correct: mg·s/(m³·L))
+  #    ├──┬ unit:MilliGM symbol: mg
+  #    │  └─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    ├─── unit:M^-3 symbol: m
+  #    └──┬ unit:L^-1 symbol: L
+  #       └──┬ unit:DeciM3 symbol: dm³
+  #          └──┬ unit:DeciM^3 symbol: dm
+  #             └─── unit:M symbol: m
+unit:MilliGM-SEC-PER-M3-L qudt:symbol "mg·s/(m³·L)" .
+
+  # WRONG SYMBOL  : unit:MilliGM-SEC-PER-M6 - calculated from factors: mg·s/m⁶, actual: (mg/m³)/(m³/s)
+  #
+  #  ──┬ unit:MilliGM-SEC-PER-M6 symbol: (mg/m³)/(m³/s) (correct: mg·s/m⁶)
+  #    ├──┬ unit:MilliGM symbol: mg
+  #    │  └─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    └─── unit:M^-6 symbol: m
+unit:MilliGM-SEC-PER-M6 qudt:symbol "mg·s/m⁶" .
+
+  # WRONG SYMBOL  : unit:MilliL-PER-BAR - calculated from factors: mL/bar, actual: ml/bar
+  #
+  #  ──┬ unit:MilliL-PER-BAR symbol: ml/bar (correct: mL/bar)
+  #    ├──┬ unit:MilliL symbol: mL
+  #    │  └──┬ unit:L symbol: L
+  #    │     └──┬ unit:DeciM3 symbol: dm³
+  #    │        └──┬ unit:DeciM^3 symbol: dm
+  #    │           └─── unit:M symbol: m
+  #    └──┬ unit:BAR^-1 symbol: bar
+  #       └──┬ unit:PA symbol: Pa
+  #          ├─── unit:M^-2 symbol: m
+  #          └──┬ unit:N symbol: N
+  #             ├──┬ unit:KiloGM symbol: kg
+  #             │  └─── unit:GM symbol: g
+  #             ├─── unit:M symbol: m
+  #             └─── unit:SEC^-2 symbol: s
+unit:MilliL-PER-BAR qudt:symbol "mL/bar" .
+
+  # WRONG SYMBOL  : unit:MilliL-PER-DAY - calculated from factors: mL/d, actual: mL/day
+  #
+  #  ──┬ unit:MilliL-PER-DAY symbol: mL/day (correct: mL/d)
+  #    ├──┬ unit:MilliL symbol: mL
+  #    │  └──┬ unit:L symbol: L
+  #    │     └──┬ unit:DeciM3 symbol: dm³
+  #    │        └──┬ unit:DeciM^3 symbol: dm
+  #    │           └─── unit:M symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:MilliL-PER-DAY qudt:symbol "mL/d" .
+
+  # WRONG SYMBOL  : unit:MilliL-PER-DAY-BAR - calculated from factors: mL/(d·bar), actual: ml/(d·bar)
+  #
+  #  ──┬ unit:MilliL-PER-DAY-BAR symbol: ml/(d·bar) (correct: mL/(d·bar))
+  #    ├──┬ unit:MilliL symbol: mL
+  #    │  └──┬ unit:L symbol: L
+  #    │     └──┬ unit:DeciM3 symbol: dm³
+  #    │        └──┬ unit:DeciM^3 symbol: dm
+  #    │           └─── unit:M symbol: m
+  #    ├──┬ unit:DAY^-1 symbol: d
+  #    │  └─── unit:SEC symbol: s
+  #    └──┬ unit:BAR^-1 symbol: bar
+  #       └──┬ unit:PA symbol: Pa
+  #          ├─── unit:M^-2 symbol: m
+  #          └──┬ unit:N symbol: N
+  #             ├──┬ unit:KiloGM symbol: kg
+  #             │  └─── unit:GM symbol: g
+  #             ├─── unit:M symbol: m
+  #             └─── unit:SEC^-2 symbol: s
+unit:MilliL-PER-DAY-BAR qudt:symbol "mL/(d·bar)" .
+
+  # WRONG SYMBOL  : unit:MilliL-PER-DAY-K - calculated from factors: mL/(d·K), actual: ml/(d·K)
+  #
+  #  ──┬ unit:MilliL-PER-DAY-K symbol: ml/(d·K) (correct: mL/(d·K))
+  #    ├──┬ unit:MilliL symbol: mL
+  #    │  └──┬ unit:L symbol: L
+  #    │     └──┬ unit:DeciM3 symbol: dm³
+  #    │        └──┬ unit:DeciM^3 symbol: dm
+  #    │           └─── unit:M symbol: m
+  #    ├──┬ unit:DAY^-1 symbol: d
+  #    │  └─── unit:SEC symbol: s
+  #    └─── unit:K^-1 symbol: K
+unit:MilliL-PER-DAY-K qudt:symbol "mL/(d·K)" .
+
+  # WRONG SYMBOL  : unit:MilliL-PER-HR-BAR - calculated from factors: mL/(h·bar), actual: ml/(h·bar)
+  #
+  #  ──┬ unit:MilliL-PER-HR-BAR symbol: ml/(h·bar) (correct: mL/(h·bar))
+  #    ├──┬ unit:MilliL symbol: mL
+  #    │  └──┬ unit:L symbol: L
+  #    │     └──┬ unit:DeciM3 symbol: dm³
+  #    │        └──┬ unit:DeciM^3 symbol: dm
+  #    │           └─── unit:M symbol: m
+  #    ├──┬ unit:HR^-1 symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    └──┬ unit:BAR^-1 symbol: bar
+  #       └──┬ unit:PA symbol: Pa
+  #          ├─── unit:M^-2 symbol: m
+  #          └──┬ unit:N symbol: N
+  #             ├──┬ unit:KiloGM symbol: kg
+  #             │  └─── unit:GM symbol: g
+  #             ├─── unit:M symbol: m
+  #             └─── unit:SEC^-2 symbol: s
+unit:MilliL-PER-HR-BAR qudt:symbol "mL/(h·bar)" .
+
+  # WRONG SYMBOL  : unit:MilliL-PER-HR-K - calculated from factors: mL/(h·K), actual: ml/(h·K)
+  #
+  #  ──┬ unit:MilliL-PER-HR-K symbol: ml/(h·K) (correct: mL/(h·K))
+  #    ├──┬ unit:MilliL symbol: mL
+  #    │  └──┬ unit:L symbol: L
+  #    │     └──┬ unit:DeciM3 symbol: dm³
+  #    │        └──┬ unit:DeciM^3 symbol: dm
+  #    │           └─── unit:M symbol: m
+  #    ├──┬ unit:HR^-1 symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    └─── unit:K^-1 symbol: K
+unit:MilliL-PER-HR-K qudt:symbol "mL/(h·K)" .
+
+  # WRONG SYMBOL  : unit:MilliL-PER-M2-DAY - calculated from factors: mL/(m²·d), actual: mL/(m²·day)
+  #
+  #  ──┬ unit:MilliL-PER-M2-DAY symbol: mL/(m²·day) (correct: mL/(m²·d))
+  #    ├──┬ unit:MilliL symbol: mL
+  #    │  └──┬ unit:L symbol: L
+  #    │     └──┬ unit:DeciM3 symbol: dm³
+  #    │        └──┬ unit:DeciM^3 symbol: dm
+  #    │           └─── unit:M symbol: m
+  #    ├─── unit:M^-2 symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:MilliL-PER-M2-DAY qudt:symbol "mL/(m²·d)" .
+
+  # WRONG SYMBOL  : unit:MilliL-PER-MIN-BAR - calculated from factors: mL/(min·bar), actual: ml/(min·bar)
+  #
+  #  ──┬ unit:MilliL-PER-MIN-BAR symbol: ml/(min·bar) (correct: mL/(min·bar))
+  #    ├──┬ unit:MilliL symbol: mL
+  #    │  └──┬ unit:L symbol: L
+  #    │     └──┬ unit:DeciM3 symbol: dm³
+  #    │        └──┬ unit:DeciM^3 symbol: dm
+  #    │           └─── unit:M symbol: m
+  #    ├──┬ unit:MIN^-1 symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    └──┬ unit:BAR^-1 symbol: bar
+  #       └──┬ unit:PA symbol: Pa
+  #          ├─── unit:M^-2 symbol: m
+  #          └──┬ unit:N symbol: N
+  #             ├──┬ unit:KiloGM symbol: kg
+  #             │  └─── unit:GM symbol: g
+  #             ├─── unit:M symbol: m
+  #             └─── unit:SEC^-2 symbol: s
+unit:MilliL-PER-MIN-BAR qudt:symbol "mL/(min·bar)" .
+
+  # WRONG SYMBOL  : unit:MilliL-PER-MIN-K - calculated from factors: mL/(min·K), actual: ml/(min·K)
+  #
+  #  ──┬ unit:MilliL-PER-MIN-K symbol: ml/(min·K) (correct: mL/(min·K))
+  #    ├──┬ unit:MilliL symbol: mL
+  #    │  └──┬ unit:L symbol: L
+  #    │     └──┬ unit:DeciM3 symbol: dm³
+  #    │        └──┬ unit:DeciM^3 symbol: dm
+  #    │           └─── unit:M symbol: m
+  #    ├──┬ unit:MIN^-1 symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    └─── unit:K^-1 symbol: K
+unit:MilliL-PER-MIN-K qudt:symbol "mL/(min·K)" .
+
+  # WRONG SYMBOL  : unit:MilliL-PER-SEC-BAR - calculated from factors: mL/(s·bar), actual: ml/(s·bar)
+  #
+  #  ──┬ unit:MilliL-PER-SEC-BAR symbol: ml/(s·bar) (correct: mL/(s·bar))
+  #    ├──┬ unit:MilliL symbol: mL
+  #    │  └──┬ unit:L symbol: L
+  #    │     └──┬ unit:DeciM3 symbol: dm³
+  #    │        └──┬ unit:DeciM^3 symbol: dm
+  #    │           └─── unit:M symbol: m
+  #    ├─── unit:SEC^-1 symbol: s
+  #    └──┬ unit:BAR^-1 symbol: bar
+  #       └──┬ unit:PA symbol: Pa
+  #          ├─── unit:M^-2 symbol: m
+  #          └──┬ unit:N symbol: N
+  #             ├──┬ unit:KiloGM symbol: kg
+  #             │  └─── unit:GM symbol: g
+  #             ├─── unit:M symbol: m
+  #             └─── unit:SEC^-2 symbol: s
+unit:MilliL-PER-SEC-BAR qudt:symbol "mL/(s·bar)" .
+
+  # WRONG SYMBOL  : unit:MilliL-PER-SEC-K - calculated from factors: mL/(s·K), actual: ml/(s·K)
+  #
+  #  ──┬ unit:MilliL-PER-SEC-K symbol: ml/(s·K) (correct: mL/(s·K))
+  #    ├──┬ unit:MilliL symbol: mL
+  #    │  └──┬ unit:L symbol: L
+  #    │     └──┬ unit:DeciM3 symbol: dm³
+  #    │        └──┬ unit:DeciM^3 symbol: dm
+  #    │           └─── unit:M symbol: m
+  #    ├─── unit:SEC^-1 symbol: s
+  #    └─── unit:K^-1 symbol: K
+unit:MilliL-PER-SEC-K qudt:symbol "mL/(s·K)" .
+
+  # WRONG SYMBOL  : unit:MilliM-PER-DAY - calculated from factors: mm/d, actual: mm/day
+  #
+  #  ──┬ unit:MilliM-PER-DAY symbol: mm/day (correct: mm/d)
+  #    ├──┬ unit:MilliM symbol: mm
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:MilliM-PER-DAY qudt:symbol "mm/d" .
+
+  # WRONG SYMBOL  : unit:MilliMOL-PER-M2-DAY - calculated from factors: mmol/(m²·d), actual: mmol/(m²·day)
+  #
+  #  ──┬ unit:MilliMOL-PER-M2-DAY symbol: mmol/(m²·day) (correct: mmol/(m²·d))
+  #    ├──┬ unit:MilliMOL symbol: mmol
+  #    │  └─── unit:MOL symbol: mol
+  #    ├─── unit:M^-2 symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:MilliMOL-PER-M2-DAY qudt:symbol "mmol/(m²·d)" .
+
+  # WRONG SYMBOL  : unit:MilliMOL-PER-M3-DAY - calculated from factors: mmol/(m³·d), actual: mmol/(m³·day)
+  #
+  #  ──┬ unit:MilliMOL-PER-M3-DAY symbol: mmol/(m³·day) (correct: mmol/(m³·d))
+  #    ├──┬ unit:MilliMOL symbol: mmol
+  #    │  └─── unit:MOL symbol: mol
+  #    ├─── unit:M^-3 symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:MilliMOL-PER-M3-DAY qudt:symbol "mmol/(m³·d)" .
+
+  # WRONG SYMBOL  : unit:MilliN-M - calculated from factors: m·mN, actual: mN·m
+  #
+  #  ──┬ unit:MilliN-M symbol: mN·m (correct: m·mN)
+  #    ├─── unit:M symbol: m
+  #    └──┬ unit:MilliN symbol: mN
+  #       └──┬ unit:N symbol: N
+  #          ├──┬ unit:KiloGM symbol: kg
+  #          │  └─── unit:GM symbol: g
+  #          ├─── unit:M symbol: m
+  #          └─── unit:SEC^-2 symbol: s
+unit:MilliN-M qudt:symbol "m·mN" .
+
+  # WRONG SYMBOL  : unit:MilliN-M-PER-M2 - calculated from factors: m·mN/m², actual: mN·m/m²
+  #
+  #  ──┬ unit:MilliN-M-PER-M2 symbol: mN·m/m² (correct: m·mN/m²)
+  #    ├─── unit:M symbol: m
+  #    ├──┬ unit:MilliN symbol: mN
+  #    │  └──┬ unit:N symbol: N
+  #    │     ├──┬ unit:KiloGM symbol: kg
+  #    │     │  └─── unit:GM symbol: g
+  #    │     ├─── unit:M symbol: m
+  #    │     └─── unit:SEC^-2 symbol: s
+  #    └─── unit:M^-2 symbol: m
+unit:MilliN-M-PER-M2 qudt:symbol "m·mN/m²" .
+
+  # WRONG SYMBOL  : unit:MilliOHM-M - calculated from factors: m·mΩ, actual: mΩ·m
+  #
+  #  ──┬ unit:MilliOHM-M symbol: mΩ·m (correct: m·mΩ)
+  #    ├─── unit:M symbol: m
+  #    └──┬ unit:MilliOHM symbol: mΩ
+  #       └──┬ unit:OHM symbol: Ω
+  #          ├─── unit:A^-1 symbol: A
+  #          └──┬ unit:V symbol: V
+  #             ├─── unit:A^-1 symbol: A
+  #             └──┬ unit:W symbol: W
+  #                ├──┬ unit:J symbol: J
+  #                │  ├─── unit:M symbol: m
+  #                │  └──┬ unit:N symbol: N
+  #                │     ├──┬ unit:KiloGM symbol: kg
+  #                │     │  └─── unit:GM symbol: g
+  #                │     ├─── unit:M symbol: m
+  #                │     └─── unit:SEC^-2 symbol: s
+  #                └─── unit:SEC^-1 symbol: s
+unit:MilliOHM-M qudt:symbol "m·mΩ" .
+
+  # WRONG SYMBOL  : unit:MilliOHM-PER-BAR - calculated from factors: mΩ/bar, actual: mΩ/bar
+  #
+  #  ──┬ unit:MilliOHM-PER-BAR symbol: mΩ/bar (correct: mΩ/bar)
+  #    ├──┬ unit:MilliOHM symbol: mΩ
+  #    │  └──┬ unit:OHM symbol: Ω
+  #    │     ├─── unit:A^-1 symbol: A
+  #    │     └──┬ unit:V symbol: V
+  #    │        ├─── unit:A^-1 symbol: A
+  #    │        └──┬ unit:W symbol: W
+  #    │           ├──┬ unit:J symbol: J
+  #    │           │  ├─── unit:M symbol: m
+  #    │           │  └──┬ unit:N symbol: N
+  #    │           │     ├──┬ unit:KiloGM symbol: kg
+  #    │           │     │  └─── unit:GM symbol: g
+  #    │           │     ├─── unit:M symbol: m
+  #    │           │     └─── unit:SEC^-2 symbol: s
+  #    │           └─── unit:SEC^-1 symbol: s
+  #    └──┬ unit:BAR^-1 symbol: bar
+  #       └──┬ unit:PA symbol: Pa
+  #          ├─── unit:M^-2 symbol: m
+  #          └──┬ unit:N symbol: N
+  #             ├──┬ unit:KiloGM symbol: kg
+  #             │  └─── unit:GM symbol: g
+  #             ├─── unit:M symbol: m
+  #             └─── unit:SEC^-2 symbol: s
+unit:MilliOHM-PER-BAR qudt:symbol "mΩ/bar" .
+
+  # WRONG SYMBOL  : unit:MilliOHM-PER-K - calculated from factors: mΩ/K, actual: mΩ/K
+  #
+  #  ──┬ unit:MilliOHM-PER-K symbol: mΩ/K (correct: mΩ/K)
+  #    ├──┬ unit:MilliOHM symbol: mΩ
+  #    │  └──┬ unit:OHM symbol: Ω
+  #    │     ├─── unit:A^-1 symbol: A
+  #    │     └──┬ unit:V symbol: V
+  #    │        ├─── unit:A^-1 symbol: A
+  #    │        └──┬ unit:W symbol: W
+  #    │           ├──┬ unit:J symbol: J
+  #    │           │  ├─── unit:M symbol: m
+  #    │           │  └──┬ unit:N symbol: N
+  #    │           │     ├──┬ unit:KiloGM symbol: kg
+  #    │           │     │  └─── unit:GM symbol: g
+  #    │           │     ├─── unit:M symbol: m
+  #    │           │     └─── unit:SEC^-2 symbol: s
+  #    │           └─── unit:SEC^-1 symbol: s
+  #    └─── unit:K^-1 symbol: K
+unit:MilliOHM-PER-K qudt:symbol "mΩ/K" .
+
+  # WRONG SYMBOL  : unit:MilliOHM-PER-M - calculated from factors: mΩ/m, actual: mΩ/m
+  #
+  #  ──┬ unit:MilliOHM-PER-M symbol: mΩ/m (correct: mΩ/m)
+  #    ├──┬ unit:MilliOHM symbol: mΩ
+  #    │  └──┬ unit:OHM symbol: Ω
+  #    │     ├─── unit:A^-1 symbol: A
+  #    │     └──┬ unit:V symbol: V
+  #    │        ├─── unit:A^-1 symbol: A
+  #    │        └──┬ unit:W symbol: W
+  #    │           ├──┬ unit:J symbol: J
+  #    │           │  ├─── unit:M symbol: m
+  #    │           │  └──┬ unit:N symbol: N
+  #    │           │     ├──┬ unit:KiloGM symbol: kg
+  #    │           │     │  └─── unit:GM symbol: g
+  #    │           │     ├─── unit:M symbol: m
+  #    │           │     └─── unit:SEC^-2 symbol: s
+  #    │           └─── unit:SEC^-1 symbol: s
+  #    └─── unit:M^-1 symbol: m
+unit:MilliOHM-PER-M qudt:symbol "mΩ/m" .
+
+  # WRONG SYMBOL  : unit:MilliW-PER-CentiM2-MicroM-SR - calculated from factors: mW/(cm²·μm·sr), actual: mW/(cm²·µm·sr)
+  #
+  #  ──┬ unit:MilliW-PER-CentiM2-MicroM-SR symbol: mW/(cm²·µm·sr) (correct: mW/(cm²·μm·sr))
+  #    ├──┬ unit:MilliW symbol: mW
+  #    │  └──┬ unit:W symbol: W
+  #    │     ├──┬ unit:J symbol: J
+  #    │     │  ├─── unit:M symbol: m
+  #    │     │  └──┬ unit:N symbol: N
+  #    │     │     ├──┬ unit:KiloGM symbol: kg
+  #    │     │     │  └─── unit:GM symbol: g
+  #    │     │     ├─── unit:M symbol: m
+  #    │     │     └─── unit:SEC^-2 symbol: s
+  #    │     └─── unit:SEC^-1 symbol: s
+  #    ├──┬ unit:CentiM^-2 symbol: cm
+  #    │  └─── unit:M symbol: m
+  #    ├──┬ unit:MicroM^-1 symbol: μm
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:SR^-1 symbol: sr
+  #       ├─── unit:M^-2 symbol: m
+  #       └─── unit:M^2 symbol: m
+unit:MilliW-PER-CentiM2-MicroM-SR qudt:symbol "mW/(cm²·μm·sr)" .
+
+  # WRONG SYMBOL  : unit:MilliW-PER-M2-NanoM-SR - calculated from factors: mW/(m²·nm·sr), actual: mW/(cm·nm·sr)
+  #
+  #  ──┬ unit:MilliW-PER-M2-NanoM-SR symbol: mW/(cm·nm·sr) (correct: mW/(m²·nm·sr))
+  #    ├──┬ unit:MilliW symbol: mW
+  #    │  └──┬ unit:W symbol: W
+  #    │     ├──┬ unit:J symbol: J
+  #    │     │  ├─── unit:M symbol: m
+  #    │     │  └──┬ unit:N symbol: N
+  #    │     │     ├──┬ unit:KiloGM symbol: kg
+  #    │     │     │  └─── unit:GM symbol: g
+  #    │     │     ├─── unit:M symbol: m
+  #    │     │     └─── unit:SEC^-2 symbol: s
+  #    │     └─── unit:SEC^-1 symbol: s
+  #    ├─── unit:M^-2 symbol: m
+  #    ├──┬ unit:NanoM^-1 symbol: nm
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:SR^-1 symbol: sr
+  #       ├─── unit:M^-2 symbol: m
+  #       └─── unit:M^2 symbol: m
+unit:MilliW-PER-M2-NanoM-SR qudt:symbol "mW/(m²·nm·sr)" .
+
+  # WRONG SYMBOL  : unit:NUM-PER-KiloGM - calculated from factors: #/kg, actual: /kg
+  #
+  #  ──┬ unit:NUM-PER-KiloGM symbol: /kg (correct: #/kg)
+  #    ├─── unit:NUM symbol: #
+  #    └──┬ unit:KiloGM^-1 symbol: kg
+  #       └─── unit:GM symbol: g
+unit:NUM-PER-KiloGM qudt:symbol "#/kg" .
+
+  # WRONG SYMBOL  : unit:NUM-PER-M2-DAY - calculated from factors: #/(m²·d), actual: #/(m²·day)
+  #
+  #  ──┬ unit:NUM-PER-M2-DAY symbol: #/(m²·day) (correct: #/(m²·d))
+  #    ├─── unit:NUM symbol: #
+  #    ├─── unit:M^-2 symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:NUM-PER-M2-DAY qudt:symbol "#/(m²·d)" .
+
+  # WRONG SYMBOL  : unit:NUM-PER-MicroL - calculated from factors: #/μL, actual: #/µL
+  #
+  #  ──┬ unit:NUM-PER-MicroL symbol: #/µL (correct: #/μL)
+  #    ├─── unit:NUM symbol: #
+  #    └──┬ unit:MicroL^-1 symbol: μL
+  #       └──┬ unit:L symbol: L
+  #          └──┬ unit:DeciM3 symbol: dm³
+  #             └──┬ unit:DeciM^3 symbol: dm
+  #                └─── unit:M symbol: m
+unit:NUM-PER-MicroL qudt:symbol "#/μL" .
+
+  # WRONG SYMBOL  : unit:NanoGM-PER-CentiM2-DAY - calculated from factors: ng/(cm²·d), actual: ng/(cm²·day)
+  #
+  #  ──┬ unit:NanoGM-PER-CentiM2-DAY symbol: ng/(cm²·day) (correct: ng/(cm²·d))
+  #    ├──┬ unit:NanoGM symbol: ng
+  #    │  └─── unit:GM symbol: g
+  #    ├──┬ unit:CentiM^-2 symbol: cm
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:NanoGM-PER-CentiM2-DAY qudt:symbol "ng/(cm²·d)" .
+
+  # WRONG SYMBOL  : unit:NanoGM-PER-DAY - calculated from factors: ng/d, actual: ng/day
+  #
+  #  ──┬ unit:NanoGM-PER-DAY symbol: ng/day (correct: ng/d)
+  #    ├──┬ unit:NanoGM symbol: ng
+  #    │  └─── unit:GM symbol: g
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:NanoGM-PER-DAY qudt:symbol "ng/d" .
+
+  # WRONG SYMBOL  : unit:NanoGM-PER-KiloGM - calculated from factors: ng/kg, actual: ng/Kg
+  #
+  #  ──┬ unit:NanoGM-PER-KiloGM symbol: ng/Kg (correct: ng/kg)
+  #    ├──┬ unit:NanoGM symbol: ng
+  #    │  └─── unit:GM symbol: g
+  #    └──┬ unit:KiloGM^-1 symbol: kg
+  #       └─── unit:GM symbol: g
+unit:NanoGM-PER-KiloGM qudt:symbol "ng/kg" .
+
+  # WRONG SYMBOL  : unit:NanoGM-PER-M2-PA-SEC - calculated from factors: ng/(m²·Pa·s), actual: kg/(m²·s·Pa)
+  #
+  #  ──┬ unit:NanoGM-PER-M2-PA-SEC symbol: kg/(m²·s·Pa) (correct: ng/(m²·Pa·s))
+  #    ├──┬ unit:NanoGM symbol: ng
+  #    │  └─── unit:GM symbol: g
+  #    ├─── unit:M^-2 symbol: m
+  #    ├──┬ unit:PA^-1 symbol: Pa
+  #    │  ├─── unit:M^-2 symbol: m
+  #    │  └──┬ unit:N symbol: N
+  #    │     ├──┬ unit:KiloGM symbol: kg
+  #    │     │  └─── unit:GM symbol: g
+  #    │     ├─── unit:M symbol: m
+  #    │     └─── unit:SEC^-2 symbol: s
+  #    └─── unit:SEC^-1 symbol: s
+unit:NanoGM-PER-M2-PA-SEC qudt:symbol "ng/(m²·Pa·s)" .
+
+  # WRONG SYMBOL  : unit:NanoGM-PER-MicroL - calculated from factors: ng/μL, actual: ng/µL
+  #
+  #  ──┬ unit:NanoGM-PER-MicroL symbol: ng/µL (correct: ng/μL)
+  #    ├──┬ unit:NanoGM symbol: ng
+  #    │  └─── unit:GM symbol: g
+  #    └──┬ unit:MicroL^-1 symbol: μL
+  #       └──┬ unit:L symbol: L
+  #          └──┬ unit:DeciM3 symbol: dm³
+  #             └──┬ unit:DeciM^3 symbol: dm
+  #                └─── unit:M symbol: m
+unit:NanoGM-PER-MicroL qudt:symbol "ng/μL" .
+
+  # WRONG SYMBOL  : unit:NanoMOL-PER-GM-HR - calculated from factors: nmol/(g·h), actual: nmol/(g.h)
+  #
+  #  ──┬ unit:NanoMOL-PER-GM-HR symbol: nmol/(g.h) (correct: nmol/(g·h))
+  #    ├──┬ unit:NanoMOL symbol: nmol
+  #    │  └─── unit:MOL symbol: mol
+  #    ├─── unit:GM^-1 symbol: g
+  #    └──┬ unit:HR^-1 symbol: h
+  #       └─── unit:SEC symbol: s
+unit:NanoMOL-PER-GM-HR qudt:symbol "nmol/(g·h)" .
+
+  # WRONG SYMBOL  : unit:NanoMOL-PER-L-DAY - calculated from factors: nmol/(L·d), actual: nmol/(L·day)
+  #
+  #  ──┬ unit:NanoMOL-PER-L-DAY symbol: nmol/(L·day) (correct: nmol/(L·d))
+  #    ├──┬ unit:NanoMOL symbol: nmol
+  #    │  └─── unit:MOL symbol: mol
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:NanoMOL-PER-L-DAY qudt:symbol "nmol/(L·d)" .
+
+  # WRONG SYMBOL  : unit:NanoMOL-PER-M2-DAY - calculated from factors: nmol/(m²·d), actual: nmol/(m²·day)
+  #
+  #  ──┬ unit:NanoMOL-PER-M2-DAY symbol: nmol/(m²·day) (correct: nmol/(m²·d))
+  #    ├──┬ unit:NanoMOL symbol: nmol
+  #    │  └─── unit:MOL symbol: mol
+  #    ├─── unit:M^-2 symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:NanoMOL-PER-M2-DAY qudt:symbol "nmol/(m²·d)" .
+
+  # WRONG SYMBOL  : unit:NanoMOL-PER-MicroGM-HR - calculated from factors: nmol/(μg·h), actual: nmol/(µg·h)
+  #
+  #  ──┬ unit:NanoMOL-PER-MicroGM-HR symbol: nmol/(µg·h) (correct: nmol/(μg·h))
+  #    ├──┬ unit:NanoMOL symbol: nmol
+  #    │  └─── unit:MOL symbol: mol
+  #    ├──┬ unit:MicroGM^-1 symbol: μg
+  #    │  └─── unit:GM symbol: g
+  #    └──┬ unit:HR^-1 symbol: h
+  #       └─── unit:SEC symbol: s
+unit:NanoMOL-PER-MicroGM-HR qudt:symbol "nmol/(μg·h)" .
+
+  # WRONG SYMBOL  : unit:NanoMOL-PER-MicroMOL - calculated from factors: nmol/μmol, actual: nmol/µmol
+  #
+  #  ──┬ unit:NanoMOL-PER-MicroMOL symbol: nmol/µmol (correct: nmol/μmol)
+  #    ├──┬ unit:NanoMOL symbol: nmol
+  #    │  └─── unit:MOL symbol: mol
+  #    └──┬ unit:MicroMOL^-1 symbol: μmol
+  #       └─── unit:MOL symbol: mol
+unit:NanoMOL-PER-MicroMOL qudt:symbol "nmol/μmol" .
+
+  # WRONG SYMBOL  : unit:NanoMOL-PER-MicroMOL-DAY - calculated from factors: nmol/(μmol·d), actual: nmol/(µmol·day)
+  #
+  #  ──┬ unit:NanoMOL-PER-MicroMOL-DAY symbol: nmol/(µmol·day) (correct: nmol/(μmol·d))
+  #    ├──┬ unit:NanoMOL symbol: nmol
+  #    │  └─── unit:MOL symbol: mol
+  #    ├──┬ unit:MicroMOL^-1 symbol: μmol
+  #    │  └─── unit:MOL symbol: mol
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:NanoMOL-PER-MicroMOL-DAY qudt:symbol "nmol/(μmol·d)" .
+
+  # WRONG SYMBOL  : unit:OHM-KiloM - calculated from factors: Ω·km, actual: Ω·km
+  #
+  #  ──┬ unit:OHM-KiloM symbol: Ω·km (correct: Ω·km)
+  #    ├──┬ unit:OHM symbol: Ω
+  #    │  ├─── unit:A^-1 symbol: A
+  #    │  └──┬ unit:V symbol: V
+  #    │     ├─── unit:A^-1 symbol: A
+  #    │     └──┬ unit:W symbol: W
+  #    │        ├──┬ unit:J symbol: J
+  #    │        │  ├─── unit:M symbol: m
+  #    │        │  └──┬ unit:N symbol: N
+  #    │        │     ├──┬ unit:KiloGM symbol: kg
+  #    │        │     │  └─── unit:GM symbol: g
+  #    │        │     ├─── unit:M symbol: m
+  #    │        │     └─── unit:SEC^-2 symbol: s
+  #    │        └─── unit:SEC^-1 symbol: s
+  #    └──┬ unit:KiloM symbol: km
+  #       └─── unit:M symbol: m
+unit:OHM-KiloM qudt:symbol "Ω·km" .
+
+  # WRONG SYMBOL  : unit:OHM-PER-BAR - calculated from factors: Ω/bar, actual: Ω/bar
+  #
+  #  ──┬ unit:OHM-PER-BAR symbol: Ω/bar (correct: Ω/bar)
+  #    ├──┬ unit:OHM symbol: Ω
+  #    │  ├─── unit:A^-1 symbol: A
+  #    │  └──┬ unit:V symbol: V
+  #    │     ├─── unit:A^-1 symbol: A
+  #    │     └──┬ unit:W symbol: W
+  #    │        ├──┬ unit:J symbol: J
+  #    │        │  ├─── unit:M symbol: m
+  #    │        │  └──┬ unit:N symbol: N
+  #    │        │     ├──┬ unit:KiloGM symbol: kg
+  #    │        │     │  └─── unit:GM symbol: g
+  #    │        │     ├─── unit:M symbol: m
+  #    │        │     └─── unit:SEC^-2 symbol: s
+  #    │        └─── unit:SEC^-1 symbol: s
+  #    └──┬ unit:BAR^-1 symbol: bar
+  #       └──┬ unit:PA symbol: Pa
+  #          ├─── unit:M^-2 symbol: m
+  #          └──┬ unit:N symbol: N
+  #             ├──┬ unit:KiloGM symbol: kg
+  #             │  └─── unit:GM symbol: g
+  #             ├─── unit:M symbol: m
+  #             └─── unit:SEC^-2 symbol: s
+unit:OHM-PER-BAR qudt:symbol "Ω/bar" .
+
+  # WRONG SYMBOL  : unit:OHM-PER-K - calculated from factors: Ω/K, actual: Ω/K
+  #
+  #  ──┬ unit:OHM-PER-K symbol: Ω/K (correct: Ω/K)
+  #    ├──┬ unit:OHM symbol: Ω
+  #    │  ├─── unit:A^-1 symbol: A
+  #    │  └──┬ unit:V symbol: V
+  #    │     ├─── unit:A^-1 symbol: A
+  #    │     └──┬ unit:W symbol: W
+  #    │        ├──┬ unit:J symbol: J
+  #    │        │  ├─── unit:M symbol: m
+  #    │        │  └──┬ unit:N symbol: N
+  #    │        │     ├──┬ unit:KiloGM symbol: kg
+  #    │        │     │  └─── unit:GM symbol: g
+  #    │        │     ├─── unit:M symbol: m
+  #    │        │     └─── unit:SEC^-2 symbol: s
+  #    │        └─── unit:SEC^-1 symbol: s
+  #    └─── unit:K^-1 symbol: K
+unit:OHM-PER-K qudt:symbol "Ω/K" .
+
+  # WRONG SYMBOL  : unit:OHM-PER-KiloM - calculated from factors: Ω/km, actual: Ω/km
+  #
+  #  ──┬ unit:OHM-PER-KiloM symbol: Ω/km (correct: Ω/km)
+  #    ├──┬ unit:OHM symbol: Ω
+  #    │  ├─── unit:A^-1 symbol: A
+  #    │  └──┬ unit:V symbol: V
+  #    │     ├─── unit:A^-1 symbol: A
+  #    │     └──┬ unit:W symbol: W
+  #    │        ├──┬ unit:J symbol: J
+  #    │        │  ├─── unit:M symbol: m
+  #    │        │  └──┬ unit:N symbol: N
+  #    │        │     ├──┬ unit:KiloGM symbol: kg
+  #    │        │     │  └─── unit:GM symbol: g
+  #    │        │     ├─── unit:M symbol: m
+  #    │        │     └─── unit:SEC^-2 symbol: s
+  #    │        └─── unit:SEC^-1 symbol: s
+  #    └──┬ unit:KiloM^-1 symbol: km
+  #       └─── unit:M symbol: m
+unit:OHM-PER-KiloM qudt:symbol "Ω/km" .
+
+  # WRONG SYMBOL  : unit:OHM-PER-M - calculated from factors: Ω/m, actual: Ω/m
+  #
+  #  ──┬ unit:OHM-PER-M symbol: Ω/m (correct: Ω/m)
+  #    ├──┬ unit:OHM symbol: Ω
+  #    │  ├─── unit:A^-1 symbol: A
+  #    │  └──┬ unit:V symbol: V
+  #    │     ├─── unit:A^-1 symbol: A
+  #    │     └──┬ unit:W symbol: W
+  #    │        ├──┬ unit:J symbol: J
+  #    │        │  ├─── unit:M symbol: m
+  #    │        │  └──┬ unit:N symbol: N
+  #    │        │     ├──┬ unit:KiloGM symbol: kg
+  #    │        │     │  └─── unit:GM symbol: g
+  #    │        │     ├─── unit:M symbol: m
+  #    │        │     └─── unit:SEC^-2 symbol: s
+  #    │        └─── unit:SEC^-1 symbol: s
+  #    └─── unit:M^-1 symbol: m
+unit:OHM-PER-M qudt:symbol "Ω/m" .
+
+  # WRONG SYMBOL  : unit:OHM-PER-MI - calculated from factors: Ω/mi, actual: Ω/mi
+  #
+  #  ──┬ unit:OHM-PER-MI symbol: Ω/mi (correct: Ω/mi)
+  #    ├──┬ unit:OHM symbol: Ω
+  #    │  ├─── unit:A^-1 symbol: A
+  #    │  └──┬ unit:V symbol: V
+  #    │     ├─── unit:A^-1 symbol: A
+  #    │     └──┬ unit:W symbol: W
+  #    │        ├──┬ unit:J symbol: J
+  #    │        │  ├─── unit:M symbol: m
+  #    │        │  └──┬ unit:N symbol: N
+  #    │        │     ├──┬ unit:KiloGM symbol: kg
+  #    │        │     │  └─── unit:GM symbol: g
+  #    │        │     ├─── unit:M symbol: m
+  #    │        │     └─── unit:SEC^-2 symbol: s
+  #    │        └─── unit:SEC^-1 symbol: s
+  #    └──┬ unit:MI^-1 symbol: mi
+  #       └─── unit:M symbol: m
+unit:OHM-PER-MI qudt:symbol "Ω/mi" .
+
+  # WRONG SYMBOL  : unit:ONE-PER-ONE - calculated from factors: one/one, actual: /1
+  #
+  #  ──┬ unit:ONE-PER-ONE symbol: /1 (correct: one/one)
+  #    ├─── unit:ONE symbol: one
+  #    └─── unit:ONE^-1 symbol: one
+unit:ONE-PER-ONE qudt:symbol "one/one" .
+
+  # WRONG SYMBOL  : unit:OZ-FT-HR-PER-IN3-LB - calculated from factors: oz·ft·h/(in³·lbm), actual: (oz/in³)/(lb/(ft·h))
+  #
+  #  ──┬ unit:OZ-FT-HR-PER-IN3-LB symbol: (oz/in³)/(lb/(ft·h)) (correct: oz·ft·h/(in³·lbm))
+  #    ├──┬ unit:OZ symbol: oz
+  #    │  └──┬ unit:LB symbol: lbm
+  #    │     └──┬ unit:KiloGM symbol: kg
+  #    │        └─── unit:GM symbol: g
+  #    ├──┬ unit:FT symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:LB^-1 symbol: lbm
+  #       └──┬ unit:KiloGM symbol: kg
+  #          └─── unit:GM symbol: g
+unit:OZ-FT-HR-PER-IN3-LB qudt:symbol "oz·ft·h/(in³·lbm)" .
+
+  # WRONG SYMBOL  : unit:OZ-FT-SEC-PER-IN3-LB - calculated from factors: oz·ft·s/(in³·lbm), actual: (oz/in³)/(lb/(ft·s))
+  #
+  #  ──┬ unit:OZ-FT-SEC-PER-IN3-LB symbol: (oz/in³)/(lb/(ft·s)) (correct: oz·ft·s/(in³·lbm))
+  #    ├──┬ unit:OZ symbol: oz
+  #    │  └──┬ unit:LB symbol: lbm
+  #    │     └──┬ unit:KiloGM symbol: kg
+  #    │        └─── unit:GM symbol: g
+  #    ├──┬ unit:FT symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    ├─── unit:SEC symbol: s
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:LB^-1 symbol: lbm
+  #       └──┬ unit:KiloGM symbol: kg
+  #          └─── unit:GM symbol: g
+unit:OZ-FT-SEC-PER-IN3-LB qudt:symbol "oz·ft·s/(in³·lbm)" .
+
+  # WRONG SYMBOL  : unit:OZ-FT2-PER-IN3-LB_F-SEC - calculated from factors: oz·ft²/(in³·lbf·s), actual: (oz/in³)/(lbf·s/ft²)
+  #
+  #  ──┬ unit:OZ-FT2-PER-IN3-LB_F-SEC symbol: (oz/in³)/(lbf·s/ft²) (correct: oz·ft²/(in³·lbf·s))
+  #    ├──┬ unit:OZ symbol: oz
+  #    │  └──┬ unit:LB symbol: lbm
+  #    │     └──┬ unit:KiloGM symbol: kg
+  #    │        └─── unit:GM symbol: g
+  #    ├──┬ unit:FT^2 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    ├──┬ unit:LB_F^-1 symbol: lbf
+  #    │  ├──┬ unit:FT symbol: ft
+  #    │  │  └──┬ unit:IN symbol: in
+  #    │  │     └─── unit:M symbol: m
+  #    │  ├─── unit:SEC^-2 symbol: s
+  #    │  └──┬ unit:SLUG symbol: slug
+  #    │     └──┬ unit:LB symbol: lbm
+  #    │        └──┬ unit:KiloGM symbol: kg
+  #    │           └─── unit:GM symbol: g
+  #    └─── unit:SEC^-1 symbol: s
+unit:OZ-FT2-PER-IN3-LB_F-SEC qudt:symbol "oz·ft²/(in³·lbf·s)" .
+
+  # WRONG SYMBOL  : unit:OZ-HR-PER-IN3-FT3 - calculated from factors: oz·h/(in³·ft³), actual: (oz/in³)/(ft³/h)
+  #
+  #  ──┬ unit:OZ-HR-PER-IN3-FT3 symbol: (oz/in³)/(ft³/h) (correct: oz·h/(in³·ft³))
+  #    ├──┬ unit:OZ symbol: oz
+  #    │  └──┬ unit:LB symbol: lbm
+  #    │     └──┬ unit:KiloGM symbol: kg
+  #    │        └─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:FT^-3 symbol: ft
+  #       └──┬ unit:IN symbol: in
+  #          └─── unit:M symbol: m
+unit:OZ-HR-PER-IN3-FT3 qudt:symbol "oz·h/(in³·ft³)" .
+
+  # WRONG SYMBOL  : unit:OZ-HR-PER-IN3-GAL_UK - calculated from factors: oz·h/(in³·gal{UK}), actual: (oz/in³)/(gal (UK)/h)
+  #
+  #  ──┬ unit:OZ-HR-PER-IN3-GAL_UK symbol: (oz/in³)/(gal (UK)/h) (correct: oz·h/(in³·gal{UK}))
+  #    ├──┬ unit:OZ symbol: oz
+  #    │  └──┬ unit:LB symbol: lbm
+  #    │     └──┬ unit:KiloGM symbol: kg
+  #    │        └─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:GAL_UK^-1 symbol: gal{UK}
+  #       └──┬ unit:L symbol: L
+  #          └──┬ unit:DeciM3 symbol: dm³
+  #             └──┬ unit:DeciM^3 symbol: dm
+  #                └─── unit:M symbol: m
+unit:OZ-HR-PER-IN3-GAL_UK qudt:symbol "oz·h/(in³·gal{UK})" .
+
+  # WRONG SYMBOL  : unit:OZ-HR-PER-IN3-GAL_US - calculated from factors: oz·h/(in³·gal{US}), actual: (oz/in³)/(gal (US)/h)
+  #
+  #  ──┬ unit:OZ-HR-PER-IN3-GAL_US symbol: (oz/in³)/(gal (US)/h) (correct: oz·h/(in³·gal{US}))
+  #    ├──┬ unit:OZ symbol: oz
+  #    │  └──┬ unit:LB symbol: lbm
+  #    │     └──┬ unit:KiloGM symbol: kg
+  #    │        └─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:GAL_US^-1 symbol: gal{US}
+  #       └──┬ unit:IN^3 symbol: in
+  #          └─── unit:M symbol: m
+unit:OZ-HR-PER-IN3-GAL_US qudt:symbol "oz·h/(in³·gal{US})" .
+
+  # WRONG SYMBOL  : unit:OZ-HR-PER-IN3-YD3 - calculated from factors: oz·h/(in³·yd³), actual: (oz/in³)/(yd³/h)
+  #
+  #  ──┬ unit:OZ-HR-PER-IN3-YD3 symbol: (oz/in³)/(yd³/h) (correct: oz·h/(in³·yd³))
+  #    ├──┬ unit:OZ symbol: oz
+  #    │  └──┬ unit:LB symbol: lbm
+  #    │     └──┬ unit:KiloGM symbol: kg
+  #    │        └─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:YD^-3 symbol: yd
+  #       └──┬ unit:FT symbol: ft
+  #          └──┬ unit:IN symbol: in
+  #             └─── unit:M symbol: m
+unit:OZ-HR-PER-IN3-YD3 qudt:symbol "oz·h/(in³·yd³)" .
+
+  # WRONG SYMBOL  : unit:OZ-HR-PER-IN6 - calculated from factors: oz·h/in⁶, actual: (oz/in³)/(in³/h)
+  #
+  #  ──┬ unit:OZ-HR-PER-IN6 symbol: (oz/in³)/(in³/h) (correct: oz·h/in⁶)
+  #    ├──┬ unit:OZ symbol: oz
+  #    │  └──┬ unit:LB symbol: lbm
+  #    │     └──┬ unit:KiloGM symbol: kg
+  #    │        └─── unit:GM symbol: g
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    └──┬ unit:IN^-6 symbol: in
+  #       └─── unit:M symbol: m
+unit:OZ-HR-PER-IN6 qudt:symbol "oz·h/in⁶" .
+
+  # WRONG SYMBOL  : unit:OZ-IN2-PER-IN3-LB_F-SEC - calculated from factors: oz·in²/(in³·lbf·s), actual: (oz/in³)/(lbf·s/in²)
+  #
+  #  ──┬ unit:OZ-IN2-PER-IN3-LB_F-SEC symbol: (oz/in³)/(lbf·s/in²) (correct: oz·in²/(in³·lbf·s))
+  #    ├──┬ unit:OZ symbol: oz
+  #    │  └──┬ unit:LB symbol: lbm
+  #    │     └──┬ unit:KiloGM symbol: kg
+  #    │        └─── unit:GM symbol: g
+  #    ├──┬ unit:IN^2 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    ├──┬ unit:LB_F^-1 symbol: lbf
+  #    │  ├──┬ unit:FT symbol: ft
+  #    │  │  └──┬ unit:IN symbol: in
+  #    │  │     └─── unit:M symbol: m
+  #    │  ├─── unit:SEC^-2 symbol: s
+  #    │  └──┬ unit:SLUG symbol: slug
+  #    │     └──┬ unit:LB symbol: lbm
+  #    │        └──┬ unit:KiloGM symbol: kg
+  #    │           └─── unit:GM symbol: g
+  #    └─── unit:SEC^-1 symbol: s
+unit:OZ-IN2-PER-IN3-LB_F-SEC qudt:symbol "oz·in²/(in³·lbf·s)" .
+
+  # WRONG SYMBOL  : unit:OZ-MIN-PER-IN3-FT3 - calculated from factors: oz·min/(in³·ft³), actual: (oz/in³)/(ft³/min)
+  #
+  #  ──┬ unit:OZ-MIN-PER-IN3-FT3 symbol: (oz/in³)/(ft³/min) (correct: oz·min/(in³·ft³))
+  #    ├──┬ unit:OZ symbol: oz
+  #    │  └──┬ unit:LB symbol: lbm
+  #    │     └──┬ unit:KiloGM symbol: kg
+  #    │        └─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:FT^-3 symbol: ft
+  #       └──┬ unit:IN symbol: in
+  #          └─── unit:M symbol: m
+unit:OZ-MIN-PER-IN3-FT3 qudt:symbol "oz·min/(in³·ft³)" .
+
+  # WRONG SYMBOL  : unit:OZ-MIN-PER-IN3-GAL_UK - calculated from factors: oz·min/(in³·gal{UK}), actual: oz·min/(in³·gal (UK))
+  #
+  #  ──┬ unit:OZ-MIN-PER-IN3-GAL_UK symbol: oz·min/(in³·gal (UK)) (correct: oz·min/(in³·gal{UK}))
+  #    ├──┬ unit:OZ symbol: oz
+  #    │  └──┬ unit:LB symbol: lbm
+  #    │     └──┬ unit:KiloGM symbol: kg
+  #    │        └─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:GAL_UK^-1 symbol: gal{UK}
+  #       └──┬ unit:L symbol: L
+  #          └──┬ unit:DeciM3 symbol: dm³
+  #             └──┬ unit:DeciM^3 symbol: dm
+  #                └─── unit:M symbol: m
+unit:OZ-MIN-PER-IN3-GAL_UK qudt:symbol "oz·min/(in³·gal{UK})" .
+
+  # WRONG SYMBOL  : unit:OZ-MIN-PER-IN3-GAL_US - calculated from factors: oz·min/(in³·gal{US}), actual: (oz/in³)/(gal (US)/min)
+  #
+  #  ──┬ unit:OZ-MIN-PER-IN3-GAL_US symbol: (oz/in³)/(gal (US)/min) (correct: oz·min/(in³·gal{US}))
+  #    ├──┬ unit:OZ symbol: oz
+  #    │  └──┬ unit:LB symbol: lbm
+  #    │     └──┬ unit:KiloGM symbol: kg
+  #    │        └─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:GAL_US^-1 symbol: gal{US}
+  #       └──┬ unit:IN^3 symbol: in
+  #          └─── unit:M symbol: m
+unit:OZ-MIN-PER-IN3-GAL_US qudt:symbol "oz·min/(in³·gal{US})" .
+
+  # WRONG SYMBOL  : unit:OZ-MIN-PER-IN3-YD3 - calculated from factors: oz·min/(in³·yd³), actual: (oz/in³)/(yd³/min)
+  #
+  #  ──┬ unit:OZ-MIN-PER-IN3-YD3 symbol: (oz/in³)/(yd³/min) (correct: oz·min/(in³·yd³))
+  #    ├──┬ unit:OZ symbol: oz
+  #    │  └──┬ unit:LB symbol: lbm
+  #    │     └──┬ unit:KiloGM symbol: kg
+  #    │        └─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:YD^-3 symbol: yd
+  #       └──┬ unit:FT symbol: ft
+  #          └──┬ unit:IN symbol: in
+  #             └─── unit:M symbol: m
+unit:OZ-MIN-PER-IN3-YD3 qudt:symbol "oz·min/(in³·yd³)" .
+
+  # WRONG SYMBOL  : unit:OZ-MIN-PER-IN6 - calculated from factors: oz·min/in⁶, actual: (oz/in³)/(in³/min)
+  #
+  #  ──┬ unit:OZ-MIN-PER-IN6 symbol: (oz/in³)/(in³/min) (correct: oz·min/in⁶)
+  #    ├──┬ unit:OZ symbol: oz
+  #    │  └──┬ unit:LB symbol: lbm
+  #    │     └──┬ unit:KiloGM symbol: kg
+  #    │        └─── unit:GM symbol: g
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    └──┬ unit:IN^-6 symbol: in
+  #       └─── unit:M symbol: m
+unit:OZ-MIN-PER-IN6 qudt:symbol "oz·min/in⁶" .
+
+  # WRONG SYMBOL  : unit:OZ-PER-DAY - calculated from factors: oz/d, actual: oz/day
+  #
+  #  ──┬ unit:OZ-PER-DAY symbol: oz/day (correct: oz/d)
+  #    ├──┬ unit:OZ symbol: oz
+  #    │  └──┬ unit:LB symbol: lbm
+  #    │     └──┬ unit:KiloGM symbol: kg
+  #    │        └─── unit:GM symbol: g
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:OZ-PER-DAY qudt:symbol "oz/d" .
+
+  # WRONG SYMBOL  : unit:OZ-PER-FT2 - calculated from factors: oz/ft², actual: oz/ft²{US}
+  #
+  #  ──┬ unit:OZ-PER-FT2 symbol: oz/ft²{US} (correct: oz/ft²)
+  #    ├──┬ unit:OZ symbol: oz
+  #    │  └──┬ unit:LB symbol: lbm
+  #    │     └──┬ unit:KiloGM symbol: kg
+  #    │        └─── unit:GM symbol: g
+  #    └──┬ unit:FT^-2 symbol: ft
+  #       └──┬ unit:IN symbol: in
+  #          └─── unit:M symbol: m
+unit:OZ-PER-FT2 qudt:symbol "oz/ft²" .
+
+  # WRONG SYMBOL  : unit:OZ-PER-YD2 - calculated from factors: oz/yd², actual: oz/yd³{US}
+  #
+  #  ──┬ unit:OZ-PER-YD2 symbol: oz/yd³{US} (correct: oz/yd²)
+  #    ├──┬ unit:OZ symbol: oz
+  #    │  └──┬ unit:LB symbol: lbm
+  #    │     └──┬ unit:KiloGM symbol: kg
+  #    │        └─── unit:GM symbol: g
+  #    └──┬ unit:YD^-2 symbol: yd
+  #       └──┬ unit:FT symbol: ft
+  #          └──┬ unit:IN symbol: in
+  #             └─── unit:M symbol: m
+unit:OZ-PER-YD2 qudt:symbol "oz/yd²" .
+
+  # WRONG SYMBOL  : unit:OZ-SEC-PER-IN3-FT3 - calculated from factors: oz·s/(in³·ft³), actual: (oz/in³)/(ft³/s)
+  #
+  #  ──┬ unit:OZ-SEC-PER-IN3-FT3 symbol: (oz/in³)/(ft³/s) (correct: oz·s/(in³·ft³))
+  #    ├──┬ unit:OZ symbol: oz
+  #    │  └──┬ unit:LB symbol: lbm
+  #    │     └──┬ unit:KiloGM symbol: kg
+  #    │        └─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:FT^-3 symbol: ft
+  #       └──┬ unit:IN symbol: in
+  #          └─── unit:M symbol: m
+unit:OZ-SEC-PER-IN3-FT3 qudt:symbol "oz·s/(in³·ft³)" .
+
+  # WRONG SYMBOL  : unit:OZ-SEC-PER-IN3-GAL_UK - calculated from factors: oz·s/(in³·gal{UK}), actual: (oz/in³)/(gal (UK)/s)
+  #
+  #  ──┬ unit:OZ-SEC-PER-IN3-GAL_UK symbol: (oz/in³)/(gal (UK)/s) (correct: oz·s/(in³·gal{UK}))
+  #    ├──┬ unit:OZ symbol: oz
+  #    │  └──┬ unit:LB symbol: lbm
+  #    │     └──┬ unit:KiloGM symbol: kg
+  #    │        └─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:GAL_UK^-1 symbol: gal{UK}
+  #       └──┬ unit:L symbol: L
+  #          └──┬ unit:DeciM3 symbol: dm³
+  #             └──┬ unit:DeciM^3 symbol: dm
+  #                └─── unit:M symbol: m
+unit:OZ-SEC-PER-IN3-GAL_UK qudt:symbol "oz·s/(in³·gal{UK})" .
+
+  # WRONG SYMBOL  : unit:OZ-SEC-PER-IN3-GAL_US - calculated from factors: oz·s/(in³·gal{US}), actual: (oz/in³)/(gal (US)/s)
+  #
+  #  ──┬ unit:OZ-SEC-PER-IN3-GAL_US symbol: (oz/in³)/(gal (US)/s) (correct: oz·s/(in³·gal{US}))
+  #    ├──┬ unit:OZ symbol: oz
+  #    │  └──┬ unit:LB symbol: lbm
+  #    │     └──┬ unit:KiloGM symbol: kg
+  #    │        └─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:GAL_US^-1 symbol: gal{US}
+  #       └──┬ unit:IN^3 symbol: in
+  #          └─── unit:M symbol: m
+unit:OZ-SEC-PER-IN3-GAL_US qudt:symbol "oz·s/(in³·gal{US})" .
+
+  # WRONG SYMBOL  : unit:OZ-SEC-PER-IN3-YD3 - calculated from factors: oz·s/(in³·yd³), actual: (oz/in³)/(yd³/s)
+  #
+  #  ──┬ unit:OZ-SEC-PER-IN3-YD3 symbol: (oz/in³)/(yd³/s) (correct: oz·s/(in³·yd³))
+  #    ├──┬ unit:OZ symbol: oz
+  #    │  └──┬ unit:LB symbol: lbm
+  #    │     └──┬ unit:KiloGM symbol: kg
+  #    │        └─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:YD^-3 symbol: yd
+  #       └──┬ unit:FT symbol: ft
+  #          └──┬ unit:IN symbol: in
+  #             └─── unit:M symbol: m
+unit:OZ-SEC-PER-IN3-YD3 qudt:symbol "oz·s/(in³·yd³)" .
+
+  # WRONG SYMBOL  : unit:OZ-SEC-PER-IN6 - calculated from factors: oz·s/in⁶, actual: (oz/in³)/(in³/s)
+  #
+  #  ──┬ unit:OZ-SEC-PER-IN6 symbol: (oz/in³)/(in³/s) (correct: oz·s/in⁶)
+  #    ├──┬ unit:OZ symbol: oz
+  #    │  └──┬ unit:LB symbol: lbm
+  #    │     └──┬ unit:KiloGM symbol: kg
+  #    │        └─── unit:GM symbol: g
+  #    ├─── unit:SEC symbol: s
+  #    └──┬ unit:IN^-6 symbol: in
+  #       └─── unit:M symbol: m
+unit:OZ-SEC-PER-IN6 qudt:symbol "oz·s/in⁶" .
+
+  # WRONG SYMBOL  : unit:OZ_VOL_UK-PER-DAY - calculated from factors: oz{UK}/d, actual: oz{UK}/day
+  #
+  #  ──┬ unit:OZ_VOL_UK-PER-DAY symbol: oz{UK}/day (correct: oz{UK}/d)
+  #    ├──┬ unit:OZ_VOL_UK symbol: oz{UK}
+  #    │  └──┬ unit:M3 symbol: m³
+  #    │     └─── unit:M^3 symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:OZ_VOL_UK-PER-DAY qudt:symbol "oz{UK}/d" .
+
+  # WRONG SYMBOL  : unit:OZ_VOL_US-PER-DAY - calculated from factors: fl oz{US}/d, actual: fl oz{US}/day
+  #
+  #  ──┬ unit:OZ_VOL_US-PER-DAY symbol: fl oz{US}/day (correct: fl oz{US}/d)
+  #    ├──┬ unit:OZ_VOL_US symbol: fl oz{US}
+  #    │  └──┬ unit:M3 symbol: m³
+  #    │     └─── unit:M^3 symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:OZ_VOL_US-PER-DAY qudt:symbol "fl oz{US}/d" .
+
+  # WRONG SYMBOL  : unit:PA-M2-PER-KiloGM - calculated from factors: Pa·m²/kg, actual: Pa/(kg/m²)
+  #
+  #  ──┬ unit:PA-M2-PER-KiloGM symbol: Pa/(kg/m²) (correct: Pa·m²/kg)
+  #    ├──┬ unit:PA symbol: Pa
+  #    │  ├─── unit:M^-2 symbol: m
+  #    │  └──┬ unit:N symbol: N
+  #    │     ├──┬ unit:KiloGM symbol: kg
+  #    │     │  └─── unit:GM symbol: g
+  #    │     ├─── unit:M symbol: m
+  #    │     └─── unit:SEC^-2 symbol: s
+  #    ├─── unit:M^2 symbol: m
+  #    └──┬ unit:KiloGM^-1 symbol: kg
+  #       └─── unit:GM symbol: g
+unit:PA-M2-PER-KiloGM qudt:symbol "Pa·m²/kg" .
+
+  # WRONG SYMBOL  : unit:PA-SEC-PER-L - calculated from factors: Pa·s/L, actual: Pa·s/l
+  #
+  #  ──┬ unit:PA-SEC-PER-L symbol: Pa·s/l (correct: Pa·s/L)
+  #    ├──┬ unit:PA symbol: Pa
+  #    │  ├─── unit:M^-2 symbol: m
+  #    │  └──┬ unit:N symbol: N
+  #    │     ├──┬ unit:KiloGM symbol: kg
+  #    │     │  └─── unit:GM symbol: g
+  #    │     ├─── unit:M symbol: m
+  #    │     └─── unit:SEC^-2 symbol: s
+  #    ├─── unit:SEC symbol: s
+  #    └──┬ unit:L^-1 symbol: L
+  #       └──┬ unit:DeciM3 symbol: dm³
+  #          └──┬ unit:DeciM^3 symbol: dm
+  #             └─── unit:M symbol: m
+unit:PA-SEC-PER-L qudt:symbol "Pa·s/L" .
+
+  # WRONG SYMBOL  : unit:PDL-SEC-PER-FT2 - calculated from factors: pdl·s/ft², actual: pdl/ft²)·s
+  #
+  #  ──┬ unit:PDL-SEC-PER-FT2 symbol: pdl/ft²)·s (correct: pdl·s/ft²)
+  #    ├──┬ unit:PDL symbol: pdl
+  #    │  └──┬ unit:N symbol: N
+  #    │     ├──┬ unit:KiloGM symbol: kg
+  #    │     │  └─── unit:GM symbol: g
+  #    │     ├─── unit:M symbol: m
+  #    │     └─── unit:SEC^-2 symbol: s
+  #    ├─── unit:SEC symbol: s
+  #    └──┬ unit:FT^-2 symbol: ft
+  #       └──┬ unit:IN symbol: in
+  #          └─── unit:M symbol: m
+unit:PDL-SEC-PER-FT2 qudt:symbol "pdl·s/ft²" .
+
+  # WRONG SYMBOL  : unit:PER-DAY - calculated from factors: /d, actual: /day
+  #
+  #  ──┬ unit:PER-DAY symbol: /day (correct: /d)
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:PER-DAY qudt:symbol "/d" .
+
+  # WRONG SYMBOL  : unit:PER-DEG_F - calculated from factors: /°F, actual: °F⁻¹
+  #
+  #  ──┬ unit:PER-DEG_F symbol: °F⁻¹ (correct: /°F)
+  #    └──┬ unit:DEG_F^-1 symbol: °F
+  #       └─── unit:K symbol: K
+unit:PER-DEG_F qudt:symbol "/°F" .
+
+  # WRONG SYMBOL  : unit:PER-IN - calculated from factors: /in, actual: in⁻¹
+  #
+  #  ──┬ unit:PER-IN symbol: in⁻¹ (correct: /in)
+  #    └──┬ unit:IN^-1 symbol: in
+  #       └─── unit:M symbol: m
+unit:PER-IN qudt:symbol "/in" .
+
+  # WRONG SYMBOL  : unit:PER-J - calculated from factors: /J, actual: J⁻¹
+  #
+  #  ──┬ unit:PER-J symbol: J⁻¹ (correct: /J)
+  #    └──┬ unit:J^-1 symbol: J
+  #       ├─── unit:M symbol: m
+  #       └──┬ unit:N symbol: N
+  #          ├──┬ unit:KiloGM symbol: kg
+  #          │  └─── unit:GM symbol: g
+  #          ├─── unit:M symbol: m
+  #          └─── unit:SEC^-2 symbol: s
+unit:PER-J qudt:symbol "/J" .
+
+  # WRONG SYMBOL  : unit:PER-KiloGM - calculated from factors: /kg, actual: kg⁻¹
+  #
+  #  ──┬ unit:PER-KiloGM symbol: kg⁻¹ (correct: /kg)
+  #    └──┬ unit:KiloGM^-1 symbol: kg
+  #       └─── unit:GM symbol: g
+unit:PER-KiloGM qudt:symbol "/kg" .
+
+  # WRONG SYMBOL  : unit:PER-LB - calculated from factors: /lbm, actual: lb⁻¹
+  #
+  #  ──┬ unit:PER-LB symbol: lb⁻¹ (correct: /lbm)
+  #    └──┬ unit:LB^-1 symbol: lbm
+  #       └──┬ unit:KiloGM symbol: kg
+  #          └─── unit:GM symbol: g
+unit:PER-LB qudt:symbol "/lbm" .
+
+  # WRONG SYMBOL  : unit:PER-M3 - calculated from factors: /m³, actual: m⁻³
+  #
+  #  ──┬ unit:PER-M3 symbol: m⁻³ (correct: /m³)
+  #    └─── unit:M^-3 symbol: m
+unit:PER-M3 qudt:symbol "/m³" .
+
+  # WRONG SYMBOL  : unit:PER-MicroM - calculated from factors: /μm, actual: /µm
+  #
+  #  ──┬ unit:PER-MicroM symbol: /µm (correct: /μm)
+  #    └──┬ unit:MicroM^-1 symbol: μm
+  #       └─── unit:M symbol: m
+unit:PER-MicroM qudt:symbol "/μm" .
+
+  # WRONG SYMBOL  : unit:PER-MicroMOL-L - calculated from factors: /(μmol·L), actual: /(µmol·L)
+  #
+  #  ──┬ unit:PER-MicroMOL-L symbol: /(µmol·L) (correct: /(μmol·L))
+  #    ├──┬ unit:MicroMOL^-1 symbol: μmol
+  #    │  └─── unit:MOL symbol: mol
+  #    └──┬ unit:L^-1 symbol: L
+  #       └──┬ unit:DeciM3 symbol: dm³
+  #          └──┬ unit:DeciM^3 symbol: dm
+  #             └─── unit:M symbol: m
+unit:PER-MicroMOL-L qudt:symbol "/(μmol·L)" .
+
+  # WRONG SYMBOL  : unit:PER-MilliGM - calculated from factors: /mg, actual: mg⁻¹
+  #
+  #  ──┬ unit:PER-MilliGM symbol: mg⁻¹ (correct: /mg)
+  #    └──┬ unit:MilliGM^-1 symbol: mg
+  #       └─── unit:GM symbol: g
+unit:PER-MilliGM qudt:symbol "/mg" .
+
+  # WRONG SYMBOL  : unit:PER-OZ - calculated from factors: /oz, actual: oz⁻¹
+  #
+  #  ──┬ unit:PER-OZ symbol: oz⁻¹ (correct: /oz)
+  #    └──┬ unit:OZ^-1 symbol: oz
+  #       └──┬ unit:LB symbol: lbm
+  #          └──┬ unit:KiloGM symbol: kg
+  #             └─── unit:GM symbol: g
+unit:PER-OZ qudt:symbol "/oz" .
+
+  # WRONG SYMBOL  : unit:PER-PA - calculated from factors: /Pa, actual: Pa⁻¹
+  #
+  #  ──┬ unit:PER-PA symbol: Pa⁻¹ (correct: /Pa)
+  #    └──┬ unit:PA^-1 symbol: Pa
+  #       ├─── unit:M^-2 symbol: m
+  #       └──┬ unit:N symbol: N
+  #          ├──┬ unit:KiloGM symbol: kg
+  #          │  └─── unit:GM symbol: g
+  #          ├─── unit:M symbol: m
+  #          └─── unit:SEC^-2 symbol: s
+unit:PER-PA qudt:symbol "/Pa" .
+
+  # WRONG SYMBOL  : unit:PER-PlanckMass2 - calculated from factors: /planckmass², actual: /mₚ²
+  #
+  #  ──┬ unit:PER-PlanckMass2 symbol: /mₚ² (correct: /planckmass²)
+  #    └──┬ unit:PlanckMass^-2 symbol: planckmass
+  #       └──┬ unit:KiloGM symbol: kg
+  #          └─── unit:GM symbol: g
+unit:PER-PlanckMass2 qudt:symbol "/planckmass²" .
+
+  # WRONG SYMBOL  : unit:PER-RAD - calculated from factors: /rad, actual: rad⁻¹
+  #
+  #  ──┬ unit:PER-RAD symbol: rad⁻¹ (correct: /rad)
+  #    └──┬ unit:RAD^-1 symbol: rad
+  #       ├─── unit:M^-1 symbol: m
+  #       └─── unit:M symbol: m
+unit:PER-RAD qudt:symbol "/rad" .
+
+  # WRONG SYMBOL  : unit:PER-SEC-M2 - calculated from factors: /(s·m²), actual: s⁻¹·m⁻²
+  #
+  #  ──┬ unit:PER-SEC-M2 symbol: s⁻¹·m⁻² (correct: /(s·m²))
+  #    ├─── unit:SEC^-1 symbol: s
+  #    └─── unit:M^-2 symbol: m
+unit:PER-SEC-M2 qudt:symbol "/(s·m²)" .
+
+  # WRONG SYMBOL  : unit:PER-SEC-M3 - calculated from factors: /(s·m³), actual: s⁻¹·m⁻³
+  #
+  #  ──┬ unit:PER-SEC-M3 symbol: s⁻¹·m⁻³ (correct: /(s·m³))
+  #    ├─── unit:SEC^-1 symbol: s
+  #    └─── unit:M^-3 symbol: m
+unit:PER-SEC-M3 qudt:symbol "/(s·m³)" .
+
+  # WRONG SYMBOL  : unit:PER-SEC-SR - calculated from factors: /(s·sr), actual: /s·sr
+  #
+  #  ──┬ unit:PER-SEC-SR symbol: /s·sr (correct: /(s·sr))
+  #    ├─── unit:SEC^-1 symbol: s
+  #    └──┬ unit:SR^-1 symbol: sr
+  #       ├─── unit:M^-2 symbol: m
+  #       └─── unit:M^2 symbol: m
+unit:PER-SEC-SR qudt:symbol "/(s·sr)" .
+
+  # WRONG SYMBOL  : unit:PER-SEC-SR-M2 - calculated from factors: /(s·sr·m²), actual: s⁻¹·sr⁻¹·m⁻²
+  #
+  #  ──┬ unit:PER-SEC-SR-M2 symbol: s⁻¹·sr⁻¹·m⁻² (correct: /(s·sr·m²))
+  #    ├─── unit:SEC^-1 symbol: s
+  #    ├──┬ unit:SR^-1 symbol: sr
+  #    │  ├─── unit:M^-2 symbol: m
+  #    │  └─── unit:M^2 symbol: m
+  #    └─── unit:M^-2 symbol: m
+unit:PER-SEC-SR-M2 qudt:symbol "/(s·sr·m²)" .
+
+  # WRONG SYMBOL  : unit:PER-TON - calculated from factors: /tn, actual: st⁻¹
+  #
+  #  ──┬ unit:PER-TON symbol: st⁻¹ (correct: /tn)
+  #    └──┬ unit:TON^-1 symbol: tn
+  #       └──┬ unit:KiloGM symbol: kg
+  #          └─── unit:GM symbol: g
+unit:PER-TON qudt:symbol "/tn" .
+
+  # WRONG SYMBOL  : unit:PER-TONNE - calculated from factors: /t, actual: t⁻¹
+  #
+  #  ──┬ unit:PER-TONNE symbol: t⁻¹ (correct: /t)
+  #    └──┬ unit:TONNE^-1 symbol: t
+  #       └──┬ unit:KiloGM symbol: kg
+  #          └─── unit:GM symbol: g
+unit:PER-TONNE qudt:symbol "/t" .
+
+  # WRONG SYMBOL  : unit:PER-V - calculated from factors: /V, actual: V⁻¹
+  #
+  #  ──┬ unit:PER-V symbol: V⁻¹ (correct: /V)
+  #    └──┬ unit:V^-1 symbol: V
+  #       ├─── unit:A^-1 symbol: A
+  #       └──┬ unit:W symbol: W
+  #          ├──┬ unit:J symbol: J
+  #          │  ├─── unit:M symbol: m
+  #          │  └──┬ unit:N symbol: N
+  #          │     ├──┬ unit:KiloGM symbol: kg
+  #          │     │  └─── unit:GM symbol: g
+  #          │     ├─── unit:M symbol: m
+  #          │     └─── unit:SEC^-2 symbol: s
+  #          └─── unit:SEC^-1 symbol: s
+unit:PER-V qudt:symbol "/V" .
+
+  # WRONG SYMBOL  : unit:PER-V-A-SEC - calculated from factors: /(V·A·s), actual: /VAs
+  #
+  #  ──┬ unit:PER-V-A-SEC symbol: /VAs (correct: /(V·A·s))
+  #    ├──┬ unit:V^-1 symbol: V
+  #    │  ├─── unit:A^-1 symbol: A
+  #    │  └──┬ unit:W symbol: W
+  #    │     ├──┬ unit:J symbol: J
+  #    │     │  ├─── unit:M symbol: m
+  #    │     │  └──┬ unit:N symbol: N
+  #    │     │     ├──┬ unit:KiloGM symbol: kg
+  #    │     │     │  └─── unit:GM symbol: g
+  #    │     │     ├─── unit:M symbol: m
+  #    │     │     └─── unit:SEC^-2 symbol: s
+  #    │     └─── unit:SEC^-1 symbol: s
+  #    ├─── unit:A^-1 symbol: A
+  #    └─── unit:SEC^-1 symbol: s
+unit:PER-V-A-SEC qudt:symbol "/(V·A·s)" .
+
+  # WRONG SYMBOL  : unit:PERCENT-FT-HR-PER-LB - calculated from factors: ft·h·%/lbm, actual: %/(lb/(ft·h))
+  #
+  #  ──┬ unit:PERCENT-FT-HR-PER-LB symbol: %/(lb/(ft·h)) (correct: ft·h·%/lbm)
+  #    ├──┬ unit:FT symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:LB^-1 symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    └─── unit:PERCENT symbol: %
+unit:PERCENT-FT-HR-PER-LB qudt:symbol "ft·h·%/lbm" .
+
+  # WRONG SYMBOL  : unit:PERCENT-FT-SEC-PER-LB - calculated from factors: ft·%·s/lbm, actual: %/(lb/(ft·s))
+  #
+  #  ──┬ unit:PERCENT-FT-SEC-PER-LB symbol: %/(lb/(ft·s)) (correct: ft·%·s/lbm)
+  #    ├──┬ unit:FT symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    ├──┬ unit:LB^-1 symbol: lbm
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    ├─── unit:PERCENT symbol: %
+  #    └─── unit:SEC symbol: s
+unit:PERCENT-FT-SEC-PER-LB qudt:symbol "ft·%·s/lbm" .
+
+  # WRONG SYMBOL  : unit:PERCENT-FT2-PER-LB_F-SEC - calculated from factors: ft²·%/(lbf·s), actual: %/(lbf·s/ft²)
+  #
+  #  ──┬ unit:PERCENT-FT2-PER-LB_F-SEC symbol: %/(lbf·s/ft²) (correct: ft²·%/(lbf·s))
+  #    ├──┬ unit:FT^2 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    ├──┬ unit:LB_F^-1 symbol: lbf
+  #    │  ├──┬ unit:FT symbol: ft
+  #    │  │  └──┬ unit:IN symbol: in
+  #    │  │     └─── unit:M symbol: m
+  #    │  ├─── unit:SEC^-2 symbol: s
+  #    │  └──┬ unit:SLUG symbol: slug
+  #    │     └──┬ unit:LB symbol: lbm
+  #    │        └──┬ unit:KiloGM symbol: kg
+  #    │           └─── unit:GM symbol: g
+  #    ├─── unit:PERCENT symbol: %
+  #    └─── unit:SEC^-1 symbol: s
+unit:PERCENT-FT2-PER-LB_F-SEC qudt:symbol "ft²·%/(lbf·s)" .
+
+  # WRONG SYMBOL  : unit:PERCENT-HR-PER-CentiM3 - calculated from factors: h·%/cm³, actual: %/(cm³/h)
+  #
+  #  ──┬ unit:PERCENT-HR-PER-CentiM3 symbol: %/(cm³/h) (correct: h·%/cm³)
+  #    ├──┬ unit:CentiM^-3 symbol: cm
+  #    │  └─── unit:M symbol: m
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    └─── unit:PERCENT symbol: %
+unit:PERCENT-HR-PER-CentiM3 qudt:symbol "h·%/cm³" .
+
+  # WRONG SYMBOL  : unit:PERCENT-HR-PER-FT3 - calculated from factors: h·%/ft³, actual: %/(ft³/h)
+  #
+  #  ──┬ unit:PERCENT-HR-PER-FT3 symbol: %/(ft³/h) (correct: h·%/ft³)
+  #    ├──┬ unit:FT^-3 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    └─── unit:PERCENT symbol: %
+unit:PERCENT-HR-PER-FT3 qudt:symbol "h·%/ft³" .
+
+  # WRONG SYMBOL  : unit:PERCENT-HR-PER-GAL_UK - calculated from factors: h·%/gal{UK}, actual: %/(gal (UK)/h)
+  #
+  #  ──┬ unit:PERCENT-HR-PER-GAL_UK symbol: %/(gal (UK)/h) (correct: h·%/gal{UK})
+  #    ├──┬ unit:GAL_UK^-1 symbol: gal{UK}
+  #    │  └──┬ unit:L symbol: L
+  #    │     └──┬ unit:DeciM3 symbol: dm³
+  #    │        └──┬ unit:DeciM^3 symbol: dm
+  #    │           └─── unit:M symbol: m
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    └─── unit:PERCENT symbol: %
+unit:PERCENT-HR-PER-GAL_UK qudt:symbol "h·%/gal{UK}" .
+
+  # WRONG SYMBOL  : unit:PERCENT-HR-PER-GAL_US - calculated from factors: h·%/gal{US}, actual: %/(gal (US)/h)
+  #
+  #  ──┬ unit:PERCENT-HR-PER-GAL_US symbol: %/(gal (US)/h) (correct: h·%/gal{US})
+  #    ├──┬ unit:GAL_US^-1 symbol: gal{US}
+  #    │  └──┬ unit:IN^3 symbol: in
+  #    │     └─── unit:M symbol: m
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    └─── unit:PERCENT symbol: %
+unit:PERCENT-HR-PER-GAL_US qudt:symbol "h·%/gal{US}" .
+
+  # WRONG SYMBOL  : unit:PERCENT-HR-PER-IN3 - calculated from factors: h·%/in³, actual: %/(in³/h)
+  #
+  #  ──┬ unit:PERCENT-HR-PER-IN3 symbol: %/(in³/h) (correct: h·%/in³)
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └─── unit:PERCENT symbol: %
+unit:PERCENT-HR-PER-IN3 qudt:symbol "h·%/in³" .
+
+  # WRONG SYMBOL  : unit:PERCENT-HR-PER-L - calculated from factors: h·%/L, actual: %/(l/h)
+  #
+  #  ──┬ unit:PERCENT-HR-PER-L symbol: %/(l/h) (correct: h·%/L)
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └─── unit:PERCENT symbol: %
+unit:PERCENT-HR-PER-L qudt:symbol "h·%/L" .
+
+  # WRONG SYMBOL  : unit:PERCENT-HR-PER-M3 - calculated from factors: h·%/m³, actual: %/(m³/h)
+  #
+  #  ──┬ unit:PERCENT-HR-PER-M3 symbol: %/(m³/h) (correct: h·%/m³)
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├─── unit:M^-3 symbol: m
+  #    └─── unit:PERCENT symbol: %
+unit:PERCENT-HR-PER-M3 qudt:symbol "h·%/m³" .
+
+  # WRONG SYMBOL  : unit:PERCENT-HR-PER-YD3 - calculated from factors: h·%/yd³, actual: %/(yd³/h)
+  #
+  #  ──┬ unit:PERCENT-HR-PER-YD3 symbol: %/(yd³/h) (correct: h·%/yd³)
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    ├─── unit:PERCENT symbol: %
+  #    └──┬ unit:YD^-3 symbol: yd
+  #       └──┬ unit:FT symbol: ft
+  #          └──┬ unit:IN symbol: in
+  #             └─── unit:M symbol: m
+unit:PERCENT-HR-PER-YD3 qudt:symbol "h·%/yd³" .
+
+  # WRONG SYMBOL  : unit:PERCENT-IN2-PER-LB_F-SEC - calculated from factors: in²·%/(lbf·s), actual: %/(lbf·s/in²)
+  #
+  #  ──┬ unit:PERCENT-IN2-PER-LB_F-SEC symbol: %/(lbf·s/in²) (correct: in²·%/(lbf·s))
+  #    ├──┬ unit:IN^2 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    ├──┬ unit:LB_F^-1 symbol: lbf
+  #    │  ├──┬ unit:FT symbol: ft
+  #    │  │  └──┬ unit:IN symbol: in
+  #    │  │     └─── unit:M symbol: m
+  #    │  ├─── unit:SEC^-2 symbol: s
+  #    │  └──┬ unit:SLUG symbol: slug
+  #    │     └──┬ unit:LB symbol: lbm
+  #    │        └──┬ unit:KiloGM symbol: kg
+  #    │           └─── unit:GM symbol: g
+  #    ├─── unit:PERCENT symbol: %
+  #    └─── unit:SEC^-1 symbol: s
+unit:PERCENT-IN2-PER-LB_F-SEC qudt:symbol "in²·%/(lbf·s)" .
+
+  # WRONG SYMBOL  : unit:PERCENT-MIN-PER-CentiM3 - calculated from factors: min·%/cm³, actual: %/(cm³/min)
+  #
+  #  ──┬ unit:PERCENT-MIN-PER-CentiM3 symbol: %/(cm³/min) (correct: min·%/cm³)
+  #    ├──┬ unit:CentiM^-3 symbol: cm
+  #    │  └─── unit:M symbol: m
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    └─── unit:PERCENT symbol: %
+unit:PERCENT-MIN-PER-CentiM3 qudt:symbol "min·%/cm³" .
+
+  # WRONG SYMBOL  : unit:PERCENT-MIN-PER-FT3 - calculated from factors: min·%/ft³, actual: %/(ft³/min)
+  #
+  #  ──┬ unit:PERCENT-MIN-PER-FT3 symbol: %/(ft³/min) (correct: min·%/ft³)
+  #    ├──┬ unit:FT^-3 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    └─── unit:PERCENT symbol: %
+unit:PERCENT-MIN-PER-FT3 qudt:symbol "min·%/ft³" .
+
+  # WRONG SYMBOL  : unit:PERCENT-MIN-PER-GAL_UK - calculated from factors: min·%/gal{UK}, actual: %/(gal (UK)/min)
+  #
+  #  ──┬ unit:PERCENT-MIN-PER-GAL_UK symbol: %/(gal (UK)/min) (correct: min·%/gal{UK})
+  #    ├──┬ unit:GAL_UK^-1 symbol: gal{UK}
+  #    │  └──┬ unit:L symbol: L
+  #    │     └──┬ unit:DeciM3 symbol: dm³
+  #    │        └──┬ unit:DeciM^3 symbol: dm
+  #    │           └─── unit:M symbol: m
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    └─── unit:PERCENT symbol: %
+unit:PERCENT-MIN-PER-GAL_UK qudt:symbol "min·%/gal{UK}" .
+
+  # WRONG SYMBOL  : unit:PERCENT-MIN-PER-GAL_US - calculated from factors: min·%/gal{US}, actual: %/(gal (US)/min)
+  #
+  #  ──┬ unit:PERCENT-MIN-PER-GAL_US symbol: %/(gal (US)/min) (correct: min·%/gal{US})
+  #    ├──┬ unit:GAL_US^-1 symbol: gal{US}
+  #    │  └──┬ unit:IN^3 symbol: in
+  #    │     └─── unit:M symbol: m
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    └─── unit:PERCENT symbol: %
+unit:PERCENT-MIN-PER-GAL_US qudt:symbol "min·%/gal{US}" .
+
+  # WRONG SYMBOL  : unit:PERCENT-MIN-PER-IN3 - calculated from factors: min·%/in³, actual: %/(in³/min)
+  #
+  #  ──┬ unit:PERCENT-MIN-PER-IN3 symbol: %/(in³/min) (correct: min·%/in³)
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    └─── unit:PERCENT symbol: %
+unit:PERCENT-MIN-PER-IN3 qudt:symbol "min·%/in³" .
+
+  # WRONG SYMBOL  : unit:PERCENT-MIN-PER-L - calculated from factors: min·%/L, actual: %/(l/min)
+  #
+  #  ──┬ unit:PERCENT-MIN-PER-L symbol: %/(l/min) (correct: min·%/L)
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    └─── unit:PERCENT symbol: %
+unit:PERCENT-MIN-PER-L qudt:symbol "min·%/L" .
+
+  # WRONG SYMBOL  : unit:PERCENT-MIN-PER-M3 - calculated from factors: min·%/m³, actual: %/(m³/min)
+  #
+  #  ──┬ unit:PERCENT-MIN-PER-M3 symbol: %/(m³/min) (correct: min·%/m³)
+  #    ├─── unit:M^-3 symbol: m
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    └─── unit:PERCENT symbol: %
+unit:PERCENT-MIN-PER-M3 qudt:symbol "min·%/m³" .
+
+  # WRONG SYMBOL  : unit:PERCENT-MIN-PER-YD3 - calculated from factors: min·%/yd³, actual: %/(yd³/min)
+  #
+  #  ──┬ unit:PERCENT-MIN-PER-YD3 symbol: %/(yd³/min) (correct: min·%/yd³)
+  #    ├──┬ unit:MIN symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    ├─── unit:PERCENT symbol: %
+  #    └──┬ unit:YD^-3 symbol: yd
+  #       └──┬ unit:FT symbol: ft
+  #          └──┬ unit:IN symbol: in
+  #             └─── unit:M symbol: m
+unit:PERCENT-MIN-PER-YD3 qudt:symbol "min·%/yd³" .
+
+  # WRONG SYMBOL  : unit:PERCENT-PER-DAY - calculated from factors: %/d, actual: %/day
+  #
+  #  ──┬ unit:PERCENT-PER-DAY symbol: %/day (correct: %/d)
+  #    ├──┬ unit:DAY^-1 symbol: d
+  #    │  └─── unit:SEC symbol: s
+  #    └─── unit:PERCENT symbol: %
+unit:PERCENT-PER-DAY qudt:symbol "%/d" .
+
+  # WRONG SYMBOL  : unit:PERCENT-PER-OHM - calculated from factors: %/Ω, actual: %/Ω
+  #
+  #  ──┬ unit:PERCENT-PER-OHM symbol: %/Ω (correct: %/Ω)
+  #    ├──┬ unit:OHM^-1 symbol: Ω
+  #    │  ├─── unit:A^-1 symbol: A
+  #    │  └──┬ unit:V symbol: V
+  #    │     ├─── unit:A^-1 symbol: A
+  #    │     └──┬ unit:W symbol: W
+  #    │        ├──┬ unit:J symbol: J
+  #    │        │  ├─── unit:M symbol: m
+  #    │        │  └──┬ unit:N symbol: N
+  #    │        │     ├──┬ unit:KiloGM symbol: kg
+  #    │        │     │  └─── unit:GM symbol: g
+  #    │        │     ├─── unit:M symbol: m
+  #    │        │     └─── unit:SEC^-2 symbol: s
+  #    │        └─── unit:SEC^-1 symbol: s
+  #    └─── unit:PERCENT symbol: %
+unit:PERCENT-PER-OHM qudt:symbol "%/Ω" .
+
+  # WRONG SYMBOL  : unit:PERCENT-SEC-PER-CentiM3 - calculated from factors: %·s/cm³, actual: %/(cm³/s)
+  #
+  #  ──┬ unit:PERCENT-SEC-PER-CentiM3 symbol: %/(cm³/s) (correct: %·s/cm³)
+  #    ├──┬ unit:CentiM^-3 symbol: cm
+  #    │  └─── unit:M symbol: m
+  #    ├─── unit:PERCENT symbol: %
+  #    └─── unit:SEC symbol: s
+unit:PERCENT-SEC-PER-CentiM3 qudt:symbol "%·s/cm³" .
+
+  # WRONG SYMBOL  : unit:PERCENT-SEC-PER-FT3 - calculated from factors: %·s/ft³, actual: %/(ft³/s)
+  #
+  #  ──┬ unit:PERCENT-SEC-PER-FT3 symbol: %/(ft³/s) (correct: %·s/ft³)
+  #    ├──┬ unit:FT^-3 symbol: ft
+  #    │  └──┬ unit:IN symbol: in
+  #    │     └─── unit:M symbol: m
+  #    ├─── unit:PERCENT symbol: %
+  #    └─── unit:SEC symbol: s
+unit:PERCENT-SEC-PER-FT3 qudt:symbol "%·s/ft³" .
+
+  # WRONG SYMBOL  : unit:PERCENT-SEC-PER-GAL_UK - calculated from factors: %·s/gal{UK}, actual: %/(gal (UK)/s)
+  #
+  #  ──┬ unit:PERCENT-SEC-PER-GAL_UK symbol: %/(gal (UK)/s) (correct: %·s/gal{UK})
+  #    ├──┬ unit:GAL_UK^-1 symbol: gal{UK}
+  #    │  └──┬ unit:L symbol: L
+  #    │     └──┬ unit:DeciM3 symbol: dm³
+  #    │        └──┬ unit:DeciM^3 symbol: dm
+  #    │           └─── unit:M symbol: m
+  #    ├─── unit:PERCENT symbol: %
+  #    └─── unit:SEC symbol: s
+unit:PERCENT-SEC-PER-GAL_UK qudt:symbol "%·s/gal{UK}" .
+
+  # WRONG SYMBOL  : unit:PERCENT-SEC-PER-GAL_US - calculated from factors: %·s/gal{US}, actual: %/(gal (US)/s)
+  #
+  #  ──┬ unit:PERCENT-SEC-PER-GAL_US symbol: %/(gal (US)/s) (correct: %·s/gal{US})
+  #    ├──┬ unit:GAL_US^-1 symbol: gal{US}
+  #    │  └──┬ unit:IN^3 symbol: in
+  #    │     └─── unit:M symbol: m
+  #    ├─── unit:PERCENT symbol: %
+  #    └─── unit:SEC symbol: s
+unit:PERCENT-SEC-PER-GAL_US qudt:symbol "%·s/gal{US}" .
+
+  # WRONG SYMBOL  : unit:PERCENT-SEC-PER-IN3 - calculated from factors: %·s/in³, actual: %/(in³/s)
+  #
+  #  ──┬ unit:PERCENT-SEC-PER-IN3 symbol: %/(in³/s) (correct: %·s/in³)
+  #    ├──┬ unit:IN^-3 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    ├─── unit:PERCENT symbol: %
+  #    └─── unit:SEC symbol: s
+unit:PERCENT-SEC-PER-IN3 qudt:symbol "%·s/in³" .
+
+  # WRONG SYMBOL  : unit:PERCENT-SEC-PER-L - calculated from factors: %·s/L, actual: %/(l/s)
+  #
+  #  ──┬ unit:PERCENT-SEC-PER-L symbol: %/(l/s) (correct: %·s/L)
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    ├─── unit:PERCENT symbol: %
+  #    └─── unit:SEC symbol: s
+unit:PERCENT-SEC-PER-L qudt:symbol "%·s/L" .
+
+  # WRONG SYMBOL  : unit:PERCENT-SEC-PER-M3 - calculated from factors: %·s/m³, actual: %/(m³/s)
+  #
+  #  ──┬ unit:PERCENT-SEC-PER-M3 symbol: %/(m³/s) (correct: %·s/m³)
+  #    ├─── unit:M^-3 symbol: m
+  #    ├─── unit:PERCENT symbol: %
+  #    └─── unit:SEC symbol: s
+unit:PERCENT-SEC-PER-M3 qudt:symbol "%·s/m³" .
+
+  # WRONG SYMBOL  : unit:PERCENT-SEC-PER-YD3 - calculated from factors: %·s/yd³, actual: %/(yd³/s)
+  #
+  #  ──┬ unit:PERCENT-SEC-PER-YD3 symbol: %/(yd³/s) (correct: %·s/yd³)
+  #    ├─── unit:PERCENT symbol: %
+  #    ├─── unit:SEC symbol: s
+  #    └──┬ unit:YD^-3 symbol: yd
+  #       └──┬ unit:FT symbol: ft
+  #          └──┬ unit:IN symbol: in
+  #             └─── unit:M symbol: m
+unit:PERCENT-SEC-PER-YD3 qudt:symbol "%·s/yd³" .
+
+  # WRONG SYMBOL  : unit:PINT_UK-PER-DAY - calculated from factors: pt{UK}/d, actual: pt{UK}/day
+  #
+  #  ──┬ unit:PINT_UK-PER-DAY symbol: pt{UK}/day (correct: pt{UK}/d)
+  #    ├──┬ unit:PINT_UK symbol: pt{UK}
+  #    │  └──┬ unit:QT_UK symbol: qt{UK}
+  #    │     └──┬ unit:GAL_UK symbol: gal{UK}
+  #    │        └──┬ unit:L symbol: L
+  #    │           └──┬ unit:DeciM3 symbol: dm³
+  #    │              └──┬ unit:DeciM^3 symbol: dm
+  #    │                 └─── unit:M symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:PINT_UK-PER-DAY qudt:symbol "pt{UK}/d" .
+
+  # WRONG SYMBOL  : unit:PINT_US-PER-DAY - calculated from factors: pt{US}/d, actual: pt{US}/day
+  #
+  #  ──┬ unit:PINT_US-PER-DAY symbol: pt{US}/day (correct: pt{US}/d)
+  #    ├──┬ unit:PINT_US symbol: pt{US}
+  #    │  └──┬ unit:QT_US symbol: qt{US liq}
+  #    │     └──┬ unit:GAL_US symbol: gal{US}
+  #    │        └──┬ unit:IN^3 symbol: in
+  #    │           └─── unit:M symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:PINT_US-PER-DAY qudt:symbol "pt{US}/d" .
+
+  # WRONG SYMBOL  : unit:PK_UK-PER-DAY - calculated from factors: peck{UK}/d, actual: peck{UK}/day
+  #
+  #  ──┬ unit:PK_UK-PER-DAY symbol: peck{UK}/day (correct: peck{UK}/d)
+  #    ├──┬ unit:PK_UK symbol: peck{UK}
+  #    │  └──┬ unit:M3 symbol: m³
+  #    │     └─── unit:M^3 symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:PK_UK-PER-DAY qudt:symbol "peck{UK}/d" .
+
+  # WRONG SYMBOL  : unit:PK_US_DRY-PER-DAY - calculated from factors: peck{US Dry}/d, actual: peck{US Dry}/day
+  #
+  #  ──┬ unit:PK_US_DRY-PER-DAY symbol: peck{US Dry}/day (correct: peck{US Dry}/d)
+  #    ├──┬ unit:PK_US_DRY symbol: peck{US Dry}
+  #    │  └──┬ unit:M3 symbol: m³
+  #    │     └─── unit:M^3 symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:PK_US_DRY-PER-DAY qudt:symbol "peck{US Dry}/d" .
+
+  # WRONG SYMBOL  : unit:PicoA-PER-MicroMOL-L - calculated from factors: pA/(μmol·L), actual: pA/(µmol·L)
+  #
+  #  ──┬ unit:PicoA-PER-MicroMOL-L symbol: pA/(µmol·L) (correct: pA/(μmol·L))
+  #    ├──┬ unit:PicoA symbol: pA
+  #    │  └─── unit:A symbol: A
+  #    ├──┬ unit:MicroMOL^-1 symbol: μmol
+  #    │  └─── unit:MOL symbol: mol
+  #    └──┬ unit:L^-1 symbol: L
+  #       └──┬ unit:DeciM3 symbol: dm³
+  #          └──┬ unit:DeciM^3 symbol: dm
+  #             └─── unit:M symbol: m
+unit:PicoA-PER-MicroMOL-L qudt:symbol "pA/(μmol·L)" .
+
+  # WRONG SYMBOL  : unit:PicoMOL-PER-L-DAY - calculated from factors: pmol/(L·d), actual: pmol/(L·day)
+  #
+  #  ──┬ unit:PicoMOL-PER-L-DAY symbol: pmol/(L·day) (correct: pmol/(L·d))
+  #    ├──┬ unit:PicoMOL symbol: pmol
+  #    │  └─── unit:MOL symbol: mol
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:PicoMOL-PER-L-DAY qudt:symbol "pmol/(L·d)" .
+
+  # WRONG SYMBOL  : unit:PicoMOL-PER-M2-DAY - calculated from factors: pmol/(m²·d), actual: pmol/(m²·day)
+  #
+  #  ──┬ unit:PicoMOL-PER-M2-DAY symbol: pmol/(m²·day) (correct: pmol/(m²·d))
+  #    ├──┬ unit:PicoMOL symbol: pmol
+  #    │  └─── unit:MOL symbol: mol
+  #    ├─── unit:M^-2 symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:PicoMOL-PER-M2-DAY qudt:symbol "pmol/(m²·d)" .
+
+  # WRONG SYMBOL  : unit:QT_UK-PER-DAY - calculated from factors: qt{UK}/d, actual: qt{UK}/day
+  #
+  #  ──┬ unit:QT_UK-PER-DAY symbol: qt{UK}/day (correct: qt{UK}/d)
+  #    ├──┬ unit:QT_UK symbol: qt{UK}
+  #    │  └──┬ unit:GAL_UK symbol: gal{UK}
+  #    │     └──┬ unit:L symbol: L
+  #    │        └──┬ unit:DeciM3 symbol: dm³
+  #    │           └──┬ unit:DeciM^3 symbol: dm
+  #    │              └─── unit:M symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:QT_UK-PER-DAY qudt:symbol "qt{UK}/d" .
+
+  # WRONG SYMBOL  : unit:QT_US-PER-DAY - calculated from factors: qt{US liq}/d, actual: qt/day
+  #
+  #  ──┬ unit:QT_US-PER-DAY symbol: qt/day (correct: qt{US liq}/d)
+  #    ├──┬ unit:QT_US symbol: qt{US liq}
+  #    │  └──┬ unit:GAL_US symbol: gal{US}
+  #    │     └──┬ unit:IN^3 symbol: in
+  #    │        └─── unit:M symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:QT_US-PER-DAY qudt:symbol "qt{US liq}/d" .
+
+  # WRONG SYMBOL  : unit:QT_US-PER-HR - calculated from factors: qt{US liq}/h, actual: qt/h
+  #
+  #  ──┬ unit:QT_US-PER-HR symbol: qt/h (correct: qt{US liq}/h)
+  #    ├──┬ unit:QT_US symbol: qt{US liq}
+  #    │  └──┬ unit:GAL_US symbol: gal{US}
+  #    │     └──┬ unit:IN^3 symbol: in
+  #    │        └─── unit:M symbol: m
+  #    └──┬ unit:HR^-1 symbol: h
+  #       └─── unit:SEC symbol: s
+unit:QT_US-PER-HR qudt:symbol "qt{US liq}/h" .
+
+  # WRONG SYMBOL  : unit:QT_US-PER-MIN - calculated from factors: qt{US liq}/min, actual: qt/min
+  #
+  #  ──┬ unit:QT_US-PER-MIN symbol: qt/min (correct: qt{US liq}/min)
+  #    ├──┬ unit:QT_US symbol: qt{US liq}
+  #    │  └──┬ unit:GAL_US symbol: gal{US}
+  #    │     └──┬ unit:IN^3 symbol: in
+  #    │        └─── unit:M symbol: m
+  #    └──┬ unit:MIN^-1 symbol: min
+  #       └─── unit:SEC symbol: s
+unit:QT_US-PER-MIN qudt:symbol "qt{US liq}/min" .
+
+  # WRONG SYMBOL  : unit:QT_US-PER-SEC - calculated from factors: qt{US liq}/s, actual: qt/s
+  #
+  #  ──┬ unit:QT_US-PER-SEC symbol: qt/s (correct: qt{US liq}/s)
+  #    ├──┬ unit:QT_US symbol: qt{US liq}
+  #    │  └──┬ unit:GAL_US symbol: gal{US}
+  #    │     └──┬ unit:IN^3 symbol: in
+  #    │        └─── unit:M symbol: m
+  #    └─── unit:SEC^-1 symbol: s
+unit:QT_US-PER-SEC qudt:symbol "qt{US liq}/s" .
+
+  # WRONG SYMBOL  : unit:REV-PER-MIN-SEC - calculated from factors: rev/(min·s), actual: rev/min/s
+  #
+  #  ──┬ unit:REV-PER-MIN-SEC symbol: rev/min/s (correct: rev/(min·s))
+  #    ├─── unit:REV symbol: rev
+  #    ├──┬ unit:MIN^-1 symbol: min
+  #    │  └─── unit:SEC symbol: s
+  #    └─── unit:SEC^-1 symbol: s
+unit:REV-PER-MIN-SEC qudt:symbol "rev/(min·s)" .
+
+  # WRONG SYMBOL  : unit:SCF-PER-HR - calculated from factors: scf/h, actual: scfh
+  #
+  #  ──┬ unit:SCF-PER-HR symbol: scfh (correct: scf/h)
+  #    ├─── unit:SCF symbol: scf
+  #    └──┬ unit:HR^-1 symbol: h
+  #       └─── unit:SEC symbol: s
+unit:SCF-PER-HR qudt:symbol "scf/h" .
+
+  # WRONG SYMBOL  : unit:SCF-PER-MIN - calculated from factors: scf/min, actual: scfm
+  #
+  #  ──┬ unit:SCF-PER-MIN symbol: scfm (correct: scf/min)
+  #    ├─── unit:SCF symbol: scf
+  #    └──┬ unit:MIN^-1 symbol: min
+  #       └─── unit:SEC symbol: s
+unit:SCF-PER-MIN qudt:symbol "scf/min" .
+
+  # WRONG SYMBOL  : unit:SCM-PER-HR - calculated from factors: scm/h, actual: scmh
+  #
+  #  ──┬ unit:SCM-PER-HR symbol: scmh (correct: scm/h)
+  #    ├─── unit:SCM symbol: scm
+  #    └──┬ unit:HR^-1 symbol: h
+  #       └─── unit:SEC symbol: s
+unit:SCM-PER-HR qudt:symbol "scm/h" .
+
+  # WRONG SYMBOL  : unit:SCM-PER-MIN - calculated from factors: scm/min, actual: scmm
+  #
+  #  ──┬ unit:SCM-PER-MIN symbol: scmm (correct: scm/min)
+  #    ├─── unit:SCM symbol: scm
+  #    └──┬ unit:MIN^-1 symbol: min
+  #       └─── unit:SEC symbol: s
+unit:SCM-PER-MIN qudt:symbol "scm/min" .
+
+  # WRONG SYMBOL  : unit:SEC-PER-FT2 - calculated from factors: s/ft², actual: (lb/ft³)/(lb/(ft·s)
+  #
+  #  ──┬ unit:SEC-PER-FT2 symbol: (lb/ft³)/(lb/(ft·s) (correct: s/ft²)
+  #    ├─── unit:SEC symbol: s
+  #    └──┬ unit:FT^-2 symbol: ft
+  #       └──┬ unit:IN symbol: in
+  #          └─── unit:M symbol: m
+unit:SEC-PER-FT2 qudt:symbol "s/ft²" .
+
+  # WRONG SYMBOL  : unit:SLUG-PER-DAY - calculated from factors: slug/d, actual: slug/day
+  #
+  #  ──┬ unit:SLUG-PER-DAY symbol: slug/day (correct: slug/d)
+  #    ├──┬ unit:SLUG symbol: slug
+  #    │  └──┬ unit:LB symbol: lbm
+  #    │     └──┬ unit:KiloGM symbol: kg
+  #    │        └─── unit:GM symbol: g
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:SLUG-PER-DAY qudt:symbol "slug/d" .
+
+  # WRONG SYMBOL  : unit:TONNE-PER-DAY - calculated from factors: t/d, actual: t/day
+  #
+  #  ──┬ unit:TONNE-PER-DAY symbol: t/day (correct: t/d)
+  #    ├──┬ unit:TONNE symbol: t
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:TONNE-PER-DAY qudt:symbol "t/d" .
+
+  # WRONG SYMBOL  : unit:TONNE-PER-YR - calculated from factors: t/a, actual: t/y
+  #
+  #  ──┬ unit:TONNE-PER-YR symbol: t/y (correct: t/a)
+  #    ├──┬ unit:TONNE symbol: t
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    └──┬ unit:YR^-1 symbol: a
+  #       └─── unit:SEC symbol: s
+unit:TONNE-PER-YR qudt:symbol "t/a" .
+
+  # WRONG SYMBOL  : unit:TON_Metric-PER-DAY - calculated from factors: t/d, actual: t/day
+  #
+  #  ──┬ unit:TON_Metric-PER-DAY symbol: t/day (correct: t/d)
+  #    ├──┬ unit:TON_Metric symbol: t
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:TON_Metric-PER-DAY qudt:symbol "t/d" .
+
+  # WRONG SYMBOL  : unit:TON_UK-PER-DAY - calculated from factors: ton{UK}/d, actual: ton{UK}/day
+  #
+  #  ──┬ unit:TON_UK-PER-DAY symbol: ton{UK}/day (correct: ton{UK}/d)
+  #    ├──┬ unit:TON_UK symbol: ton{UK}
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:TON_UK-PER-DAY qudt:symbol "ton{UK}/d" .
+
+  # WRONG SYMBOL  : unit:TON_US-PER-DAY - calculated from factors: ton{US}/d, actual: ton{US}/day
+  #
+  #  ──┬ unit:TON_US-PER-DAY symbol: ton{US}/day (correct: ton{US}/d)
+  #    ├──┬ unit:TON_US symbol: ton{US}
+  #    │  └──┬ unit:KiloGM symbol: kg
+  #    │     └─── unit:GM symbol: g
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:TON_US-PER-DAY qudt:symbol "ton{US}/d" .
+
+  # WRONG SYMBOL  : unit:V-IN2-PER-LB_F - calculated from factors: V·in²/lbf, actual: V/psi
+  #
+  #  ──┬ unit:V-IN2-PER-LB_F symbol: V/psi (correct: V·in²/lbf)
+  #    ├──┬ unit:V symbol: V
+  #    │  ├─── unit:A^-1 symbol: A
+  #    │  └──┬ unit:W symbol: W
+  #    │     ├──┬ unit:J symbol: J
+  #    │     │  ├─── unit:M symbol: m
+  #    │     │  └──┬ unit:N symbol: N
+  #    │     │     ├──┬ unit:KiloGM symbol: kg
+  #    │     │     │  └─── unit:GM symbol: g
+  #    │     │     ├─── unit:M symbol: m
+  #    │     │     └─── unit:SEC^-2 symbol: s
+  #    │     └─── unit:SEC^-1 symbol: s
+  #    ├──┬ unit:IN^2 symbol: in
+  #    │  └─── unit:M symbol: m
+  #    └──┬ unit:LB_F^-1 symbol: lbf
+  #       ├──┬ unit:FT symbol: ft
+  #       │  └──┬ unit:IN symbol: in
+  #       │     └─── unit:M symbol: m
+  #       ├─── unit:SEC^-2 symbol: s
+  #       └──┬ unit:SLUG symbol: slug
+  #          └──┬ unit:LB symbol: lbm
+  #             └──┬ unit:KiloGM symbol: kg
+  #                └─── unit:GM symbol: g
+unit:V-IN2-PER-LB_F qudt:symbol "V·in²/lbf" .
+
+  # WRONG SYMBOL  : unit:V-PER-L-MIN - calculated from factors: V/(L·min), actual: V/(l·min)
+  #
+  #  ──┬ unit:V-PER-L-MIN symbol: V/(l·min) (correct: V/(L·min))
+  #    ├──┬ unit:V symbol: V
+  #    │  ├─── unit:A^-1 symbol: A
+  #    │  └──┬ unit:W symbol: W
+  #    │     ├──┬ unit:J symbol: J
+  #    │     │  ├─── unit:M symbol: m
+  #    │     │  └──┬ unit:N symbol: N
+  #    │     │     ├──┬ unit:KiloGM symbol: kg
+  #    │     │     │  └─── unit:GM symbol: g
+  #    │     │     ├─── unit:M symbol: m
+  #    │     │     └─── unit:SEC^-2 symbol: s
+  #    │     └─── unit:SEC^-1 symbol: s
+  #    ├──┬ unit:L^-1 symbol: L
+  #    │  └──┬ unit:DeciM3 symbol: dm³
+  #    │     └──┬ unit:DeciM^3 symbol: dm
+  #    │        └─── unit:M symbol: m
+  #    └──┬ unit:MIN^-1 symbol: min
+  #       └─── unit:SEC symbol: s
+unit:V-PER-L-MIN qudt:symbol "V/(L·min)" .
+
+  # WRONG SYMBOL  : unit:W-HR-PER-L - calculated from factors: W·h/L, actual: W·h/l
+  #
+  #  ──┬ unit:W-HR-PER-L symbol: W·h/l (correct: W·h/L)
+  #    ├──┬ unit:W symbol: W
+  #    │  ├──┬ unit:J symbol: J
+  #    │  │  ├─── unit:M symbol: m
+  #    │  │  └──┬ unit:N symbol: N
+  #    │  │     ├──┬ unit:KiloGM symbol: kg
+  #    │  │     │  └─── unit:GM symbol: g
+  #    │  │     ├─── unit:M symbol: m
+  #    │  │     └─── unit:SEC^-2 symbol: s
+  #    │  └─── unit:SEC^-1 symbol: s
+  #    ├──┬ unit:HR symbol: h
+  #    │  └─── unit:SEC symbol: s
+  #    └──┬ unit:L^-1 symbol: L
+  #       └──┬ unit:DeciM3 symbol: dm³
+  #          └──┬ unit:DeciM^3 symbol: dm
+  #             └─── unit:M symbol: m
+unit:W-HR-PER-L qudt:symbol "W·h/L" .
+
+  # WRONG SYMBOL  : unit:YD2 - calculated from factors: yd², actual: sqyd
+  #
+  #  ──┬ unit:YD2 symbol: sqyd (correct: yd²)
+  #    └──┬ unit:YD^2 symbol: yd
+  #       └──┬ unit:FT symbol: ft
+  #          └──┬ unit:IN symbol: in
+  #             └─── unit:M symbol: m
+unit:YD2 qudt:symbol "yd²" .
+
+  # WRONG SYMBOL  : unit:YD3-PER-DAY - calculated from factors: yd³/d, actual: yd³/day
+  #
+  #  ──┬ unit:YD3-PER-DAY symbol: yd³/day (correct: yd³/d)
+  #    ├──┬ unit:YD^3 symbol: yd
+  #    │  └──┬ unit:FT symbol: ft
+  #    │     └──┬ unit:IN symbol: in
+  #    │        └─── unit:M symbol: m
+  #    └──┬ unit:DAY^-1 symbol: d
+  #       └─── unit:SEC symbol: s
+unit:YD3-PER-DAY qudt:symbol "yd³/d" .
 


### PR DESCRIPTION
Fixes #1112 

This will not build as there are additional qudt:symbol triples with comments explaining how they were formed.

Presumably we will find a few bugs, which would be best handled by fixing them in qudtlib and regenerating the changes.

Once the changes are all ok, we can generate a query that deletes the wrong symbols and then add the correct ones, so we don't really have to merge it all manually.