### PR TITLE
used qudt:unit vs qudt:Unit, and removed lang tag on plainTextDescription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
 ### Changed
 
 - Updated constraint for use of hasFactorUnit in OWL schema
+- Added `qk:Emissivity` to `unit:PERCENT`
 
 ## [3.1.0] - 2025-03-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
 
 - Updated constraint for use of hasFactorUnit in OWL schema
 - Added `qk:Emissivity` to `unit:PERCENT`
+- Fixed mistakes on MicroW-PER-CentiM2-MicroM-SR, unit:W-PER-M2-MicroM, unit:W-PER-M2-MicroM-SR variously replaceing
+  qudit:unit to qudt:Unit, adding SI as applicable system, and removing @en-us tag from a plainTextDescription.
 
 ## [3.1.0] - 2025-03-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
 
 - Updated constraint for use of hasFactorUnit in OWL schema
 - Added `qk:Emissivity` to `unit:PERCENT`
-- Fixed mistakes on MicroW-PER-CentiM2-MicroM-SR, unit:W-PER-M2-MicroM, unit:W-PER-M2-MicroM-SR, J-PER-M2-SEC0pt5-K variously replacing qudit:unit to qudt:Unit, adding SI as applicable system, and removing @en-us tag from a plainTextDescription, and changing conversionMultiplierSM to conversionMultiplierSN.
+- Fixed mistakes on MicroW-PER-CentiM2-MicroM-SR, unit:W-PER-M2-MicroM, unit:W-PER-M2-MicroM-SR, J-PER-M2-SEC0pt5-K variously replacing qudit:unit to qudt:Unit, adding SI as applicable system, and removing @en-us tag from a plainTextDescription, changing conversionMultiplierSM to conversionMultiplierSN, and adding decimal point to xsd:double values.
 
 ## [3.1.0] - 2025-03-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,7 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
 
 - Updated constraint for use of hasFactorUnit in OWL schema
 - Added `qk:Emissivity` to `unit:PERCENT`
-- Fixed mistakes on MicroW-PER-CentiM2-MicroM-SR, unit:W-PER-M2-MicroM, unit:W-PER-M2-MicroM-SR variously replaceing
-  qudit:unit to qudt:Unit, adding SI as applicable system, and removing @en-us tag from a plainTextDescription.
+- Fixed mistakes on MicroW-PER-CentiM2-MicroM-SR, unit:W-PER-M2-MicroM, unit:W-PER-M2-MicroM-SR, J-PER-M2-SEC0pt5-K variously replacing qudit:unit to qudt:Unit, adding SI as applicable system, and removing @en-us tag from a plainTextDescription, and changing conversionMultiplierSM to conversionMultiplierSN.
 
 ## [3.1.0] - 2025-03-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
 
 - Updated constraint for use of hasFactorUnit in OWL schema
 - Added `qk:Emissivity` to `unit:PERCENT`
-- Fixed mistakes on MicroW-PER-CentiM2-MicroM-SR, unit:W-PER-M2-MicroM, unit:W-PER-M2-MicroM-SR, J-PER-M2-SEC0pt5-K variously replacing qudit:unit to qudt:Unit, adding SI as applicable system, and removing @en-us tag from a plainTextDescription, changing conversionMultiplierSM to conversionMultiplierSN, and adding decimal point to xsd:double values.
+- Fixed mistakes on MicroW-PER-CentiM2-MicroM-SR, unit:W-PER-M2-MicroM, unit:W-PER-M2-MicroM-SR, J-PER-M2-SEC0pt5-K variously replacing qudit:unit to qudt:Unit, adding SI as applicable system, and removing @en-us tag from a plainTextDescription, changing conversionMultiplierSM to conversionMultiplierSN, and adding decimal point to xsd:double values, and avoiding using explicit datatypes on conversion factors.
 
 ## [3.1.0] - 2025-03-20
 

--- a/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
+++ b/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
@@ -17032,8 +17032,8 @@ unit:J-PER-M2
   rdfs:label "Joule per Square Metre"@en .
 
 unit:J-PER-M2-SEC0pt5-K
