### PR TITLE
 Refactored and cleaned up applicable units for ElectricPower subtree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
 ### Deprecated
 
 - Removed 8 invalid dimension vectors (without deprecation since they were invalid)
+- Quantity kind ComplexPower, replaced by ElectricPower. ActivePower, ReactivePower and ApparentPower are still available, having skos:broader of ElectricPower.
 
 ### Changed
 
@@ -26,6 +27,7 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
 - Fixed mistakes on MicroW-PER-CentiM2-MicroM-SR, unit:W-PER-M2-MicroM, unit:W-PER-M2-MicroM-SR, J-PER-M2-SEC0pt5-K variously replacing qudit:unit to qudt:Unit, adding SI as applicable system, and removing @en-us tag from a plainTextDescription, changing conversionMultiplierSM to conversionMultiplierSN, and adding decimal point to xsd:double values, and avoiding using explicit datatypes on conversion factors.
 - Upgraded the closed world validation constraint from sh:Info to sh:Violation. Errors will now cause the build to fail.
 - Untangled unit:AWG and unit:CCY_AWG that had becomed combined in migration of currency into units graph
+- Refactored and cleaned up applicable units for ElectricPower subtree, deprecating ComplexPower
 
 ## [3.1.0] - 2025-03-20
 

--- a/src/main/rdf/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL.ttl
+++ b/src/main/rdf/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL.ttl
@@ -2050,6 +2050,27 @@ quantitykind:ComplexFrequency_Real
   rdfs:label "real part of complex frequency" ;
   skos:broader quantitykind:Frequency .
 
+quantitykind:ComplexPower
+  a qudt:QuantityKind ;
+  dcterms:description """
+  $\\textit{Complex Power}$, under sinusoidal conditions,
+   is the product of the phasor $\\mathbf{U}$ representing the voltage between the terminals of a linear two-terminal element,
+   or two-terminal circuit and the complex conjugate of the phasor $I$ representing the electric current in the element or circuit.
+  """^^qudt:LatexString ;
+  dcterms:isReplacedBy quantitykind:ElectricPower ;
+  qudt:deprecated true ;
+  qudt:expression "$complex-power$"^^qudt:LatexString ;
+  qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
+  qudt:informativeReference "http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=131-11-39"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:latexDefinition "$\\underline{S} = \\underline{U}\\underline{I^*}$, where $\\underline{U}$ is voltage phasor and $\\underline{I^*}$ is the complex conjugate of the current phasor."^^qudt:LatexString ;
+  qudt:latexSymbol "$\\underline{S}$"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
+  rdfs:label "Complex Power"@en ;
+  rdfs:seeAlso quantitykind:ElectricCurrentPhasor ;
+  rdfs:seeAlso quantitykind:VoltagePhasor ;
+  skos:broader quantitykind:ElectricPower .
+
 quantitykind:CompoundPlaneAngle
   a qudt:QuantityKind ;
   dcterms:description "A \"Compound Plane Angle\" is a compound measure of plane angle in degrees, minutes, seconds, and optionally millionth-seconds of arc."^^qudt:LatexString ;

--- a/src/main/rdf/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL.ttl
+++ b/src/main/rdf/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL.ttl
@@ -282,9 +282,8 @@ quantitykind:ActivePower
   qudt:symbol "P" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Active Power"@en ;
-  rdfs:seeAlso quantitykind:ComplexPower ;
   rdfs:seeAlso quantitykind:InstantaneousPower ;
-  skos:broader quantitykind:ComplexPower .
+  skos:broader quantitykind:ElectricPower .
 
 quantitykind:Activity
   a qudt:QuantityKind ;
@@ -828,7 +827,7 @@ quantitykind:ApparentPower
   rdfs:seeAlso quantitykind:ElectricCurrent ;
   rdfs:seeAlso quantitykind:Voltage ;
   skos:altLabel "表观功率"@zh ;
