### PR TITLE
adding SoC to quantitykind with SI unit percent

### DIFF
--- a/src/main/rdf/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL.ttl
+++ b/src/main/rdf/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL.ttl
@@ -12917,6 +12917,18 @@ quantitykind:StateDensityAsExpressionOfAngularFrequency
   rdfs:label "state density as expression of angular frequency)" ;
   rdfs:label "state density as expression of angular frequency"@en-US .
 
+quantitykind:StateOfCharge
+  a qudt:QuantityKind ;
+  dcterms:description "\"State of Charge\",quantifies the remaining capacity available in a battery at a given time and in relation to a given state of ageing."^^qudt:LatexString ;
+  qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
+  qudt:plainTextDescription """"\"State of Charge\",quantifies the remaining capacity available in a battery at a given time and in relation to a given state of ageing.""" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "StateOfCharge"@en ;
+  qudt:informativeReference "https://en.wikipedia.org/wiki/State_of_charge"^^xsd:anyURI ;
+  qudt:applicableSIUnit unit:PERCENT ; 
+  qudt:symbol "SoC" ;
+  skos:broader quantitykind:DimensionlessRatio .
+
 quantitykind:StaticFriction
   a qudt:QuantityKind ;
   dcterms:description "Static friction is friction between two or more solid objects that are not moving relative to each other. For example, static friction can prevent an object from sliding down a sloped surface. "^^qudt:LatexString ;


### PR DESCRIPTION
state of charge is commonly used for both electrical and thermal batteries, and is generally measured as a percent. Closes #991 