### PR TITLE
Fix IEC Codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
 
 ## [Unreleased]
 
+## [3.0.0] - 2025-02-16
+
+### Changed
+
+- Removed invalid qudt:iec61360Code values (most in the 'UAD' range) from about 40 units, most notably unit:M that was submitted as a bug.
+  
 ### Added
 
 - New Units

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
 ### Changed
 
 - Removed invalid qudt:iec61360Code values (most in the 'UAD' range) from about 40 units, most notably unit:M that was submitted as a bug.
-  
+
 ### Added
 
 - New Units

--- a/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
+++ b/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
@@ -53,7 +53,6 @@ Note that SI supports only the use of symbols and deprecates the use of any abbr
   qudt:hasQuantityKind quantitykind:MagnetomotiveForce ;
   qudt:hasQuantityKind quantitykind:TotalCurrent ;
   qudt:iec61360Code "0112/2///62720#UAA101" ;
-  qudt:iec61360Code "0112/2///62720#UAD717" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Ampere?oldid=494026699"^^xsd:anyURI ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/ampere> ;
   qudt:siExactMatch si-unit:ampere ;
@@ -380,7 +379,6 @@ unit:A-PER-KiloGM
   qudt:hasDimensionVector qkdv:A0E1L0I0M-1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:MassicElectricCurrent ;
   qudt:iec61360Code "0112/2///62720#UAB485" ;
-  qudt:iec61360Code "0112/2///62720#UAD543" ;
   qudt:symbol "A/kg" ;
   qudt:ucumCode "A.kg-1"^^qudt:UCUMcs ;
   qudt:ucumCode "A/kg"^^qudt:UCUMcs ;
@@ -447,7 +445,6 @@ This unit is commonly used in the SI unit system.
   qudt:hasQuantityKind quantitykind:ElectricCurrentDensity ;
   qudt:hasQuantityKind quantitykind:TotalCurrentDensity ;
   qudt:iec61360Code "0112/2///62720#UAA105" ;
-  qudt:iec61360Code "0112/2///62720#UAD533" ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Current_density"^^xsd:anyURI ;
   qudt:symbol "A/m²" ;
   qudt:ucumCode "A.m-2"^^qudt:UCUMcs ;
@@ -4276,7 +4273,6 @@ unit:CD
   qudt:hasDimensionVector qkdv:A0E0L0I1M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:LuminousIntensity ;
   qudt:iec61360Code "0112/2///62720#UAA370" ;
-  qudt:iec61360Code "0112/2///62720#UAD719" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Candela?oldid=484253082"^^xsd:anyURI ;
   qudt:informativeReference "http://www.simetric.co.uk/siderived.htm"^^xsd:anyURI ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/candela> ;
@@ -14787,7 +14783,6 @@ unit:K
   qudt:hasQuantityKind quantitykind:Temperature ;
   qudt:hasQuantityKind quantitykind:ThermodynamicTemperature ;
   qudt:iec61360Code "0112/2///62720#UAA185" ;
-  qudt:iec61360Code "0112/2///62720#UAD721" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Kelvin?oldid=495075694"^^xsd:anyURI ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/kelvin> ;
   qudt:siExactMatch si-unit:kelvin ;
@@ -14936,7 +14931,6 @@ unit:K-PER-K
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:TemperatureRatio ;
   qudt:iec61360Code "0112/2///62720#UAA186" ;
-  qudt:iec61360Code "0112/2///62720#UAD694" ;
   qudt:plainTextDescription "SI base unit kelvin divided by the SI base unit kelvin" ;
   qudt:symbol "K/K" ;
   qudt:ucumCode "K.K-1"^^qudt:UCUMcs ;
@@ -16194,7 +16188,6 @@ unit:KiloGM
   qudt:hasQuantityKind quantitykind:CO2Equivalent ;
   qudt:hasQuantityKind quantitykind:Mass ;
   qudt:iec61360Code "0112/2///62720#UAA594" ;
-  qudt:iec61360Code "0112/2///62720#UAD720" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Kilogram?oldid=493633626"^^xsd:anyURI ;
   qudt:plainTextDescription "The kilogram or kilogramme (SI symbol: kg), also known as the kilo, is the base unit of mass in the International System of Units and is defined as being equal to the mass of the International Prototype Kilogram (IPK), which is almost exactly equal to the mass of one liter of water. The avoirdupois (or international) pound, used in both the Imperial system and U.S. customary units, is defined as exactly 0.45359237 kg, making one kilogram approximately equal to 2.2046 avoirdupois pounds." ;
   qudt:siExactMatch si-unit:kilogram ;
@@ -16734,7 +16727,6 @@ unit:KiloGM-PER-K
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H-1T0D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA595" ;
-  qudt:iec61360Code "0112/2///62720#UAD684" ;
   qudt:symbol "kg/K" ;
   qudt:ucumCode "kg.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F15" ;
