### PR TITLE
Derive conversion multipliers during build where possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,11 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
 - Deprecated unit:IN-PER-2PiRAD, replaced with unit:IN-PER-REV.
 - Deprecated the ambiguous unit:PIXEL, with seeAlso notes to unit:PIXEL_Area and unit:PIXEL_Count.
 
+### Changed
+
+- conversion multipliers:
+  a SHACL check was added to compare the conversion multipliers of derived units withthe conversion multiplier obtained from the factor units, failing the build if there is a discrepancy. This is a first step toward more stability with regard to conversion multipliers.
+
 ### Fixed
 
 - Corrected symbol of `unit:BU_US` and `unit:GAL_US`, which both were `in³`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,11 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
 ### Changed
 
 - Build process
-  - Introduced new maven goal `rdfio:pipeline` that allows for fine-grained rdf file manipulation
-  - introduced `mainPipeline` execution for the bulk of rdf munging
+  - New maven goal `rdfio:pipeline` that allows for fine-grained rdf file manipulation
+  - New `mainPipeline` execution for the bulk of rdf munging
+  - New `src/main/rdf/validation/qudt-shacl-functions.ttl` to make some intricate functionality
+    available to SPARQL and SHACL
+  - New `unitTestPipeline` for unit testing the SHACL functions
 - All instances of `xsd:decimal` are limited to a maximum precision of 34 significant digits
 - Derived units: recalculation of `qudt:conversionMultiplier` and `qudt:conversionMultiplierSN`
   - During the build, all derived units' conversion multipliers are checked based on their `qudt:factorUnits`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
 
 ### Changed
 
+- Build process
+  - Introduced new maven goal `rdfio:pipeline` that allows for fine-grained rdf file manipulation
+  - introduced `mainPipeline` execution for the bulk of rdf munging
+- All instances of `xsd:decimal` are limited to a maximum precision of 34 significant digits
+- Derived units: recalculation of `qudt:conversionMultiplier` and `qudt:conversionMultiplierSN`
+  - During the build, all derived units' conversion multipliers are checked based on their `qudt:factorUnits`
+    and replaced with the calculated result if necessary
+
 ### Deprecated
 
 - Deprecated unit:CHF-PER-KiloGM in favor of unit:CCY_CHF-PER-KiloGM
@@ -26,6 +34,8 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
 
 - Fixed erroneous prefix definition for cross-references to SI Quantity (equivalent to qudt:QuantityKind)
 - Corrected symbol for `unit:IN_H2O` from `inH₂0` to `inH₂O` [Reto Schneebeli](https://github.com/reto-siemens)
+- Removed wrong `qudt:conversionMultipliers` from `src` (they are now generated correctly in `target`, see 'Changed'). Affected units:
+  - `unit:MicroKAT-PER-L, unit:MilliKAT-PER-L, unit:NanoKAT-PER-L, unit:PicoKAT-PER-L, unit:MilliOSM-PER-KiloGM`
 
 ## [3.1.2] - 2025-05-30
 

--- a/pom.xml
+++ b/pom.xml
@@ -48,8 +48,7 @@
                       process-sources          check-source-format, shacl-validate-src
                       generate-resources       copy-rdf, copy-docs, copy-root-files, validate-shacl-files
                       process-resources        generate-iec-links
-                      compile                  infer-and-format
-                      process-classes
+                      process-classes          mainRdfPipeline
                       generate-test-sources
                       process-test-sources
                       generate-test-resources
@@ -235,7 +234,7 @@
                             def allAspectDirs = srcgenDir.listFiles().findAll { it.isDirectory() }
                             def validAspectDirs = []
                             // Map to store omitted dirs and missing files
-                            def omittedAspectDirsWithReasons = [:] 
+                            def omittedAspectDirsWithReasons = [:]
 
                             allAspectDirs.each { dir ->
                                 def aspectName = dir.name
@@ -254,9 +253,9 @@
 
                                 if (missingFiles.isEmpty()) {
                                     // All files present, add to valid list
-                                    validAspectDirs << dir  
+                                    validAspectDirs << dir
                                     // Record missing files
-                                    } else { omittedAspectDirsWithReasons[dir] = missingFiles 
+                                    } else { omittedAspectDirsWithReasons[dir] = missingFiles
                                      }
                             }
 
@@ -306,7 +305,7 @@
                                 println "The following aspects were omitted due to missing required files:"
                                 // Simplify to file names
                                 omittedAspectDirsWithReasons.each { dir, missingFiles ->
-                                    def missingFileNames = missingFiles.collect { it.toString().replaceAll('^.*\\.', '') } 
+                                    def missingFileNames = missingFiles.collect { it.toString().replaceAll('^.*\\.', '') }
                                     println " - ${dir.name}: Missing ${missingFileNames.join(', ')}"
                                 }
                             } else {
@@ -333,163 +332,7 @@
                 <artifactId>shacl-maven-plugin</artifactId>
                 <version>1.0.5</version>
                 <executions>
-                    <execution>
-                        <!-- infers qudt:applicableUnits and writes them to target/inferred/applicableUnits.ttl -->
-                        <id>infer-applicableUnits</id>
-                        <phase>none</phase>
-                        <goals>
-                            <goal>infer</goal>
-                        </goals>
-                        <configuration>
-                            <inferences>
-                                <inference>
-                                    <message>Inferring qudt:applicableUnit triples (non-currency units)</message>
-                                    <shapes>
-                                        <include>src/build/inference/inferApplicableUnits.ttl</include>
-                                    </shapes>
-                                    <data>
-                                        <include>
-                                            src/main/rdf/vocab/unit/*.ttl
-                                            src/main/rdf/vocab/quantitykinds/*.ttl
-                                        </include>
-                                    </data>
-                                    <outputFile>target/inferred/applicableUnits.ttl</outputFile>
-                                </inference>
-                                <inference>
-                                    <message>Inferring qudt:applicableUnit triples (currency units)</message>
-                                    <shapes>
-                                        <include>src/build/inference/inferApplicableUnits.ttl</include>
-                                    </shapes>
-                                    <data>
-                                        <include>
-                                            src/main/rdf/vocab/currency/VOCAB_QUDT-UNITS-CURRENCY.ttl
-                                        </include>
-                                    </data>
-                                    <outputFile>target/inferred/applicableUnits-currency.ttl</outputFile>
-                                </inference>
-                                <inference>
-                                    <message>Performing our custom subset of OWL inferences</message>
-                                    <shapes>
-                                        <include>
-                                            src/build/inference/owl-subset.shapes.ttl
-                                        </include>
-                                    </shapes>
-                                    <data>
-                                        <include>
-                                            src/main/rdf/schema/SCHEMA_QUDT.ttl
-                                            src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
-                                        </include>
-                                    </data>
-                                    <outputFile>target/inferred/owl-subset.ttl</outputFile>
-                                </inference>
-                            </inferences>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <!-- infers qudt:applicableUnits and writes them to target/inferred/applicableUnits.ttl -->
-                        <id>infer-owlSubset</id>
-                        <phase>none</phase>
-                        <goals>
-                            <goal>infer</goal>
-                        </goals>
-                        <configuration>
-                            <inferences>
-                                <inference>
-                                    <message>Performing our custom subset of OWL inferences</message>
-                                    <shapes>
-                                        <include>
-                                            src/build/inference/owl-subset.shapes.ttl
-                                        </include>
-                                    </shapes>
-                                    <data>
-                                        <include>
-                                            src/main/rdf/schema/SCHEMA_QUDT.ttl
-                                            src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
-                                        </include>
-                                    </data>
-                                    <outputFile>target/inferred/owl-subset.ttl</outputFile>
-                                </inference>
-                            </inferences>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <!-- infers qudt:hasFactorUnit RDF molecules and writes them to target/inferred/factorUnits.ttl -->
-                        <id>infer-factorUnits</id>
-                        <phase>none</phase>
-                        <goals>
-                            <goal>infer</goal>
-                        </goals>
-                        <configuration>
-                            <inferences>
-                                <inference>
-                                    <shapes>
-                                        <include>target/srcgen/factorUnits/infer.ttl</include>
-                                    </shapes>
-                                    <data>
-                                        <include>
-                                            <!-- assuming predefined units have already been merged into the target units -->
-                                            target/dist/vocab/unit/*.ttl
-                                            target/dist/vocab/prefixes/*.ttl
-                                        </include>
-                                    </data>
-                                    <outputFile>target/inferred/factorUnits.ttl</outputFile>
-                                </inference>
-                            </inferences>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <!-- infers qudt:scalingOf triples and writes them to target/inferred/scalingOf.ttl -->
-                        <id>infer-scalingOf</id>
-                        <phase>none</phase>
-                        <goals>
-                            <goal>infer</goal>
-                        </goals>
-                        <configuration>
-                            <inferences>
-                                <inference>
-                                    <shapes>
-                                        <include>target/srcgen/scalingOf/infer.ttl</include>
-                                    </shapes>
-                                    <data>
-                                        <include>
-                                            <!-- assuming predefined units and factor units have already been merged into the target units -->
-                                            target/dist/vocab/unit/*.ttl
-                                            target/dist/vocab/prefixes/*.ttl
-                                        </include>
-                                    </data>
-                                    <outputFile>target/inferred/scalingOf.ttl</outputFile>
-                                </inference>
-                            </inferences>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <!-- infers qudt:conversionMultiplier triples and writes them to target/inferred/conversionMultiplier.ttl -->
-                        <id>infer-conversionMultiplier</id>
-                        <phase>none</phase>
-                        <goals>
-                            <goal>infer</goal>
-                        </goals>
-                        <configuration>
-                            <inferences>
-                                <inference>
-                                    <shapes>
-                                        <include>
-                                            target/srcgen/conversionMultiplier/infer.ttl
-                                            src/main/rdf/validation/qudt-shacl-functions.ttl
-                                        </include>
-                                    </shapes>
-                                    <data>
-                                        <include>
-                                            <!-- assuming predefined units and factor units have already been merged into the target units -->
-                                            target/dist/vocab/unit/*.ttl
-                                            target/dist/vocab/prefixes/*.ttl
-                                        </include>
-                                    </data>
-                                    <outputFile>target/inferred/conversionMultiplier.ttl</outputFile>
-                                </inference>
-                            </inferences>
-                        </configuration>
-                    </execution>
+
                     <execution>
                         <!--
                         SHACL-validates the union of all ttl files in src/vocab and the No-OWL schema
@@ -548,6 +391,7 @@
                                     <data>
                                         <include>
                                             target/dist/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
+                                            target/dist/vocab/prefixes/VOCAB_QUDT-PREFIXES.ttl
                                         </include>
                                     </data>
                                     <outputFile>target/validation/validationReport-conversionMultiplier.ttl</outputFile>
@@ -643,224 +487,286 @@
             <plugin>
                 <groupId>io.github.qudtlib</groupId>
                 <artifactId>rdfio-maven-plugin</artifactId>
-                <version>1.3.2</version>
+                <version>1.3.3-SNAPSHOT</version>
                 <executions>
                     <execution>
-                        <!--
-                        adds the qudt:applicableUnits triples we generated with SHACL to the quantitykinds target file.
-                        -->
-                        <id>merge-applicableUnits-target</id>
-                        <phase>none</phase>
+                        <id>mainPipeline</id>
+                        <phase>compile</phase>
                         <goals>
-                            <goal>make</goal>
+                            <goal>pipeline</goal>
                         </goals>
                         <configuration>
-                            <products>
-                                <singleFile>
-                                    <input>
-                                        <include>
-                                            target/inferred/applicableUnits.ttl
-                                            target/dist/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL.ttl
-                                        </include>
-                                    </input>
-                                    <outputFile>target/dist/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL.ttl</outputFile>
-                                </singleFile>
-                                <singleFile>
-                                    <input>
-                                        <include>
-                                            target/inferred/applicableUnits-currency.ttl
-                                            target/dist/vocab/currency/VOCAB_QUDT-UNITS-CURRENCY.ttl
-                                        </include>
-                                    </input>
-                                    <outputFile>target/dist/vocab/currency/VOCAB_QUDT-UNITS-CURRENCY.ttl</outputFile>
-                                </singleFile>
-                                <singleFile>
-                                    <input>
-                                        <include>
-                                            target/inferred/owl-subset.ttl
-                                            target/dist/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
-                                        </include>
-                                    </input>
-                                    <outputFile>target/dist/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl</outputFile>
-                                </singleFile>
-                            </products>
+                            <pipeline>
+                                <id>mainPipeline</id>
+                                <steps>
+                                    <!-- make custom shacl functions available in inference and SPARQL-->
+                                    <shaclFunctions>
+                                        <file>src/main/rdf/validation/qudt-shacl-functions.ttl</file>
+                                    </shaclFunctions>
+
+                                    <add> <!-- load target quantitykinds into <target:quantityKinds> (associating that graph with the file)-->
+                                        <file>src/main/rdf/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL.ttl</file>
+                                        <toGraph>modified:quantityKinds</toGraph>
+                                    </add>
+                                    <add> <!-- load target units into <modified:units>  (associating that graph with the file) -->
+                                        <file>src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl</file>
+                                        <toGraph>modified:units</toGraph>
+                                    </add>
+                                    <add> <!-- load applicableUnits shapes (rules) into <shapes:applicableUnits> because we need them twice (see below) -->
+                                        <file>src/build/inference/inferApplicableUnits.ttl</file>
+                                        <toGraph>shapes:applicableUnits</toGraph>
+                                    </add>
+
+                                    <shaclInfer> <!-- do the quantitykinds inference -->
+                                        <message>Inferring qudt:applicableUnit triples (non-currency units)</message>
+                                        <shapes>
+                                            <graph>shapes:applicableUnits</graph>
+                                        </shapes>
+                                        <data>
+                                            <graph>modified:quantityKinds</graph>
+                                            <graph>modified:units</graph>
+                                        </data>
+                                        <inferred>
+                                            <graph>inferred:applicableUnits</graph>
+                                            <file>target/inferred/applicableUnits.ttl</file>
+                                        </inferred>
+                                    </shaclInfer>
+
+                                    <add> <!-- add the results of the quantitykinds inference to the quantityKinds graph -->
+                                        <graph>inferred:applicableUnits</graph>
+                                        <toGraph>modified:quantityKinds</toGraph>
+                                    </add>
+
+                                    <!-- start from here if nothing has changed in the inputs of the earlier steps -->
+                                    <savepoint><id>01-applicableUnits</id></savepoint>
+                                    <add>
+                                        <file>src/main/rdf/vocab/currency/VOCAB_QUDT-UNITS-CURRENCY.ttl</file>
+                                        <toGraph>target:currencyUnits</toGraph>
+                                    </add>
+                                    <shaclInfer>  <!-- do the quantitykinds inference for currency units -->
+                                        <message>Inferring qudt:applicableUnit triples (currency units)</message>
+                                        <shapes><graph>shapes:applicableUnits</graph></shapes>
+                                        <data>
+                                            <graph>target:currencyUnits</graph>
+                                        </data>
+                                        <inferred>
+                                            <graph>inferred:applicableCurrencyUnits</graph>
+                                            <file>target/inferred/applicableUnits-currency.ttl</file>
+                                        </inferred>
+                                    </shaclInfer>
+                                    <write>
+                                        <graph>target:currencyUnits</graph>
+                                        <graph>inferred:applicableCurrencyUnits</graph>
+                                        <toFile>target/dist/vocab/currency/VOCAB_QUDT-UNITS-CURRENCY.ttl</toFile>
+                                    </write>
+
+                                    <!-- start from here if nothing has changed in the inputs of the earlier steps -->
+                                    <savepoint><id>02-applicableUnits-currencies</id></savepoint>
+
+                                    <shaclInfer> <!-- do the custom OWL subset inference -->
+                                        <message>Performing our custom subset of OWL inferences</message>
+                                        <shapes>
+                                            <file>src/build/inference/owl-subset.shapes.ttl</file>
+                                        </shapes>
+                                        <data>
+                                            <files>
+                                                <include>
+                                                    src/main/rdf/schema/SCHEMA_QUDT.ttl
+                                                    src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
+                                                </include>
+                                            </files>
+                                        </data>
+                                        <inferred>
+                                            <graph>inferred:owl-subset-units</graph>
+                                            <file>target/inferred/owl-subset-units.ttl</file>
+                                        </inferred>
+                                    </shaclInfer>
+
+                                    <add> <!-- add the inferred triples to the units graph -->
+                                        <graph>inferred:owl-subset-units</graph>
+                                        <toGraph>modified:units</toGraph>
+                                    </add>
+
+                                    <!-- start from here if nothing has changed in the inputs of the earlier steps -->
+                                    <savepoint><id>03-owl-subset-units</id></savepoint>
+
+                                    <add>
+                                        <file>src/build/inference/factorUnits/predefined-factors-and-scalings.ttl</file>
+                                        <toGraph>modified:units</toGraph>
+                                    </add>
+                                    <add>
+                                        <files>
+                                            <include>target/dist/vocab/prefixes/*.ttl</include>
+                                        </files>
+                                        <toGraph>target:prefixes</toGraph>
+                                    </add>
+
+                                    <shaclInfer> <!-- infer ther factor units -->
+                                        <message>Inferring qudt:hasFactorUnit</message>
+                                        <shapes>
+                                            <file>target/srcgen/factorUnits/infer.ttl</file>
+                                        </shapes>
+                                        <data>
+                                            <graphs>
+                                                <include>
+                                                    modified:units
+                                                    target:prefixes
+                                                </include>
+                                            </graphs>
+                                        </data>
+                                        <inferred>
+                                            <graph>inferred:factorUnits</graph>
+                                            <file>target/inferred/factorUnits.ttl</file>
+                                        </inferred>
+                                    </shaclInfer>
+                                    <add>
+                                        <graph>inferred:factorUnits</graph>
+                                        <toGraph>modified:units</toGraph>
+                                    </add>
+                                    <savepoint><id>04-infer-factor-units</id></savepoint>
+                                    <shaclInfer>
+                                        <message>Inferring qudt:scalingOf</message>
+                                        <shapes>
+                                            <file>target/srcgen/scalingOf/infer.ttl</file>
+                                        </shapes>
+                                        <data>
+                                            <graph>modified:units</graph>
+                                            <graph>target:prefixes</graph>
+                                        </data>
+                                        <inferred>
+                                            <graph>inferred:scalingOf</graph>
+                                            <file>target/inferred/scalingOf.ttl</file>
+                                        </inferred>
+                                    </shaclInfer>
+                                    <add>
+                                        <graph>inferred:scalingOf</graph>
+                                        <toGraph>modified:units</toGraph>
+                                    </add>
+                                    <savepoint><id>05-infer-scalingOf</id></savepoint>
+                                    <until>
+                                        <message>Replacing invalid conversionMultipliers iteratively until no more are found</message>
+                                        <indexVar>index_cm</indexVar>
+                                        <sparqlAsk>
+                                            ASK {
+                                                BIND(IRI(CONCAT("inferred:conversionMultiplierToDelete_",STR(?index_cm))) as ?graph)
+                                                GRAPH ?graph {
+                                                    ?report
+                                                        a               sh:ValidationReport;
+                                                        sh:conforms     true;
+                                                }
+                                            }
+                                        </sparqlAsk>
+                                        <body>
+                                            <shaclValidate>
+                                                <message>Validating qudt:conversionMultiplier (will delete invalid ones in subsequent step)</message>
+                                                <!-- we don't want to fail, we want to know the errors so we can delete triples-->
+                                                <failOnSeverity>None</failOnSeverity>
+                                                <shapes>
+                                                    <file>target/srcgen/conversionMultiplier/validate.ttl</file>
+                                                </shapes>
+                                                <data>
+                                                    <graph>modified:units</graph>
+                                                    <graph>target:prefixes</graph>
+                                                </data>
+                                                <validationReport>
+                                                    <graph>inferred:conversionMultiplierToDelete_${index_cm}</graph>
+                                                    <file>target/validation/conversionMultiplier-toDelete_${index_cm}.ttl</file>
+                                                </validationReport>
+                                            </shaclValidate>
+                                            <sparqlUpdate>
+                                                <message>Deleting invalid conversion multipliers</message>
+                                                <sparql>
+                                                    <![CDATA[
+                                                DELETE {
+                                                    GRAPH <modified:units> {
+                                                        ?unit qudt:conversionMultiplier ?m .
+                                                        ?unit  qudt:conversionMultiplierSN ?mSN .
+                                                    }
+                                                }
+                                                WHERE {
+                                                    GRAPH <modified:units> {
+                                                        {
+                                                            ?unit qudt:conversionMultiplier ?m .
+                                                        } UNION {
+                                                            ?unit qudt:conversionMultiplierSN ?mSN .
+                                                        }
+                                                    }
+                                                    BIND(IRI(CONCAT("inferred:conversionMultiplierToDelete_",STR(?index_cm))) as ?graph)
+                                                    GRAPH ?graph {
+                                                        ?res
+                                                            rdf:type                      sh:ValidationResult;
+                                                            sh:resultPath                 qudt:conversionMultiplier;
+                                                            sh:resultSeverity             sh:Violation;
+                                                            sh:value                      ?unit
+                                                    }
+                                                }
+                                                ]]>
+                                                </sparql>
+                                            </sparqlUpdate>
+
+                                            <shaclInfer>
+                                                <message>Inferring qudt:conversionMultiplier</message>
+                                                <iterateUntilStable>true</iterateUntilStable>
+                                                <iterationOutputFilePattern>target/inferred/conversionMultiplier-${index_cm}_${index}.ttl</iterationOutputFilePattern>
+                                                <shapes>
+                                                    <file>target/srcgen/conversionMultiplier/infer.ttl</file>
+                                                </shapes>
+                                                <data>
+                                                    <graph>modified:units</graph>
+                                                    <graph>target:prefixes</graph>
+                                                </data>
+                                                <inferred>
+                                                    <graph>inferred:conversionMultiplier_${index_cm}</graph>
+                                                    <file>target/inferred/conversionMultiplier_${index_cm}.ttl</file>
+                                                </inferred>
+                                            </shaclInfer>
+                                            <add>
+                                                <graph>inferred:conversionMultiplier_${index_cm}</graph>
+                                                <toGraph>modified:units</toGraph>
+                                            </add>
+                                        </body>
+
+                                    </until>
+                                    <savepoint><id>08-infer-conversionMultiplier</id></savepoint>
+                                    <sparqlUpdate>
+                                        <message>Generate conversion multipliers in xsd:double format where it's missing</message>
+                                        <sparql>
+                                            <![CDATA[
+                                            INSERT {
+                                                GRAPH <modified:units> {
+                                                    ?unit qudt:conversionMultiplierSN ?cmsn
+                                                }
+                                            }
+                                            WHERE {
+                                                GRAPH <modified:units> {
+                                                    ?unit a qudt:Unit ;
+                                                          qudt:conversionMultiplier ?cm .
+                                                    FILTER NOT EXISTS {
+                                                        ?unit qudt:conversionMultiplierSN ?any .
+                                                    }
+                                                    BIND(qfn:decimalToDouble(?cm) as ?cmsn)
+                                                }
+                                            }
+                                            ]]>
+                                        </sparql>
+                                    </sparqlUpdate>
+                                    <!-- write the main outputs: units and quantitykinds files (back to the files they were initially read from) -->
+                                    <write>
+                                        <graph>modified:units</graph>
+                                        <toFile>target/dist/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl</toFile>
+                                    </write>
+
+                                    <write>
+                                        <graph>modified:quantityKinds</graph>
+                                        <toFile>target/dist/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL.ttl</toFile>
+                                    </write>
+                                    <!-- start from here if nothing has changed in the inputs of the earlier steps -->
+                                    <savepoint><id>99-endOfPipeline</id></savepoint>
+                                </steps>
+                            </pipeline>
                         </configuration>
                     </execution>
-                    <execution>
-                        <!--
-                        adds the qudt:applicableUnits triples we generated with SHACL to the quantitykinds target file.
-                        -->
-                        <id>merge-owlSubset-target</id>
-                        <phase>none</phase>
-                        <goals>
-                            <goal>make</goal>
-                        </goals>
-                        <configuration>
-                            <products>
-                                <singleFile>
-                                    <input>
-                                        <include>
-                                            target/inferred/owl-subset.ttl
-                                            target/dist/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
-                                        </include>
-                                    </input>
-                                    <outputFile>target/dist/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl</outputFile>
-                                </singleFile>
-                            </products>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <!--
-                        adds the qudt:applicableUnits triples we generated with SHACL to the quantitykinds target file.
-                        -->
-                        <id>merge-predefinedUnits-target</id>
-                        <phase>none</phase>
-                        <goals>
-                            <goal>make</goal>
-                        </goals>
-                        <configuration>
-                            <products>
-                                <singleFile>
-                                    <input>
-                                        <include>
-                                            src/build/inference/factorUnits/predefined-factors-and-scalings.ttl
-                                            target/dist/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
-                                        </include>
-                                    </input>
-                                    <outputFile>target/dist/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl</outputFile>
-                                </singleFile>
-                            </products>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <!--
-                        adds the qudt:hasFactorUnit triples we generated with SHACL to the units source file.
-                        -->
-                        <id>merge-factorUnits-target</id>
-                        <phase>none</phase>
-                        <goals>
-                            <goal>make</goal>
-                        </goals>
-                        <configuration>
-                            <products>
-                                <singleFile>
-                                    <input>
-                                        <include>
-                                            target/inferred/factorUnits.ttl
-                                            target/dist/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
-                                        </include>
-                                    </input>
-                                    <outputFile>target/dist/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl</outputFile>
-                                </singleFile>
-                            </products>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <!--
-                        adds the qudt:hasFactorUnit triples we generated with SHACL to the units source file.
-                        -->
-                        <id>merge-conversionMultiplier-target</id>
-                        <phase>none</phase>
-                        <goals>
-                            <goal>make</goal>
-                        </goals>
-                        <configuration>
-                            <products>
-                                <singleFile>
-                                    <input>
-                                        <include>
-                                            target/inferred/conversionMultiplier.ttl
-                                            target/dist/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
-                                        </include>
-                                    </input>
-                                    <outputFile>target/dist/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl</outputFile>
-                                </singleFile>
-                            </products>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <!--
-                        executes the query that is used to generate/validate qudt:hasFactorUnit triples
-                        -->
-                        <id>query-factorUnits</id>
-                        <phase>none</phase>
-                        <goals>
-                            <goal>make</goal>
-                        </goals>
-                        <configuration>
-                            <products>
-                                <singleFile>
-                                    <input>
-                                        <include>
-                                            target/inferred/factorUnits.ttl
-                                            src/build/inference/factorUnits/predefined-factors-and-scalings.ttl
-                                            src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
-                                            src/main/rdf/vocab/prefixes/VOCAB_QUDT-PREFIXES.ttl
-                                        </include>
-                                    </input>
-                                    <filters>
-                                        <sparqlSelectFile>src/build/srcgen/factorUnits/query.rq</sparqlSelectFile>
-                                    </filters>
-                                    <outputFile>target/ignore.txt</outputFile>
-                                </singleFile>
-                            </products>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <!--
-                        executes the query that is used to generate/validate qudt:scalingOf triples
-                        -->
-                        <id>query-scalingOf</id>
-                        <phase>none</phase>
-                        <goals>
-                            <goal>make</goal>
-                        </goals>
-                        <configuration>
-                            <products>
-                                <singleFile>
-                                    <input>
-                                        <include>
-                                            <!--
-                                                we include anything we might have already inferrd, and we
-                                                include the predefined scalings (they are merged into the target units later)
-                                            -->
-                                            src/build/inference/factorUnits/predefined-factors-and-scalings.ttl
-                                            target/inferred/scalingOf.ttl
-                                            src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
-                                            src/main/rdf/vocab/prefixes/VOCAB_QUDT-PREFIXES.ttl
-                                        </include>
-                                    </input>
-                                    <filters>
-                                        <sparqlSelectFile>src/build/srcgen/scalingOf/query.rq</sparqlSelectFile>
-                                    </filters>
-                                    <outputFile>target/ignore.txt</outputFile>
-                                </singleFile>
-                            </products>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <!--
-                        adds the qudt:hasFactorUnit triples we generated with SHACL to the units source file.
-                        -->
-                        <id>merge-scalingOf-target</id>
-                        <phase>none</phase>
-                        <goals>
-                            <goal>make</goal>
-                        </goals>
-                        <configuration>
-                            <products>
-                                <singleFile>
-                                    <input>
-                                        <include>
-                                            target/inferred/scalingOf.ttl
-                                            target/dist/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
-                                        </include>
-                                    </input>
-                                    <outputFile>target/dist/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl</outputFile>
-                                </singleFile>
-                            </products>
-                        </configuration>
-                    </execution>
+
                     <execution>
                         <!--
                         generates links to IEC CDD
@@ -897,37 +803,6 @@
                                         </sparqlUpdate>
                                     </filters>
                                 </eachFile>
-                            </products>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <!--
-                        execute any query you like (not used in the build - just edit below an run
-                        ```
-                        mvn rdfio:make@myQuery
-                        ```
-                        -->
-                        <id>myQuery</id>
-                        <phase>none</phase>
-                        <goals>
-                            <goal>make</goal>
-                        </goals>
-                        <configuration>
-                            <products>
-                                <singleFile>
-                                    <input>
-                                        <include>
-                                            target/dist/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
-                                        </include>
-                                    </input>
-                                    <filters>
-                                        <!-- put any query here -->
-                                        <sparqlSelectFile>
-                                            src/build/srcgen/conversionMultiplier/query.rq
-                                        </sparqlSelectFile>
-                                    </filters>
-                                    <outputFile>target/ignore.txt</outputFile>
-                                </singleFile>
                             </products>
                         </configuration>
                     </execution>
@@ -1049,12 +924,24 @@
                             <goal>check</goal>
                         </goals>
                         <configuration>
+                            <formats>
+                            <!--
+                            does our placeholder replacements using the maven properties
+                            that were set using the groovy plugin
+                            -->
+                                <format>
+                                    <excludes>
+                                        <exclude>target/**/*.*</exclude>
+                                    </excludes>
+                                </format>
+                            </formats>
+
                             <rdf>
                                 <includes>
                                     <include>src/**/*.ttl</include>
                                 </includes>
                                 <excludes>
-                                    <exclude>**/target/**/*.*</exclude>
+                                    <exclude>target/**/*.*</exclude>
                                     <exclude>src/build/srcgen/**/infer.ttl</exclude>
                                     <exclude>src/build/srcgen/**/validate.ttl</exclude>
                                 </excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
                 Here are the phases and the execution ids that are linked to them (executed in the order they appear in this file):
                       validate                 defineAdditionalProperties, preprocess-shacl-files
                       initialize               [Profile -Pfix: reformat-sources]
-                      generate-sources
+                      generate-sources         unitTestPipeline
                       process-sources          check-source-format, shacl-validate-src
                       generate-resources       copy-rdf, copy-docs, copy-root-files, validate-shacl-files
                       process-resources        generate-iec-links
@@ -381,7 +381,7 @@
             <plugin>
                 <groupId>io.github.qudtlib</groupId>
                 <artifactId>rdfio-maven-plugin</artifactId>
-                <version>1.4.1</version>
+                <version>1.4.2</version>
                 <executions>
                     <execution>
                         <id>badness</id>
@@ -430,7 +430,7 @@
                                                         ), xsd:decimal)
                                                     AS ?badness)
                                                 FILTER(BOUND(?badness))