-  skos:broader quantitykind:ComplexPower .
+  skos:broader quantitykind:ElectricPower .
 
 quantitykind:ApparentThermalInertia
   a qudt:QuantityKind ;
@@ -1393,7 +1392,7 @@ quantitykind:BloodGlucoseLevel
   """^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T0D0 ;
   qudt:informativeReference "http://www.faqs.org/faqs/diabetes/faq/part1/section-9.html"^^xsd:anyURI ;
-  rdfs:comment "citation: https://en.wikipedia.org/wiki/Blood_sugar_level" ;
+  qudt:informativeReference "https://en.wikipedia.org/wiki/Blood_sugar_level"^^xsd:anyURI ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Blood Glucose Level"@en ;
   rdfs:seeAlso quantitykind:BloodGlucoseLevel_Mass .
@@ -1422,7 +1421,7 @@ quantitykind:BloodGlucoseLevel_Mass
   """^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H0T0D0 ;
   qudt:informativeReference "http://www.faqs.org/faqs/diabetes/faq/part1/section-9.html"^^xsd:anyURI ;
-  rdfs:comment "citation: https://en.wikipedia.org/wiki/Blood_sugar_level" ;
+  qudt:informativeReference "https://en.wikipedia.org/wiki/Blood_sugar_level"^^xsd:anyURI ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Blood Glucose Level by Mass"@en ;
   rdfs:seeAlso quantitykind:BloodGlucoseLevel .
@@ -2050,25 +2049,6 @@ quantitykind:ComplexFrequency_Real
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "real part of complex frequency" ;
   skos:broader quantitykind:Frequency .
-
-quantitykind:ComplexPower
-  a qudt:QuantityKind ;
-  dcterms:description """
-  $\\textit{Complex Power}$, under sinusoidal conditions,
-   is the product of the phasor $\\mathbf{U}$ representing the voltage between the terminals of a linear two-terminal element,
-   or two-terminal circuit and the complex conjugate of the phasor $I$ representing the electric current in the element or circuit.
-  """^^qudt:LatexString ;
-  qudt:expression "$complex-power$"^^qudt:LatexString ;
-  qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
-  qudt:informativeReference "http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=131-11-39"^^xsd:anyURI ;
-  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
-  qudt:latexDefinition "$\\underline{S} = \\underline{U}\\underline{I^*}$, where $\\underline{U}$ is voltage phasor and $\\underline{I^*}$ is the complex conjugate of the current phasor."^^qudt:LatexString ;
-  qudt:latexSymbol "$\\underline{S}$"^^qudt:LatexString ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Complex Power"@en ;
-  rdfs:seeAlso quantitykind:ElectricCurrentPhasor ;
-  rdfs:seeAlso quantitykind:VoltagePhasor ;
-  skos:broader quantitykind:ElectricPower .
 
 quantitykind:CompoundPlaneAngle
   a qudt:QuantityKind ;
@@ -11058,8 +11038,7 @@ quantitykind:ReactivePower
   rdfs:label "توان راکتیو"@fa ;
   rdfs:label "无功功率"@zh ;
   rdfs:label "無効電力"@ja ;
-  rdfs:seeAlso quantitykind:ComplexPower ;
-  skos:broader quantitykind:ComplexPower .
+  skos:broader quantitykind:ElectricPower .
 
 quantitykind:Reactivity
   a qudt:QuantityKind ;