@@ -16946,7 +16938,6 @@ unit:KiloGM-PER-M-SEC
   qudt:hasQuantityKind quantitykind:DynamicViscosity ;
   qudt:hasQuantityKind quantitykind:Viscosity ;
   qudt:iec61360Code "0112/2///62720#UAB429" ;
-  qudt:iec61360Code "0112/2///62720#UAD529" ;
   qudt:symbol "kg/(m·s)" ;
   qudt:ucumCode "kg.m-1.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "N37" ;
@@ -16968,7 +16959,6 @@ unit:KiloGM-PER-M-SEC2
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerArea ;
   qudt:hasQuantityKind quantitykind:VaporPressure ;
-  qudt:iec61360Code "0112/2///62720#UAD540" ;
   qudt:siUnitsExpression "kg/m/s^2" ;
   qudt:symbol "kg/(m·s²)" ;
   qudt:ucumCode "kg.m-1.s-2"^^qudt:UCUMcs ;
@@ -17135,7 +17125,6 @@ unit:KiloGM-PER-M3-K
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H-1T0D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA620" ;
-  qudt:iec61360Code "0112/2///62720#UAD685" ;
   qudt:symbol "kg/(m³·K)" ;
   qudt:ucumCode "kg.m-3.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G40" ;
@@ -17368,7 +17357,6 @@ unit:KiloGM-PER-SEC-K
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA630" ;
-  qudt:iec61360Code "0112/2///62720#UAD687" ;
   qudt:symbol "kg/(s·K)" ;
   qudt:ucumCode "kg.s-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F42" ;
@@ -21650,7 +21638,6 @@ unit:M
   qudt:hasQuantityKind quantitykind:ElevationRelativeToNAP ;
   qudt:hasQuantityKind quantitykind:Length ;
   qudt:iec61360Code "0112/2///62720#UAA726" ;
-  qudt:iec61360Code "0112/2///62720#UAD718" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Metre?oldid=495145797"^^xsd:anyURI ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/metre> ;
   qudt:plainTextDescription "The metric and SI base unit of distance.   The meter is equal to approximately 1.093 613 3 yards, 3.280 840 feet, or 39.370 079 inches." ;
@@ -21874,7 +21861,6 @@ unit:M-PER-K
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H-1T0D0 ;
   qudt:hasQuantityKind quantitykind:LinearThermalExpansion ;
   qudt:iec61360Code "0112/2///62720#UAA728" ;
-  qudt:iec61360Code "0112/2///62720#UAD682" ;
   qudt:symbol "m/K" ;
   qudt:ucumCode "m/K"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F52" ;
@@ -21968,7 +21954,6 @@ The official SI symbolic abbreviation is mu00b7s-1, or equivalently either m/s."
   qudt:hasQuantityKind quantitykind:Speed ;
   qudt:hasQuantityKind quantitykind:Velocity ;
   qudt:iec61360Code "0112/2///62720#UAA733" ;
-  qudt:iec61360Code "0112/2///62720#UAD515" ;
   qudt:symbol "m/s" ;
   qudt:ucumCode "m.s-1"^^qudt:UCUMcs ;
   qudt:ucumCode "m/s"^^qudt:UCUMcs ;
@@ -22020,7 +22005,6 @@ unit:M-PER-SEC-K
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAC009" ;
-  qudt:iec61360Code "0112/2///62720#UAD696" ;
   qudt:symbol "m/(s·K)" ;
   qudt:ucumCode "m.s-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L12" ;
@@ -22057,7 +22041,6 @@ unit:M-PER-SEC2
   qudt:hasQuantityKind quantitykind:Acceleration ;
   qudt:hasQuantityKind quantitykind:LinearAcceleration ;
   qudt:iec61360Code "0112/2///62720#UAA736" ;
-  qudt:iec61360Code "0112/2///62720#UAD503" ;
   qudt:symbol "m/s²" ;
   qudt:ucumCode "m.s-2"^^qudt:UCUMcs ;
   qudt:ucumCode "m/s2"^^qudt:UCUMcs ;
@@ -22577,7 +22560,6 @@ unit:M2-PER-SEC
   qudt:hasQuantityKind quantitykind:NeutronDiffusionCoefficient ;
   qudt:hasQuantityKind quantitykind:ThermalDiffusionRatioCoefficient ;
   qudt:iec61360Code "0112/2///62720#UAA752" ;
-  qudt:iec61360Code "0112/2///62720#UAD526" ;
   qudt:symbol "m²/s" ;
   qudt:ucumCode "m2.s-1"^^qudt:UCUMcs ;
   qudt:ucumCode "m2/s"^^qudt:UCUMcs ;