-                                                FILTER(ABS(?badness) > 0.01)
+                                                FILTER(ABS(?badness) > 0.000001)
                                             } order by ABS(?badness)
                                             ]]>
                                         </sparql>
@@ -439,6 +439,88 @@
                             </pipeline>
                         </configuration>
                     </execution>
+                    <execution>
+                        <!-- unit tests for SHACL functions -->
+                        <id>unitTestPipeline</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>pipeline</goal>
+                        </goals>
+                        <configuration>
+                        <pipeline>
+                            <id>unitTestPipeline</id>
+                            <steps>
+                                <!-- make custom shacl functions available in inference and SPARQL-->
+                                <shaclFunctions>
+                                    <file>src/main/rdf/validation/qudt-shacl-functions.ttl</file>
+                                </shaclFunctions>
+                                <assert>
+                                    <message>Test qfn:decimalPrecision()</message>
+                                    <failureMessage>Unit test failed for qfn:decimalPrecision()</failureMessage>
+                                    <sparqlSelect>
+                                        SELECT *
+                                        WHERE {
+                                        VALUES (?input ?expectedOutput) {
+                                        (0            0)
+                                        (0.0          0)
+                                        (1            1)
+                                        (1.0          1)
+                                        (-1           1)
+                                        (-1.0         1)
+                                        (-.1          1)
+                                        (10           1)
+                                        (100          1)
+                                        (100.001      6)
+                                        (100.000      1)
+                                        (00123.456000 6)
+                                        (-0.00000001  1)
+                                        }
+                                        BIND(qfn:decimalPrecision(?input) AS ?precision)
+                                        FILTER(!BOUND(?precision) || ?precision != ?expectedOutput)
+                                        }
+                                    </sparqlSelect>
+                                </assert>
+                                <assert>
+                                    <message>Test qfn:decimalRoundToPrecision()</message>
+                                    <failureMessage>Unit test failed for qfn:decimalRoundToPrecision()</failureMessage>
+                                    <sparqlSelect>
+                                        SELECT *
+                                        WHERE {
+                                        VALUES (?input ?precision ?expectedOutput) {
+                                            (0            1         0.0)
+                                            (0.0          1         0.0)
+                                            (0.1          1         0.1)
+                                            (.1           1         0.1)
+                                            (1            1         1.0)
+                                            (+1           1         1.0)
+                                            (+1.0         1         1.0)
+                                            (+.0          1         0.0)
+                                            (+.1          1         0.1)
+                                            (1.0          1         1.0)
+                                            (-1           1        -1.0)
+                                            (-1.0         1        -1.0)
+                                            (-.1          1        -0.1)
+                                            (10           1        10.0)
+                                            (100          1       100.0)
+                                            (100.001      6       100.001)
+                                            (100.000      1       100.0)
+                                            (00123.456000 6       123.456)
+                                            (-0.00000001  1        -0.00000001)
+                                            (-00123.456000 3     -123.0)
+                                            (00123.456000 3       123.0)
+                                            (0.000000011574074074074074074  10 0.00000001157407407)
+                                            (-0.000000011574074074074074074  10 -0.00000001157407407)
+                                        }
+                                        BIND(qfn:decimalRoundToPrecision(?input, ?precision) AS ?rounded)
+                                        FILTER(!BOUND(?rounded) || ?rounded != ?expectedOutput)
+                                        }
+                                    </sparqlSelect>
+                                </assert>
+                            </steps>
+                            </pipeline>
+                        </configuration>
+                    </execution>
+
                     <execution>
                         <id>mainPipeline</id>
                         <phase>compile</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -316,6 +316,7 @@
                                     <!--skip>true</skip-->
                                     <shapes>
                                         <include>
+                                            src/main/rdf/validation/qudt-shacl-functions.ttl
                                             target/srcgen/factorUnits/validate.ttl
                                         </include>
                                     </shapes>
@@ -332,6 +333,7 @@
                                     <!--skip>true</skip-->
                                     <shapes>
                                         <include>
+                                            src/main/rdf/validation/qudt-shacl-functions.ttl
                                             target/srcgen/scalingOf/validate.ttl
                                         </include>
                                     </shapes>
@@ -340,7 +342,7 @@
                                             target/dist/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
                                         </include>
                                     </data>
-                                    <outputFile>target/validation/validationReport-factorUnits.ttl</outputFile>
+                                    <outputFile>target/validation/validationReport-scalingOf.ttl</outputFile>
                                 </validation>
                             </validations>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -793,6 +793,53 @@
                                         <toFile>target/dist/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL.ttl</toFile>
                                     </write>
                                     <!-- start from here if nothing has changed in the inputs of the earlier steps -->
+
+                                    <clear/>
+                                    <savepoint><id>09-afterClear</id></savepoint>
+                                    <shaclFunctions>
+                                        <file>src/main/rdf/validation/qudt-shacl-functions.ttl</file>
+                                    </shaclFunctions>
+                                    <add>
+                                        <files>
+                                            <include>target/dist/**/*.ttl</include>
+                                        </files>
+                                        <toGraphsPattern>target:${name}</toGraphsPattern>
+                                    </add>
+                                    <sparqlUpdate>
+                                        <message>Limit any xsd:decimal's precision to 34</message>
+                                        <sparql>
+                                        DELETE {
+                                            GRAPH ?g {
+                                                ?s ?p ?oldVal .
+                                                ?s ?pSN ?oldValSN .
+                                            }
+                                        }
+                                        INSERT {
+                                            GRAPH ?g {
+                                                ?s ?p ?newVal .
+                                                ?s ?pSN ?newValSN .
+                                            }
+                                        }
+                                        WHERE {
+                                           GRAPH ?g {
+                                                ?s ?p ?oldVal .
+                                                FILTER (DATATYPE(?oldVal) = xsd:decimal)
+                                                FILTER(qfn:decimalPrecision(?oldVal) > 34)
+                                                BIND(IRI(CONCAT(STR(?p),"SN")) as ?pSN)
+                                                BIND(qfn:decimalRoundToPrecision(?oldVal, 34) AS ?newVal)
+                                                BIND(qfn:decimalToDouble(?newVal) AS ?newValSN)
+                                                OPTIONAL {
+                                                    ?s ?pSN ?oldValSN .
+                                                }
+                                           }
+                                        }
+                                        </sparql>
+                                    </sparqlUpdate>
+                                    <write>
+                                        <graphs>
+                                            <include>target:*</include>
+                                        </graphs>
+                                    </write>
                                     <savepoint><id>99-endOfPipeline</id></savepoint>
                                 </steps>
                             </pipeline>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
                       generate-sources         unitTestPipeline
                       process-sources          check-source-format, shacl-validate-src
                       generate-resources       copy-rdf, copy-docs, copy-root-files, validate-shacl-files
-                      process-resources        generate-iec-links
+                      process-resources
                       process-classes          mainRdfPipeline
                       generate-test-sources
                       process-test-sources
@@ -386,62 +386,6 @@
                 <version>1.4.2</version>
                 <executions>
                     <execution>
-                        <id>badness</id>
-                        <phase>none</phase>
-                        <goals>
-                            <goal>pipeline</goal>
-                        </goals>
-                        <configuration>
-                            <pipeline>
-                                <id>badnessPipeline</id>
-                                <steps>
-                                    <add>
-                                        <files>
-                                            <include>
-                                                target/validation/conversionMultiplier-toDelete*.ttl
-                                            </include>
-                                        </files>
-                                    </add>
-                                    <add>
-                                        <file>src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl</file>
-                                        <toGraph>units:src</toGraph>
-                                    </add>
-                                    <add>
-                                        <file>target/dist/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl</file>
-                                        <toGraph>units:target</toGraph>
-                                    </add>
-                                    <sparqlQuery>
-                                        <sparql>
-                                            <![CDATA[
-                                            SELECT ?focusNode ?badness ?originalConversionMultiplier ?cmCalculated WHERE {
-                                                ?report sh:resultMessage ?message .
-                                                ?report sh:focusNode ?focusNode .
-                                                GRAPH <units:src> {
-                                                    ?focusNode qudt:conversionMultiplier ?originalConversionMultiplier .
-                                                }
-                                                GRAPH <units:target> {
-                                                    ?focusNode qudt:conversionMultiplier ?cmCalculated .
-                                                }
-                                                BIND(
-                                                    STRDT(
-                                                        REPLACE(
-                                                            ?message,
-                                                            "^(.|\\r\\n)*badness\\s+: ([0-9]+\\.[0-9]+)(.|\\r\\n)*$",
-                                                            "$2",
-                                                            "mi"
-                                                        ), xsd:decimal)
-                                                    AS ?badness)
-                                                FILTER(BOUND(?badness))
-                                                FILTER(ABS(?badness) > 0.000001)
-                                            } order by ABS(?badness)
-                                            ]]>
-                                        </sparql>
-                                    </sparqlQuery>
-                                </steps>
-                            </pipeline>
-                        </configuration>
-                    </execution>
-                    <execution>
                         <!-- unit tests for SHACL functions -->
                         <id>unitTestPipeline</id>
                         <phase>generate-sources</phase>
@@ -537,15 +481,45 @@
                                     <shaclFunctions>
                                         <file>src/main/rdf/validation/qudt-shacl-functions.ttl</file>
                                     </shaclFunctions>
+                                    <!-- first, handle the IEC links -->
+                                    <add>
+                                        <!--
+                                            this reads each file in target into a graph named 'target:{filename}'
+                                            in the dataset and remembers the file association (see <write> at the end)
+                                        -->
+                                        <files>
+                                            <include>target/dist/vocab/**/*.ttl</include>
+                                        </files>
+                                        <toGraphsPattern>target:${name}</toGraphsPattern>
+                                    </add>
+                                    <sparqlUpdate>
+                                        <message>Adding IEC links</message>
+                                        <sparql>
+                                            <![CDATA[
+                                            INSERT {
+                                                GRAPH ?g {
+                                                    ?x qudt:informativeReference ?new}
+                                                }
+                                            WHERE {
+                                                GRAPH ?g {
+                                                    ?x a ?type; qudt:iec61360Code ?irdi.
+                                                    VALUES (?type ?prefix) {
+                                                        (qudt:Unit         "https://cdd.iec.ch/cdd/iec62720/iec62720.nsf/Units/")
+                                                        (qudt:QuantityKind "https://cdd.iec.ch/cdd/iec61987/iec61987.nsf/ListsOfUnitsAllVersions/")
+                                                        (qudt:PhysicalConstant "https://cdd.iec.ch/cdd/iec61987/iec61987.nsf/ListsOfUnitsAllVersions/")
+                                                    }
+                                                    OPTIONAL {
+                                                        ?x qudt:informativeReference ?old filter(strstarts(str(?old),"https://cdd.iec.ch"))
+                                                    }
+                                                    BIND(replace(replace(str(?irdi),"/","-"),"#","%23") as ?irdi_new)
+                                                    BIND(strdt(concat(?prefix,?irdi_new),xsd:anyURI) as ?new)
+                                                }
+                                            }
+                                            ]]>
+                                        </sparql>
+                                    </sparqlUpdate>
+                                    <savepoint><id>01-iec-links</id></savepoint>
 
-                                    <add> <!-- load target quantitykinds into <target:quantityKinds> (associating that graph with the file)-->
-                                        <file>src/main/rdf/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL.ttl</file>
-                                        <toGraph>modified:quantityKinds</toGraph>
-                                    </add>
-                                    <add> <!-- load target units into <modified:units>  (associating that graph with the file) -->
-                                        <file>src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl</file>
-                                        <toGraph>modified:units</toGraph>
-                                    </add>
                                     <add> <!-- load applicableUnits shapes (rules) into <shapes:applicableUnits> because we need them twice (see below) -->
                                         <file>src/build/inference/inferApplicableUnits.ttl</file>
                                         <toGraph>shapes:applicableUnits</toGraph>
@@ -557,8 +531,8 @@
                                             <graph>shapes:applicableUnits</graph>
                                         </shapes>
                                         <data>
-                                            <graph>modified:quantityKinds</graph>
-                                            <graph>modified:units</graph>
+                                            <graph>target:VOCAB_QUDT-QUANTITY-KINDS-ALL.ttl</graph>
+                                            <graph>target:VOCAB_QUDT-UNITS-ALL.ttl</graph>
                                         </data>
                                         <inferred>
                                             <graph>inferred:applicableUnits</graph>
@@ -568,31 +542,26 @@
 
                                     <add> <!-- add the results of the quantitykinds inference to the quantityKinds graph -->
                                         <graph>inferred:applicableUnits</graph>
-                                        <toGraph>modified:quantityKinds</toGraph>
+                                        <toGraph>target:VOCAB_QUDT-QUANTITY-KINDS-ALL.ttl</toGraph>
                                     </add>
 
                                     <!-- start from here if nothing has changed in the inputs of the earlier steps -->
-                                    <savepoint><id>01-applicableUnits</id></savepoint>
-                                    <add>
-                                        <file>src/main/rdf/vocab/currency/VOCAB_QUDT-UNITS-CURRENCY.ttl</file>
-                                        <toGraph>target:currencyUnits</toGraph>
-                                    </add>
+                                    <savepoint><id>02-applicableUnits</id></savepoint>
                                     <shaclInfer>  <!-- do the quantitykinds inference for currency units -->
                                         <message>Inferring qudt:applicableUnit triples (currency units)</message>
                                         <shapes><graph>shapes:applicableUnits</graph></shapes>
                                         <data>
-                                            <graph>target:currencyUnits</graph>
+                                            <graph>target:VOCAB_QUDT-UNITS-CURRENCY.ttl</graph>
                                         </data>
                                         <inferred>
                                             <graph>inferred:applicableCurrencyUnits</graph>
                                             <file>target/inferred/applicableUnits-currency.ttl</file>
                                         </inferred>
                                     </shaclInfer>
-                                    <write>
-                                        <graph>target:currencyUnits</graph>
+                                    <add>
                                         <graph>inferred:applicableCurrencyUnits</graph>
-                                        <toFile>target/dist/vocab/currency/VOCAB_QUDT-UNITS-CURRENCY.ttl</toFile>
-                                    </write>
+                                        <toGraph>target:VOCAB_QUDT-UNITS-CURRENCY.ttl</toGraph>
+                                    </add>
 
                                     <!-- start from here if nothing has changed in the inputs of the earlier steps -->
                                     <savepoint><id>02-applicableUnits-currencies</id></savepoint>
@@ -606,9 +575,9 @@
                                             <files>
                                                 <include>
                                                     src/main/rdf/schema/SCHEMA_QUDT.ttl
-                                                    src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
                                                 </include>
                                             </files>
+                                            <graph>target:VOCAB_QUDT-UNITS-ALL.ttl</graph>
                                         </data>
                                         <inferred>
                                             <graph>inferred:owl-subset-units</graph>
@@ -618,7 +587,7 @@
 
                                     <add> <!-- add the inferred triples to the units graph -->
                                         <graph>inferred:owl-subset-units</graph>
-                                        <toGraph>modified:units</toGraph>
+                                        <toGraph>target:VOCAB_QUDT-UNITS-ALL.ttl</toGraph>
                                     </add>
 
                                     <!-- start from here if nothing has changed in the inputs of the earlier steps -->
@@ -626,13 +595,7 @@
 
                                     <add>
                                         <file>src/build/inference/factorUnits/predefined-factors-and-scalings.ttl</file>