@@ -14773,7 +14752,6 @@ $k = \\frac{2\\pi}{\\lambda}= \\frac{2\\pi\\upsilon}{\\upsilon_p}=\\frac{\\omega
 quantitykind:WebTime
   a qudt:QuantityKind ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T1D0 ;
-  rdfs:comment "Web Time" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Web Time"@en ;
   skos:broader quantitykind:Time .

--- a/src/main/rdf/vocab/systems/VOCAB_QUDT-SYSTEM-OF-QUANTITY-KINDS-ALL.ttl
+++ b/src/main/rdf/vocab/systems/VOCAB_QUDT-SYSTEM-OF-QUANTITY-KINDS-ALL.ttl
@@ -254,7 +254,6 @@ soqk:ISQ
   qudt:hasQuantityKind quantitykind:Coercivity ;
   qudt:hasQuantityKind quantitykind:ColdReceptorThreshold ;
   qudt:hasQuantityKind quantitykind:CombinedNonEvaporativeHeatTransferCoefficient ;
-  qudt:hasQuantityKind quantitykind:ComplexPower ;
   qudt:hasQuantityKind quantitykind:Compressibility ;
   qudt:hasQuantityKind quantitykind:CompressibilityFactor ;
   qudt:hasQuantityKind quantitykind:Conductance ;

--- a/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
+++ b/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
@@ -10969,8 +10969,7 @@ unit:ExaV-A
   dcterms:isReplacedBy unit:ExaVA ;
   qudt:deprecated true ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:ComplexPower ;
-  qudt:hasQuantityKind quantitykind:NonActivePower ;
+  qudt:hasQuantityKind quantitykind:ApparentPower ;
   qudt:iec61360Code "0112/2///62720#UAB537" ;
   qudt:symbol "EV·A" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -10980,8 +10979,7 @@ unit:ExaVA
   a qudt:Unit ;
   dcterms:description "1,000,000,000,000,000,000-fold of the product of the SI base unit volt with the SI base unit ampere" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:ComplexPower ;
-  qudt:hasQuantityKind quantitykind:NonActivePower ;
+  qudt:hasQuantityKind quantitykind:ApparentPower ;
   qudt:iec61360Code "0112/2///62720#UAB537" ;
   qudt:symbol "EVA" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -10993,8 +10991,8 @@ unit:ExaW
   qudt:conversionMultiplier 1000000000000000000.0 ;
   qudt:conversionMultiplierSN 1.0E18 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:ActivePower ;
   qudt:hasQuantityKind quantitykind:Power ;
+  qudt:hasQuantityKind quantitykind:quantitykind:ApparentPower ;
   qudt:iec61360Code "0112/2///62720#UAB507" ;
   qudt:symbol "EW" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -11536,7 +11534,6 @@ unit:FT-LB_F-PER-HR
   qudt:definedUnitOfSystem sou:USCS ;
   qudt:expression "$ft-lbf/h$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:ActivePower ;
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAA444" ;
   qudt:symbol "ft·lbf/h" ;
@@ -11570,7 +11567,6 @@ unit:FT-LB_F-PER-MIN
   qudt:definedUnitOfSystem sou:USCS ;
   qudt:expression "$ft-lbf/min$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:ActivePower ;
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAA445" ;
   qudt:symbol "ft·lbf/min" ;
@@ -11590,7 +11586,6 @@ unit:FT-LB_F-PER-SEC
   qudt:definedUnitOfSystem sou:USCS ;
   qudt:expression "$ft-lbf/s$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:ActivePower ;
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAA446" ;
   qudt:symbol "ft·lbf/s" ;
@@ -15101,8 +15096,7 @@ unit:GigaV-A
   qudt:conversionMultiplierSN 1.0E9 ;
   qudt:deprecated true ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:ComplexPower ;
-  qudt:hasQuantityKind quantitykind:NonActivePower ;
+  qudt:hasQuantityKind quantitykind:ApparentPower ;
   qudt:iec61360Code "0112/2///62720#UAB534" ;
   qudt:symbol "GV·A" ;
   qudt:ucumCode "GV.A"^^qudt:UCUMcs ;
@@ -15127,8 +15121,7 @@ unit:GigaVA
   qudt:conversionMultiplier 1000000000.0 ;
   qudt:conversionMultiplierSN 1.0E9 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:ComplexPower ;
-  qudt:hasQuantityKind quantitykind:NonActivePower ;
+  qudt:hasQuantityKind quantitykind:ApparentPower ;
   qudt:iec61360Code "0112/2///62720#UAB534" ;
   qudt:symbol "GVA" ;
   qudt:ucumCode "GVA"^^qudt:UCUMcs ;
@@ -15156,7 +15149,7 @@ unit:GigaW
   qudt:conversionMultiplier 1000000000.0 ;
   qudt:conversionMultiplierSN 1.0E9 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:ActivePower ;
+  qudt:hasQuantityKind quantitykind:ElectricPower ;
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAA154" ;
   qudt:plainTextDescription "1 000 000 000-fold of the SI derived unit watt" ;
@@ -15433,7 +15426,6 @@ unit:HP_Boiler
   qudt:conversionMultiplierSN 9.8095E3 ;
   qudt:expression "$boiler_hp$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:ActivePower ;
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAA535" ;
   qudt:symbol "HP{boiler}" ;
@@ -15475,7 +15467,7 @@ unit:HP_H2O
   qudt:conversionMultiplier 746.043 ;
   qudt:conversionMultiplierSN 7.46043E2 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:ActivePower ;
+  qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAA538" ;
   qudt:symbol "water hp" ;
   qudt:uneceCommonCode "F80" ;
@@ -20103,7 +20095,6 @@ unit:KiloGM_F-M-PER-SEC
   qudt:conversionMultiplier 9.80665 ;
   qudt:conversionMultiplierSN 9.80665E0 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:ActivePower ;
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAB154" ;
   qudt:plainTextDescription "product of the SI base unit metre and the unit kilogram-force according to the Anglo-American and Imperial system of units divided by the SI base unit second" ;
@@ -21417,7 +21408,7 @@ unit:KiloV-A
   qudt:conversionMultiplierSN 1.0E3 ;
   qudt:deprecated true ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:ComplexPower ;
+  qudt:hasQuantityKind quantitykind:ApparentPower ;
   qudt:iec61360Code "0112/2///62720#UAA581" ;
   qudt:plainTextDescription "1 000-fold of the product of the SI derived unit volt and the SI base unit ampere" ;
   qudt:symbol "kV·A" ;
@@ -21536,7 +21527,7 @@ unit:KiloVA
   qudt:conversionMultiplier 1000.0 ;
   qudt:conversionMultiplierSN 1.0E3 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:ComplexPower ;
+  qudt:hasQuantityKind quantitykind:ApparentPower ;
   qudt:iec61360Code "0112/2///62720#UAA581" ;
   qudt:plainTextDescription "1 000-fold of the product of the SI derived unit volt and the SI base unit ampere" ;
   qudt:symbol "kVA" ;
@@ -21631,7 +21622,7 @@ unit:KiloW
   qudt:conversionMultiplierSN 1.0E3 ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Watt"^^xsd:anyURI ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:ActivePower ;
+  qudt:hasQuantityKind quantitykind:ElectricPower ;
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAA583" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Watt?oldid=494906356"^^xsd:anyURI ;
@@ -28411,7 +28402,7 @@ unit:MegaV-A
   qudt:conversionMultiplierSN 1.0E6 ;
   qudt:deprecated true ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:ComplexPower ;
+  qudt:hasQuantityKind quantitykind:ApparentPower ;
   qudt:iec61360Code "0112/2///62720#UAA222" ;
   qudt:plainTextDescription "1,000,000-fold of the product of the SI derived unit volt and the SI base unit ampere" ;
   qudt:symbol "MV·A" ;
@@ -28501,7 +28492,7 @@ unit:MegaVA
   qudt:conversionMultiplier 1000000.0 ;
   qudt:conversionMultiplierSN 1.0E6 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:ComplexPower ;
+  qudt:hasQuantityKind quantitykind:ApparentPower ;
   qudt:iec61360Code "0112/2///62720#UAA222" ;
   qudt:plainTextDescription "1,000,000-fold of the product of the SI derived unit volt and the SI base unit ampere" ;
   qudt:symbol "MVA" ;
@@ -28567,7 +28558,7 @@ unit:MegaW
   qudt:conversionMultiplier 1000000.0 ;
   qudt:conversionMultiplierSN 1.0E6 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:ActivePower ;
+  qudt:hasQuantityKind quantitykind:ElectricPower ;
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAA224" ;
   qudt:symbol "MW" ;
@@ -30344,8 +30335,7 @@ unit:MicroV-A
   qudt:conversionMultiplierSN 1.0E-6 ;
   qudt:deprecated true ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:ComplexPower ;
-  qudt:hasQuantityKind quantitykind:NonActivePower ;
+  qudt:hasQuantityKind quantitykind:ApparentPower ;
   qudt:iec61360Code "0112/2///62720#UAB532" ;
   qudt:symbol "µV·A" ;
   qudt:ucumCode "uV.A"^^qudt:UCUMcs ;
@@ -30416,8 +30406,7 @@ unit:MicroVA
   qudt:conversionMultiplier 0.000001 ;
   qudt:conversionMultiplierSN 1.0E-6 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:ComplexPower ;
-  qudt:hasQuantityKind quantitykind:NonActivePower ;
+  qudt:hasQuantityKind quantitykind:ApparentPower ;
   qudt:iec61360Code "0112/2///62720#UAB532" ;
   qudt:symbol "µVA" ;
   qudt:ucumCode "uVA"^^qudt:UCUMcs ;
@@ -30468,7 +30457,7 @@ unit:MicroW
   qudt:conversionMultiplier 0.000001 ;
   qudt:conversionMultiplierSN 1.0E-6 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:ActivePower ;
+  qudt:hasQuantityKind quantitykind:ElectricPower ;
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAA080" ;
   qudt:plainTextDescription "0.000001-fold of the SI derived unit watt" ;
@@ -33877,8 +33866,7 @@ unit:MilliV-A
   qudt:conversionMultiplierSN 1.0E-3 ;
   qudt:deprecated true ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:ComplexPower ;
-  qudt:hasQuantityKind quantitykind:NonActivePower ;
+  qudt:hasQuantityKind quantitykind:ApparentPower ;
   qudt:iec61360Code "0112/2///62720#UAB533" ;
   qudt:symbol "mV·A" ;
   qudt:ucumCode "mV.A"^^qudt:UCUMcs ;
@@ -33984,8 +33972,7 @@ unit:MilliVA
   qudt:conversionMultiplier 0.001 ;
   qudt:conversionMultiplierSN 1.0E-3 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:ComplexPower ;
-  qudt:hasQuantityKind quantitykind:NonActivePower ;
+  qudt:hasQuantityKind quantitykind:ApparentPower ;
   qudt:iec61360Code "0112/2///62720#UAB533" ;
   qudt:symbol "mVA" ;
   qudt:ucumCode "mVA"^^qudt:UCUMcs ;
@@ -34036,7 +34023,7 @@ unit:MilliW
   qudt:conversionMultiplier 0.001 ;
   qudt:conversionMultiplierSN 1.0E-3 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:ActivePower ;
+  qudt:hasQuantityKind quantitykind:ElectricPower ;
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAA807" ;
   qudt:symbol "mW" ;
@@ -36409,8 +36396,7 @@ unit:NanoV-A
   qudt:conversionMultiplierSN 1.0E-9 ;
   qudt:deprecated true ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:ComplexPower ;
-  qudt:hasQuantityKind quantitykind:NonActivePower ;
+  qudt:hasQuantityKind quantitykind:ApparentPower ;
   qudt:iec61360Code "0112/2///62720#UAB531" ;
   qudt:symbol "nV·A" ;
   qudt:ucumCode "nV.A"^^qudt:UCUMcs ;
@@ -36435,8 +36421,7 @@ unit:NanoVA
   qudt:conversionMultiplier 0.000000001 ;
   qudt:conversionMultiplierSN 1.0E-9 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:ComplexPower ;
-  qudt:hasQuantityKind quantitykind:NonActivePower ;
+  qudt:hasQuantityKind quantitykind:ApparentPower ;
   qudt:iec61360Code "0112/2///62720#UAB531" ;
   qudt:symbol "nVA" ;
   qudt:ucumCode "nVA"^^qudt:UCUMcs ;
@@ -36464,7 +36449,7 @@ unit:NanoW
   qudt:conversionMultiplier 0.000000001 ;
   qudt:conversionMultiplierSN 1.0E-9 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:ActivePower ;
+  qudt:hasQuantityKind quantitykind:ElectricPower ;
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAA910" ;
   qudt:plainTextDescription "0.000000001-fold of the SI derived unit watt" ;
@@ -40806,7 +40791,6 @@ unit:PFERDESTAERKE
   a qudt:Unit ;
   dcterms:description "obsolete, non-legal unit of the power in Germany relating to DIN 1301-3:1979" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:ActivePower ;
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAB438" ;
   qudt:symbol "PS" ;
@@ -42040,8 +42024,7 @@ unit:PetaV-A
   dcterms:isReplacedBy unit:PetaVA ;
   qudt:deprecated true ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:ComplexPower ;
-  qudt:hasQuantityKind quantitykind:NonActivePower ;
+  qudt:hasQuantityKind quantitykind:ApparentPower ;
   qudt:iec61360Code "0112/2///62720#UAB536" ;
   qudt:symbol "PV·A" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -42051,8 +42034,7 @@ unit:PetaVA
   a qudt:Unit ;
   dcterms:description "1,000,000,000,000,000-fold of the SI derived unit ampere" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:ComplexPower ;
-  qudt:hasQuantityKind quantitykind:NonActivePower ;
+  qudt:hasQuantityKind quantitykind:ApparentPower ;
   qudt:iec61360Code "0112/2///62720#UAB536" ;
   qudt:symbol "PVA" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -42064,7 +42046,7 @@ unit:PetaW
   qudt:conversionMultiplier 1000000000000000.0 ;
   qudt:conversionMultiplierSN 1.0E15 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:ActivePower ;
+  qudt:hasQuantityKind quantitykind:ElectricPower ;
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAB506" ;
   qudt:symbol "PW" ;
@@ -42635,8 +42617,7 @@ unit:PicoV-A
   qudt:conversionMultiplierSN 1.0E-12 ;
   qudt:deprecated true ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:ComplexPower ;
-  qudt:hasQuantityKind quantitykind:NonActivePower ;
+  qudt:hasQuantityKind quantitykind:ApparentPower ;
   qudt:iec61360Code "0112/2///62720#UAB530" ;
   qudt:symbol "pV·A" ;
   qudt:ucumCode "pV.A"^^qudt:UCUMcs ;
@@ -42661,8 +42642,7 @@ unit:PicoVA
   qudt:conversionMultiplier 0.000000000001 ;
   qudt:conversionMultiplierSN 1.0E-12 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:ComplexPower ;
-  qudt:hasQuantityKind quantitykind:NonActivePower ;
+  qudt:hasQuantityKind quantitykind:ApparentPower ;
   qudt:iec61360Code "0112/2///62720#UAB530" ;
   qudt:symbol "pVA" ;
   qudt:ucumCode "pVA"^^qudt:UCUMcs ;
@@ -42690,7 +42670,7 @@ unit:PicoW
   qudt:conversionMultiplier 0.000000000001 ;
   qudt:conversionMultiplierSN 1.0E-12 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:ActivePower ;
+  qudt:hasQuantityKind quantitykind:ElectricPower ;
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAA935" ;
   qudt:plainTextDescription "0.000000000001-fold of the SI derived unit watt" ;
@@ -46458,7 +46438,7 @@ unit:TeraJ-PER-SEC
   qudt:conversionMultiplier 1000000000000.0 ;
   qudt:conversionMultiplierSN 1.0E12 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:ActivePower ;
+  qudt:hasQuantityKind quantitykind:ElectricPower ;
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAB513" ;
   qudt:symbol "TJ/s" ;
@@ -46509,8 +46489,7 @@ unit:TeraV-A
   qudt:conversionMultiplierSN 1.0E12 ;
   qudt:deprecated true ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:ComplexPower ;
-  qudt:hasQuantityKind quantitykind:NonActivePower ;
+  qudt:hasQuantityKind quantitykind:ApparentPower ;
   qudt:iec61360Code "0112/2///62720#UAB535" ;
   qudt:symbol "TV·A" ;
   qudt:ucumCode "TV.A"^^qudt:UCUMcs ;
@@ -46535,8 +46514,7 @@ unit:TeraVA
   qudt:conversionMultiplier 1000000000000.0 ;
   qudt:conversionMultiplierSN 1.0E12 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:ComplexPower ;
-  qudt:hasQuantityKind quantitykind:NonActivePower ;
+  qudt:hasQuantityKind quantitykind:ApparentPower ;
   qudt:iec61360Code "0112/2///62720#UAB535" ;
   qudt:symbol "TVA" ;
   qudt:ucumCode "TVA"^^qudt:UCUMcs ;
@@ -46564,7 +46542,7 @@ unit:TeraW
   qudt:conversionMultiplier 1000000000000.0 ;
   qudt:conversionMultiplierSN 1.0E12 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:ActivePower ;
+  qudt:hasQuantityKind quantitykind:ElectricPower ;
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAA289" ;
   qudt:plainTextDescription "1,000,000,000,000-fold of the SI derived unit watt" ;
@@ -46841,8 +46819,7 @@ unit:V-A
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:deprecated true ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:ComplexPower ;
-  qudt:hasQuantityKind quantitykind:NonActivePower ;
+  qudt:hasQuantityKind quantitykind:ApparentPower ;
   qudt:iec61360Code "0112/2///62720#UAA298" ;
   qudt:plainTextDescription "product of the SI derived unit volt and the SI base unit ampere" ;
   qudt:symbol "V·A" ;
@@ -47256,8 +47233,7 @@ unit:VA
   qudt:conversionMultiplier 1.0 ;
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:ComplexPower ;
-  qudt:hasQuantityKind quantitykind:NonActivePower ;
+  qudt:hasQuantityKind quantitykind:ApparentPower ;
   qudt:iec61360Code "0112/2///62720#UAA298" ;
   qudt:plainTextDescription "Product of the RMS value of the voltage and the RMS value of an alternating electric current" ;
   qudt:symbol "VA" ;
@@ -47467,7 +47443,7 @@ unit:W
   qudt:definedUnitOfSystem sou:SI ;
   qudt:derivedCoherentUnitOfSystem sou:SI ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:ActivePower ;
+  qudt:hasQuantityKind quantitykind:ElectricPower ;
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAA306" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Watt?oldid=494906356"^^xsd:anyURI ;

--- a/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
+++ b/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
@@ -10991,8 +10991,8 @@ unit:ExaW
   qudt:conversionMultiplier 1000000000000000000.0 ;
   qudt:conversionMultiplierSN 1.0E18 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
+  qudt:hasQuantityKind quantitykind:ElectricPower ;
   qudt:hasQuantityKind quantitykind:Power ;
-  qudt:hasQuantityKind quantitykind:quantitykind:ApparentPower ;
   qudt:iec61360Code "0112/2///62720#UAB507" ;
   qudt:symbol "EW" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;


### PR DESCRIPTION
Based upon a discussion with an electricity expert, it became clear that quantitykind:ComplexPower was not needed. Instead, ApparentPower, ActivePower and ReactivePower are directly related to ElectricPower via the skos:broader relation.