### PR TITLE
added applicable units to quantitykind:BatteryCapacity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
 - Increased the severity of some validation constraints
 - Added description to unit:DEG_F-DAY
 - Added qudt:Unit to hasUnit, hasDefinedUnit & hasAllowedUnit
+- Added `qudt:hasQuantityKind quantitykind:BatteryCapacity` to `unit:A-HR`, `unit:A-SEC`, `unit:KiloA-HR` and `unit:MilliA-HR`
 
 ### Fixed
 

--- a/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
+++ b/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
@@ -114,6 +114,7 @@ unit:A-HR
   qudt:conversionMultiplier 3600.0 ;
   qudt:conversionMultiplierSN 3.6E3 ;
   qudt:hasDimensionVector qkdv:A0E1L0I0M0H0T1D0 ;
+  qudt:hasQuantityKind quantitykind:BatteryCapacity ;
   qudt:hasQuantityKind quantitykind:ElectricCharge ;
   qudt:iec61360Code "0112/2///62720#UAA102" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Ampere-hour"^^xsd:anyURI ;
@@ -581,6 +582,7 @@ unit:A-SEC
   qudt:conversionMultiplier 1.0 ;
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E1L0I0M0H0T1D0 ;
+  qudt:hasQuantityKind quantitykind:BatteryCapacity ;
   qudt:hasQuantityKind quantitykind:ElectricCharge ;
   qudt:iec61360Code "0112/2///62720#UAA107" ;
   qudt:iec61360Code "0112/2///62720#UAD516" ;
@@ -18074,6 +18076,7 @@ unit:KiloA-HR
   qudt:conversionMultiplier 3600000.0 ;
   qudt:conversionMultiplierSN 3.6E6 ;
   qudt:hasDimensionVector qkdv:A0E1L0I0M0H0T1D0 ;
+  qudt:hasQuantityKind quantitykind:BatteryCapacity ;
   qudt:hasQuantityKind quantitykind:ElectricCharge ;
   qudt:iec61360Code "0112/2///62720#UAB053" ;
   qudt:plainTextDescription "product of the 1 000-fold of the SI base unit ampere and the unit hour" ;
@@ -30715,6 +30718,7 @@ unit:MilliA-HR
   qudt:conversionMultiplier 3.6 ;
   qudt:conversionMultiplierSN 3.6E0 ;
   qudt:hasDimensionVector qkdv:A0E1L0I0M0H0T1D0 ;
+  qudt:hasQuantityKind quantitykind:BatteryCapacity ;
   qudt:hasQuantityKind quantitykind:ElectricCharge ;
   qudt:iec61360Code "0112/2///62720#UAA777" ;
   qudt:plainTextDescription "product of the 0.001-fold of the SI base unit ampere and the unit hour" ;


### PR DESCRIPTION
It's actually uncommon to use [unit:A-MIN](http://qudt.org/vocab/unit/A-MIN) for battery capacity so I added some more common units.