-  qudt:conversionMultiplier "1"^^xsd:decimal ;
-  qudt:conversionMultiplierSN "1.0"^^xsd:double ;
+  qudt:conversionMultiplier 1.0 ;
+  qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E-2L2I0M1H-1T-2.5D0 ;
   qudt:hasQuantityKind quantitykind:ThermalInertia ;
   qudt:plainTextDescription "A unit of thermal inertia measured as Joules per meter squared per square root Seconds per degree Kelvin " ;
@@ -30475,7 +30475,7 @@ unit:MicroW
 
 unit:MicroW-PER-CentiM2-MicroM-SR
   a qudt:Unit ;
-  qudt:conversionMultiplier "10000"^^xsd:decimal ;
+  qudt:conversionMultiplier 10000.0 ;
   qudt:conversionMultiplierSN 1.0E4 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:SpectralRadiance ;
@@ -47906,7 +47906,7 @@ unit:W-PER-M2-M-SR
 
 unit:W-PER-M2-MicroM
   a qudt:Unit ;
-  qudt:conversionMultiplier "1000000"^^xsd:decimal ;
+  qudt:conversionMultiplier 1000000.0 ;
   qudt:conversionMultiplierSN 1.0E6 ;
   qudt:hasDimensionVector qkdv:A0E0L-4I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:SpectralEmittance ;
@@ -47920,7 +47920,7 @@ unit:W-PER-M2-MicroM
 
 unit:W-PER-M2-MicroM-SR
   a qudt:Unit ;
-  qudt:conversionMultiplier "1000000"^^xsd:decimal ;
+  qudt:conversionMultiplier 1000000.0 ;
   qudt:conversionMultiplierSN 1.0E6 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:SpectralRadiance ;

--- a/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
+++ b/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
@@ -17033,7 +17033,7 @@ unit:J-PER-M2
 
 unit:J-PER-M2-SEC0pt5-K
   qudt:conversionMultiplier "1"^^xsd:decimal ;
-  qudt:conversionMultiplierSN "1"^^xsd:double ;
+  qudt:conversionMultiplierSN "1.0"^^xsd:double ;
   qudt:hasDimensionVector qkdv:A0E-2L2I0M1H-1T-2.5D0 ;
   qudt:hasQuantityKind quantitykind:ThermalInertia ;
   qudt:plainTextDescription "A unit of thermal inertia measured as Joules per meter squared per square root Seconds per degree Kelvin " ;
@@ -30476,7 +30476,7 @@ unit:MicroW
 unit:MicroW-PER-CentiM2-MicroM-SR
   a qudt:Unit ;
   qudt:conversionMultiplier "10000"^^xsd:decimal ;
-  qudt:conversionMultiplierSN 1E4 ;
+  qudt:conversionMultiplierSN 1.0E4 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:SpectralRadiance ;
   qudt:plainTextDescription "A unit of spectral radiance that is the power radiating from a surface per unit of solid angle per unit of wavelength, measured in units of watts per centimeter squared per micrometer per steradian" ;
@@ -47907,7 +47907,7 @@ unit:W-PER-M2-M-SR
 unit:W-PER-M2-MicroM
   a qudt:Unit ;
   qudt:conversionMultiplier "1000000"^^xsd:decimal ;
-  qudt:conversionMultiplierSN 1E6 ;
+  qudt:conversionMultiplierSN 1.0E6 ;
   qudt:hasDimensionVector qkdv:A0E0L-4I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:SpectralEmittance ;
   qudt:hasQuantityKind quantitykind:SpectralIrradiance ;
@@ -47921,7 +47921,7 @@ unit:W-PER-M2-MicroM
 unit:W-PER-M2-MicroM-SR
   a qudt:Unit ;
   qudt:conversionMultiplier "1000000"^^xsd:decimal ;
-  qudt:conversionMultiplierSN 1E6 ;
+  qudt:conversionMultiplierSN 1.0E6 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:SpectralRadiance ;
   qudt:plainTextDescription "A unit of spectral radiance that is the power radiating from a surface per unit of solid angle per unit of wavelength, measured in units of watts per meter squared per micrometer per steradian" ;

--- a/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
+++ b/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
@@ -47910,7 +47910,7 @@ unit:W-PER-M2-MicroM
   qudt:hasDimensionVector qkdv:A0E0L-4I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:SpectralEmittance ;
   qudt:hasQuantityKind quantitykind:SpectralIrradiance ;