-                                        <toGraph>modified:units</toGraph>
-                                    </add>
-                                    <add>
-                                        <files>
-                                            <include>target/dist/vocab/prefixes/*.ttl</include>
-                                        </files>
-                                        <toGraph>target:prefixes</toGraph>
+                                        <toGraph>target:VOCAB_QUDT-UNITS-ALL.ttl</toGraph>
                                     </add>
 
                                     <shaclInfer> <!-- infer ther factor units -->
@@ -643,8 +606,8 @@
                                         <data>
                                             <graphs>
                                                 <include>
-                                                    modified:units
-                                                    target:prefixes
+                                                    target:VOCAB_QUDT-UNITS-ALL.ttl
+                                                    target:VOCAB_QUDT-PREFIXES.ttl
                                                 </include>
                                             </graphs>
                                         </data>
@@ -655,7 +618,7 @@
                                     </shaclInfer>
                                     <add>
                                         <graph>inferred:factorUnits</graph>
-                                        <toGraph>modified:units</toGraph>
+                                        <toGraph>target:VOCAB_QUDT-UNITS-ALL.ttl</toGraph>
                                     </add>
                                     <savepoint><id>04-infer-factor-units</id></savepoint>
                                     <shaclInfer>
@@ -664,8 +627,8 @@
                                             <file>target/srcgen/scalingOf/infer.ttl</file>
                                         </shapes>
                                         <data>
-                                            <graph>modified:units</graph>
-                                            <graph>target:prefixes</graph>
+                                            <graph>target:VOCAB_QUDT-UNITS-ALL.ttl</graph>
+                                            <graph>target:VOCAB_QUDT-PREFIXES.ttl</graph>
                                         </data>
                                         <inferred>
                                             <graph>inferred:scalingOf</graph>
@@ -674,7 +637,7 @@
                                     </shaclInfer>
                                     <add>
                                         <graph>inferred:scalingOf</graph>
-                                        <toGraph>modified:units</toGraph>
+                                        <toGraph>target:VOCAB_QUDT-UNITS-ALL.ttl</toGraph>
                                     </add>
                                     <savepoint><id>05-infer-scalingOf</id></savepoint>
                                     <until>
@@ -699,8 +662,8 @@
                                                     <file>target/srcgen/conversionMultiplier/validate.ttl</file>
                                                 </shapes>
                                                 <data>
-                                                    <graph>modified:units</graph>
-                                                    <graph>target:prefixes</graph>
+                                                    <graph>target:VOCAB_QUDT-UNITS-ALL.ttl</graph>
+                                                    <graph>target:VOCAB_QUDT-PREFIXES.ttl</graph>
                                                 </data>
                                                 <validationReport>
                                                     <graph>inferred:conversionMultiplierToDelete_${index_cm}</graph>
@@ -712,13 +675,13 @@
                                                 <sparql>
                                                     <![CDATA[
                                                 DELETE {
-                                                    GRAPH <modified:units> {
+                                                    GRAPH <target:VOCAB_QUDT-UNITS-ALL.ttl> {
                                                         ?unit qudt:conversionMultiplier ?m .
                                                         ?unit  qudt:conversionMultiplierSN ?mSN .
                                                     }
                                                 }
                                                 WHERE {
-                                                    GRAPH <modified:units> {
+                                                    GRAPH <target:VOCAB_QUDT-UNITS-ALL.ttl> {
                                                         {
                                                             ?unit qudt:conversionMultiplier ?m .
                                                         } UNION {
@@ -746,8 +709,8 @@
                                                     <file>target/srcgen/conversionMultiplier/infer.ttl</file>
                                                 </shapes>
                                                 <data>
-                                                    <graph>modified:units</graph>
-                                                    <graph>target:prefixes</graph>
+                                                    <graph>target:VOCAB_QUDT-UNITS-ALL.ttl</graph>
+                                                    <graph>target:VOCAB_QUDT-PREFIXES.ttl</graph>
                                                 </data>
                                                 <inferred>
                                                     <graph>inferred:conversionMultiplier_${index_cm}</graph>
@@ -756,23 +719,23 @@
                                             </shaclInfer>
                                             <add>
                                                 <graph>inferred:conversionMultiplier_${index_cm}</graph>
-                                                <toGraph>modified:units</toGraph>
+                                                <toGraph>target:VOCAB_QUDT-UNITS-ALL.ttl</toGraph>
                                             </add>
                                         </body>
 
                                     </until>
-                                    <savepoint><id>08-infer-conversionMultiplier</id></savepoint>
+
                                     <sparqlUpdate>
                                         <message>Generate conversion multipliers in xsd:double format where it's missing</message>
                                         <sparql>
                                             <![CDATA[
                                             INSERT {
-                                                GRAPH <modified:units> {
+                                                GRAPH <target:VOCAB_QUDT-UNITS-ALL.ttl> {
                                                     ?unit qudt:conversionMultiplierSN ?cmsn
                                                 }
                                             }
                                             WHERE {
-                                                GRAPH <modified:units> {
+                                                GRAPH <target:VOCAB_QUDT-UNITS-ALL.ttl> {
                                                     ?unit a qudt:Unit ;
                                                           qudt:conversionMultiplier ?cm .
                                                     FILTER NOT EXISTS {
@@ -784,29 +747,8 @@
                                             ]]>
                                         </sparql>
                                     </sparqlUpdate>
-                                    <!-- write the main outputs: units and quantitykinds files (back to the files they were initially read from) -->
-                                    <write>
-                                        <graph>modified:units</graph>
-                                        <toFile>target/dist/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl</toFile>
-                                    </write>
+                                    <savepoint><id>08-infer-conversionMultiplier</id></savepoint>
 
-                                    <write>
-                                        <graph>modified:quantityKinds</graph>
-                                        <toFile>target/dist/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL.ttl</toFile>
-                                    </write>
-                                    <!-- start from here if nothing has changed in the inputs of the earlier steps -->
-
-                                    <clear/>
-                                    <savepoint><id>09-afterClear</id></savepoint>
-                                    <shaclFunctions>
-                                        <file>src/main/rdf/validation/qudt-shacl-functions.ttl</file>
-                                    </shaclFunctions>
-                                    <add>
-                                        <files>
-                                            <include>target/dist/**/*.ttl</include>
-                                        </files>
-                                        <toGraphsPattern>target:${name}</toGraphsPattern>
-                                    </add>
                                     <sparqlUpdate>
                                         <message>Limit any xsd:decimal's precision to 34</message>
                                         <sparql>
@@ -837,6 +779,7 @@
                                         }
                                         </sparql>
                                     </sparqlUpdate>
+
                                     <write>
                                         <graphs>
                                             <include>target:*</include>
@@ -845,46 +788,6 @@
                                     <savepoint><id>99-endOfPipeline</id></savepoint>
                                 </steps>
                             </pipeline>
-                        </configuration>
-                    </execution>
-
-                    <execution>
-                        <!--
-                        generates links to IEC CDD
-                        -->
-                        <id>generate-iec-links</id>
-                        <phase>process-resources</phase>
-                        <goals>
-                            <goal>make</goal>
-                        </goals>
-                        <configuration>
-                            <products>
-                                <eachFile>
-                                    <replaceInputFiles>true</replaceInputFiles>
-                                    <input>
-                                        <include>target/dist/vocab/**/*.ttl</include>
-                                    </input>
-                                    <filters>
-                                        <sparqlUpdate>
-                                            prefix qudt:&lt;http://qudt.org/schema/qudt/&gt;
-                                            prefix xsd:&lt;http://www.w3.org/2001/XMLSchema#&gt;
-
-                                            insert {?x qudt:informativeReference ?new}
-                                            where {
-                                                ?x a ?type; qudt:iec61360Code ?irdi.
-                                                values (?type ?prefix) {
-                                                    (qudt:Unit         "https://cdd.iec.ch/cdd/iec62720/iec62720.nsf/Units/")
-                                                    (qudt:QuantityKind "https://cdd.iec.ch/cdd/iec61987/iec61987.nsf/ListsOfUnitsAllVersions/")
-                                                    (qudt:PhysicalConstant "https://cdd.iec.ch/cdd/iec61987/iec61987.nsf/ListsOfUnitsAllVersions/")
-                                                }
-                                                optional {?x qudt:informativeReference ?old filter(strstarts(str(?old),"https://cdd.iec.ch"))}
-                                                bind(replace(replace(str(?irdi),"/","-"),"#","%23") as ?irdi_new)
-                                                bind(strdt(concat(?prefix,?irdi_new),xsd:anyURI) as ?new)
-                                            }
-                                        </sparqlUpdate>
-                                    </filters>
-                                </eachFile>
-                            </products>
                         </configuration>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -381,7 +381,7 @@
             <plugin>
                 <groupId>io.github.qudtlib</groupId>
                 <artifactId>rdfio-maven-plugin</artifactId>
-                <version>1.3.3-SNAPSHOT</version>
+                <version>1.4.0</version>
                 <executions>
                     <execution>
                         <id>mainPipeline</id>

--- a/pom.xml
+++ b/pom.xml
@@ -68,264 +68,158 @@
                 Executions with phase 'none' (invocable directly via command line, not bound to lifecycle):
                       none                     infer-and-format, infer-factorUnits, infer-scalingOf, merge-factorUnits-target, query-factorUnits, query-scalingOf, merge-scalingOf-target, reformat-sources
             -->
+
             <plugin>
-                <groupId>io.github.qudtlib</groupId>
-                <artifactId>seq-maven-plugin</artifactId>
-                <version>1.0.0</version>
+                <groupId>org.codehaus.gmavenplus</groupId>
+                <artifactId>gmavenplus-plugin</artifactId>
+                <version>4.1.1</version>
                 <executions>
-                    <execution>
-                        <id>infer-and-format</id>
-                        <phase>compile</phase>
-                        <goals><goal>run</goal></goals>
-                        <configuration>
-                            <label>make all inferences and write to target</label>
-                            <steps>
-                                <step>
-                                    <pluginCoordinates>rdfio:make@merge-predefinedUnits-target</pluginCoordinates>
-                                </step>
-                                <step>
-                                    <pluginCoordinates>shacl:infer@infer-factorUnits</pluginCoordinates>
-                                </step>
-                                <step>
-                                    <pluginCoordinates>rdfio:make@merge-factorUnits-target</pluginCoordinates>
-                                </step>
-                                <step>
-                                    <pluginCoordinates>shacl:infer@infer-scalingOf</pluginCoordinates>
-                                </step>
-                                <step>
-                                    <pluginCoordinates>rdfio:make@merge-scalingOf-target</pluginCoordinates>
-                                </step>
-                                <step>
-                                    <pluginCoordinates>shacl:infer@infer-conversionMultiplier</pluginCoordinates>
-                                </step>
-                                <step>
-                                    <pluginCoordinates>rdfio:make@merge-conversionMultiplier-target</pluginCoordinates>
-                                </step>
-                                <step>
-                                    <pluginCoordinates>shacl:infer@infer-applicableUnits</pluginCoordinates>
-                                </step>
-                                <step>
-                                    <pluginCoordinates>rdfio:make@merge-applicableUnits-target</pluginCoordinates>
-                                </step>
-                                <step>
-                                    <pluginCoordinates>shacl:infer@infer-owlSubset</pluginCoordinates>
-                                </step>
-                                <step>
-                                    <pluginCoordinates>rdfio:make@merge-owlSubset-target</pluginCoordinates>
-                                </step>
-                            </steps>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>infer-factorUnits</id>
-                        <phase>none</phase>
-                        <goals><goal>run</goal></goals>
-                        <configuration>
-                            <label>factor units</label>
-                            <steps>
-                                <step>
-                                    <pluginCoordinates>shacl:infer@infer-factorUnits</pluginCoordinates>
-                                </step>
-                                <step>
-                                    <pluginCoordinates>rdfio:make@merge-factorUnits-target</pluginCoordinates>
-                                </step>
-                                <step>
-                                    <pluginCoordinates>spotless:apply@reformat-sources</pluginCoordinates>
-                                </step>
-                            </steps>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>infer-scalingOf</id>
-                        <phase>none</phase>
-                        <goals><goal>run</goal></goals>
-                        <configuration>
-                            <label>scalingOf</label>
-                            <steps>
-                                <step>
-                                    <pluginCoordinates>shacl:infer@infer-scalingOf</pluginCoordinates>
-                                </step>
-                                <step>
-                                    <pluginCoordinates>rdfio:make@merge-scalingOf-target</pluginCoordinates>
-                                </step>
-                                <step>
-                                    <pluginCoordinates>spotless:apply@reformat-sources</pluginCoordinates>
-                                </step>
-                            </steps>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>infer-derivedUnit-conversionMultiplier</id>
-                        <phase>none</phase>
-                        <goals><goal>run</goal></goals>
-                        <configuration>
-                            <label>derived units multipliers</label>
-                            <steps>
-                                <step>
-                                    <pluginCoordinates>shacl:infer@infer-conversionMultipliers</pluginCoordinates>
-                                </step>
-                                <step>
-                                    <pluginCoordinates>rdfio:make@merge-conversionMultipliers-target</pluginCoordinates>
-                                </step>
-                                <step>
-                                    <pluginCoordinates>spotless:apply@reformat-sources</pluginCoordinates>
-                                </step>
-                            </steps>
+                <!-- Ported execution: defineAdditionalProperties -->
+                <execution>
+                    <id>defineAdditionalProperties</id>
+                    <phase>validate</phase>
+                    <goals>
+                        <goal>execute</goal>
+                    </goals>
+                    <configuration>
+                        <scripts>
+                            <script><![CDATA[
+                                    import java.time.OffsetDateTime
+                                    import java.time.format.DateTimeFormatter
+                                    import java.time.temporal.ChronoField
+
+                                    def majorMinorVersion = "${project.version}".replaceAll('^(\\w+\\.\\w+).*\$', '\$1')
+                                    project.properties.setProperty('project.version.majorminor', majorMinorVersion)
+                                    project.properties.setProperty('qudt.versioned.iri.prefix', "http://qudt.org/${majorMinorVersion}/")
+                                    def now = OffsetDateTime.now().with(ChronoField.MILLI_OF_SECOND, 0)
+                                    project.properties.setProperty('qudt.build.date', "${now}")
+                                    def currentMonth = now.format(DateTimeFormatter.ofPattern("MM"))
+                                    def currentYear = now.format(DateTimeFormatter.ofPattern("YYYY"))
+                                    project.properties.setProperty('qudt.current.month', currentMonth)
+                                    project.properties.setProperty('qudt.current.year', currentYear)
+                                ]]></script>
+                        </scripts>
+                    </configuration>
+                </execution>
+                <!-- New execution: preprocess-shacl-files -->
+                <execution>
+                    <id>preprocess-shacl-files</id>
+                    <phase>validate</phase>
+                    <goals>
+                        <goal>execute</goal>
+                    </goals>
+                    <configuration>
+                        <scripts>
+                            <script><![CDATA[
+                                // Define base directories
+                                def basedir = project.basedir.toString()
+                                def srcgenDir = new File(basedir, "src/build/srcgen")
+                                def targetDir = new File(basedir, "target/srcgen")
+
+                                // Validate source directory
+                                if (!srcgenDir.exists() || !srcgenDir.isDirectory()) {
+                                    throw new Exception("Source generation directory not found: ${srcgenDir}")
+                                }
+
+                                // Ensure target directory exists
+                                targetDir.mkdirs()
+
+                                // Step 1: Collect all aspect directories and their file status
+                                def allAspectDirs = srcgenDir.listFiles().findAll { it.isDirectory() }
+                                def validAspectDirs = []
+                                // Map to store omitted dirs and missing files
+                                def omittedAspectDirsWithReasons = [:]
+
+                                allAspectDirs.each { dir ->
+                                    def aspectName = dir.name
+                                    def queryFile = new File(dir, "query.rq")
+                                    def inferTemplateFile = new File(dir, "infer-template.ttl")
+                                    def validateTemplateFile = new File(dir, "validate-template.ttl")
+
+                                    def requiredFiles = [
+                                        queryFile: queryFile,
+                                        inferTemplateFile: inferTemplateFile,
+                                        validateTemplateFile: validateTemplateFile
+                                    ]
+
+                                    // Find missing files for this directory
+                                    def missingFiles = requiredFiles.findAll { !it.value.exists() }.keySet()
+
+                                    if (missingFiles.isEmpty()) {
+                                        // All files present, add to valid list
+                                        validAspectDirs << dir
+                                        // Record missing files
+                                        } else { omittedAspectDirsWithReasons[dir] = missingFiles
+                                         }
+                                }
+
+                                // Step 2: Process valid directories
+                                validAspectDirs.each { aspectDir ->
+                                    def aspectName = aspectDir.name
+                                    println "Processing aspect: ${aspectName}"
+
+                                    // Load required files
+                                    def queryFile = new File(aspectDir, "query.rq")
+                                    def inferTemplateFile = new File(aspectDir, "infer-template.ttl")
+                                    def validateTemplateFile = new File(aspectDir, "validate-template.ttl")
+
+                                    // Process query file (e.g., remove prefixes)
+                                    def queryText = queryFile.text
+                                    def queryWithoutPrefixes = queryText.replaceAll('(?is)^\\s*(PREFIX\\s+[^\\n]*\\n)*\\s*', '')
+                                                                .replaceAll('(?is)\\s*$', '')
+                                    if (!queryWithoutPrefixes) {
+                                        throw new Exception("No query body found in ${queryFile}")
+                                    }
+                                    queryWithoutPrefixes = queryWithoutPrefixes.replaceAll("\\\\", "\\\\\\\\")
+
+                                    // Create output directory for this aspect
+                                    def aspectOutputDir = new File(targetDir, aspectName)
+                                    aspectOutputDir.mkdirs()
+
+                                    // Define templates to process
+                                    def templates = [
+                                        [source: inferTemplateFile, target: "infer.ttl"],
+                                        [source: validateTemplateFile, target: "validate.ttl"]
+                                    ]
+
+                                    // Generate output files
+                                    templates.each { template ->
+                                        def content = template.source.text
+                                        def outputContent = content.replace('{{QUERY_WITHOUT_PREFIXES}}', queryWithoutPrefixes)
+                                        outputContent = outputContent.replace('{{AUTOGENERATED_WARNING_DO_NOT_EDIT}}',
+                                            " Auto-generated file - ALL EDITS WILL BE LOST! Edit the '-template.ttl' file instead!")
+                                        def outputFile = new File(aspectOutputDir, template.target)
+                                        outputFile.text = outputContent
+                                        println "Generated: ${outputFile}"
+                                    }
+                                }
+
+                                // Step 3: Log omitted directories with missing file details
+                                if (omittedAspectDirsWithReasons) {
+                                    println "The following aspects were omitted due to missing required files:"
+                                    // Simplify to file names
+                                    omittedAspectDirsWithReasons.each { dir, missingFiles ->
+                                        def missingFileNames = missingFiles.collect { it.toString().replaceAll('^.*\\.', '') }
+                                        println " - ${dir.name}: Missing ${missingFileNames.join(', ')}"
+                                    }
+                                } else {
+                                    println "All aspects processed successfully; no missing files detected."
+                                }
+                            ]]>
+                                </script>
+                            </scripts>
                         </configuration>
                     </execution>
                 </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.groovy</groupId>
+                        <artifactId>groovy-ant</artifactId>
+                        <version>4.0.23</version>
+                        <scope>runtime</scope>
+                    </dependency>
+                </dependencies>
             </plugin>
-            <plugin>
-            <groupId>org.codehaus.gmavenplus</groupId>
-            <artifactId>gmavenplus-plugin</artifactId>
-            <version>4.1.1</version>
-            <executions>
-            <!-- Ported execution: defineAdditionalProperties -->
-            <execution>
-                <id>defineAdditionalProperties</id>
-                <phase>validate</phase>
-                <goals>
-                    <goal>execute</goal>
-                </goals>
-                <configuration>
-                    <scripts>
-                        <script><![CDATA[
-                                import java.time.OffsetDateTime
-                                import java.time.format.DateTimeFormatter
-                                import java.time.temporal.ChronoField
-
-                                def majorMinorVersion = "${project.version}".replaceAll('^(\\w+\\.\\w+).*\$', '\$1')
-                                project.properties.setProperty('project.version.majorminor', majorMinorVersion)
-                                project.properties.setProperty('qudt.versioned.iri.prefix', "http://qudt.org/${majorMinorVersion}/")
-                                def now = OffsetDateTime.now().with(ChronoField.MILLI_OF_SECOND, 0)
-                                project.properties.setProperty('qudt.build.date', "${now}")
-                                def currentMonth = now.format(DateTimeFormatter.ofPattern("MM"))
-                                def currentYear = now.format(DateTimeFormatter.ofPattern("YYYY"))
-                                project.properties.setProperty('qudt.current.month', currentMonth)
-                                project.properties.setProperty('qudt.current.year', currentYear)
-                            ]]></script>
-                    </scripts>
-                </configuration>
-            </execution>
-            <!-- New execution: preprocess-shacl-files -->
-            <execution>
-                <id>preprocess-shacl-files</id>
-                <phase>validate</phase>
-                <goals>
-                    <goal>execute</goal>
-                </goals>
-                <configuration>
-                    <scripts>
-                        <script><![CDATA[
-                            // Define base directories
-                            def basedir = project.basedir.toString()
-                            def srcgenDir = new File(basedir, "src/build/srcgen")
-                            def targetDir = new File(basedir, "target/srcgen")
-
-                            // Validate source directory
-                            if (!srcgenDir.exists() || !srcgenDir.isDirectory()) {
-                                throw new Exception("Source generation directory not found: ${srcgenDir}")
-                            }
-
-                            // Ensure target directory exists
-                            targetDir.mkdirs()
-
-                            // Step 1: Collect all aspect directories and their file status
-                            def allAspectDirs = srcgenDir.listFiles().findAll { it.isDirectory() }
-                            def validAspectDirs = []
-                            // Map to store omitted dirs and missing files
-                            def omittedAspectDirsWithReasons = [:]
-
-                            allAspectDirs.each { dir ->
-                                def aspectName = dir.name
-                                def queryFile = new File(dir, "query.rq")
-                                def inferTemplateFile = new File(dir, "infer-template.ttl")
-                                def validateTemplateFile = new File(dir, "validate-template.ttl")
-
-                                def requiredFiles = [
-                                    queryFile: queryFile,
-                                    inferTemplateFile: inferTemplateFile,
-                                    validateTemplateFile: validateTemplateFile
-                                ]
-
-                                // Find missing files for this directory
-                                def missingFiles = requiredFiles.findAll { !it.value.exists() }.keySet()
-
-                                if (missingFiles.isEmpty()) {
-                                    // All files present, add to valid list
-                                    validAspectDirs << dir
-                                    // Record missing files
-                                    } else { omittedAspectDirsWithReasons[dir] = missingFiles
-                                     }
-                            }
-
-                            // Step 2: Process valid directories
-                            validAspectDirs.each { aspectDir ->
-                                def aspectName = aspectDir.name
-                                println "Processing aspect: ${aspectName}"
-
-                                // Load required files
-                                def queryFile = new File(aspectDir, "query.rq")
-                                def inferTemplateFile = new File(aspectDir, "infer-template.ttl")
-                                def validateTemplateFile = new File(aspectDir, "validate-template.ttl")
-
-                                // Process query file (e.g., remove prefixes)
-                                def queryText = queryFile.text
-                                def queryWithoutPrefixes = queryText.replaceAll('(?is)^\\s*(PREFIX\\s+[^\\n]*\\n)*\\s*', '')
-                                                            .replaceAll('(?is)\\s*$', '')
-                                if (!queryWithoutPrefixes) {
-                                    throw new Exception("No query body found in ${queryFile}")
-                                }
-                                queryWithoutPrefixes = queryWithoutPrefixes.replaceAll("\\\\", "\\\\\\\\")
-
-                                // Create output directory for this aspect
-                                def aspectOutputDir = new File(targetDir, aspectName)
-                                aspectOutputDir.mkdirs()
-
-                                // Define templates to process
-                                def templates = [
-                                    [source: inferTemplateFile, target: "infer.ttl"],
-                                    [source: validateTemplateFile, target: "validate.ttl"]
-                                ]
-
-                                // Generate output files
-                                templates.each { template ->
-                                    def content = template.source.text
-                                    def outputContent = content.replace('{{QUERY_WITHOUT_PREFIXES}}', queryWithoutPrefixes)
-                                    outputContent = outputContent.replace('{{AUTOGENERATED_WARNING_DO_NOT_EDIT}}',
-                                        " Auto-generated file - ALL EDITS WILL BE LOST! Edit the '-template.ttl' file instead!")
-                                    def outputFile = new File(aspectOutputDir, template.target)
-                                    outputFile.text = outputContent
-                                    println "Generated: ${outputFile}"
-                                }
-                            }
-
-                            // Step 3: Log omitted directories with missing file details
-                            if (omittedAspectDirsWithReasons) {
-                                println "The following aspects were omitted due to missing required files:"
-                                // Simplify to file names
-                                omittedAspectDirsWithReasons.each { dir, missingFiles ->
-                                    def missingFileNames = missingFiles.collect { it.toString().replaceAll('^.*\\.', '') }
-                                    println " - ${dir.name}: Missing ${missingFileNames.join(', ')}"
-                                }
-                            } else {
-                                println "All aspects processed successfully; no missing files detected."
-                            }
-                        ]]>
-                        </script>
-                    </scripts>
-                </configuration>
-            </execution>
-        </executions>
-        <dependencies>
-            <dependency>
-                <groupId>org.apache.groovy</groupId>
-                <artifactId>groovy-ant</artifactId>
-                <version>4.0.23</version>
-                <scope>runtime</scope>
-            </dependency>
-        </dependencies>
-        </plugin>
 
             <plugin>
                 <groupId>io.github.qudtlib</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -384,6 +384,62 @@
                 <version>1.4.1</version>
                 <executions>
                     <execution>