@@ -22638,7 +22620,6 @@ unit:M2-PER-SEC-K
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA753" ;
-  qudt:iec61360Code "0112/2///62720#UAD680" ;
   qudt:symbol "m²/(s·K)" ;
   qudt:ucumCode "m2.s-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G09" ;
@@ -22708,7 +22689,6 @@ unit:M2-PER-SR
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:AngularCrossSection ;
   qudt:iec61360Code "0112/2///62720#UAA755" ;
-  qudt:iec61360Code "0112/2///62720#UAD507" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Steradian?oldid=494317847"^^xsd:anyURI ;
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
   qudt:symbol "m²/sr" ;
@@ -23037,7 +23017,6 @@ unit:M3-PER-K
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H-1T0D0 ;
   qudt:hasQuantityKind quantitykind:VolumeThermalExpansion ;
   qudt:iec61360Code "0112/2///62720#UAA758" ;
-  qudt:iec61360Code "0112/2///62720#UAD699" ;
   qudt:symbol "m³/K" ;
   qudt:ucumCode "m3.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G29" ;
@@ -23120,7 +23099,6 @@ unit:M3-PER-M3
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:VolumeFraction ;
   qudt:iec61360Code "0112/2///62720#UAA767" ;
-  qudt:iec61360Code "0112/2///62720#UAD706" ;
   qudt:plainTextDescription "power of the SI base unit metre with the exponent 3 divided by the power of the SI base unit metre with the exponent 3" ;
   qudt:symbol "m³/m³" ;
   qudt:ucumCode "m3.m-3"^^qudt:UCUMcs ;
@@ -23262,7 +23240,6 @@ unit:M3-PER-SEC
   qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
   qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA772" ;
-  qudt:iec61360Code "0112/2///62720#UAD705" ;
   qudt:symbol "m³/s" ;
   qudt:ucumCode "m3.s-1"^^qudt:UCUMcs ;
   qudt:ucumCode "m3/s"^^qudt:UCUMcs ;
@@ -23293,7 +23270,6 @@ unit:M3-PER-SEC-K
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H-1T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA773" ;
-  qudt:iec61360Code "0112/2///62720#UAD701" ;
   qudt:symbol "m³/(s·K)" ;
   qudt:ucumCode "m3.s-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G72" ;
@@ -23915,7 +23891,6 @@ unit:MOL
   qudt:hasQuantityKind quantitykind:AmountOfSubstance ;
   qudt:hasQuantityKind quantitykind:ExtentOfReaction ;
   qudt:iec61360Code "0112/2///62720#UAA882" ;
-  qudt:iec61360Code "0112/2///62720#UAD716" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Mole_(unit)"^^xsd:anyURI ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/mole> ;
   qudt:siExactMatch si-unit:mole ;
@@ -24073,7 +24048,6 @@ unit:MOL-PER-KiloGM-K
   qudt:hasDimensionVector qkdv:A1E0L0I0M-1H-1T0D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA886" ;
-  qudt:iec61360Code "0112/2///62720#UAD689" ;
   qudt:symbol "mol/(K·kg)" ;
   qudt:ucumCode "mol.K-1.kg-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L24" ;
@@ -24232,7 +24206,6 @@ unit:MOL-PER-M3
   qudt:hasQuantityKind quantitykind:Concentration ;
   qudt:hasQuantityKind quantitykind:Solubility_Water ;
   qudt:iec61360Code "0112/2///62720#UAA891" ;
-  qudt:iec61360Code "0112/2///62720#UAD505" ;
   qudt:symbol "mol/m³" ;
   qudt:ucumCode "mol.m-3"^^qudt:UCUMcs ;
   qudt:ucumCode "mol/m3"^^qudt:UCUMcs ;
@@ -24263,7 +24236,6 @@ unit:MOL-PER-M3-K
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H-1T0D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA892" ;
-  qudt:iec61360Code "0112/2///62720#UAD691" ;
   qudt:symbol "mol/(m³·K)" ;
   qudt:ucumCode "mol.m-3.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L28" ;
@@ -24339,7 +24311,6 @@ unit:MOL-PER-SEC
   qudt:hasDimensionVector qkdv:A1E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:MolarFlowRate ;
   qudt:iec61360Code "0112/2///62720#UAA895" ;
-  qudt:iec61360Code "0112/2///62720#UAD519" ;
   qudt:plainTextDescription "SI base unit mol divided by the SI base unit second" ;
   qudt:symbol "mol/s" ;
   qudt:ucumCode "mol.s-1"^^qudt:UCUMcs ;
@@ -35922,7 +35893,6 @@ unit:PER-M
   qudt:hasQuantityKind quantitykind:PhaseCoefficient ;
   qudt:hasQuantityKind quantitykind:PropagationCoefficient ;
   qudt:iec61360Code "0112/2///62720#UAA738" ;
