### PR TITLE
Enable filtering of SHACL validation results

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <qudtPrevReleaseYear>TODO-set-property-qudtPrevReleaseYear</qudtPrevReleaseYear>
         <qudtPrevReleaseMonth>TODO-set-property-qudtPrevReleaseMonth</qudtPrevReleaseMonth>
+        <shacl.severity.log>Violation</shacl.severity.log>
     </properties>
     <scm>
         <connection>scm:git:https://github.com/qudt/qudt-public-repo.git</connection>
@@ -302,7 +303,7 @@
             <plugin>
                 <groupId>io.github.qudtlib</groupId>
                 <artifactId>shacl-maven-plugin</artifactId>
-                <version>1.0.4</version>
+                <version>1.0.5</version>
                 <executions>
                     <execution>
                         <!-- infers qudt:applicableUnits and writes them to target/inferred/applicableUnits.ttl -->


### PR DESCRIPTION
By default, results of severity Info are filtered out. 

This can be configured at the global level with the maven property `shacl.severity.log`. e.g
```
mvn -Dshacl.severity.log=Info install
```

Every <validation> block can also be configured with <logSeverity>