+                        <id>badness</id>
+                        <phase>none</phase>
+                        <goals>
+                            <goal>pipeline</goal>
+                        </goals>
+                        <configuration>
+                            <pipeline>
+                                <id>badnessPipeline</id>
+                                <steps>
+                                    <add>
+                                        <files>
+                                            <include>
+                                                target/validation/conversionMultiplier-toDelete*.ttl
+                                            </include>
+                                        </files>
+                                    </add>
+                                    <add>
+                                        <file>src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl</file>
+                                        <toGraph>units:src</toGraph>
+                                    </add>
+                                    <add>
+                                        <file>target/dist/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl</file>
+                                        <toGraph>units:target</toGraph>
+                                    </add>
+                                    <sparqlQuery>
+                                        <sparql>
+                                            <![CDATA[
+                                            SELECT ?focusNode ?badness ?originalConversionMultiplier ?cmCalculated WHERE {
+                                                ?report sh:resultMessage ?message .
+                                                ?report sh:focusNode ?focusNode .
+                                                GRAPH <units:src> {
+                                                    ?focusNode qudt:conversionMultiplier ?originalConversionMultiplier .
+                                                }
+                                                GRAPH <units:target> {
+                                                    ?focusNode qudt:conversionMultiplier ?cmCalculated .
+                                                }
+                                                BIND(
+                                                    STRDT(
+                                                        REPLACE(
+                                                            ?message,
+                                                            "^(.|\\r\\n)*badness\\s+: ([0-9]+\\.[0-9]+)(.|\\r\\n)*$",
+                                                            "$2",
+                                                            "mi"
+                                                        ), xsd:decimal)
+                                                    AS ?badness)
+                                                FILTER(BOUND(?badness))
+                                                FILTER(ABS(?badness) > 0.01)
+                                            } order by ABS(?badness)
+                                            ]]>
+                                        </sparql>
+                                    </sparqlQuery>
+                                </steps>
+                            </pipeline>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>mainPipeline</id>
                         <phase>compile</phase>
                         <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -564,7 +564,7 @@
                                     </add>
 
                                     <!-- start from here if nothing has changed in the inputs of the earlier steps -->
-                                    <savepoint><id>02-applicableUnits-currencies</id></savepoint>
+                                    <savepoint><id>03-applicableUnits-currencies</id></savepoint>
 
                                     <shaclInfer> <!-- do the custom OWL subset inference -->
                                         <message>Performing our custom subset of OWL inferences</message>
@@ -591,7 +591,7 @@
                                     </add>
 
                                     <!-- start from here if nothing has changed in the inputs of the earlier steps -->
-                                    <savepoint><id>03-owl-subset-units</id></savepoint>
+                                    <savepoint><id>04-owl-subset-units</id></savepoint>
 
                                     <add>
                                         <file>src/build/inference/factorUnits/predefined-factors-and-scalings.ttl</file>
@@ -620,7 +620,7 @@
                                         <graph>inferred:factorUnits</graph>
                                         <toGraph>target:VOCAB_QUDT-UNITS-ALL.ttl</toGraph>
                                     </add>
-                                    <savepoint><id>04-infer-factor-units</id></savepoint>
+                                    <savepoint><id>05-infer-factor-units</id></savepoint>
                                     <shaclInfer>
                                         <message>Inferring qudt:scalingOf</message>
                                         <shapes>
@@ -639,7 +639,7 @@
                                         <graph>inferred:scalingOf</graph>
                                         <toGraph>target:VOCAB_QUDT-UNITS-ALL.ttl</toGraph>
                                     </add>
-                                    <savepoint><id>05-infer-scalingOf</id></savepoint>
+                                    <savepoint><id>06-infer-scalingOf</id></savepoint>
                                     <until>
                                         <message>Replacing invalid conversionMultipliers iteratively until no more are found</message>
                                         <indexVar>index_cm</indexVar>
@@ -747,7 +747,7 @@
                                             ]]>
                                         </sparql>
                                     </sparqlUpdate>
-                                    <savepoint><id>08-infer-conversionMultiplier</id></savepoint>
+                                    <savepoint><id>07-infer-conversionMultiplier</id></savepoint>
 
                                     <sparqlUpdate>
                                         <message>Limit any xsd:decimal's precision to 34</message>

--- a/pom.xml
+++ b/pom.xml
@@ -381,7 +381,7 @@
             <plugin>
                 <groupId>io.github.qudtlib</groupId>
                 <artifactId>rdfio-maven-plugin</artifactId>
-                <version>1.4.0</version>
+                <version>1.4.1</version>
                 <executions>
                     <execution>
                         <id>mainPipeline</id>

--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,12 @@
                                     <pluginCoordinates>rdfio:make@merge-scalingOf-target</pluginCoordinates>
                                 </step>
                                 <step>
+                                    <pluginCoordinates>shacl:infer@infer-conversionMultiplier</pluginCoordinates>
+                                </step>
+                                <step>
+                                    <pluginCoordinates>rdfio:make@merge-conversionMultiplier-target</pluginCoordinates>
+                                </step>
+                                <step>
                                     <pluginCoordinates>shacl:infer@infer-applicableUnits</pluginCoordinates>
                                 </step>
                                 <step>
@@ -142,6 +148,25 @@
                                 </step>
                                 <step>
                                     <pluginCoordinates>rdfio:make@merge-scalingOf-target</pluginCoordinates>
+                                </step>
+                                <step>
+                                    <pluginCoordinates>spotless:apply@reformat-sources</pluginCoordinates>
+                                </step>
+                            </steps>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>infer-derivedUnit-conversionMultiplier</id>
+                        <phase>none</phase>
+                        <goals><goal>run</goal></goals>
+                        <configuration>
+                            <label>derived units multipliers</label>
+                            <steps>
+                                <step>
+                                    <pluginCoordinates>shacl:infer@infer-conversionMultipliers</pluginCoordinates>
+                                </step>
+                                <step>
+                                    <pluginCoordinates>rdfio:make@merge-conversionMultipliers-target</pluginCoordinates>
                                 </step>
                                 <step>
                                     <pluginCoordinates>spotless:apply@reformat-sources</pluginCoordinates>
@@ -438,6 +463,34 @@
                         </configuration>
                     </execution>
                     <execution>