-  qudt:iec61360Code "0112/2///62720#UAD635" ;
   qudt:symbol "/m" ;
   qudt:ucumCode "/m"^^qudt:UCUMcs ;
   qudt:ucumCode "m-1"^^qudt:UCUMcs ;
@@ -36020,7 +35990,6 @@ unit:PER-M2
   qudt:exactMatch unit:NUM-PER-M2 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:ParticleFluence ;
-  qudt:iec61360Code "0112/2///62720#UAA739" ;
   qudt:iec61360Code "0112/2///62720#UAD611" ;
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
   qudt:symbol "/m²" ;
@@ -36069,7 +36038,6 @@ unit:PER-M3
   qudt:hasDimensionVector qkdv:A0E0L-3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:InverseVolume ;
   qudt:iec61360Code "0112/2///62720#UAA740" ;
-  qudt:iec61360Code "0112/2///62720#UAD524" ;
   qudt:symbol "/m³" ;
   qudt:ucumCode "/m3"^^qudt:UCUMcs ;
   qudt:ucumCode "m-3"^^qudt:UCUMcs ;
@@ -36172,7 +36140,6 @@ unit:PER-MOL
   qudt:expression "$/mol$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A-1E0L0I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:InverseAmountOfSubstance ;
-  qudt:iec61360Code "0112/2///62720#UAA896" ;
   qudt:iec61360Code "0112/2///62720#UAD514" ;
   qudt:symbol "/mol" ;
   qudt:ucumCode "/mol"^^qudt:UCUMcs ;
@@ -37028,7 +36995,6 @@ unit:PERCENT-HR-PER-YD3
   qudt:hasDimensionVector qkdv:A0E0L-3I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAC787" ;
-  qudt:iec61360Code "0112/2///62720#UAD872" ;
   qudt:symbol "h·%/yd³" ;
   qudt:ucumCode "h.%.[yd_i]-3"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -40320,7 +40286,6 @@ unit:RAD-PER-M
   qudt:hasQuantityKind quantitykind:DebyeAngularWavenumber ;
   qudt:hasQuantityKind quantitykind:FermiAngularWavenumber ;
   qudt:iec61360Code "0112/2///62720#UAA967" ;
-  qudt:iec61360Code "0112/2///62720#UAD510" ;
   qudt:informativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
   qudt:symbol "rad/m" ;
   qudt:ucumCode "rad.m-1"^^qudt:UCUMcs ;
@@ -40381,7 +40346,6 @@ unit:RAD-PER-SEC
   qudt:hasQuantityKind quantitykind:AngularFrequency ;
   qudt:hasQuantityKind quantitykind:AngularVelocity ;
   qudt:iec61360Code "0112/2///62720#UAA968" ;
-  qudt:iec61360Code "0112/2///62720#UAD509" ;
   qudt:symbol "rad/s" ;
   qudt:ucumCode "rad.s-1"^^qudt:UCUMcs ;
   qudt:ucumCode "rad/s"^^qudt:UCUMcs ;
@@ -40421,7 +40385,6 @@ unit:RAD-PER-SEC2
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:AngularAcceleration ;
   qudt:iec61360Code "0112/2///62720#UAA969" ;
-  qudt:iec61360Code "0112/2///62720#UAD506" ;
   qudt:symbol "rad/s²" ;
   qudt:ucumCode "rad.s-2"^^qudt:UCUMcs ;
   qudt:ucumCode "rad/s2"^^qudt:UCUMcs ;
@@ -40934,7 +40897,6 @@ Under the International System of Units (via the International Committee for Wei
   qudt:hasQuantityKind quantitykind:Period ;
   qudt:hasQuantityKind quantitykind:Time ;
   qudt:iec61360Code "0112/2///62720#UAA972" ;
-  qudt:iec61360Code "0112/2///62720#UAD722" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Second?oldid=495241006"^^xsd:anyURI ;
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/second-Time> ;
   qudt:siExactMatch si-unit:second ;
@@ -41005,7 +40967,6 @@ unit:SEC-PER-KiloGM
   qudt:hasDimensionVector qkdv:A0E0L0I0M-1H0T1D0 ;
   qudt:hasQuantityKind quantitykind:EinsteinCoefficients ;
   qudt:iec61360Code "0112/2///62720#UAB349" ;
-  qudt:iec61360Code "0112/2///62720#UAD530" ;
   qudt:symbol "s/kg" ;
   qudt:ucumCode "s.kg-1"^^qudt:UCUMcs ;
   qudt:ucumCode "s/kg"^^qudt:UCUMcs ;


### PR DESCRIPTION
Remove invalid iec61360Code values on about 40 units, including unit:M.

Fixes #1118 