### PR TITLE
Bump rdfio-maven-plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -570,7 +570,7 @@
             <plugin>
                 <groupId>io.github.qudtlib</groupId>
                 <artifactId>rdfio-maven-plugin</artifactId>
-                <version>1.3.1</version>
+                <version>1.3.2</version>
                 <executions>
                     <execution>
                         <!--


### PR DESCRIPTION
This is a purely cosmetic update - the plugin now formats its log output more nicely.