+                        <!-- infers qudt:conversionMultiplier triples and writes them to target/inferred/conversionMultiplier.ttl -->
+                        <id>infer-conversionMultiplier</id>
+                        <phase>none</phase>
+                        <goals>
+                            <goal>infer</goal>
+                        </goals>
+                        <configuration>
+                            <inferences>
+                                <inference>
+                                    <shapes>
+                                        <include>
+                                            target/srcgen/conversionMultiplier/infer.ttl
+                                            src/main/rdf/validation/qudt-shacl-functions.ttl
+                                        </include>
+                                    </shapes>
+                                    <data>
+                                        <include>
+                                            <!-- assuming predefined units and factor units have already been merged into the target units -->
+                                            target/dist/vocab/unit/*.ttl
+                                            target/dist/vocab/prefixes/*.ttl
+                                        </include>
+                                    </data>
+                                    <outputFile>target/inferred/conversionMultiplier.ttl</outputFile>
+                                </inference>
+                            </inferences>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <!--
                         SHACL-validates the union of all ttl files in src/vocab and the No-OWL schema
                         against the union of QA-Tests and No-OWL schema
@@ -484,12 +537,29 @@
                         <configuration>
                             <validations>
                                 <validation>
+                                    <message>Validating QUDT conversionMultiplier</message>
+                                    <failureMessage>Problems found</failureMessage>
+                                    <shapes>
+                                        <include>
+                                            target/srcgen/conversionMultiplier/validate.ttl
+                                            src/main/rdf/validation/qudt-shacl-functions.ttl
+                                        </include>
+                                    </shapes>
+                                    <data>
+                                        <include>
+                                            target/dist/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
+                                        </include>
+                                    </data>
+                                    <outputFile>target/validation/validationReport-conversionMultiplier.ttl</outputFile>
+                                </validation>
+                                <validation>
                                     <message>Validating QUDT build output (target/dist/)</message>
                                     <!--skip>true</skip-->
                                     <shapes>
                                         <include>
                                             src/main/rdf/validation/COLLECTION_QUDT_QA_TESTS_ALL.ttl
                                             src/main/rdf/validation/COLLECTION_QUDT_USER_TESTS.ttl
+                                            src/main/rdf/validation/qudt-shacl-functions.ttl
                                             src/main/rdf/schema/shacl/SCHEMA_QUDT_NoOWL.ttl
                                             src/main/rdf/schema/shacl/SCHEMA_QUDT-DATATYPES_NoOWL.ttl
                                         </include>
@@ -677,6 +747,29 @@
                                     <input>
                                         <include>
                                             target/inferred/factorUnits.ttl
+                                            target/dist/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
+                                        </include>
+                                    </input>
+                                    <outputFile>target/dist/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl</outputFile>
+                                </singleFile>
+                            </products>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <!--
+                        adds the qudt:hasFactorUnit triples we generated with SHACL to the units source file.
+                        -->
+                        <id>merge-conversionMultiplier-target</id>
+                        <phase>none</phase>
+                        <goals>
+                            <goal>make</goal>
+                        </goals>
+                        <configuration>
+                            <products>
+                                <singleFile>
+                                    <input>
+                                        <include>
+                                            target/inferred/conversionMultiplier.ttl
                                             target/dist/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
                                         </include>
                                     </input>

--- a/src/build/srcgen/conversionMultiplier/infer-template.ttl
+++ b/src/build/srcgen/conversionMultiplier/infer-template.ttl
@@ -1,0 +1,34 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix qfn: <http://qudt.org/shacl/functions#> .
+@prefix qudt: <http://qudt.org/schema/qudt/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+
+qfn:inferConversionMultiplier
+  a owl:Ontology ;
+  owl:imports qfn: .
+
+qfn:conversionMultiplierRule
+  a sh:NodeShape ;
+  sh:rule [
+    a sh:SPARQLRule ;
+    sh:construct """
+        CONSTRUCT {
+            ?this qudt:conversionMultiplier ?calculatedMultiplier .
+        }
+        WHERE
+        {
+            {
+                {{QUERY_WITHOUT_PREFIXES}}
+            }
+            FILTER ( ?relDiff < 0.00001 ) # the lower the threshold, the fewer, less error-prone inferences
+        }
+
+
+        """ ;
+    sh:prefixes qfn: ;
+  ] ;
+  sh:targetClass qudt:Unit .
+
+

--- a/src/build/srcgen/conversionMultiplier/infer-template.ttl
+++ b/src/build/srcgen/conversionMultiplier/infer-template.ttl
@@ -19,13 +19,7 @@ qfn:conversionMultiplierRule
         }
         WHERE
         {
-            {
-                {{QUERY_WITHOUT_PREFIXES}}
-            }
-            #FILTER ( ?relDiff < 0.00001 ) # the lower the threshold, the fewer, less error-prone inferences
-            FILTER NOT EXISTS {
-                ?this qudt:conversionMultiplier ?cm .
-            }
+            {{QUERY_WITHOUT_PREFIXES}}
         }
 
 

--- a/src/build/srcgen/conversionMultiplier/infer-template.ttl
+++ b/src/build/srcgen/conversionMultiplier/infer-template.ttl
@@ -22,7 +22,10 @@ qfn:conversionMultiplierRule
             {
                 {{QUERY_WITHOUT_PREFIXES}}
             }
-            FILTER ( ?relDiff < 0.00001 ) # the lower the threshold, the fewer, less error-prone inferences
+            #FILTER ( ?relDiff < 0.00001 ) # the lower the threshold, the fewer, less error-prone inferences
+            FILTER NOT EXISTS {
+                ?this qudt:conversionMultiplier ?cm .
+            }
         }
 
 

--- a/src/build/srcgen/conversionMultiplier/query.rq
+++ b/src/build/srcgen/conversionMultiplier/query.rq
@@ -1,51 +1,73 @@
-PREFIX qudt: <http://qudt.org/schema/qudt/>
-PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-
-SELECT ?this (xsd:decimal(?m1 * ?m2 * ?m3 * ?m4 * ?m5 * ?m6 * ?m7) AS ?total_multiplier)
+SELECT ?this ?relDiff ?actualMultiplier ?calculatedMultiplier
 WHERE {
-  # Inner query to get concatenated multipliers
+  ?this a qudt:Unit .
+  OPTIONAL { ?this qudt:conversionMultiplier ?actualMultiplier . }
+
+  # Subquery to compute and concatenate factor unit contributions
   {
-    SELECT ?this (GROUP_CONCAT(?fu_multiplier; SEPARATOR="|") AS ?concat)
+    SELECT ?this (GROUP_CONCAT(?factorContribution; SEPARATOR="|") AS ?contributions)
     WHERE {
-      ?this qudt:hasFactorUnit ?fu .
-      ?fu qudt:hasUnit ?baseUnit ;
-          qudt:exponent ?exp .
-      ?baseUnit qudt:conversionMultiplier ?b .
-      BIND(
-        IF(ABS(?exp) = 1, ?b,
-          IF(ABS(?exp) = 2, ?b * ?b,
-          IF(ABS(?exp) = 3, ?b * ?b * ?b,
-          IF(ABS(?exp) = 4, ?b * ?b * ?b * ?b,
-          IF(ABS(?exp) = 5, ?b * ?b * ?b * ?b * ?b,
-          IF(ABS(?exp) = 6, ?b * ?b * ?b * ?b * ?b * ?b,
-          IF(ABS(?exp) = 7, ?b * ?b * ?b * ?b * ?b * ?b * ?b,
-            CONCAT("Error: cannot handle exponent ", ?exp))))))))
-        AS ?m_tmp
-      )
-      BIND(
-        IF(?exp < 0, 1 / ?m_tmp,
-          IF(?exp = 0, 1.0, ?m_tmp))
-        AS ?fu_multiplier
-      )
+      ?this qudt:hasFactorUnit ?factor .
+      ?factor qudt:hasUnit ?baseUnit ;
+              qudt:exponent ?exponent .
+      ?baseUnit qudt:conversionMultiplier ?baseMultiplier .
+      # Compute contribution (exponents 0 to 8)
+      BIND(ABS(?exponent) as ?absoluteExponent)
+            BIND(if (?exponent < 0, 1.0 / ?baseMultiplier, ?baseMultiplier ) as ?multiplier)
+            BIND(
+        IF(?absoluteExponent = 0, 1.1,
+        IF(?absoluteExponent = 1, ?multiplier,
+        IF(?absoluteExponent = 2, ?multiplier * ?multiplier,
+        IF(?absoluteExponent = 3, ?multiplier * ?multiplier * ?multiplier,
+        IF(?absoluteExponent = 4, ?multiplier * ?multiplier * ?multiplier * ?multiplier,
+        IF(?absoluteExponent = 5, ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier,
+        IF(?absoluteExponent = 6, ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier,
+        IF(?absoluteExponent = 7, ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier,
+        IF(?absoluteExponent = 8, ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier,
+                                                            CONCAT("CANNOT HANDLE EXPONENT ", ?exponent)))))))))) AS ?factorContribution )
+
+
     }
     GROUP BY ?this
   }
+    # Disassemble contributions into up to 10 variables
+    BIND(COALESCE(CONCAT("|",?contributions), "|") AS ?contribString)
 
-  # Extract each multiplier using regex, default to "1" if not present
-  BIND( REPLACE(?concat, "^([^|]*).*", "$1") AS ?m1_str )
-  BIND( IF(REGEX(?concat, "\\|"), REPLACE(?concat, "^[^|]*\\|([^|]*).*", "$1"), "1") AS ?m2_str )
-  BIND( IF(REGEX(?concat, "\\|.*\\|"), REPLACE(?concat, "^[^|]*\\|[^|]*\\|([^|]*).*", "$1"), "1") AS ?m3_str )
-  BIND( IF(REGEX(?concat, "\\|.*\\|.*\\|"), REPLACE(?concat, "^[^|]*\\|[^|]*\\|[^|]*\\|([^|]*).*", "$1"), "1") AS ?m4_str )
-  BIND( IF(REGEX(?concat, "\\|.*\\|.*\\|.*\\|"), REPLACE(?concat, "^[^|]*\\|[^|]*\\|[^|]*\\|[^|]*\\|([^|]*).*", "$1"), "1") AS ?m5_str )
-  BIND( IF(REGEX(?concat, "\\|.*\\|.*\\|.*\\|.*\\|"), REPLACE(?concat, "^[^|]*\\|[^|]*\\|[^|]*\\|[^|]*\\|[^|]*\\|([^|]*).*", "$1"), "1") AS ?m6_str )
-  BIND( IF(REGEX(?concat, "\\|.*\\|.*\\|.*\\|.*\\|.*\\|"), REPLACE(?concat, "^[^|]*\\|[^|]*\\|[^|]*\\|[^|]*\\|[^|]*\\|[^|]*\\|([^|]*).*", "$1"), "1") AS ?m7_str )
-
-  # Convert strings to doubles for multiplication
-  BIND( xsd:decimal(?m1_str) AS ?m1 )
-  BIND( xsd:decimal(?m2_str) AS ?m2 )
-  BIND( xsd:decimal(?m3_str) AS ?m3 )
-  BIND( xsd:decimal(?m4_str) AS ?m4 )
-  BIND( xsd:decimal(?m5_str) AS ?m5 )
-  BIND( xsd:decimal(?m6_str) AS ?m6 )
-  BIND( xsd:decimal(?m7_str) AS ?m7 )
+    # Make sure we don't accidentally swallow stuff that isn't made of numbers
+    FILTER(REGEX("[0-9\\-\\.\\|]+", ?contribString))
+    
+    BIND(REPLACE(?contribString, ".*\\|", "") as ?f1)
+    BIND(SUBSTR(?contribString, 0, STRLEN(?contribString) - STRLEN(?f1)) as ?f1removed)
+    BIND(REPLACE(?f1removed, ".*\\|", "") as ?f2)
+    BIND(SUBSTR(?f1removed, 0, STRLEN(?f1removed) - STRLEN(?f2)) as ?f2removed)
+    BIND(REPLACE(?f2removed, ".*\\|", "") as ?f3)
+    BIND(SUBSTR(?f2removed, 0, STRLEN(?f2removed) - STRLEN(?f3)) as ?f3removed)
+    BIND(REPLACE(?f3removed, ".*\\|", "") as ?f4)
+    BIND(SUBSTR(?f3removed, 0, STRLEN(?f3removed) - STRLEN(?f4)) as ?f4removed)
+    BIND(REPLACE(?f4removed, ".*\\|", "") as ?f5)
+    BIND(SUBSTR(?f4removed, 0, STRLEN(?f4removed) - STRLEN(?f5)) as ?f5removed)
+    BIND(REPLACE(?f5removed, ".*\\|", "") as ?f6)
+    BIND(SUBSTR(?f5removed, 0, STRLEN(?f5removed) - STRLEN(?f6)) as ?f6removed)
+    BIND(REPLACE(?f6removed, ".*\\|", "") as ?f7)
+    BIND(SUBSTR(?f6removed, 0, STRLEN(?f6removed) - STRLEN(?f7)) as ?f7removed)
+    BIND(REPLACE(?f7removed, ".*\\|", "") as ?f8)
+    BIND(SUBSTR(?f7removed, 0, STRLEN(?f7removed) - STRLEN(?f8)) as ?f8removed)
+    BIND(REPLACE(?f8removed, ".*\\|", "") as ?f9)
+  # Compute calculatedMultiplier by multiplying all contributions
+    BIND(COALESCE(xsd:decimal(?f1), 1.0)
+        * COALESCE(xsd:decimal(?f2), 1.0)
+        * COALESCE(xsd:decimal(?f3), 1.0)
+        * COALESCE(xsd:decimal(?f4), 1.0)
+        * COALESCE(xsd:decimal(?f5), 1.0)
+        * COALESCE(xsd:decimal(?f6), 1.0)
+        * COALESCE(xsd:decimal(?f7), 1.0)
+        * COALESCE(xsd:decimal(?f8), 1.0)
+        * COALESCE(xsd:decimal(?f9), 1.0) as ?cumMul)
+    BIND(qfn:decimalRoundToPrecision(?cumMul, 34) as ?calculatedMultiplier)
+    BIND (?actualMultiplier - ?calculatedMultiplier as ?diff)
+    BIND (IF (?actualMultiplier = 0 , 0.0, ABS(?diff) / ABS(?actualMultiplier)) as ?relDiffAct)
+    BIND (IF( ?calculatedMultiplier = 0, 0.0, ABS(?diff) / ABS(?calculatedMultiplier)) as ?relDiffCalc)
+    BIND(IF(?relDiffAct > ?relDiffCalc, ?relDiffAct, ?relDiffCalc) as ?relDiff)
+    FILTER(?actualMultiplier != ?calculatedMultiplier)
 }
+ORDER BY DESC(?relDiff)

--- a/src/build/srcgen/conversionMultiplier/query.rq
+++ b/src/build/srcgen/conversionMultiplier/query.rq
@@ -12,67 +12,82 @@ WHERE {
   OPTIONAL { ?this qudt:conversionMultiplier ?actualMultiplier . }
   # Subquery to compute and concatenate factor unit contributions
   {
-    SELECT ?this (GROUP_CONCAT(?factorContribution; SEPARATOR="|") AS ?contributions) (GROUP_CONCAT(?multiplierFound;SEPARATOR="|") AS ?allMultipliersFound)
-    WHERE {
-      ?this qudt:hasFactorUnit ?factor .
-      ?factor qudt:hasUnit ?baseUnit ;
-              qudt:exponent ?exponent .
-      OPTIONAL {              
-        ?baseUnit qudt:conversionMultiplier ?baseMultiplier .
-      }
-      OPTIONAL {
-        ?this qudt:factorUnitScalar ?factorUnitScalar
-      }
-      
-      # did we find the multiplier?
-      BIND(IF(BOUND(?baseMultiplier), "YES", "NO") AS ?multiplierFound)
-      BIND(IF(BOUND(?factorUnitScalar), ?factorUnitScalar, 1.0) AS ?scalar)
-      BIND(?scalar * qfn:exp(?baseMultiplier, ?exponent) AS ?factorContribution)
+      {
+        SELECT
+            ?this
+            (GROUP_CONCAT(?factorContribution; SEPARATOR="|") AS ?contributions)
+            (GROUP_CONCAT(?multiplierFound;SEPARATOR="|") AS ?allMultipliersFound)
+        WHERE {
+          ?this qudt:hasFactorUnit ?factor .
+          ?factor qudt:hasUnit ?baseUnit ;
+                  qudt:exponent ?exponent .
+          OPTIONAL {
+            ?baseUnit qudt:conversionMultiplier ?baseMultiplier .
+          }
 
+
+          # did we find the multiplier?
+          BIND(IF(BOUND(?baseMultiplier), "YES", "NO") AS ?multiplierFound)
+          BIND(qfn:exp(?baseMultiplier, ?exponent) AS ?factorContribution)
+
+        }
+        GROUP BY ?this
+      }
+        # Dont continue if we could not find all multipliers
+        FILTER(!CONTAINS(?allMultipliersFound,"NO"))
+
+        # Disassemble contributions into up to 10 variables
+        BIND(COALESCE(CONCAT("|",?contributions), "|") AS ?contribString)
+
+        # Make sure we don't accidentally swallow stuff that isn't made of numbers
+        FILTER(REGEX("[0-9\\-\\.\\|]+", ?contribString))
+
+        BIND(REPLACE(?contribString, ".*\\|", "") as ?f1)
+        BIND(SUBSTR(?contribString, 0, STRLEN(?contribString) - STRLEN(?f1)) as ?f1removed)
+        BIND(REPLACE(?f1removed, ".*\\|", "") as ?f2)
+        BIND(SUBSTR(?f1removed, 0, STRLEN(?f1removed) - STRLEN(?f2)) as ?f2removed)
+        BIND(REPLACE(?f2removed, ".*\\|", "") as ?f3)
+        BIND(SUBSTR(?f2removed, 0, STRLEN(?f2removed) - STRLEN(?f3)) as ?f3removed)
+        BIND(REPLACE(?f3removed, ".*\\|", "") as ?f4)
+        BIND(SUBSTR(?f3removed, 0, STRLEN(?f3removed) - STRLEN(?f4)) as ?f4removed)
+        BIND(REPLACE(?f4removed, ".*\\|", "") as ?f5)
+        BIND(SUBSTR(?f4removed, 0, STRLEN(?f4removed) - STRLEN(?f5)) as ?f5removed)
+        BIND(REPLACE(?f5removed, ".*\\|", "") as ?f6)
+        BIND(SUBSTR(?f5removed, 0, STRLEN(?f5removed) - STRLEN(?f6)) as ?f6removed)
+        BIND(REPLACE(?f6removed, ".*\\|", "") as ?f7)
+        BIND(SUBSTR(?f6removed, 0, STRLEN(?f6removed) - STRLEN(?f7)) as ?f7removed)
+        BIND(REPLACE(?f7removed, ".*\\|", "") as ?f8)
+        BIND(SUBSTR(?f7removed, 0, STRLEN(?f7removed) - STRLEN(?f8)) as ?f8removed)
+        BIND(REPLACE(?f8removed, ".*\\|", "") as ?f9)
+      # Compute calculatedMultiplier by multiplying all contributions
+        OPTIONAL {
+            ?this qudt:factorUnitScalar ?factorUnitScalar
+        }
+        BIND(IF(BOUND(?factorUnitScalar), ?factorUnitScalar, 1.0) AS ?scalar)
+        BIND( ?scalar
+            * COALESCE(xsd:decimal(?f1), 1.0)
+            * COALESCE(xsd:decimal(?f2), 1.0)
+            * COALESCE(xsd:decimal(?f3), 1.0)
+            * COALESCE(xsd:decimal(?f4), 1.0)
+            * COALESCE(xsd:decimal(?f5), 1.0)
+            * COALESCE(xsd:decimal(?f6), 1.0)
+            * COALESCE(xsd:decimal(?f7), 1.0)
+            * COALESCE(xsd:decimal(?f8), 1.0)
+            * COALESCE(xsd:decimal(?f9), 1.0) as ?rawCalculatedMultiplier)
+    } UNION {
+        ?this
+            qudt:scalingOf/qudt:conversionMultiplier ?baseCM ;
+            qudt:prefix/qudt:conversionMultiplier ?prefixCM .
+        BIND (?baseCM * ?prefixCM as ?rawCalculatedMultiplier)
     }
-    GROUP BY ?this
-  }
-    # Dont continue if we could not find all multipliers
-    FILTER(!CONTAINS(?allMultipliersFound,"NO"))
-  
-    # Disassemble contributions into up to 10 variables
-    BIND(COALESCE(CONCAT("|",?contributions), "|") AS ?contribString)
-
-    # Make sure we don't accidentally swallow stuff that isn't made of numbers
-    FILTER(REGEX("[0-9\\-\\.\\|]+", ?contribString))
-    
-    BIND(REPLACE(?contribString, ".*\\|", "") as ?f1)
-    BIND(SUBSTR(?contribString, 0, STRLEN(?contribString) - STRLEN(?f1)) as ?f1removed)
-    BIND(REPLACE(?f1removed, ".*\\|", "") as ?f2)
-    BIND(SUBSTR(?f1removed, 0, STRLEN(?f1removed) - STRLEN(?f2)) as ?f2removed)
-    BIND(REPLACE(?f2removed, ".*\\|", "") as ?f3)
-    BIND(SUBSTR(?f2removed, 0, STRLEN(?f2removed) - STRLEN(?f3)) as ?f3removed)
-    BIND(REPLACE(?f3removed, ".*\\|", "") as ?f4)
-    BIND(SUBSTR(?f3removed, 0, STRLEN(?f3removed) - STRLEN(?f4)) as ?f4removed)
-    BIND(REPLACE(?f4removed, ".*\\|", "") as ?f5)
-    BIND(SUBSTR(?f4removed, 0, STRLEN(?f4removed) - STRLEN(?f5)) as ?f5removed)
-    BIND(REPLACE(?f5removed, ".*\\|", "") as ?f6)
-    BIND(SUBSTR(?f5removed, 0, STRLEN(?f5removed) - STRLEN(?f6)) as ?f6removed)
-    BIND(REPLACE(?f6removed, ".*\\|", "") as ?f7)
-    BIND(SUBSTR(?f6removed, 0, STRLEN(?f6removed) - STRLEN(?f7)) as ?f7removed)
-    BIND(REPLACE(?f7removed, ".*\\|", "") as ?f8)
-    BIND(SUBSTR(?f7removed, 0, STRLEN(?f7removed) - STRLEN(?f8)) as ?f8removed)
-    BIND(REPLACE(?f8removed, ".*\\|", "") as ?f9)
-  # Compute calculatedMultiplier by multiplying all contributions
-    BIND(COALESCE(xsd:decimal(?f1), 1.0)
-        * COALESCE(xsd:decimal(?f2), 1.0)
-        * COALESCE(xsd:decimal(?f3), 1.0)
-        * COALESCE(xsd:decimal(?f4), 1.0)
-        * COALESCE(xsd:decimal(?f5), 1.0)
-        * COALESCE(xsd:decimal(?f6), 1.0)
-        * COALESCE(xsd:decimal(?f7), 1.0)
-        * COALESCE(xsd:decimal(?f8), 1.0)
-        * COALESCE(xsd:decimal(?f9), 1.0) as ?cumMul)
-    BIND(qfn:decimalRoundToPrecision(?cumMul, 34) as ?calculatedMultiplier)
+    BIND (qfn:decimalRoundToPrecision(?rawCalculatedMultiplier, 34) as ?calculatedMultiplier)
     BIND (?actualMultiplier - ?calculatedMultiplier as ?diff)
     BIND (IF (?actualMultiplier = 0 , 0.0, ABS(?diff) / ABS(?actualMultiplier)) as ?relDiffAct)
     BIND (IF( ?calculatedMultiplier = 0, 0.0, ABS(?diff) / ABS(?calculatedMultiplier)) as ?relDiffCalc)
     BIND(IF(?relDiffAct > ?relDiffCalc, ?relDiffAct, ?relDiffCalc) as ?relDiff)
-    FILTER(!BOUND(?actualMultiplier) || ?actualMultiplier != ?calculatedMultiplier)
+    FILTER(
+        !BOUND(?actualMultiplier)                               # no actual multiplier? use calculated!
+        || (?actualMultiplier != 0.0                            # actual multiplier is 0? skip!!
+            && ?actualMultiplier != ?calculatedMultiplier))     # no result if calculated == actual
 }
 ORDER BY DESC(?relDiff)

--- a/src/build/srcgen/conversionMultiplier/query.rq
+++ b/src/build/srcgen/conversionMultiplier/query.rq
@@ -77,7 +77,7 @@ WHERE {
     } UNION {
         ?this
             qudt:scalingOf/qudt:conversionMultiplier ?baseCM ;
-            qudt:prefix/qudt:conversionMultiplier ?prefixCM .
+            qudt:prefix/qudt:prefixMultiplier ?prefixCM .
         BIND (?baseCM * ?prefixCM as ?rawCalculatedMultiplier)
     }
     BIND (qfn:decimalRoundToPrecision(?rawCalculatedMultiplier, 34) as ?calculatedMultiplier)

--- a/src/build/srcgen/conversionMultiplier/query.rq
+++ b/src/build/srcgen/conversionMultiplier/query.rq
@@ -1,35 +1,40 @@
-SELECT ?this ?relDiff ?actualMultiplier ?calculatedMultiplier
+prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+prefix xsd: <http://www.w3.org/2001/XMLSchema#>
+prefix owl: <http://www.w3.org/2002/07/owl#>
+prefix qfn: <http://qudt.org/shacl/functions#>
+prefix qudt: <http://qudt.org/schema/qudt/>
+prefix sh: <http://www.w3.org/ns/shacl#>
+
+SELECT ?this (qudt:conversionMultiplier as ?path) ?relDiff ?actualMultiplier ?calculatedMultiplier
 WHERE {
   ?this a qudt:Unit .
   OPTIONAL { ?this qudt:conversionMultiplier ?actualMultiplier . }
-
   # Subquery to compute and concatenate factor unit contributions
   {
-    SELECT ?this (GROUP_CONCAT(?factorContribution; SEPARATOR="|") AS ?contributions)
+    SELECT ?this (GROUP_CONCAT(?factorContribution; SEPARATOR="|") AS ?contributions) (GROUP_CONCAT(?multiplierFound;SEPARATOR="|") AS ?allMultipliersFound)
     WHERE {
       ?this qudt:hasFactorUnit ?factor .
       ?factor qudt:hasUnit ?baseUnit ;
               qudt:exponent ?exponent .
-      ?baseUnit qudt:conversionMultiplier ?baseMultiplier .
-      # Compute contribution (exponents 0 to 8)
-      BIND(ABS(?exponent) as ?absoluteExponent)
-            BIND(if (?exponent < 0, 1.0 / ?baseMultiplier, ?baseMultiplier ) as ?multiplier)
-            BIND(
-        IF(?absoluteExponent = 0, 1.1,
-        IF(?absoluteExponent = 1, ?multiplier,
-        IF(?absoluteExponent = 2, ?multiplier * ?multiplier,
-        IF(?absoluteExponent = 3, ?multiplier * ?multiplier * ?multiplier,
-        IF(?absoluteExponent = 4, ?multiplier * ?multiplier * ?multiplier * ?multiplier,
-        IF(?absoluteExponent = 5, ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier,
-        IF(?absoluteExponent = 6, ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier,
-        IF(?absoluteExponent = 7, ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier,
-        IF(?absoluteExponent = 8, ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier,
-                                                            CONCAT("CANNOT HANDLE EXPONENT ", ?exponent)))))))))) AS ?factorContribution )
-
+      OPTIONAL {              
+        ?baseUnit qudt:conversionMultiplier ?baseMultiplier .
+      }
+      OPTIONAL {
+        ?this qudt:factorUnitScalar ?factorUnitScalar
+      }
+      
+      # did we find the multiplier?
+      BIND(IF(BOUND(?baseMultiplier), "YES", "NO") AS ?multiplierFound)
+      BIND(IF(BOUND(?factorUnitScalar), ?factorUnitScalar, 1.0) AS ?scalar)
+      BIND(?scalar * qfn:exp(?baseMultiplier, ?exponent) AS ?factorContribution)
 
     }
     GROUP BY ?this
   }
+    # Dont continue if we could not find all multipliers
+    FILTER(!CONTAINS(?allMultipliersFound,"NO"))
+  
     # Disassemble contributions into up to 10 variables
     BIND(COALESCE(CONCAT("|",?contributions), "|") AS ?contribString)
 
@@ -68,6 +73,6 @@ WHERE {
     BIND (IF (?actualMultiplier = 0 , 0.0, ABS(?diff) / ABS(?actualMultiplier)) as ?relDiffAct)
     BIND (IF( ?calculatedMultiplier = 0, 0.0, ABS(?diff) / ABS(?calculatedMultiplier)) as ?relDiffCalc)
     BIND(IF(?relDiffAct > ?relDiffCalc, ?relDiffAct, ?relDiffCalc) as ?relDiff)
-    FILTER(?actualMultiplier != ?calculatedMultiplier)
+    FILTER(!BOUND(?actualMultiplier) || ?actualMultiplier != ?calculatedMultiplier)
 }
 ORDER BY DESC(?relDiff)

--- a/src/build/srcgen/conversionMultiplier/validate-template.ttl
+++ b/src/build/srcgen/conversionMultiplier/validate-template.ttl
@@ -5,7 +5,7 @@
 @prefix qudt: <http://qudt.org/schema/qudt/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 
-qfn:inferConversionMultiplier
+qfn:ValidateConversionMultiplier
   a owl:Ontology ;
   owl:imports qfn: .
 

--- a/src/build/srcgen/conversionMultiplier/validate-template.ttl
+++ b/src/build/srcgen/conversionMultiplier/validate-template.ttl
@@ -1,0 +1,35 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix qfn: <http://qudt.org/shacl/functions#> .
+@prefix qudt: <http://qudt.org/schema/qudt/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+
+qfn:inferConversionMultiplier
+  a owl:Ontology ;
+  owl:imports qfn: .
+
+qfn:conversionMultiplierRule
+  a sh:NodeShape ;
+  sh:severity sh:Violation ;
+  sh:sparql [
+    a sh:SPARQLConstraint ;
+    sh:message """
+        {$this}
+        Multiplier differs from the multiplier calculated from its factor units.
+        actual multiplier : {?actualMultiplier}
+        calculated        : {?calculatedMultiplier}
+        badness           : {?relDiff}
+        The badness is the relative difference of the difference and the actual or calculated multiplier, whichever is bigger. A badness >> 0 is a real issue to look at. A badness ~ 0 is usually due to a difference in precision and should be resolved by using the calculated value.
+        A
+        """ ;
+    sh:prefixes qfn: ;
+    sh:select """
+
+    {{QUERY_WITHOUT_PREFIXES}}
+
+    """ ;
+  ] ;
+  sh:targetClass qudt:Unit .
+
+

--- a/src/build/srcgen/factorUnits/infer-template.ttl
+++ b/src/build/srcgen/factorUnits/infer-template.ttl
@@ -1,37 +1,15 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix qk: <http://qudt.org/schema/quantitykind/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix qfn: <http://qudt.org/shacl/functions#> .
 @prefix qudt: <http://qudt.org/schema/qudt/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix sq: <http://qudt.org/2.1/shacl/infer/applicableUnits> .
 
-qk:
-  sh:declare [
-    sh:namespace "http://qudt.org/vocab/quantitykind/"^^xsd:anyURI ;
-    sh:prefix "qk" ;
-  ] .
+qfn:inferFactorUnits
+  a owl:Ontology ;
+  owl:imports qfn: .
 
-qudt:
-  sh:declare [
-    sh:namespace "http://qudt.org/schema/qudt/"^^xsd:anyURI ;
-    sh:prefix "qudt" ;
-  ] .
-
-rdfs:
-  sh:declare [
-    sh:namespace "http://www.w3.org/2000/01/rdf-schema#" ;
-    sh:prefix "rdfs" ;
-  ] .
-
-skos:
-  sh:declare [
-    sh:namespace "http://www.w3.org/2004/02/skos/core#"^^xsd:anyURI ;
-    sh:prefix "skos" ;
-  ] .
-
-sq:qkRule
+qfn:qkRule
   a sh:NodeShape ;
   sh:rule [
     a sh:SPARQLRule ;
@@ -49,18 +27,8 @@ sq:qkRule
         }
 
         """ ;
-    sh:prefixes qk: ;
-    sh:prefixes qudt: ;
-    sh:prefixes rdfs: ;
-    sh:prefixes skos: ;
-    sh:prefixes xsd: ;
+    sh:prefixes qfn: ;
   ] ;
   sh:targetClass qudt:Unit .
-
-xsd:
-  sh:declare [
-    sh:namespace "http://www.w3.org/2001/XMLSchema#"^^xsd:anyURI ;
-    sh:prefix "xsd" ;
-  ] .
 
 

--- a/src/build/srcgen/factorUnits/validate-template.ttl
+++ b/src/build/srcgen/factorUnits/validate-template.ttl
@@ -1,47 +1,21 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix qk: <http://qudt.org/schema/quantitykind/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix qfn: <http://qudt.org/shacl/functions#> .
 @prefix qudt: <http://qudt.org/schema/qudt/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix sq: <http://qudt.org/2.1/shacl/infer/applicableUnits> .
 
-qk:
-  sh:declare [
-    sh:namespace "http://qudt.org/vocab/quantitykind/"^^xsd:anyURI ;
-    sh:prefix "qk" ;
-  ] .
+qfn:ValidateFactorUnits
+  a owl:Ontology ;
+  owl:imports qfn: .
 
-qudt:
-  sh:declare [
-    sh:namespace "http://qudt.org/schema/qudt/"^^xsd:anyURI ;
-    sh:prefix "qudt" ;
-  ] .
-
-rdfs:
-  sh:declare [
-    sh:namespace "http://www.w3.org/2000/01/rdf-schema#" ;
-    sh:prefix "rdfs" ;
-  ] .
-
-skos:
-  sh:declare [
-    sh:namespace "http://www.w3.org/2004/02/skos/core#"^^xsd:anyURI ;
-    sh:prefix "skos" ;
-  ] .
-
-sq:qkRule
+qfn:qkRule
   a sh:NodeShape ;
   sh:severity sh:Violation ;
   sh:sparql [
     a sh:SPARQLConstraint ;
     sh:message "Unit {?this} does not have required qudt:hasFactorUnit reference to {?baseUnit}." ;
-    sh:prefixes qk: ;
-    sh:prefixes qudt: ;
-    sh:prefixes rdfs: ;
-    sh:prefixes skos: ;
-    sh:prefixes xsd: ;
+    sh:prefixes qfn: ;
     sh:select """
 
     {{QUERY_WITHOUT_PREFIXES}}
@@ -49,11 +23,5 @@ sq:qkRule
     """ ;
   ] ;
   sh:targetClass qudt:Unit .
-
-xsd:
-  sh:declare [
-    sh:namespace "http://www.w3.org/2001/XMLSchema#"^^xsd:anyURI ;
-    sh:prefix "xsd" ;
-  ] .
 
 

--- a/src/build/srcgen/scalingOf/infer-template.ttl
+++ b/src/build/srcgen/scalingOf/infer-template.ttl
@@ -1,37 +1,15 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix qk: <http://qudt.org/schema/quantitykind/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix qfn: <http://qudt.org/shacl/functions#> .
 @prefix qudt: <http://qudt.org/schema/qudt/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix sq: <http://qudt.org/2.1/shacl/infer/applicableUnits> .
 
-qk:
-  sh:declare [
-    sh:namespace "http://qudt.org/vocab/quantitykind/"^^xsd:anyURI ;
-    sh:prefix "qk" ;
-  ] .
+qfn:inferFactorUnits
+  a owl:Ontology ;
+  owl:imports qfn: .
 
-qudt:
-  sh:declare [
-    sh:namespace "http://qudt.org/schema/qudt/"^^xsd:anyURI ;
-    sh:prefix "qudt" ;
-  ] .
-
-rdfs:
-  sh:declare [
-    sh:namespace "http://www.w3.org/2000/01/rdf-schema#" ;
-    sh:prefix "rdfs" ;
-  ] .
-
-skos:
-  sh:declare [
-    sh:namespace "http://www.w3.org/2004/02/skos/core#"^^xsd:anyURI ;
-    sh:prefix "skos" ;
-  ] .
-
-sq:qkRule
+qfn:qkRule
   a sh:NodeShape ;
   sh:rule [
     a sh:SPARQLRule ;
@@ -50,18 +28,8 @@ sq:qkRule
         }
 
         """ ;
-    sh:prefixes qk: ;
-    sh:prefixes qudt: ;
-    sh:prefixes rdfs: ;
-    sh:prefixes skos: ;
-    sh:prefixes xsd: ;
+    sh:prefixes qfn: ;
   ] ;
   sh:targetClass qudt:Unit .
-
-xsd:
-  sh:declare [
-    sh:namespace "http://www.w3.org/2001/XMLSchema#"^^xsd:anyURI ;
-    sh:prefix "xsd" ;
-  ] .
 
 

--- a/src/build/srcgen/scalingOf/infer-template.ttl
+++ b/src/build/srcgen/scalingOf/infer-template.ttl
@@ -17,8 +17,6 @@ qfn:qkRule
         CONSTRUCT {
                  ?this
                     qudt:scalingOf ?baseUnit ;
-                    qudt:conversionMultiplier ?scaledUnitConversionMultiplier ;
-                    qudt:conversionOffset ?scaledUnitConversionOffset ;
                     qudt:prefix ?prefix .
                 }
         WHERE

--- a/src/build/srcgen/scalingOf/query.rq
+++ b/src/build/srcgen/scalingOf/query.rq
@@ -91,5 +91,6 @@ where
             ?this qudt:hasFactorUnit ?x . # for derived units, we don't generate a prefix.
         }
     }
+    FILTER(?this != unit:KiloGM)
 }
 order by ?baseUnit ?this

--- a/src/build/srcgen/scalingOf/query.rq
+++ b/src/build/srcgen/scalingOf/query.rq
@@ -4,7 +4,7 @@ PREFIX prefix: <http://qudt.org/vocab/prefix/>
 PREFIX kind: <http://qudt.org/vocab/quantitykind/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
-SELECT ?this ?baseUnit ?prefix ?scaledUnitConversionMultiplier ?scaledUnitConversionOffset
+SELECT ?this ?baseUnit ?prefix
 where
 {
     {
@@ -62,23 +62,9 @@ where
             FILTER (!CONTAINS(?baseUnitLocalName, "-"))
             FILTER (CONTAINS(?scaledUnitLocalName, STR(?prefixLabel)))
     }
-    OPTIONAL {
-        # if the scaled unit does not have a conversionMultiplier, generate it
-        FILTER NOT EXISTS {
-            ?this qudt:conversionMultiplier ?any .
-        }
-        ?baseUnit qudt:conversionMultiplier ?cm .
-        optional {
-            ?baseUnit qudt:conversionOffset ?co
-        }
-        ?prefix a qudt:Prefix ;
-            qudt:prefixMultiplier ?prefixMultiplier ;
-            rdfs:label ?prefixLabel ;
-            FILTER (!CONTAINS(?baseUnitLocalName, "-"))
-            FILTER (CONTAINS(?scaledUnitLocalName, STR(?prefixLabel)))
-        BIND (?cm * ?prefixMultiplier as ?scaledUnitConversionMultiplier )
-        BIND (?co as ?scaledUnitConversionOffset )
-    }
+
+    # NOTE: conversion multiplier calcluation for scaled units
+    # is done in src/build/srcgen/conversionMultiplier
 
     OPTIONAL {
         ?baseUnit qudt:dimensionVector ?dv .

--- a/src/build/srcgen/scalingOf/validate-template.ttl
+++ b/src/build/srcgen/scalingOf/validate-template.ttl
@@ -1,47 +1,21 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix qk: <http://qudt.org/schema/quantitykind/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix qfn: <http://qudt.org/shacl/functions#> .
 @prefix qudt: <http://qudt.org/schema/qudt/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix sq: <http://qudt.org/2.1/shacl/infer/applicableUnits> .
 
-qk:
-  sh:declare [
-    sh:namespace "http://qudt.org/vocab/quantitykind/"^^xsd:anyURI ;
-    sh:prefix "qk" ;
-  ] .
+qfn:inferFactorUnits
+  a owl:Ontology ;
+  owl:imports qfn: .
 
-qudt:
-  sh:declare [
-    sh:namespace "http://qudt.org/schema/qudt/"^^xsd:anyURI ;
-    sh:prefix "qudt" ;
-  ] .
-
-rdfs:
-  sh:declare [
-    sh:namespace "http://www.w3.org/2000/01/rdf-schema#" ;
-    sh:prefix "rdfs" ;
-  ] .
-
-skos:
-  sh:declare [
-    sh:namespace "http://www.w3.org/2004/02/skos/core#"^^xsd:anyURI ;
-    sh:prefix "skos" ;
-  ] .
-
-sq:qkRule
+qfn:qkRule
   a sh:NodeShape ;
   sh:severity sh:Violation ;
   sh:sparql [
     a sh:SPARQLConstraint ;
     sh:message "Unit {?this} does not have required qudt:scalingOf reference to {?baseUnit}" ;
-    sh:prefixes qk: ;
-    sh:prefixes qudt: ;
-    sh:prefixes rdfs: ;
-    sh:prefixes skos: ;
-    sh:prefixes xsd: ;
+    sh:prefixes qfn: ;
     sh:select """
 
     {{QUERY_WITHOUT_PREFIXES}}
@@ -49,11 +23,5 @@ sq:qkRule
     """ ;
   ] ;
   sh:targetClass qudt:Unit .
-
-xsd:
-  sh:declare [
-    sh:namespace "http://www.w3.org/2001/XMLSchema#"^^xsd:anyURI ;
-    sh:prefix "xsd" ;
-  ] .
 
 

--- a/src/build/validation/factorUnits/decimalRoundToPrecision.rq
+++ b/src/build/validation/factorUnits/decimalRoundToPrecision.rq
@@ -1,0 +1,68 @@
+    PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+    SELECT *
+    WHERE {
+        # rounds input decimal v to precision p
+        #
+        # unscaled number: significant digits
+        # precision: number of significant digits
+        # scale: (value = unscaled * 10^(-scale) ) eg: 123.45: unscaled: 12345 scale = 2;  110 = unscaled: 11, scale = -1; 0.000123 = unscaled: 123, scale = 6
+        #
+        # Algorithm:
+        #
+        # 1. val = normalized v (strip leading 0s, don't add trailing 0 if it has no dot)
+        # 2. find the dot position dVal (dVal = length(val) if no dot)
+        # 3. find the unscaled number uVal as the digits without the dot, leading 0s removed, trailing 0s kept
+        # 4. length of uVal is the precision of our value, pVal = length(uVal)
+        # 5. find the position eVal in val at which the unscaled number ends
+        # 6. scale sVal = eVal - dVal (e.g 123.456: dVal = 3, eVal = 6, sVal = 3, pVal = 6; 123: dVal = 0; 12345: dVal = 5, eVal = 5, sVal = 0, pVal = 5; 12000: dVal = 5, eVal = 2, sVal = -3, pVal = 2; 0.00123: dVal = 1, eVal=6, sVal= 5, pVal=3 )
+        # 7. precision to use pNew = min (p, pVal)
+        # 8. New unscaled number uNew with given precision. if pNew == pVal: uNew = uVal . otherwise, make tmp value from unscaled, inserting a dot at position pNew and use ROUND on it, ie uNew = ROUND(tmp)
+        # 9. New scale sNew = sVal - (pVal - pNew)
+        # 10. if sNew = 0 : newVal = CONCAT(uVal)
+        #     if sNew < 0 : newVal = CONCAT(uNew, SUBSTR(zeros,1,- sNew) ) - append zeros for each negative scale point
+        #     if sNew > 0 : newVal = CONCAT("0.", SUBSTR(zeros, 1, - sNew - pNew), uNew) - insert zeros to fill if needed
+        # 11. result = xsd:decimal(newVal)
+        #
+        # for testing:
+    VALUES (?value ?precision) { ( 438735434.18234027234132943816725522054055902409299111398204019161729399005 7 )(12345678 4) (0.00123456 3) (.00123456 4) (000123.456000 2) (123456789.0123456789 14) (0.123 5) (12345 3) (2 10) (3 1) (7 0) }
+        #
+    	BIND(IF(bound(?precision), ?precision, 34) as ?p)
+        BIND("0000000000000000000000000000000000000000000000000000000000000000000000000000000000000" as ?zeroPad)
+        # 1: normalize
+        BIND(STR(?value) as ?tmpValueStr)
+        # leading 0 before the dot are insignificant. strip.
+        BIND(REPLACE(?tmpValueStr, "^0*(0\\.|[1-9])","$1") as ?tmpValueStrNoLeading0)
+        # if the number starts with '.', prepend '0'
+        BIND(IF(STRSTARTS(?tmpValueStrNoLeading0, "."), CONCAT("0", ?tmpValueStrNoLeading0), ?tmpValueStrNoLeading0) as ?val)
+        # 2. dVal
+        BIND(STRLEN(STRBEFORE(?val,".")) as ?tmp0)
+        BIND(IF(?tmp0 = 0, STRLEN(?val), ?tmp0) as ?dVal)
+        # 3. uVal
+        BIND(REPLACE(REPLACE(?val,"\\.",""), "^0+","") as ?uVal)
+        # 4. pVal
+        BIND(STRLEN(?uVal) as ?pVal)
+        # 5. eVal
+        BIND(REPLACE(?val,"\\.","") as ?tmp1)
+        BIND(STRLEN(?tmp1) - STRLEN(STRAFTER(?tmp1,?uVal)) as ?eVal)
+        # 6. sVal
+        BIND(?eVal - ?dVal as ?sVal)
+        # 7. pNew
+        BIND(IF(?p < ?pVal, ?p, ?pVal) as ?pNew)
+        # 8. uNew
+        BIND(CONCAT(SUBSTR(?uVal,1,?pNew),".", SUBSTR(?uVal, ?pNew+1) ) as ?tmp2)
+        BIND(IF(?pNew = ?pVal, ?uVal, REPlACE(STR(ROUND(xsd:decimal(?tmp2))), ".0$","")) as ?uNew)
+        # 9. sNew
+        BIND(?sVal - (?pVal - ?pNew) as ?sNew)
+        # 10. newVal
+        BIND(IF(?sNew = 0, ?uNew,
+                IF (?sNew < 0 ,
+                    CONCAT(?uNew, SUBSTR(?zeroPad, 1, - ?sNew)),
+                    CONCAT(SUBSTR(?zeroPad, 1, ?sNew - ?pNew), ?uNew)
+                )) as ?tmp3)
+        BIND(IF(?sNew <= 0, ?tmp3,
+                CONCAT(SUBSTR(?tmp3,1,STRLEN(?tmp3) - ?sNew), ".", SUBSTR(?tmp3, STRLEN(?tmp3) - ?sNew + 1))
+            ) as ?tmp4)
+        BIND(IF(STRSTARTS(?tmp4, "."), CONCAT("0",?tmp4), ?tmp4) as ?newVal)
+        # 11. result
+        BIND(xsd:decimal(?newVal) as ?result)
+    }

--- a/src/build/validation/factorUnits/identifyMultiplierProblems.rq
+++ b/src/build/validation/factorUnits/identifyMultiplierProblems.rq
@@ -1,0 +1,79 @@
+PREFIX qudt: <http://qudt.org/schema/qudt/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+SELECT ?this ?relDiff
+       (IF(?actualMultiplier = ?calculatedMultiplier, "Equal", "Not Equal") AS ?equalityFlag)
+       ?actualMultiplier ?calculatedMultiplier
+WHERE {
+  ?this a qudt:Unit .
+  OPTIONAL { ?this qudt:conversionMultiplier ?actualMultiplier . }
+
+  # Subquery to compute and concatenate factor unit contributions
+  {
+    SELECT ?this (GROUP_CONCAT(?factorContribution; SEPARATOR="|") AS ?contributions)
+    WHERE {
+      ?this qudt:hasFactorUnit ?factor .
+      ?factor qudt:hasUnit ?baseUnit ;
+              qudt:exponent ?exponent .
+      ?baseUnit qudt:conversionMultiplier ?baseMultiplier .
+      # Compute contribution (exponents 0 to 8)
+      BIND(ABS(?exponent) as ?absoluteExponent)
+            BIND(if (?exponent < 0, 1.0 / ?baseMultiplier, ?baseMultiplier ) as ?multiplier)
+            BIND(
+        IF(?absoluteExponent = 0, 1.0,
+        IF(?absoluteExponent = 1, ?multiplier,
+        IF(?absoluteExponent = 2, ?multiplier * ?multiplier,
+        IF(?absoluteExponent = 3, ?multiplier * ?multiplier * ?multiplier,
+        IF(?absoluteExponent = 4, ?multiplier * ?multiplier * ?multiplier * ?multiplier,
+        IF(?absoluteExponent = 5, ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier,
+        IF(?absoluteExponent = 6, ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier,
+        IF(?absoluteExponent = 7, ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier,
+        IF(?absoluteExponent = 8, ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier,
+                                                            CONCAT("CANNOT HANDLE EXPONENT ", ?exponent)))))))))) AS ?factorContribution )
+
+
+    }
+    GROUP BY ?this
+  }
+    # Disassemble contributions into up to 10 variables
+    BIND(COALESCE(CONCAT("|",?contributions), "|") AS ?contribString)
+
+    # Make sure we don't accidentally swallow stuff that isn't made of numbers
+    FILTER(REGEX("[0-9\\-.|]+", ?contribString))
+
+    BIND(REPLACE(?contribString, ".*\\|", "") as ?f1)
+    BIND(SUBSTR(?contribString, 0, STRLEN(?contribString) - STRLEN(?f1)) as ?f1removed)
+    BIND(REPLACE(?f1removed, ".*\\|", "") as ?f2)
+    BIND(SUBSTR(?f1removed, 0, STRLEN(?f1removed) - STRLEN(?f2)) as ?f2removed)
+    BIND(REPLACE(?f2removed, ".*\\|", "") as ?f3)
+  	BIND(SUBSTR(?f2removed, 0, STRLEN(?f2removed) - STRLEN(?f3)) as ?f3removed)
+    BIND(REPLACE(?f3removed, ".*\\|", "") as ?f4)
+    BIND(SUBSTR(?f3removed, 0, STRLEN(?f3removed) - STRLEN(?f4)) as ?f4removed)
+    BIND(REPLACE(?f4removed, ".*\\|", "") as ?f5)
+    BIND(SUBSTR(?f4removed, 0, STRLEN(?f4removed) - STRLEN(?f5)) as ?f5removed)
+    BIND(REPLACE(?f5removed, ".*\\|", "") as ?f6)
+    BIND(SUBSTR(?f5removed, 0, STRLEN(?f5removed) - STRLEN(?f6)) as ?f6removed)
+    BIND(REPLACE(?f6removed, ".*\\|", "") as ?f7)
+    BIND(SUBSTR(?f6removed, 0, STRLEN(?f6removed) - STRLEN(?f7)) as ?f7removed)
+    BIND(REPLACE(?f7removed, ".*\\|", "") as ?f8)
+    BIND(SUBSTR(?f7removed, 0, STRLEN(?f7removed) - STRLEN(?f8)) as ?f8removed)
+    BIND(REPLACE(?f8removed, ".*\\|", "") as ?f9)
+  # Compute calculatedMultiplier by multiplying all contributions
+    BIND(COALESCE(xsd:decimal(?f1), 1.0)
+        * COALESCE(xsd:decimal(?f2), 1.0)
+        * COALESCE(xsd:decimal(?f3), 1.0)
+        * COALESCE(xsd:decimal(?f4), 1.0)
+        * COALESCE(xsd:decimal(?f5), 1.0)
+        * COALESCE(xsd:decimal(?f6), 1.0)
+        * COALESCE(xsd:decimal(?f7), 1.0)
+        * COALESCE(xsd:decimal(?f8), 1.0)
+        * COALESCE(xsd:decimal(?f9), 1.0) as ?calculatedMultiplier)
+
+    BIND (?actualMultiplier - ?calculatedMultiplier as ?diff)
+    BIND (ABS(?diff) / ABS(?actualMultiplier) as ?relDiffAct)
+    BIND (ABS(?diff) / ABS(?calculatedMultiplier) as ?relDiffCalc)
+    BIND(IF(?relDiffAct > ?relDiffCalc, ?relDiffAct, ?relDiffCalc) as ?relDiff)
+    FILTER(?actualMultiplier != ?calculatedMultiplier)
+}
+ORDER BY DESC(?relDiff)

--- a/src/build/validation/factorUnits/identifyMultiplierProblemsMoreVars.rq
+++ b/src/build/validation/factorUnits/identifyMultiplierProblemsMoreVars.rq
@@ -1,0 +1,77 @@
+PREFIX qudt: <http://qudt.org/schema/qudt/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+SELECT *
+WHERE {
+  ?this a qudt:Unit .
+  OPTIONAL { ?this qudt:conversionMultiplier ?actualMultiplier . }
+
+  # Subquery to compute and concatenate factor unit contributions
+  {
+    SELECT ?this (GROUP_CONCAT(?factorContribution; SEPARATOR="|") AS ?contributions)
+    WHERE {
+      ?this qudt:hasFactorUnit ?factor .
+      ?factor qudt:hasUnit ?baseUnit ;
+              qudt:exponent ?exponent .
+      ?baseUnit qudt:conversionMultiplier ?baseMultiplier .
+      # Compute contribution (exponents 0 to 8)
+      BIND(ABS(?exponent) as ?absoluteExponent)
+            BIND(if (?exponent < 0, 1.0 / ?baseMultiplier, ?baseMultiplier ) as ?multiplier)
+            BIND(
+        IF(?absoluteExponent = 0, 1.0,
+        IF(?absoluteExponent = 1, ?multiplier,
+        IF(?absoluteExponent = 2, ?multiplier * ?multiplier,
+        IF(?absoluteExponent = 3, ?multiplier * ?multiplier * ?multiplier,
+        IF(?absoluteExponent = 4, ?multiplier * ?multiplier * ?multiplier * ?multiplier,
+        IF(?absoluteExponent = 5, ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier,
+        IF(?absoluteExponent = 6, ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier,
+        IF(?absoluteExponent = 7, ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier,
+        IF(?absoluteExponent = 8, ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier,
+                                                            CONCAT("CANNOT HANDLE EXPONENT ", ?exponent)))))))))) AS ?factorContribution )
+
+
+    }
+    GROUP BY ?this
+  }
+    # Disassemble contributions into up to 10 variables
+    BIND(COALESCE(CONCAT("|",?contributions), "|") AS ?contribString)
+
+    # Make sure we don't accidentally swallow stuff that isn't made of numbers
+    FILTER(REGEX("[0-9\\-.|]+", ?contribString))
+
+    BIND(REPLACE(?contribString, ".*\\|", "") as ?f1)
+    BIND(SUBSTR(?contribString, 0, STRLEN(?contribString) - STRLEN(?f1)) as ?f1removed)
+    BIND(REPLACE(?f1removed, ".*\\|", "") as ?f2)
+    BIND(SUBSTR(?f1removed, 0, STRLEN(?f1removed) - STRLEN(?f2)) as ?f2removed)
+    BIND(REPLACE(?f2removed, ".*\\|", "") as ?f3)
+  	BIND(SUBSTR(?f2removed, 0, STRLEN(?f2removed) - STRLEN(?f3)) as ?f3removed)
+    BIND(REPLACE(?f3removed, ".*\\|", "") as ?f4)
+    BIND(SUBSTR(?f3removed, 0, STRLEN(?f3removed) - STRLEN(?f4)) as ?f4removed)
+    BIND(REPLACE(?f4removed, ".*\\|", "") as ?f5)
+    BIND(SUBSTR(?f4removed, 0, STRLEN(?f4removed) - STRLEN(?f5)) as ?f5removed)
+    BIND(REPLACE(?f5removed, ".*\\|", "") as ?f6)
+    BIND(SUBSTR(?f5removed, 0, STRLEN(?f5removed) - STRLEN(?f6)) as ?f6removed)
+    BIND(REPLACE(?f6removed, ".*\\|", "") as ?f7)
+    BIND(SUBSTR(?f6removed, 0, STRLEN(?f6removed) - STRLEN(?f7)) as ?f7removed)
+    BIND(REPLACE(?f7removed, ".*\\|", "") as ?f8)
+    BIND(SUBSTR(?f7removed, 0, STRLEN(?f7removed) - STRLEN(?f8)) as ?f8removed)
+    BIND(REPLACE(?f8removed, ".*\\|", "") as ?f9)
+  # Compute calculatedMultiplier by multiplying all contributions
+    BIND(COALESCE(xsd:decimal(?f1), 1.0)
+        * COALESCE(xsd:decimal(?f2), 1.0)
+        * COALESCE(xsd:decimal(?f3), 1.0)
+        * COALESCE(xsd:decimal(?f4), 1.0)
+        * COALESCE(xsd:decimal(?f5), 1.0)
+        * COALESCE(xsd:decimal(?f6), 1.0)
+        * COALESCE(xsd:decimal(?f7), 1.0)
+        * COALESCE(xsd:decimal(?f8), 1.0)
+        * COALESCE(xsd:decimal(?f9), 1.0) as ?calculatedMultiplier)
+
+    BIND (?actualMultiplier - ?calculatedMultiplier as ?diff)
+    BIND (ABS(?diff) / ABS(?actualMultiplier) as ?relDiffAct)
+    BIND (ABS(?diff) / ABS(?calculatedMultiplier) as ?relDiffCalc)
+    BIND(IF(?relDiffAct > ?relDiffCalc, ?relDiffAct, ?relDiffCalc) as ?relDiff)
+    FILTER(?actualMultiplier != ?calculatedMultiplier)
+}
+ORDER BY DESC(?relDiff)

--- a/src/main/rdf/validation/COLLECTION_QUDT_QA_TESTS_ALL.ttl
+++ b/src/main/rdf/validation/COLLECTION_QUDT_QA_TESTS_ALL.ttl
@@ -2,15 +2,16 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix qfn: <http://qudt.org/shacl/functions#> .
 @prefix qudt: <http://qudt.org/schema/qudt/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix qfn: <http://qudt.org/schema/qudt/fn#> .
 
 <http://qudt.org/$$QUDT_VERSION$$/collection/qa/all>
   a owl:Ontology ;
   owl:imports <http://qudt.org/$$QUDT_VERSION$$/collection/usertest> ;
   owl:imports <http://qudt.org/$$QUDT_VERSION$$/vocab/constant> ;
   owl:imports <http://qudt.org/$$QUDT_VERSION$$/vocab/soqk> ;
+  owl:imports qfn: ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/collection/qa/all> ;
   rdfs:label "QUDT Collection - QA TESTS - ALL - v $$QUDT_VERSION$$" ;
   sh:declare [
@@ -62,11 +63,6 @@
     a sh:PrefixDeclaration ;
     sh:namespace "http://www.w3.org/2004/02/skos/core#"^^xsd:anyURI ;
     sh:prefix "skos" ;
-  ] ;
-  sh:declare [
-   a sh:PrefixDeclaration ;
-   sh:namespace "http://qudt.org/schema/qudt/fn#"^^xsd:anyURI ;
-   sh:prefix "qfn" ;
   ] ;
   sh:declare [
     a sh:PrefixDeclaration ;
@@ -555,203 +551,6 @@ qudt:prefixMultiplierSnShape
         """ ;
   ] ;
   sh:targetClass qudt:Prefix .
-
-
-qfn:decimalRoundToPrecision a sh:SPARQLFunction ;
-  sh:parameter [
-    sh:path qfn:value ;
-    sh:order 0 ;
-    sh:datatype xsd:decimal ;
-    sh:description "The decimal value to normalize" ;
-  ] ;
-  sh:parameter [
-    sh:path qfn:precision ;
-    sh:order 1 ;
-    sh:datatype xsd:integer ;
-    sh:description "Number of significant digits" ;
-  ] ;
-  sh:returnType xsd:decimal ;
-  sh:prefixes <http://qudt.org/$$QUDT_VERSION$$/collection/qa/all> ;
-  sh:select """
-        PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-        SELECT ?result
-        WHERE {
-            # rounds input decimal v to precision p
-            #
-            # unscaled number: significant digits
-            # precision: number of significant digits
-            # scale: (value = unscaled * 10^(-scale) ) eg: 123.45: unscaled: 12345 scale = 2;  110 = unscaled: 11, scale = -1; 0.000123 = unscaled: 123, scale = 6
-            #
-            # Algorithm:
-            #
-            # 1. val = normalized v (strip leading 0s, don't add trailing 0 if it has no dot)
-            # 2. find the dot position dVal (dVal = length(val) if no dot)
-            # 3. find the unscaled number uVal as the digits without the dot, leading 0s removed, trailing 0s kept
-            # 4. length of uVal is the precision of our value, pVal = length(uVal)
-            # 5. find the position eVal in val at which the unscaled number ends
-            # 6. scale sVal = eVal - dVal (e.g 123.456: dVal = 3, eVal = 6, sVal = 3, pVal = 6; 123: dVal = 0; 12345: dVal = 5, eVal = 5, sVal = 0, pVal = 5; 12000: dVal = 5, eVal = 2, sVal = -3, pVal = 2; 0.00123: dVal = 1, eVal=6, sVal= 5, pVal=3 )
-            # 7. precision to use pNew = min (p, pVal)
-            # 8. New unscaled number uNew with given precision. if pNew == pVal: uNew = uVal . otherwise, make tmp value from unscaled, inserting a dot at position pNew and use ROUND on it, ie uNew = ROUND(tmp)
-            # 9. New scale sNew = sVal - (pVal - pNew)
-            # 10. if sNew = 0 : newVal = CONCAT(uVal)
-            #     if sNew < 0 : newVal = CONCAT(uNew, SUBSTR(zeros,1,- sNew) ) - append zeros for each negative scale point
-            #     if sNew > 0 : newVal = CONCAT("0.", SUBSTR(zeros, 1, - sNew - pNew), uNew) - insert zeros to fill if needed
-            # 11. result = xsd:decimal(newVal)
-            #
-            # for testing:
-            # VALUES (?value ?precision) { (12345678 4) (0.00123456 3) (.00123456 4) (000123.456000 2) (123456789.0123456789 14) (0.123 5) (12345 3) (2 10) (3 1) (7 0) }
-            #
-        	BIND(IF(bound(?precision), ?precision, 34) as ?p)
-            BIND("0000000000000000000000000000000000000000000000000000000000000000000000000000000000000" as ?zeroPad)
-            # 1: normalize
-            BIND(STR(?value) as ?tmpValueStr)
-            # leading 0 before the dot are insignificant. strip.
-            BIND(REPLACE(?tmpValueStr, "^0*(0\\\\.|[1-9])","$1") as ?tmpValueStrNoLeading0)
-            # if the number starts with '.', prepend '0'
-            BIND(IF(STRSTARTS(?tmpValueStrNoLeading0, "."), CONCAT("0", ?tmpValueStrNoLeading0), ?tmpValueStrNoLeading0) as ?val)
-            # 2. dVal
-            BIND(STRLEN(STRBEFORE(?val,".")) as ?tmp0)
-            BIND(IF(?tmp0 = 0, STRLEN(?val), ?tmp0) as ?dVal)
-            # 3. uVal
-            BIND(REPLACE(REPLACE(?val,"\\\\.",""), "^0+","") as ?uVal)
-            # 4. pVal
-            BIND(STRLEN(?uVal) as ?pVal)
-            # 5. eVal
-            BIND(REPLACE(?val,"\\\\.","") as ?tmp1)
-            BIND(STRLEN(?tmp1) - STRLEN(STRAFTER(?tmp1,?uVal)) as ?eVal)
-            # 6. sVal
-            BIND(?eVal - ?dVal as ?sVal)
-            # 7. pNew
-            BIND(IF(?p < ?pVal, ?p, ?pVal) as ?pNew)
-            # 8. uNew
-            BIND(CONCAT(SUBSTR(?uVal,1,?pNew),".", SUBSTR(?uVal, ?pNew+1) ) as ?tmp2)
-            BIND(IF(?pNew = ?pVal, ?uVal, REPlACE(STR(ROUND(xsd:decimal(?tmp2))), ".0$","")) as ?uNew)
-            # 9. sNew
-            BIND(?sVal - (?pVal - ?pNew) as ?sNew)
-            # 10. newVal
-            BIND(IF(?sNew = 0, ?uNew,
-                    IF (?sNew < 0 ,
-                        CONCAT(?uNew, SUBSTR(?zeroPad, 1, - ?sNew)),
-                        CONCAT(SUBSTR(?zeroPad, 1, ?sNew - ?pNew), ?uNew)
-                    )) as ?tmp3)
-            BIND(IF(?sNew <= 0, ?tmp3,
-                    CONCAT(SUBSTR(?tmp3,1,STRLEN(?tmp3) - ?sNew), ".", SUBSTR(?tmp3, STRLEN(?tmp3) - ?sNew + 1))
-                ) as ?tmp4)
-            BIND(IF(STRSTARTS(?tmp4, "."), CONCAT("0",?tmp4), ?tmp4) as ?newVal)
-            # 11. result
-            BIND(xsd:decimal(?newVal) as ?result)
-        }
-    """
-  .
-
-qudt:scaledUnitMultiplierShape
-  a sh:NodeShape ;
-  rdfs:isDefinedBy <http://qudt.org/2.1/collection/qa/all> ;
-  sh:severity sh:Violation ;
-  sh:sparql [
-    a sh:SPARQLConstraint ;
-    rdfs:comment """
-       Ensure that
-         - if unit u has factor units f_1, ..., f_n (n <= 10!)
-         - and if u has a mulitipler m_u
-         - and if all f_i have a multiplier m_i and an exponent e_i
-      then
-         m_u = (Product over all i:) m_i ^ e_i
-    """ ;
-    sh:message """
-    {$this}
-    Multiplier differs from the multiplier calculated from its factor units.
-    actual multiplier : {?actualMultiplier}
-    calculated        : {?calculatedMultiplier}
-    badness           : {?relDiff}
-    The badness is the relative difference of the difference and the actual or calculated multiplier, whichever is bigger. A badness >> 0 is a real issue to look at. A badness ~ 0 is usually due to a difference in precision and should be resolved by using the calculated value.
-    A
-    """ ;
-    sh:prefixes <http://qudt.org/$$QUDT_VERSION$$/collection/qa/all> ;
-    sh:select """
-
-PREFIX qudt: <http://qudt.org/schema/qudt/>
-PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-
-SELECT ?this ?relDiff
-       (IF(?actualMultiplier = ?calculatedMultiplier, "Equal", "Not Equal") AS ?equalityFlag)
-       ?actualMultiplier ?calculatedMultiplier
-WHERE {
-  ?this a qudt:Unit .
-  OPTIONAL { ?this qudt:conversionMultiplier ?actualMultiplier . }
-
-  # Subquery to compute and concatenate factor unit contributions
-  {
-    SELECT ?this (GROUP_CONCAT(?factorContribution; SEPARATOR="|") AS ?contributions)
-    WHERE {
-      ?this qudt:hasFactorUnit ?factor .
-      ?factor qudt:hasUnit ?baseUnit ;
-              qudt:exponent ?exponent .
-      ?baseUnit qudt:conversionMultiplier ?baseMultiplier .
-      # Compute contribution (exponents 0 to 8)
-      BIND(ABS(?exponent) as ?absoluteExponent)
-            BIND(if (?exponent < 0, 1.0 / ?baseMultiplier, ?baseMultiplier ) as ?multiplier)
-            BIND(
-        IF(?absoluteExponent = 0, 1.0,
-        IF(?absoluteExponent = 1, ?multiplier,
-        IF(?absoluteExponent = 2, ?multiplier * ?multiplier,
-        IF(?absoluteExponent = 3, ?multiplier * ?multiplier * ?multiplier,
-        IF(?absoluteExponent = 4, ?multiplier * ?multiplier * ?multiplier * ?multiplier,
-        IF(?absoluteExponent = 5, ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier,
-        IF(?absoluteExponent = 6, ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier,
-        IF(?absoluteExponent = 7, ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier,
-        IF(?absoluteExponent = 8, ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier,
-                                                            CONCAT("CANNOT HANDLE EXPONENT ", ?exponent)))))))))) AS ?factorContribution )
-
-
-    }
-    GROUP BY ?this
-  }
-    # Disassemble contributions into up to 10 variables
-    BIND(COALESCE(CONCAT("|",?contributions), "|") AS ?contribString)
-
-    # Make sure we don't accidentally swallow stuff that isn't made of numbers
-    FILTER(REGEX("[0-9\\\\-\\\\.\\\\|]+", ?contribString))
-
-    BIND(REPLACE(?contribString, ".*\\\\|", "") as ?f1)
-    BIND(SUBSTR(?contribString, 0, STRLEN(?contribString) - STRLEN(?f1)) as ?f1removed)
-    BIND(REPLACE(?f1removed, ".*\\\\|", "") as ?f2)
-    BIND(SUBSTR(?f1removed, 0, STRLEN(?f1removed) - STRLEN(?f2)) as ?f2removed)
-    BIND(REPLACE(?f2removed, ".*\\\\|", "") as ?f3)
-  \tBIND(SUBSTR(?f2removed, 0, STRLEN(?f2removed) - STRLEN(?f3)) as ?f3removed)
-    BIND(REPLACE(?f3removed, ".*\\\\|", "") as ?f4)
-    BIND(SUBSTR(?f3removed, 0, STRLEN(?f3removed) - STRLEN(?f4)) as ?f4removed)
-    BIND(REPLACE(?f4removed, ".*\\\\|", "") as ?f5)
-    BIND(SUBSTR(?f4removed, 0, STRLEN(?f4removed) - STRLEN(?f5)) as ?f5removed)
-    BIND(REPLACE(?f5removed, ".*\\\\|", "") as ?f6)
-    BIND(SUBSTR(?f5removed, 0, STRLEN(?f5removed) - STRLEN(?f6)) as ?f6removed)
-    BIND(REPLACE(?f6removed, ".*\\\\|", "") as ?f7)
-    BIND(SUBSTR(?f6removed, 0, STRLEN(?f6removed) - STRLEN(?f7)) as ?f7removed)
-    BIND(REPLACE(?f7removed, ".*\\\\|", "") as ?f8)
-    BIND(SUBSTR(?f7removed, 0, STRLEN(?f7removed) - STRLEN(?f8)) as ?f8removed)
-    BIND(REPLACE(?f8removed, ".*\\\\|", "") as ?f9)
-  # Compute calculatedMultiplier by multiplying all contributions
-    BIND(COALESCE(xsd:decimal(?f1), 1.0)
-        * COALESCE(xsd:decimal(?f2), 1.0)
-        * COALESCE(xsd:decimal(?f3), 1.0)
-        * COALESCE(xsd:decimal(?f4), 1.0)
-        * COALESCE(xsd:decimal(?f5), 1.0)
-        * COALESCE(xsd:decimal(?f6), 1.0)
-        * COALESCE(xsd:decimal(?f7), 1.0)
-        * COALESCE(xsd:decimal(?f8), 1.0)
-        * COALESCE(xsd:decimal(?f9), 1.0) as ?cumMul)
-    BIND(qfn:decimalRoundToPrecision(?cumMul, 34) as ?calculatedMultiplier)
-    BIND (?actualMultiplier - ?calculatedMultiplier as ?diff)
-    BIND (IF (?actualMultiplier = 0 , 0.0, ABS(?diff) / ABS(?actualMultiplier)) as ?relDiffAct)
-    BIND (IF( ?calculatedMultiplier = 0, 0.0, ABS(?diff) / ABS(?calculatedMultiplier)) as ?relDiffCalc)
-    BIND(IF(?relDiffAct > ?relDiffCalc, ?relDiffAct, ?relDiffCalc) as ?relDiff)
-    FILTER(?actualMultiplier != ?calculatedMultiplier)
-}
-ORDER BY DESC(?relDiff)
-""" ;
-  ] ;
-  sh:targetClass qudt:Unit .
 
 qudt:standardUncertaintySnShape
   rdfs:comment "qudt:standardUncertainty must match qudt:standardUncertaintySN if present" ;

--- a/src/main/rdf/validation/COLLECTION_QUDT_QA_TESTS_ALL.ttl
+++ b/src/main/rdf/validation/COLLECTION_QUDT_QA_TESTS_ALL.ttl
@@ -550,6 +550,115 @@ qudt:prefixMultiplierSnShape
   ] ;
   sh:targetClass qudt:Prefix .
 
+qudt:scaledUnitMultiplierShape
+  a sh:NodeShape ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/collection/qa/all> ;
+  sh:severity sh:Violation ;
+  sh:sparql [
+    a sh:SPARQLConstraint ;
+    rdfs:comment """
+       Ensure that
+         - if unit u has factor units f_1, ..., f_n (n <= 10!)
+         - and if u has a mulitipler m_u
+         - and if all f_i have a multiplier m_i and an exponent e_i
+      then
+         m_u = (Product over all i:) m_i ^ e_i
+    """ ;
+    sh:message """
+    {$this}
+    Multiplier differs from the multiplier calculated from its factor units.
+    actual multiplier : {?actualMultiplier}
+    calculated        : {?calculatedMultiplier}
+    badness           : {?relDiff}
+    The badness is the relative difference of the difference and the actual or calculated multiplier, whichever is bigger. A badness >> 0 is a real issue to look at. A badness ~ 0 is usually due to a difference in precision and should be resolved by using the calculated value.
+    A
+    """ ;
+    sh:prefixes <http://qudt.org/$$QUDT_VERSION$$/collection/qa/all> ;
+    sh:select """
+
+PREFIX qudt: <http://qudt.org/schema/qudt/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+SELECT ?this ?relDiff
+       (IF(?actualMultiplier = ?calculatedMultiplier, "Equal", "Not Equal") AS ?equalityFlag)
+       ?actualMultiplier ?calculatedMultiplier
+WHERE {
+  ?this a qudt:Unit .
+  OPTIONAL { ?this qudt:conversionMultiplier ?actualMultiplier . }
+
+  # Subquery to compute and concatenate factor unit contributions
+  {
+    SELECT ?this (GROUP_CONCAT(?factorContribution; SEPARATOR="|") AS ?contributions)
+    WHERE {
+      ?this qudt:hasFactorUnit ?factor .
+      ?factor qudt:hasUnit ?baseUnit ;
+              qudt:exponent ?exponent .
+      ?baseUnit qudt:conversionMultiplier ?baseMultiplier .
+      # Compute contribution (exponents 0 to 8)
+      BIND(ABS(?exponent) as ?absoluteExponent)
+            BIND(if (?exponent < 0, 1.0 / ?baseMultiplier, ?baseMultiplier ) as ?multiplier)
+            BIND(
+        IF(?absoluteExponent = 0, 1.0,
+        IF(?absoluteExponent = 1, ?multiplier,
+        IF(?absoluteExponent = 2, ?multiplier * ?multiplier,
+        IF(?absoluteExponent = 3, ?multiplier * ?multiplier * ?multiplier,
+        IF(?absoluteExponent = 4, ?multiplier * ?multiplier * ?multiplier * ?multiplier,
+        IF(?absoluteExponent = 5, ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier,
+        IF(?absoluteExponent = 6, ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier,
+        IF(?absoluteExponent = 7, ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier,
+        IF(?absoluteExponent = 8, ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier,
+                                                            CONCAT("CANNOT HANDLE EXPONENT ", ?exponent)))))))))) AS ?factorContribution )
+
+
+    }
+    GROUP BY ?this
+  }
+    # Disassemble contributions into up to 10 variables
+    BIND(COALESCE(CONCAT("|",?contributions), "|") AS ?contribString)
+
+    # Make sure we don't accidentally swallow stuff that isn't made of numbers
+    FILTER(REGEX("[0-9\\\\-\\\\.\\\\|]+", ?contribString))
+
+    BIND(REPLACE(?contribString, ".*\\\\|", "") as ?f1)
+    BIND(SUBSTR(?contribString, 0, STRLEN(?contribString) - STRLEN(?f1)) as ?f1removed)
+    BIND(REPLACE(?f1removed, ".*\\\\|", "") as ?f2)
+    BIND(SUBSTR(?f1removed, 0, STRLEN(?f1removed) - STRLEN(?f2)) as ?f2removed)
+    BIND(REPLACE(?f2removed, ".*\\\\|", "") as ?f3)
+  \tBIND(SUBSTR(?f2removed, 0, STRLEN(?f2removed) - STRLEN(?f3)) as ?f3removed)
+    BIND(REPLACE(?f3removed, ".*\\\\|", "") as ?f4)
+    BIND(SUBSTR(?f3removed, 0, STRLEN(?f3removed) - STRLEN(?f4)) as ?f4removed)
+    BIND(REPLACE(?f4removed, ".*\\\\|", "") as ?f5)
+    BIND(SUBSTR(?f4removed, 0, STRLEN(?f4removed) - STRLEN(?f5)) as ?f5removed)
+    BIND(REPLACE(?f5removed, ".*\\\\|", "") as ?f6)
+    BIND(SUBSTR(?f5removed, 0, STRLEN(?f5removed) - STRLEN(?f6)) as ?f6removed)
+    BIND(REPLACE(?f6removed, ".*\\\\|", "") as ?f7)
+    BIND(SUBSTR(?f6removed, 0, STRLEN(?f6removed) - STRLEN(?f7)) as ?f7removed)
+    BIND(REPLACE(?f7removed, ".*\\\\|", "") as ?f8)
+    BIND(SUBSTR(?f7removed, 0, STRLEN(?f7removed) - STRLEN(?f8)) as ?f8removed)
+    BIND(REPLACE(?f8removed, ".*\\\\|", "") as ?f9)
+  # Compute calculatedMultiplier by multiplying all contributions
+    BIND(COALESCE(xsd:decimal(?f1), 1.0)
+        * COALESCE(xsd:decimal(?f2), 1.0)
+        * COALESCE(xsd:decimal(?f3), 1.0)
+        * COALESCE(xsd:decimal(?f4), 1.0)
+        * COALESCE(xsd:decimal(?f5), 1.0)
+        * COALESCE(xsd:decimal(?f6), 1.0)
+        * COALESCE(xsd:decimal(?f7), 1.0)
+        * COALESCE(xsd:decimal(?f8), 1.0)
+        * COALESCE(xsd:decimal(?f9), 1.0) as ?calculatedMultiplier)
+
+    BIND (?actualMultiplier - ?calculatedMultiplier as ?diff)
+    BIND (IF (?actualMultiplier = 0 , 0.0, ABS(?diff) / ABS(?actualMultiplier)) as ?relDiffAct)
+    BIND (IF( ?calculatedMultiplier = 0, 0.0, ABS(?diff) / ABS(?calculatedMultiplier)) as ?relDiffCalc)
+    BIND(IF(?relDiffAct > ?relDiffCalc, ?relDiffAct, ?relDiffCalc) as ?relDiff)
+    FILTER(?actualMultiplier != ?calculatedMultiplier)
+}
+ORDER BY DESC(?relDiff)
+""" ;
+  ] ;
+  sh:targetClass qudt:Unit .
+
 qudt:standardUncertaintySnShape
   rdfs:comment "qudt:standardUncertainty must match qudt:standardUncertaintySN if present" ;
   sh:sparql [

--- a/src/main/rdf/validation/COLLECTION_QUDT_QA_TESTS_ALL.ttl
+++ b/src/main/rdf/validation/COLLECTION_QUDT_QA_TESTS_ALL.ttl
@@ -4,6 +4,7 @@
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix qudt: <http://qudt.org/schema/qudt/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix qfn: <http://qudt.org/schema/qudt/fn#> .
 
 <http://qudt.org/$$QUDT_VERSION$$/collection/qa/all>
   a owl:Ontology ;
@@ -61,6 +62,11 @@
     a sh:PrefixDeclaration ;
     sh:namespace "http://www.w3.org/2004/02/skos/core#"^^xsd:anyURI ;
     sh:prefix "skos" ;
+  ] ;
+  sh:declare [
+   a sh:PrefixDeclaration ;
+   sh:namespace "http://qudt.org/schema/qudt/fn#"^^xsd:anyURI ;
+   sh:prefix "qfn" ;
   ] ;
   sh:declare [
     a sh:PrefixDeclaration ;
@@ -550,6 +556,94 @@ qudt:prefixMultiplierSnShape
   ] ;
   sh:targetClass qudt:Prefix .
 
+
+qfn:decimalRoundToPrecision a sh:SPARQLFunction ;
+  sh:parameter [
+    sh:path qfn:value ;
+    sh:order 0 ;
+    sh:datatype xsd:decimal ;
+    sh:description "The decimal value to normalize" ;
+  ] ;
+  sh:parameter [
+    sh:path qfn:precision ;
+    sh:order 1 ;
+    sh:datatype xsd:integer ;
+    sh:description "Number of significant digits" ;
+  ] ;
+  sh:returnType xsd:decimal ;
+  sh:prefixes <http://qudt.org/$$QUDT_VERSION$$/collection/qa/all> ;
+  sh:select """
+        PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+        SELECT ?result
+        WHERE {
+            # rounds input decimal v to precision p
+            #
+            # unscaled number: significant digits
+            # precision: number of significant digits
+            # scale: (value = unscaled * 10^(-scale) ) eg: 123.45: unscaled: 12345 scale = 2;  110 = unscaled: 11, scale = -1; 0.000123 = unscaled: 123, scale = 6
+            #
+            # Algorithm:
+            #
+            # 1. val = normalized v (strip leading 0s, don't add trailing 0 if it has no dot)
+            # 2. find the dot position dVal (dVal = length(val) if no dot)
+            # 3. find the unscaled number uVal as the digits without the dot, leading 0s removed, trailing 0s kept
+            # 4. length of uVal is the precision of our value, pVal = length(uVal)
+            # 5. find the position eVal in val at which the unscaled number ends
+            # 6. scale sVal = eVal - dVal (e.g 123.456: dVal = 3, eVal = 6, sVal = 3, pVal = 6; 123: dVal = 0; 12345: dVal = 5, eVal = 5, sVal = 0, pVal = 5; 12000: dVal = 5, eVal = 2, sVal = -3, pVal = 2; 0.00123: dVal = 1, eVal=6, sVal= 5, pVal=3 )
+            # 7. precision to use pNew = min (p, pVal)
+            # 8. New unscaled number uNew with given precision. if pNew == pVal: uNew = uVal . otherwise, make tmp value from unscaled, inserting a dot at position pNew and use ROUND on it, ie uNew = ROUND(tmp)
+            # 9. New scale sNew = sVal - (pVal - pNew)
+            # 10. if sNew = 0 : newVal = CONCAT(uVal)
+            #     if sNew < 0 : newVal = CONCAT(uNew, SUBSTR(zeros,1,- sNew) ) - append zeros for each negative scale point
+            #     if sNew > 0 : newVal = CONCAT("0.", SUBSTR(zeros, 1, - sNew - pNew), uNew) - insert zeros to fill if needed
+            # 11. result = xsd:decimal(newVal)
+            #
+            # for testing:
+            # VALUES (?value ?precision) { (12345678 4) (0.00123456 3) (.00123456 4) (000123.456000 2) (123456789.0123456789 14) (0.123 5) (12345 3) (2 10) (3 1) (7 0) }
+            #
+        	BIND(IF(bound(?precision), ?precision, 34) as ?p)
+            BIND("0000000000000000000000000000000000000000000000000000000000000000000000000000000000000" as ?zeroPad)
+            # 1: normalize
+            BIND(STR(?value) as ?tmpValueStr)
+            # leading 0 before the dot are insignificant. strip.
+            BIND(REPLACE(?tmpValueStr, "^0*(0\\\\.|[1-9])","$1") as ?tmpValueStrNoLeading0)
+            # if the number starts with '.', prepend '0'
+            BIND(IF(STRSTARTS(?tmpValueStrNoLeading0, "."), CONCAT("0", ?tmpValueStrNoLeading0), ?tmpValueStrNoLeading0) as ?val)
+            # 2. dVal
+            BIND(STRLEN(STRBEFORE(?val,".")) as ?tmp0)
+            BIND(IF(?tmp0 = 0, STRLEN(?val), ?tmp0) as ?dVal)
+            # 3. uVal
+            BIND(REPLACE(REPLACE(?val,"\\\\.",""), "^0+","") as ?uVal)
+            # 4. pVal
+            BIND(STRLEN(?uVal) as ?pVal)
+            # 5. eVal
+            BIND(REPLACE(?val,"\\\\.","") as ?tmp1)
+            BIND(STRLEN(?tmp1) - STRLEN(STRAFTER(?tmp1,?uVal)) as ?eVal)
+            # 6. sVal
+            BIND(?eVal - ?dVal as ?sVal)
+            # 7. pNew
+            BIND(IF(?p < ?pVal, ?p, ?pVal) as ?pNew)
+            # 8. uNew
+            BIND(CONCAT(SUBSTR(?uVal,1,?pNew),".", SUBSTR(?uVal, ?pNew+1) ) as ?tmp2)
+            BIND(IF(?pNew = ?pVal, ?uVal, REPlACE(STR(ROUND(xsd:decimal(?tmp2))), ".0$","")) as ?uNew)
+            # 9. sNew
+            BIND(?sVal - (?pVal - ?pNew) as ?sNew)
+            # 10. newVal
+            BIND(IF(?sNew = 0, ?uNew,
+                    IF (?sNew < 0 ,
+                        CONCAT(?uNew, SUBSTR(?zeroPad, 1, - ?sNew)),
+                        CONCAT(SUBSTR(?zeroPad, 1, ?sNew - ?pNew), ?uNew)
+                    )) as ?tmp3)
+            BIND(IF(?sNew <= 0, ?tmp3,
+                    CONCAT(SUBSTR(?tmp3,1,STRLEN(?tmp3) - ?sNew), ".", SUBSTR(?tmp3, STRLEN(?tmp3) - ?sNew + 1))
+                ) as ?tmp4)
+            BIND(IF(STRSTARTS(?tmp4, "."), CONCAT("0",?tmp4), ?tmp4) as ?newVal)
+            # 11. result
+            BIND(xsd:decimal(?newVal) as ?result)
+        }
+    """
+  .
+
 qudt:scaledUnitMultiplierShape
   a sh:NodeShape ;
   rdfs:isDefinedBy <http://qudt.org/2.1/collection/qa/all> ;
@@ -646,8 +740,8 @@ WHERE {
         * COALESCE(xsd:decimal(?f6), 1.0)
         * COALESCE(xsd:decimal(?f7), 1.0)
         * COALESCE(xsd:decimal(?f8), 1.0)
-        * COALESCE(xsd:decimal(?f9), 1.0) as ?calculatedMultiplier)
-
+        * COALESCE(xsd:decimal(?f9), 1.0) as ?cumMul)
+    BIND(qfn:decimalRoundToPrecision(?cumMul, 34) as ?calculatedMultiplier)
     BIND (?actualMultiplier - ?calculatedMultiplier as ?diff)
     BIND (IF (?actualMultiplier = 0 , 0.0, ABS(?diff) / ABS(?actualMultiplier)) as ?relDiffAct)
     BIND (IF( ?calculatedMultiplier = 0, 0.0, ABS(?diff) / ABS(?calculatedMultiplier)) as ?relDiffCalc)

--- a/src/main/rdf/validation/qudt-shacl-functions.ttl
+++ b/src/main/rdf/validation/qudt-shacl-functions.ttl
@@ -75,7 +75,7 @@ qfn:decimalRoundToPrecision
   ] ;
   sh:parameter [
     sh:datatype xsd:integer ;
-    sh:description "Number of significant digits" ;
+    sh:description "Number of significant digits (default: 34)" ;
     sh:order 1 ;
     sh:path qfn:precision ;
   ] ;
@@ -145,10 +145,144 @@ qfn:decimalRoundToPrecision
             BIND(IF(?sNew <= 0, ?tmp3,
                     CONCAT(SUBSTR(?tmp3,1,STRLEN(?tmp3) - ?sNew), ".", SUBSTR(?tmp3, STRLEN(?tmp3) - ?sNew + 1))
                 ) as ?tmp4)
-            BIND(IF(STRSTARTS(?tmp4, "."), CONCAT("0",?tmp4), ?tmp4) as ?newVal)
+            BIND(IF(STRSTARTS(?tmp4, "."), CONCAT("0",?tmp4), ?tmp4) as ?tmp5)
             # 11. result
+            # 12. append '.0' if there is no '.' in the string
+            BIND(IF(CONTAINS(?tmp5,"."), ?tmp5, CONCAT(?tmp5,".0")) AS ?tmp6)
+            BIND(REPLACE(?tmp6, "^0*([1-9][0-9]*.[0-9][1-9]*)0*$", "$1", "") AS ?newVal)
             BIND(xsd:decimal(?newVal) as ?result)
         }
+    """ .
+
+qfn:decimalToDouble
+  a sh:SPARQLFunction ;
+  sh:parameter [
+    sh:datatype xsd:decimal ;
+    sh:description "The decimal value to expess as double" ;
+    sh:order 0 ;
+    sh:path qfn:input ;
+  ] ;
+  sh:prefixes qfn: ;
+  sh:returnType xsd:decimal ;
+  sh:select """
+    SELECT ?result
+    WHERE {
+      BIND(IF(?input = 0.0, "0.0", "") AS ?zeroCheck)
+      BIND(STR(?input) AS ?str)
+      BIND(STRSTARTS(?str, "-") AS ?isNegative)
+      BIND(IF(?isNegative, SUBSTR(?str, 2), ?str) AS ?absStr)
+      BIND(CONTAINS(?absStr, ".") AS ?hasDecimal)
+      BIND(IF(?hasDecimal, STRBEFORE(?absStr, "."), ?absStr) AS ?intPart)
+      BIND(IF(?hasDecimal, STRAFTER(?absStr, "."), "") AS ?fracPart)
+      BIND(IF(?intPart = "", "", REPLACE(?intPart, "^0+", "", "")) AS ?trimmedInt)
+      BIND(IF(?fracPart = "", "", REPLACE(?fracPart, "^0+", "", "")) AS ?trimmedFrac)  # Only trim leading zeros
+      BIND(IF(?fracPart = "", "", REPLACE(?fracPart, "0+$","","")) AS ?fracTrimmedAtEnd) # only trim trailing zeros
+      BIND(STRLEN(?trimmedInt) AS ?trimmedIntLen)
+      BIND(STRLEN(?trimmedFrac) AS ?trimmedFracLen)
+      BIND(STRLEN(?fracPart) AS ?fracLen)
+      BIND(IF(
+        ?trimmedIntLen > 0,
+        ?trimmedIntLen - 1,
+        IF(
+          ?trimmedFracLen > 0,
+          -(?fracLen - ?trimmedFracLen + 1),
+          0
+        )
+      ) AS ?exp)
+      BIND(IF(
+        ?trimmedIntLen > 0,
+        CONCAT(
+          SUBSTR(?trimmedInt, 1, 1),
+          IF(?trimmedIntLen > 1 || ?trimmedFracLen > 0, ".", ""),
+          SUBSTR(?trimmedInt, 2),
+          ?fracTrimmedAtEnd
+        ),
+        IF(
+          ?trimmedFracLen > 0,
+          CONCAT(
+            SUBSTR(?trimmedFrac, 1, 1),
+            IF(?trimmedFracLen > 1, ".", ""),
+            SUBSTR(?trimmedFrac, 2)
+          ),
+          "0.0"
+        )
+      ) AS ?mantissaTmpStr)
+      BIND(REPLACE(?mantissaTmpStr, "^0*([0-9]+(\\\\.[0-9][1-9]*)?)0*$", "$1","") AS ?mantissaStr)
+      BIND(STRDT(IF(
+        ?zeroCheck = "0.0",
+        "0E0",
+        CONCAT(
+          IF(?isNegative, "-", ""),
+          ?mantissaStr,
+          "E",
+          STR(?exp)
+        )
+      ), xsd:double) AS ?result)
+    }
+    """ .
+
+qfn:defaultValue
+  a sh:SPARQLFunction ;
+  sh:parameter [
+    sh:description "Any value, may also be unbound" ;
+    sh:order 0 ;
+    sh:path qfn:value ;
+  ] ;
+  sh:parameter [
+    sh:description "The default value to return if value is unbound" ;
+    sh:order 1 ;
+    sh:path qfn:defaultValue ;
+  ] ;
+  sh:prefixes qfn: ;
+  sh:select """
+    SELECT
+        (IF(BOUND(?value), ?value, ?defaultValue) AS ?result)
+    WHERE {}
+    """ .
+
+qfn:exp
+  a sh:SPARQLFunction ;
+  sh:parameter [
+    sh:datatype xsd:decimal ;
+    sh:description "The decimal value to exponentiate" ;
+    sh:order 0 ;
+    sh:path qfn:value ;
+  ] ;
+  sh:parameter [
+    sh:datatype xsd:integer ;
+    sh:description "The exponent - an integer between 0 and 8 (inclusive)" ;
+    sh:order 1 ;
+    sh:path qfn:exponent ;
+  ] ;
+  sh:prefixes qfn: ;
+  sh:returnType xsd:decimal ;
+  sh:select """
+    SELECT ?result
+    WHERE {
+        # supports exponents 0 to 8
+        BIND(ABS(?exponent) as ?absoluteExponent)
+        BIND(if (?exponent < 0, 1.0 / ?value, ?value ) as ?multiplier)
+        BIND(
+            IF(?absoluteExponent = 0, 1.1,
+                IF(?absoluteExponent = 1,
+                    ?multiplier,
+                    IF(?absoluteExponent = 2,
+                        ?multiplier * ?multiplier,
+                        IF(?absoluteExponent = 3,
+                            ?multiplier * ?multiplier * ?multiplier,
+                            IF(?absoluteExponent = 4,
+                                ?multiplier * ?multiplier * ?multiplier * ?multiplier,
+                                IF(?absoluteExponent = 5,
+                                    ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier,
+                                    IF(?absoluteExponent = 6,
+                                        ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier,
+                                        IF(?absoluteExponent = 7,
+                                            ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier,
+                                            IF(?absoluteExponent = 8,
+                                                ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier,
+                                                CONCAT("CANNOT HANDLE EXPONENT ", ?exponent))))))))))
+        AS ?result )
+    }
     """ .
 
 

--- a/src/main/rdf/validation/qudt-shacl-functions.ttl
+++ b/src/main/rdf/validation/qudt-shacl-functions.ttl
@@ -65,6 +65,37 @@ qfn:
     sh:prefix "sh" ;
   ] .
 
+qfn:decimalPrecision
+  a sh:SPARQLFunction ;
+  rdfs:comment "Determines the precision (number of significant digits) of the decimal number provided as its first argument" ;
+  sh:parameter [
+    sh:datatype xsd:decimal ;
+    sh:description "The decimal value of which to determine the precision " ;
+    sh:order 0 ;
+    sh:path qfn:value ;
+  ] ;
+  sh:prefixes qfn: ;
+  sh:returnType xsd:decimal ;
+  sh:select """
+        SELECT ?result
+        WHERE {
+            # determines precision of input
+            # simple: remove any '.' if present
+            BIND(STR(?value) as ?tmpVal)
+            BIND(REPLACE(?tmpVal, "([^.]*)\\\\.([^.]*)", "$1$2") as ?tmpVal1)
+            # leading 0 before the dot are insignificant, trailing 0 after the dot are insignificant. strip.
+            BIND(REPLACE(?tmpVal1, "^\\\\s*[+-]?\\\\s*0*([1-9]([0-9]*[1-9])?)0*$","$1") as ?val)
+            # 2. dVal
+            BIND(STRLEN(STRBEFORE(?val,".")) as ?tmp0)
+            BIND(IF(?tmp0 = 0, STRLEN(?val), ?tmp0) as ?dVal)
+            # 3. uVal
+            BIND(REPLACE(REPLACE(?val,"\\\\.",""), "^0+","") as ?uVal)
+            # 4. pVal
+            BIND(STRLEN(?uVal) as ?pVal)
+            BIND(xsd:integer(?pVal) as ?result)
+        }
+    """ .
+
 qfn:decimalRoundToPrecision
   a sh:SPARQLFunction ;
   sh:parameter [
@@ -109,12 +140,15 @@ qfn:decimalRoundToPrecision
             # for testing:
             # VALUES (?value ?precision) { (12345678 4) (0.00123456 3) (.00123456 4) (000123.456000 2) (123456789.0123456789 14) (0.123 5) (12345 3) (2 10) (3 1) (7 0) }
             #
-        \tBIND(IF(bound(?precision), ?precision, 34) as ?p)
+            BIND(IF(bound(?precision), ?precision, 34) as ?p)
             BIND("0000000000000000000000000000000000000000000000000000000000000000000000000000000000000" as ?zeroPad)
+
             # 1: normalize
             BIND(STR(?value) as ?tmpValueStr)
             # leading 0 before the dot are insignificant. strip.
-            BIND(REPLACE(?tmpValueStr, "^0*(0\\\\.|[1-9])","$1") as ?tmpValueStrNoLeading0)
+            BIND(REPLACE(?tmpValueStr, "^[+-]?0*(0?\\\\.|[1-9])","$1") as ?tmpValueStrNoLeading0)
+            # remember sign if negative
+            BIND(IF(REGEX(?tmpValueStr, "^-"), "-","") AS ?sign)
             # if the number starts with '.', prepend '0'
             BIND(IF(STRSTARTS(?tmpValueStrNoLeading0, "."), CONCAT("0", ?tmpValueStrNoLeading0), ?tmpValueStrNoLeading0) as ?val)
             # 2. dVal
@@ -149,7 +183,8 @@ qfn:decimalRoundToPrecision
             # 11. result
             # 12. append '.0' if there is no '.' in the string
             BIND(IF(CONTAINS(?tmp5,"."), ?tmp5, CONCAT(?tmp5,".0")) AS ?tmp6)
-            BIND(REPLACE(?tmp6, "^0*([1-9][0-9]*.[0-9][1-9]*)0*$", "$1", "") AS ?newVal)
+            BIND(REPLACE(?tmp6, "^0*([1-9][0-9]*.[0-9][1-9]*)0*$", "$1", "") AS ?tmp7)
+            BIND(CONCAT(?sign, ?tmp7) AS ?newVal)
             BIND(xsd:decimal(?newVal) as ?result)
         }
     """ .

--- a/src/main/rdf/validation/qudt-shacl-functions.ttl
+++ b/src/main/rdf/validation/qudt-shacl-functions.ttl
@@ -1,0 +1,154 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix qfn: <http://qudt.org/shacl/functions#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+
+qfn:
+  a owl:Ontology ;
+  rdfs:isDefinedBy qfn: ;
+  rdfs:label "QUDT SHACL FUNCTIONS" ;
+  sh:declare [
+    a sh:PrefixDeclaration ;
+    sh:namespace "http://qudt.org/shacl/functions#"^^xsd:anyURI ;
+    sh:prefix "qfn" ;
+  ] ;
+  sh:declare [
+    a sh:PrefixDeclaration ;
+    sh:namespace "http://qudt.org/schema/qudt/"^^xsd:anyURI ;
+    sh:prefix "qudt" ;
+  ] ;
+  sh:declare [
+    a sh:PrefixDeclaration ;
+    sh:namespace "http://qudt.org/vocab/dimensionvector/"^^xsd:anyURI ;
+    sh:prefix "qkdv" ;
+  ] ;
+  sh:declare [
+    a sh:PrefixDeclaration ;
+    sh:namespace "http://qudt.org/vocab/quantitykind/"^^xsd:anyURI ;
+    sh:prefix "quantitykind" ;
+  ] ;
+  sh:declare [
+    a sh:PrefixDeclaration ;
+    sh:namespace "http://qudt.org/vocab/unit/"^^xsd:anyURI ;
+    sh:prefix "unit" ;
+  ] ;
+  sh:declare [
+    a sh:PrefixDeclaration ;
+    sh:namespace "http://www.w3.org/1999/02/22-rdf-syntax-ns#"^^xsd:anyURI ;
+    sh:prefix "rdf" ;
+  ] ;
+  sh:declare [
+    a sh:PrefixDeclaration ;
+    sh:namespace "http://www.w3.org/2000/01/rdf-schema#"^^xsd:anyURI ;
+    sh:prefix "rdfs" ;
+  ] ;
+  sh:declare [
+    a sh:PrefixDeclaration ;
+    sh:namespace "http://www.w3.org/2001/XMLSchema#"^^xsd:anyURI ;
+    sh:prefix "xsd" ;
+  ] ;
+  sh:declare [
+    a sh:PrefixDeclaration ;
+    sh:namespace "http://www.w3.org/2002/07/owl#"^^xsd:anyURI ;
+    sh:prefix "owl" ;
+  ] ;
+  sh:declare [
+    a sh:PrefixDeclaration ;
+    sh:namespace "http://www.w3.org/2004/02/skos/core#"^^xsd:anyURI ;
+    sh:prefix "skos" ;
+  ] ;
+  sh:declare [
+    a sh:PrefixDeclaration ;
+    sh:namespace "http://www.w3.org/ns/shacl#"^^xsd:anyURI ;
+    sh:prefix "sh" ;
+  ] .
+
+qfn:decimalRoundToPrecision
+  a sh:SPARQLFunction ;
+  sh:parameter [
+    sh:datatype xsd:decimal ;
+    sh:description "The decimal value to normalize" ;
+    sh:order 0 ;
+    sh:path qfn:value ;
+  ] ;
+  sh:parameter [
+    sh:datatype xsd:integer ;
+    sh:description "Number of significant digits" ;
+    sh:order 1 ;
+    sh:path qfn:precision ;
+  ] ;
+  sh:prefixes qfn: ;
+  sh:returnType xsd:decimal ;
+  sh:select """
+        SELECT ?result
+        WHERE {
+            # rounds input decimal v to precision p
+            #
+            # unscaled number: significant digits
+            # precision: number of significant digits
+            # scale: (value = unscaled * 10^(-scale) ) eg: 123.45: unscaled: 12345 scale = 2;  110 = unscaled: 11, scale = -1; 0.000123 = unscaled: 123, scale = 6
+            #
+            # Algorithm:
+            #
+            # 1. val = normalized v (strip leading 0s, don't add trailing 0 if it has no dot)
+            # 2. find the dot position dVal (dVal = length(val) if no dot)
+            # 3. find the unscaled number uVal as the digits without the dot, leading 0s removed, trailing 0s kept
+            # 4. length of uVal is the precision of our value, pVal = length(uVal)
+            # 5. find the position eVal in val at which the unscaled number ends
+            # 6. scale sVal = eVal - dVal (e.g 123.456: dVal = 3, eVal = 6, sVal = 3, pVal = 6; 123: dVal = 0; 12345: dVal = 5, eVal = 5, sVal = 0, pVal = 5; 12000: dVal = 5, eVal = 2, sVal = -3, pVal = 2; 0.00123: dVal = 1, eVal=6, sVal= 5, pVal=3 )
+            # 7. precision to use pNew = min (p, pVal)
+            # 8. New unscaled number uNew with given precision. if pNew == pVal: uNew = uVal . otherwise, make tmp value from unscaled, inserting a dot at position pNew and use ROUND on it, ie uNew = ROUND(tmp)
+            # 9. New scale sNew = sVal - (pVal - pNew)
+            # 10. if sNew = 0 : newVal = CONCAT(uVal)
+            #     if sNew < 0 : newVal = CONCAT(uNew, SUBSTR(zeros,1,- sNew) ) - append zeros for each negative scale point
+            #     if sNew > 0 : newVal = CONCAT("0.", SUBSTR(zeros, 1, - sNew - pNew), uNew) - insert zeros to fill if needed
+            # 11. result = xsd:decimal(newVal)
+            #
+            # for testing:
+            # VALUES (?value ?precision) { (12345678 4) (0.00123456 3) (.00123456 4) (000123.456000 2) (123456789.0123456789 14) (0.123 5) (12345 3) (2 10) (3 1) (7 0) }
+            #
+        \tBIND(IF(bound(?precision), ?precision, 34) as ?p)
+            BIND("0000000000000000000000000000000000000000000000000000000000000000000000000000000000000" as ?zeroPad)
+            # 1: normalize
+            BIND(STR(?value) as ?tmpValueStr)
+            # leading 0 before the dot are insignificant. strip.
+            BIND(REPLACE(?tmpValueStr, "^0*(0\\\\.|[1-9])","$1") as ?tmpValueStrNoLeading0)
+            # if the number starts with '.', prepend '0'
+            BIND(IF(STRSTARTS(?tmpValueStrNoLeading0, "."), CONCAT("0", ?tmpValueStrNoLeading0), ?tmpValueStrNoLeading0) as ?val)
+            # 2. dVal
+            BIND(STRLEN(STRBEFORE(?val,".")) as ?tmp0)
+            BIND(IF(?tmp0 = 0, STRLEN(?val), ?tmp0) as ?dVal)
+            # 3. uVal
+            BIND(REPLACE(REPLACE(?val,"\\\\.",""), "^0+","") as ?uVal)
+            # 4. pVal
+            BIND(STRLEN(?uVal) as ?pVal)
+            # 5. eVal
+            BIND(REPLACE(?val,"\\\\.","") as ?tmp1)
+            BIND(STRLEN(?tmp1) - STRLEN(STRAFTER(?tmp1,?uVal)) as ?eVal)
+            # 6. sVal
+            BIND(?eVal - ?dVal as ?sVal)
+            # 7. pNew
+            BIND(IF(?p < ?pVal, ?p, ?pVal) as ?pNew)
+            # 8. uNew
+            BIND(CONCAT(SUBSTR(?uVal,1,?pNew),".", SUBSTR(?uVal, ?pNew+1) ) as ?tmp2)
+            BIND(IF(?pNew = ?pVal, ?uVal, REPlACE(STR(ROUND(xsd:decimal(?tmp2))), ".0$","")) as ?uNew)
+            # 9. sNew
+            BIND(?sVal - (?pVal - ?pNew) as ?sNew)
+            # 10. newVal
+            BIND(IF(?sNew = 0, ?uNew,
+                    IF (?sNew < 0 ,
+                        CONCAT(?uNew, SUBSTR(?zeroPad, 1, - ?sNew)),
+                        CONCAT(SUBSTR(?zeroPad, 1, ?sNew - ?pNew), ?uNew)
+                    )) as ?tmp3)
+            BIND(IF(?sNew <= 0, ?tmp3,
+                    CONCAT(SUBSTR(?tmp3,1,STRLEN(?tmp3) - ?sNew), ".", SUBSTR(?tmp3, STRLEN(?tmp3) - ?sNew + 1))
+                ) as ?tmp4)
+            BIND(IF(STRSTARTS(?tmp4, "."), CONCAT("0",?tmp4), ?tmp4) as ?newVal)
+            # 11. result
+            BIND(xsd:decimal(?newVal) as ?result)
+        }
+    """ .
+
+

--- a/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
+++ b/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
@@ -29659,8 +29659,6 @@ unit:MicroKAT-PER-L
   a qudt:DerivedUnit, qudt:Unit ;
   dcterms:description "A unit of catalytic activity used especially in the chemistry of enzymes. A catalyst is a substance that starts or speeds a chemical reaction. Enzymes are proteins that act as catalysts within the bodies of living plants and animals. A catalyst has an activity of one katal if it enables a reaction to proceed at the rate of one mole per second. "^^rdf:HTML ;
   qudt:applicableSystem sou:SI ;
-  qudt:conversionMultiplier 0.000000001 ;
-  qudt:conversionMultiplierSN 1.0E-9 ;
   qudt:definedUnitOfSystem sou:SI ;
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:CatalyticActivityConcentration ;
@@ -32560,8 +32558,6 @@ unit:MilliKAT-PER-L
   a qudt:DerivedUnit, qudt:Unit ;
   dcterms:description "A unit of catalytic activity used especially in the chemistry of enzymes. A catalyst is a substance that starts or speeds a chemical reaction. Enzymes are proteins that act as catalysts within the bodies of living plants and animals. A catalyst has an activity of one katal if it enables a reaction to proceed at the rate of one mole per second. "^^rdf:HTML ;
   qudt:applicableSystem sou:SI ;
-  qudt:conversionMultiplier 0.000001 ;
-  qudt:conversionMultiplierSN 1.0E-6 ;
   qudt:definedUnitOfSystem sou:SI ;
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:CatalyticActivityConcentration ;
@@ -33721,8 +33717,6 @@ unit:MilliOSM
 unit:MilliOSM-PER-KiloGM
   a qudt:Unit ;
   dcterms:description "0.001-fold of the unit Osmol divided by the SI base unit kilogram" ;
-  qudt:conversionMultiplier 0.001 ;
-  qudt:conversionMultiplierSN 1.0E-3 ;
   qudt:hasDimensionVector qkdv:A1E0L0I0M-1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:AmountOfSubstancePerMass ;
   qudt:symbol "mOsmol/kg" ;
@@ -36124,8 +36118,6 @@ unit:NanoKAT-PER-L
   a qudt:DerivedUnit, qudt:Unit ;
   dcterms:description "A unit of catalytic activity used especially in the chemistry of enzymes. A catalyst is a substance that starts or speeds a chemical reaction. Enzymes are proteins that act as catalysts within the bodies of living plants and animals. A catalyst has an activity of one katal if it enables a reaction to proceed at the rate of one mole per second. "^^rdf:HTML ;
   qudt:applicableSystem sou:SI ;
-  qudt:conversionMultiplier 0.000000000001 ;
-  qudt:conversionMultiplierSN 1.0E-12 ;
   qudt:definedUnitOfSystem sou:SI ;
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:CatalyticActivityConcentration ;
@@ -42607,8 +42599,6 @@ unit:PicoKAT-PER-L
   a qudt:DerivedUnit, qudt:Unit ;
   dcterms:description "A unit of catalytic activity used especially in the chemistry of enzymes. A catalyst is a substance that starts or speeds a chemical reaction. Enzymes are proteins that act as catalysts within the bodies of living plants and animals. A catalyst has an activity of one katal if it enables a reaction to proceed at the rate of one mole per second. "^^rdf:HTML ;
   qudt:applicableSystem sou:SI ;
-  qudt:conversionMultiplier 0.000000000000001 ;
-  qudt:conversionMultiplierSN 1.0E-15 ;
   qudt:definedUnitOfSystem sou:SI ;
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:CatalyticActivityConcentration ;


### PR DESCRIPTION
Replaces a number of plugin executions with the `mainPipeline` execution that centralizes most of the RDF processing. 

The main change to the output is that conversion multipliers of derived units recalculated based on their factor units using 34 digit precision.