-  qudt:plainTextDescription "A unit of spectral emittance or spectral irradiance, which is the emittance or irradiance per unit of wavelength. It is watts per square meter per micrometer"@en-us ;
+  qudt:plainTextDescription "A unit of spectral emittance or spectral irradiance, which is the emittance or irradiance per unit of wavelength. It is watts per square meter per micrometer" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Watts per meter squared micrometer" ;
   rdfs:seeAlso quantitykind:Emittance ;

--- a/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
+++ b/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
@@ -17033,7 +17033,7 @@ unit:J-PER-M2
 
 unit:J-PER-M2-SEC0pt5-K
   qudt:conversionMultiplier "1"^^xsd:decimal ;
-  qudt:conversionMultiplierSM "1"^^xsd:double ;
+  qudt:conversionMultiplierSN "1"^^xsd:double ;
   qudt:hasDimensionVector qkdv:A0E-2L2I0M1H-1T-2.5D0 ;
   qudt:hasQuantityKind quantitykind:ThermalInertia ;
   qudt:plainTextDescription "A unit of thermal inertia measured as Joules per meter squared per square root Seconds per degree Kelvin " ;
@@ -30476,7 +30476,7 @@ unit:MicroW
 unit:MicroW-PER-CentiM2-MicroM-SR
   a qudt:Unit ;
   qudt:conversionMultiplier "10000"^^xsd:decimal ;
-  qudt:conversionMultiplierSM 1E4 ;
+  qudt:conversionMultiplierSN 1E4 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:SpectralRadiance ;
   qudt:plainTextDescription "A unit of spectral radiance that is the power radiating from a surface per unit of solid angle per unit of wavelength, measured in units of watts per centimeter squared per micrometer per steradian" ;
@@ -47907,7 +47907,7 @@ unit:W-PER-M2-M-SR
 unit:W-PER-M2-MicroM
   a qudt:Unit ;
   qudt:conversionMultiplier "1000000"^^xsd:decimal ;
-  qudt:conversionMultiplierSM 1E6 ;
+  qudt:conversionMultiplierSN 1E6 ;
   qudt:hasDimensionVector qkdv:A0E0L-4I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:SpectralEmittance ;
   qudt:hasQuantityKind quantitykind:SpectralIrradiance ;
@@ -47921,7 +47921,7 @@ unit:W-PER-M2-MicroM
 unit:W-PER-M2-MicroM-SR
   a qudt:Unit ;
   qudt:conversionMultiplier "1000000"^^xsd:decimal ;
-  qudt:conversionMultiplierSM 1E6 ;
+  qudt:conversionMultiplierSN 1E6 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:SpectralRadiance ;
   qudt:plainTextDescription "A unit of spectral radiance that is the power radiating from a surface per unit of solid angle per unit of wavelength, measured in units of watts per meter squared per micrometer per steradian" ;

--- a/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
+++ b/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
@@ -17038,6 +17038,7 @@ unit:J-PER-M2-SEC0pt5-K
   qudt:hasQuantityKind quantitykind:ThermalInertia ;
   qudt:plainTextDescription "A unit of thermal inertia measured as Joules per meter squared per square root Seconds per degree Kelvin " ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  qudt:applicableSystem sou:SI ;
   rdfs:label "Joules per meter squared sqrt(second) degree kelvin" .
 
 unit:J-PER-M3
@@ -47914,6 +47915,7 @@ unit:W-PER-M2-MicroM
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Watts per meter squared micrometer" ;
   rdfs:seeAlso quantitykind:Emittance ;
+  qudt:applicableSystem sou:SI ;
   rdfs:seeAlso quantitykind:Irradiance .
 
 unit:W-PER-M2-MicroM-SR
@@ -47924,6 +47926,7 @@ unit:W-PER-M2-MicroM-SR
   qudt:hasQuantityKind quantitykind:SpectralRadiance ;
   qudt:plainTextDescription "A unit of spectral radiance that is the power radiating from a surface per unit of solid angle per unit of wavelength, measured in units of watts per meter squared per micrometer per steradian" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  qudt:applicableSystem sou:SI ;
   rdfs:label "Watts per meter squared micrometer steradian" .
 
 unit:W-PER-M2-NanoM

--- a/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
+++ b/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
@@ -39823,6 +39823,7 @@ unit:PERCENT
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:DimensionlessRatio ;
   qudt:hasQuantityKind quantitykind:DutyCycle ;
+  qudt:hasQuantityKind quantitykind:Emissivity ;
   qudt:hasQuantityKind quantitykind:LengthRatio ;
   qudt:hasQuantityKind quantitykind:LuminousFluxRatio ;
   qudt:hasQuantityKind quantitykind:OpeningRatio ;

--- a/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
+++ b/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
@@ -17037,13 +17037,13 @@ unit:J-PER-M2
   rdfs:label "Joule per Square Metre"@en .
 
 unit:J-PER-M2-SEC0pt5-K
+  qudt:applicableSystem sou:SI ;
   qudt:conversionMultiplier 1.0 ;
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E-2L2I0M1H-1T-2.5D0 ;
   qudt:hasQuantityKind quantitykind:ThermalInertia ;
   qudt:plainTextDescription "A unit of thermal inertia measured as Joules per meter squared per square root Seconds per degree Kelvin " ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
-  qudt:applicableSystem sou:SI ;
   rdfs:label "Joules per meter squared sqrt(second) degree kelvin" .
 
 unit:J-PER-M3
@@ -47911,6 +47911,7 @@ unit:W-PER-M2-M-SR
 
 unit:W-PER-M2-MicroM
   a qudt:Unit ;
+  qudt:applicableSystem sou:SI ;
   qudt:conversionMultiplier 1000000.0 ;
   qudt:conversionMultiplierSN 1.0E6 ;
   qudt:hasDimensionVector qkdv:A0E0L-4I0M1H0T-3D0 ;
@@ -47920,18 +47921,17 @@ unit:W-PER-M2-MicroM
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Watts per meter squared micrometer" ;
   rdfs:seeAlso quantitykind:Emittance ;
-  qudt:applicableSystem sou:SI ;
   rdfs:seeAlso quantitykind:Irradiance .
 
 unit:W-PER-M2-MicroM-SR
   a qudt:Unit ;
+  qudt:applicableSystem sou:SI ;
   qudt:conversionMultiplier 1000000.0 ;
   qudt:conversionMultiplierSN 1.0E6 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:SpectralRadiance ;
   qudt:plainTextDescription "A unit of spectral radiance that is the power radiating from a surface per unit of solid angle per unit of wavelength, measured in units of watts per meter squared per micrometer per steradian" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
-  qudt:applicableSystem sou:SI ;
   rdfs:label "Watts per meter squared micrometer steradian" .
 
 unit:W-PER-M2-NanoM

--- a/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
+++ b/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
@@ -30473,7 +30473,7 @@ unit:MicroW
   rdfs:label "Microwatt"@en .
 
 unit:MicroW-PER-CentiM2-MicroM-SR
-  a qudt:unit ;
+  a qudt:Unit ;
   qudt:conversionMultiplier "10000"^^xsd:decimal ;
   qudt:conversionMultiplierSM 1E4 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-3D0 ;
@@ -47904,7 +47904,7 @@ unit:W-PER-M2-M-SR
   rdfs:label "Watts per square metre metre steradian"@en .
 
 unit:W-PER-M2-MicroM
-  a qudt:unit ;
+  a qudt:Unit ;
   qudt:conversionMultiplier "1000000"^^xsd:decimal ;
   qudt:conversionMultiplierSM 1E6 ;
   qudt:hasDimensionVector qkdv:A0E0L-4I0M1H0T-3D0 ;
@@ -47917,7 +47917,7 @@ unit:W-PER-M2-MicroM
   rdfs:seeAlso quantitykind:Irradiance .
 
 unit:W-PER-M2-MicroM-SR
-  a qudt:unit ;
+  a qudt:Unit ;
   qudt:conversionMultiplier "1000000"^^xsd:decimal ;
   qudt:conversionMultiplierSM 1E6 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-3D0 ;


### PR DESCRIPTION
In my earlier submission inadvertently used qudt:unit as the type vs qudt:Unit. This fixes that.