### PR TITLE
Srr add missing multipliers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,11 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
 - Deprecated unit:IN-PER-2PiRAD, replaced with unit:IN-PER-REV.
 - Deprecated the ambiguous unit:PIXEL, with seeAlso notes to unit:PIXEL_Area and unit:PIXEL_Count.
 
+### Changed
+
+- conversion multipliers:
+  a SHACL check was added to compare the conversion multipliers of derived units withthe conversion multiplier obtained from the factor units, failing the build if there is a discrepancy. This is a first step toward more stability with regard to conversion multipliers.
+
 ### Fixed
 
 - Corrected symbol of `unit:BU_US` and `unit:GAL_US`, which both were `in³`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,11 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
 ### Changed
 
 - Build process
-  - Introduced new maven goal `rdfio:pipeline` that allows for fine-grained rdf file manipulation
-  - introduced `mainPipeline` execution for the bulk of rdf munging
+  - New maven goal `rdfio:pipeline` that allows for fine-grained rdf file manipulation
+  - New `mainPipeline` execution for the bulk of rdf munging
+  - New `src/main/rdf/validation/qudt-shacl-functions.ttl` to make some intricate functionality
+    available to SPARQL and SHACL
+  - New `unitTestPipeline` for unit testing the SHACL functions
 - All instances of `xsd:decimal` are limited to a maximum precision of 34 significant digits
 - Derived units: recalculation of `qudt:conversionMultiplier` and `qudt:conversionMultiplierSN`
   - During the build, all derived units' conversion multipliers are checked based on their `qudt:factorUnits`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
 - Deprecated roughly 36 Quantity Kinds in favor of more consistently-named and natural-language-friendly URIs. Specifically, URIs containing
   underscores are renamed except when the underscore identifies a component (e.g. x, y, z, imaginary, real).
   Quantity Kinds raised to a power are renamed (e.g. Time_Squared becomes SquareTime)
+- Cleaned up some confusion regarding unit:PERM_US and unit:PERM_Metric, resulting in the deprecation of some related units. The summary
+  is that the magnitude of a PERM does not change with temperature, but measurements made on materials will have different measured values
+  at different temperatures.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
 
 ### Changed
 
+- Build process
+  - Introduced new maven goal `rdfio:pipeline` that allows for fine-grained rdf file manipulation
+  - introduced `mainPipeline` execution for the bulk of rdf munging
+- All instances of `xsd:decimal` are limited to a maximum precision of 34 significant digits
+- Derived units: recalculation of `qudt:conversionMultiplier` and `qudt:conversionMultiplierSN`
+  - During the build, all derived units' conversion multipliers are checked based on their `qudt:factorUnits`
+    and replaced with the calculated result if necessary
+
 ### Deprecated
 
 - Deprecated unit:CHF-PER-KiloGM in favor of unit:CCY_CHF-PER-KiloGM
@@ -26,6 +34,8 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
 
 - Fixed erroneous prefix definition for cross-references to SI Quantity (equivalent to qudt:QuantityKind)
 - Corrected symbol for `unit:IN_H2O` from `inH₂0` to `inH₂O` [Reto Schneebeli](https://github.com/reto-siemens)
+- Removed wrong `qudt:conversionMultipliers` from `src` (they are now generated correctly in `target`, see 'Changed'). Affected units:
+  - `unit:MicroKAT-PER-L, unit:MilliKAT-PER-L, unit:NanoKAT-PER-L, unit:PicoKAT-PER-L, unit:MilliOSM-PER-KiloGM`
 
 ## [3.1.2] - 2025-05-30
 

--- a/pom.xml
+++ b/pom.xml
@@ -48,8 +48,7 @@
                       process-sources          check-source-format, shacl-validate-src
                       generate-resources       copy-rdf, copy-docs, copy-root-files, validate-shacl-files
                       process-resources        generate-iec-links
-                      compile                  infer-and-format
-                      process-classes
+                      process-classes          mainRdfPipeline
                       generate-test-sources
                       process-test-sources
                       generate-test-resources
@@ -235,7 +234,7 @@
                             def allAspectDirs = srcgenDir.listFiles().findAll { it.isDirectory() }
                             def validAspectDirs = []
                             // Map to store omitted dirs and missing files
-                            def omittedAspectDirsWithReasons = [:] 
+                            def omittedAspectDirsWithReasons = [:]
 
                             allAspectDirs.each { dir ->
                                 def aspectName = dir.name
@@ -254,9 +253,9 @@
 
                                 if (missingFiles.isEmpty()) {
                                     // All files present, add to valid list
-                                    validAspectDirs << dir  
+                                    validAspectDirs << dir
                                     // Record missing files
-                                    } else { omittedAspectDirsWithReasons[dir] = missingFiles 
+                                    } else { omittedAspectDirsWithReasons[dir] = missingFiles
                                      }
                             }
 
@@ -306,7 +305,7 @@
                                 println "The following aspects were omitted due to missing required files:"
                                 // Simplify to file names
                                 omittedAspectDirsWithReasons.each { dir, missingFiles ->
-                                    def missingFileNames = missingFiles.collect { it.toString().replaceAll('^.*\\.', '') } 
+                                    def missingFileNames = missingFiles.collect { it.toString().replaceAll('^.*\\.', '') }
                                     println " - ${dir.name}: Missing ${missingFileNames.join(', ')}"
                                 }
                             } else {
@@ -333,163 +332,7 @@
                 <artifactId>shacl-maven-plugin</artifactId>
                 <version>1.0.5</version>
                 <executions>
-                    <execution>
-                        <!-- infers qudt:applicableUnits and writes them to target/inferred/applicableUnits.ttl -->
-                        <id>infer-applicableUnits</id>
-                        <phase>none</phase>
-                        <goals>
-                            <goal>infer</goal>
-                        </goals>
-                        <configuration>
-                            <inferences>
-                                <inference>
-                                    <message>Inferring qudt:applicableUnit triples (non-currency units)</message>
-                                    <shapes>
-                                        <include>src/build/inference/inferApplicableUnits.ttl</include>
-                                    </shapes>
-                                    <data>
-                                        <include>
-                                            src/main/rdf/vocab/unit/*.ttl
-                                            src/main/rdf/vocab/quantitykinds/*.ttl
-                                        </include>
-                                    </data>
-                                    <outputFile>target/inferred/applicableUnits.ttl</outputFile>
-                                </inference>
-                                <inference>
-                                    <message>Inferring qudt:applicableUnit triples (currency units)</message>
-                                    <shapes>
-                                        <include>src/build/inference/inferApplicableUnits.ttl</include>
-                                    </shapes>
-                                    <data>
-                                        <include>
-                                            src/main/rdf/vocab/currency/VOCAB_QUDT-UNITS-CURRENCY.ttl
-                                        </include>
-                                    </data>
-                                    <outputFile>target/inferred/applicableUnits-currency.ttl</outputFile>
-                                </inference>
-                                <inference>
-                                    <message>Performing our custom subset of OWL inferences</message>
-                                    <shapes>
-                                        <include>
-                                            src/build/inference/owl-subset.shapes.ttl
-                                        </include>
-                                    </shapes>
-                                    <data>
-                                        <include>
-                                            src/main/rdf/schema/SCHEMA_QUDT.ttl
-                                            src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
-                                        </include>
-                                    </data>
-                                    <outputFile>target/inferred/owl-subset.ttl</outputFile>
-                                </inference>
-                            </inferences>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <!-- infers qudt:applicableUnits and writes them to target/inferred/applicableUnits.ttl -->
-                        <id>infer-owlSubset</id>
-                        <phase>none</phase>
-                        <goals>
-                            <goal>infer</goal>
-                        </goals>
-                        <configuration>
-                            <inferences>
-                                <inference>
-                                    <message>Performing our custom subset of OWL inferences</message>
-                                    <shapes>
-                                        <include>
-                                            src/build/inference/owl-subset.shapes.ttl
-                                        </include>
-                                    </shapes>
-                                    <data>
-                                        <include>
-                                            src/main/rdf/schema/SCHEMA_QUDT.ttl
-                                            src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
-                                        </include>
-                                    </data>
-                                    <outputFile>target/inferred/owl-subset.ttl</outputFile>
-                                </inference>
-                            </inferences>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <!-- infers qudt:hasFactorUnit RDF molecules and writes them to target/inferred/factorUnits.ttl -->
-                        <id>infer-factorUnits</id>
-                        <phase>none</phase>
-                        <goals>
-                            <goal>infer</goal>
-                        </goals>
-                        <configuration>
-                            <inferences>
-                                <inference>
-                                    <shapes>
-                                        <include>target/srcgen/factorUnits/infer.ttl</include>
-                                    </shapes>
-                                    <data>
-                                        <include>
-                                            <!-- assuming predefined units have already been merged into the target units -->
-                                            target/dist/vocab/unit/*.ttl
-                                            target/dist/vocab/prefixes/*.ttl
-                                        </include>
-                                    </data>
-                                    <outputFile>target/inferred/factorUnits.ttl</outputFile>
-                                </inference>
-                            </inferences>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <!-- infers qudt:scalingOf triples and writes them to target/inferred/scalingOf.ttl -->
-                        <id>infer-scalingOf</id>
-                        <phase>none</phase>
-                        <goals>
-                            <goal>infer</goal>
-                        </goals>
-                        <configuration>
-                            <inferences>
-                                <inference>
-                                    <shapes>
-                                        <include>target/srcgen/scalingOf/infer.ttl</include>
-                                    </shapes>
-                                    <data>
-                                        <include>
-                                            <!-- assuming predefined units and factor units have already been merged into the target units -->
-                                            target/dist/vocab/unit/*.ttl
-                                            target/dist/vocab/prefixes/*.ttl
-                                        </include>
-                                    </data>
-                                    <outputFile>target/inferred/scalingOf.ttl</outputFile>
-                                </inference>
-                            </inferences>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <!-- infers qudt:conversionMultiplier triples and writes them to target/inferred/conversionMultiplier.ttl -->
-                        <id>infer-conversionMultiplier</id>
-                        <phase>none</phase>
-                        <goals>
-                            <goal>infer</goal>
-                        </goals>
-                        <configuration>
-                            <inferences>
-                                <inference>
-                                    <shapes>
-                                        <include>
-                                            target/srcgen/conversionMultiplier/infer.ttl
-                                            src/main/rdf/validation/qudt-shacl-functions.ttl
-                                        </include>
-                                    </shapes>
-                                    <data>
-                                        <include>
-                                            <!-- assuming predefined units and factor units have already been merged into the target units -->
-                                            target/dist/vocab/unit/*.ttl
-                                            target/dist/vocab/prefixes/*.ttl
-                                        </include>
-                                    </data>
-                                    <outputFile>target/inferred/conversionMultiplier.ttl</outputFile>
-                                </inference>
-                            </inferences>
-                        </configuration>
-                    </execution>
+
                     <execution>
                         <!--
                         SHACL-validates the union of all ttl files in src/vocab and the No-OWL schema
@@ -548,6 +391,7 @@
                                     <data>
                                         <include>
                                             target/dist/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
+                                            target/dist/vocab/prefixes/VOCAB_QUDT-PREFIXES.ttl
                                         </include>
                                     </data>
                                     <outputFile>target/validation/validationReport-conversionMultiplier.ttl</outputFile>
@@ -643,224 +487,286 @@
             <plugin>
                 <groupId>io.github.qudtlib</groupId>
                 <artifactId>rdfio-maven-plugin</artifactId>
-                <version>1.3.2</version>
+                <version>1.3.3-SNAPSHOT</version>
                 <executions>
                     <execution>
-                        <!--
-                        adds the qudt:applicableUnits triples we generated with SHACL to the quantitykinds target file.
-                        -->
-                        <id>merge-applicableUnits-target</id>
-                        <phase>none</phase>
+                        <id>mainPipeline</id>
+                        <phase>compile</phase>
                         <goals>
-                            <goal>make</goal>
+                            <goal>pipeline</goal>
                         </goals>
                         <configuration>
-                            <products>
-                                <singleFile>
-                                    <input>
-                                        <include>
-                                            target/inferred/applicableUnits.ttl
-                                            target/dist/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL.ttl
-                                        </include>
-                                    </input>
-                                    <outputFile>target/dist/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL.ttl</outputFile>
-                                </singleFile>
-                                <singleFile>
-                                    <input>
-                                        <include>
-                                            target/inferred/applicableUnits-currency.ttl
-                                            target/dist/vocab/currency/VOCAB_QUDT-UNITS-CURRENCY.ttl
-                                        </include>
-                                    </input>
-                                    <outputFile>target/dist/vocab/currency/VOCAB_QUDT-UNITS-CURRENCY.ttl</outputFile>
-                                </singleFile>
-                                <singleFile>
-                                    <input>
-                                        <include>
-                                            target/inferred/owl-subset.ttl
-                                            target/dist/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
-                                        </include>
-                                    </input>
-                                    <outputFile>target/dist/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl</outputFile>
-                                </singleFile>
-                            </products>
+                            <pipeline>
+                                <id>mainPipeline</id>
+                                <steps>
+                                    <!-- make custom shacl functions available in inference and SPARQL-->
+                                    <shaclFunctions>
+                                        <file>src/main/rdf/validation/qudt-shacl-functions.ttl</file>
+                                    </shaclFunctions>
+
+                                    <add> <!-- load target quantitykinds into <target:quantityKinds> (associating that graph with the file)-->
+                                        <file>src/main/rdf/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL.ttl</file>
+                                        <toGraph>modified:quantityKinds</toGraph>
+                                    </add>
+                                    <add> <!-- load target units into <modified:units>  (associating that graph with the file) -->
+                                        <file>src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl</file>
+                                        <toGraph>modified:units</toGraph>
+                                    </add>
+                                    <add> <!-- load applicableUnits shapes (rules) into <shapes:applicableUnits> because we need them twice (see below) -->
+                                        <file>src/build/inference/inferApplicableUnits.ttl</file>
+                                        <toGraph>shapes:applicableUnits</toGraph>
+                                    </add>
+
+                                    <shaclInfer> <!-- do the quantitykinds inference -->
+                                        <message>Inferring qudt:applicableUnit triples (non-currency units)</message>
+                                        <shapes>
+                                            <graph>shapes:applicableUnits</graph>
+                                        </shapes>
+                                        <data>
+                                            <graph>modified:quantityKinds</graph>
+                                            <graph>modified:units</graph>
+                                        </data>
+                                        <inferred>
+                                            <graph>inferred:applicableUnits</graph>
+                                            <file>target/inferred/applicableUnits.ttl</file>
+                                        </inferred>
+                                    </shaclInfer>
+
+                                    <add> <!-- add the results of the quantitykinds inference to the quantityKinds graph -->
+                                        <graph>inferred:applicableUnits</graph>
+                                        <toGraph>modified:quantityKinds</toGraph>
+                                    </add>
+
+                                    <!-- start from here if nothing has changed in the inputs of the earlier steps -->
+                                    <savepoint><id>01-applicableUnits</id></savepoint>
+                                    <add>
+                                        <file>src/main/rdf/vocab/currency/VOCAB_QUDT-UNITS-CURRENCY.ttl</file>
+                                        <toGraph>target:currencyUnits</toGraph>
+                                    </add>
+                                    <shaclInfer>  <!-- do the quantitykinds inference for currency units -->
+                                        <message>Inferring qudt:applicableUnit triples (currency units)</message>
+                                        <shapes><graph>shapes:applicableUnits</graph></shapes>
+                                        <data>
+                                            <graph>target:currencyUnits</graph>
+                                        </data>
+                                        <inferred>
+                                            <graph>inferred:applicableCurrencyUnits</graph>
+                                            <file>target/inferred/applicableUnits-currency.ttl</file>
+                                        </inferred>
+                                    </shaclInfer>
+                                    <write>
+                                        <graph>target:currencyUnits</graph>
+                                        <graph>inferred:applicableCurrencyUnits</graph>
+                                        <toFile>target/dist/vocab/currency/VOCAB_QUDT-UNITS-CURRENCY.ttl</toFile>
+                                    </write>
+
+                                    <!-- start from here if nothing has changed in the inputs of the earlier steps -->
+                                    <savepoint><id>02-applicableUnits-currencies</id></savepoint>
+
+                                    <shaclInfer> <!-- do the custom OWL subset inference -->
+                                        <message>Performing our custom subset of OWL inferences</message>
+                                        <shapes>
+                                            <file>src/build/inference/owl-subset.shapes.ttl</file>
+                                        </shapes>
+                                        <data>
+                                            <files>
+                                                <include>
+                                                    src/main/rdf/schema/SCHEMA_QUDT.ttl
+                                                    src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
+                                                </include>
+                                            </files>
+                                        </data>
+                                        <inferred>
+                                            <graph>inferred:owl-subset-units</graph>
+                                            <file>target/inferred/owl-subset-units.ttl</file>
+                                        </inferred>
+                                    </shaclInfer>
+
+                                    <add> <!-- add the inferred triples to the units graph -->
+                                        <graph>inferred:owl-subset-units</graph>
+                                        <toGraph>modified:units</toGraph>
+                                    </add>
+
+                                    <!-- start from here if nothing has changed in the inputs of the earlier steps -->
+                                    <savepoint><id>03-owl-subset-units</id></savepoint>
+
+                                    <add>
+                                        <file>src/build/inference/factorUnits/predefined-factors-and-scalings.ttl</file>
+                                        <toGraph>modified:units</toGraph>
+                                    </add>
+                                    <add>
+                                        <files>
+                                            <include>target/dist/vocab/prefixes/*.ttl</include>
+                                        </files>
+                                        <toGraph>target:prefixes</toGraph>
+                                    </add>
+
+                                    <shaclInfer> <!-- infer ther factor units -->
+                                        <message>Inferring qudt:hasFactorUnit</message>
+                                        <shapes>
+                                            <file>target/srcgen/factorUnits/infer.ttl</file>
+                                        </shapes>
+                                        <data>
+                                            <graphs>
+                                                <include>
+                                                    modified:units
+                                                    target:prefixes
+                                                </include>
+                                            </graphs>
+                                        </data>
+                                        <inferred>
+                                            <graph>inferred:factorUnits</graph>
+                                            <file>target/inferred/factorUnits.ttl</file>
+                                        </inferred>
+                                    </shaclInfer>
+                                    <add>
+                                        <graph>inferred:factorUnits</graph>
+                                        <toGraph>modified:units</toGraph>
+                                    </add>
+                                    <savepoint><id>04-infer-factor-units</id></savepoint>
+                                    <shaclInfer>
+                                        <message>Inferring qudt:scalingOf</message>
+                                        <shapes>
+                                            <file>target/srcgen/scalingOf/infer.ttl</file>
+                                        </shapes>
+                                        <data>
+                                            <graph>modified:units</graph>
+                                            <graph>target:prefixes</graph>
+                                        </data>
+                                        <inferred>
+                                            <graph>inferred:scalingOf</graph>
+                                            <file>target/inferred/scalingOf.ttl</file>
+                                        </inferred>
+                                    </shaclInfer>
+                                    <add>
+                                        <graph>inferred:scalingOf</graph>
+                                        <toGraph>modified:units</toGraph>
+                                    </add>
+                                    <savepoint><id>05-infer-scalingOf</id></savepoint>
+                                    <until>
+                                        <message>Replacing invalid conversionMultipliers iteratively until no more are found</message>
+                                        <indexVar>index_cm</indexVar>
+                                        <sparqlAsk>
+                                            ASK {
+                                                BIND(IRI(CONCAT("inferred:conversionMultiplierToDelete_",STR(?index_cm))) as ?graph)
+                                                GRAPH ?graph {
+                                                    ?report
+                                                        a               sh:ValidationReport;
+                                                        sh:conforms     true;
+                                                }
+                                            }
+                                        </sparqlAsk>
+                                        <body>
+                                            <shaclValidate>
+                                                <message>Validating qudt:conversionMultiplier (will delete invalid ones in subsequent step)</message>
+                                                <!-- we don't want to fail, we want to know the errors so we can delete triples-->
+                                                <failOnSeverity>None</failOnSeverity>
+                                                <shapes>
+                                                    <file>target/srcgen/conversionMultiplier/validate.ttl</file>
+                                                </shapes>
+                                                <data>
+                                                    <graph>modified:units</graph>
+                                                    <graph>target:prefixes</graph>
+                                                </data>
+                                                <validationReport>
+                                                    <graph>inferred:conversionMultiplierToDelete_${index_cm}</graph>
+                                                    <file>target/validation/conversionMultiplier-toDelete_${index_cm}.ttl</file>
+                                                </validationReport>
+                                            </shaclValidate>
+                                            <sparqlUpdate>
+                                                <message>Deleting invalid conversion multipliers</message>
+                                                <sparql>
+                                                    <![CDATA[
+                                                DELETE {
+                                                    GRAPH <modified:units> {
+                                                        ?unit qudt:conversionMultiplier ?m .
+                                                        ?unit  qudt:conversionMultiplierSN ?mSN .
+                                                    }
+                                                }
+                                                WHERE {
+                                                    GRAPH <modified:units> {
+                                                        {
+                                                            ?unit qudt:conversionMultiplier ?m .
+                                                        } UNION {
+                                                            ?unit qudt:conversionMultiplierSN ?mSN .
+                                                        }
+                                                    }
+                                                    BIND(IRI(CONCAT("inferred:conversionMultiplierToDelete_",STR(?index_cm))) as ?graph)
+                                                    GRAPH ?graph {
+                                                        ?res
+                                                            rdf:type                      sh:ValidationResult;
+                                                            sh:resultPath                 qudt:conversionMultiplier;
+                                                            sh:resultSeverity             sh:Violation;
+                                                            sh:value                      ?unit
+                                                    }
+                                                }
+                                                ]]>
+                                                </sparql>
+                                            </sparqlUpdate>
+
+                                            <shaclInfer>
+                                                <message>Inferring qudt:conversionMultiplier</message>
+                                                <iterateUntilStable>true</iterateUntilStable>
+                                                <iterationOutputFilePattern>target/inferred/conversionMultiplier-${index_cm}_${index}.ttl</iterationOutputFilePattern>
+                                                <shapes>
+                                                    <file>target/srcgen/conversionMultiplier/infer.ttl</file>
+                                                </shapes>
+                                                <data>
+                                                    <graph>modified:units</graph>
+                                                    <graph>target:prefixes</graph>
+                                                </data>
+                                                <inferred>
+                                                    <graph>inferred:conversionMultiplier_${index_cm}</graph>
+                                                    <file>target/inferred/conversionMultiplier_${index_cm}.ttl</file>
+                                                </inferred>
+                                            </shaclInfer>
+                                            <add>
+                                                <graph>inferred:conversionMultiplier_${index_cm}</graph>
+                                                <toGraph>modified:units</toGraph>
+                                            </add>
+                                        </body>
+
+                                    </until>
+                                    <savepoint><id>08-infer-conversionMultiplier</id></savepoint>
+                                    <sparqlUpdate>
+                                        <message>Generate conversion multipliers in xsd:double format where it's missing</message>
+                                        <sparql>
+                                            <![CDATA[
+                                            INSERT {
+                                                GRAPH <modified:units> {
+                                                    ?unit qudt:conversionMultiplierSN ?cmsn
+                                                }
+                                            }
+                                            WHERE {
+                                                GRAPH <modified:units> {
+                                                    ?unit a qudt:Unit ;
+                                                          qudt:conversionMultiplier ?cm .
+                                                    FILTER NOT EXISTS {
+                                                        ?unit qudt:conversionMultiplierSN ?any .
+                                                    }
+                                                    BIND(qfn:decimalToDouble(?cm) as ?cmsn)
+                                                }
+                                            }
+                                            ]]>
+                                        </sparql>
+                                    </sparqlUpdate>
+                                    <!-- write the main outputs: units and quantitykinds files (back to the files they were initially read from) -->
+                                    <write>
+                                        <graph>modified:units</graph>
+                                        <toFile>target/dist/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl</toFile>
+                                    </write>
+
+                                    <write>
+                                        <graph>modified:quantityKinds</graph>
+                                        <toFile>target/dist/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL.ttl</toFile>
+                                    </write>
+                                    <!-- start from here if nothing has changed in the inputs of the earlier steps -->
+                                    <savepoint><id>99-endOfPipeline</id></savepoint>
+                                </steps>
+                            </pipeline>
                         </configuration>
                     </execution>
-                    <execution>
-                        <!--
-                        adds the qudt:applicableUnits triples we generated with SHACL to the quantitykinds target file.
-                        -->
-                        <id>merge-owlSubset-target</id>
-                        <phase>none</phase>
-                        <goals>
-                            <goal>make</goal>
-                        </goals>
-                        <configuration>
-                            <products>
-                                <singleFile>
-                                    <input>
-                                        <include>
-                                            target/inferred/owl-subset.ttl
-                                            target/dist/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
-                                        </include>
-                                    </input>
-                                    <outputFile>target/dist/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl</outputFile>
-                                </singleFile>
-                            </products>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <!--
-                        adds the qudt:applicableUnits triples we generated with SHACL to the quantitykinds target file.
-                        -->
-                        <id>merge-predefinedUnits-target</id>
-                        <phase>none</phase>
-                        <goals>
-                            <goal>make</goal>
-                        </goals>
-                        <configuration>
-                            <products>
-                                <singleFile>
-                                    <input>
-                                        <include>
-                                            src/build/inference/factorUnits/predefined-factors-and-scalings.ttl
-                                            target/dist/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
-                                        </include>
-                                    </input>
-                                    <outputFile>target/dist/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl</outputFile>
-                                </singleFile>
-                            </products>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <!--
-                        adds the qudt:hasFactorUnit triples we generated with SHACL to the units source file.
-                        -->
-                        <id>merge-factorUnits-target</id>
-                        <phase>none</phase>
-                        <goals>
-                            <goal>make</goal>
-                        </goals>
-                        <configuration>
-                            <products>
-                                <singleFile>
-                                    <input>
-                                        <include>
-                                            target/inferred/factorUnits.ttl
-                                            target/dist/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
-                                        </include>
-                                    </input>
-                                    <outputFile>target/dist/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl</outputFile>
-                                </singleFile>
-                            </products>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <!--
-                        adds the qudt:hasFactorUnit triples we generated with SHACL to the units source file.
-                        -->
-                        <id>merge-conversionMultiplier-target</id>
-                        <phase>none</phase>
-                        <goals>
-                            <goal>make</goal>
-                        </goals>
-                        <configuration>
-                            <products>
-                                <singleFile>
-                                    <input>
-                                        <include>
-                                            target/inferred/conversionMultiplier.ttl
-                                            target/dist/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
-                                        </include>
-                                    </input>
-                                    <outputFile>target/dist/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl</outputFile>
-                                </singleFile>
-                            </products>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <!--
-                        executes the query that is used to generate/validate qudt:hasFactorUnit triples
-                        -->
-                        <id>query-factorUnits</id>
-                        <phase>none</phase>
-                        <goals>
-                            <goal>make</goal>
-                        </goals>
-                        <configuration>
-                            <products>
-                                <singleFile>
-                                    <input>
-                                        <include>
-                                            target/inferred/factorUnits.ttl
-                                            src/build/inference/factorUnits/predefined-factors-and-scalings.ttl
-                                            src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
-                                            src/main/rdf/vocab/prefixes/VOCAB_QUDT-PREFIXES.ttl
-                                        </include>
-                                    </input>
-                                    <filters>
-                                        <sparqlSelectFile>src/build/srcgen/factorUnits/query.rq</sparqlSelectFile>
-                                    </filters>
-                                    <outputFile>target/ignore.txt</outputFile>
-                                </singleFile>
-                            </products>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <!--
-                        executes the query that is used to generate/validate qudt:scalingOf triples
-                        -->
-                        <id>query-scalingOf</id>
-                        <phase>none</phase>
-                        <goals>
-                            <goal>make</goal>
-                        </goals>
-                        <configuration>
-                            <products>
-                                <singleFile>
-                                    <input>
-                                        <include>
-                                            <!--
-                                                we include anything we might have already inferrd, and we
-                                                include the predefined scalings (they are merged into the target units later)
-                                            -->
-                                            src/build/inference/factorUnits/predefined-factors-and-scalings.ttl
-                                            target/inferred/scalingOf.ttl
-                                            src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
-                                            src/main/rdf/vocab/prefixes/VOCAB_QUDT-PREFIXES.ttl
-                                        </include>
-                                    </input>
-                                    <filters>
-                                        <sparqlSelectFile>src/build/srcgen/scalingOf/query.rq</sparqlSelectFile>
-                                    </filters>
-                                    <outputFile>target/ignore.txt</outputFile>
-                                </singleFile>
-                            </products>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <!--
-                        adds the qudt:hasFactorUnit triples we generated with SHACL to the units source file.
-                        -->
-                        <id>merge-scalingOf-target</id>
-                        <phase>none</phase>
-                        <goals>
-                            <goal>make</goal>
-                        </goals>
-                        <configuration>
-                            <products>
-                                <singleFile>
-                                    <input>
-                                        <include>
-                                            target/inferred/scalingOf.ttl
-                                            target/dist/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
-                                        </include>
-                                    </input>
-                                    <outputFile>target/dist/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl</outputFile>
-                                </singleFile>
-                            </products>
-                        </configuration>
-                    </execution>
+
                     <execution>
                         <!--
                         generates links to IEC CDD
@@ -897,37 +803,6 @@
                                         </sparqlUpdate>
                                     </filters>
                                 </eachFile>
-                            </products>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <!--
-                        execute any query you like (not used in the build - just edit below an run
-                        ```
-                        mvn rdfio:make@myQuery
-                        ```
-                        -->
-                        <id>myQuery</id>
-                        <phase>none</phase>
-                        <goals>
-                            <goal>make</goal>
-                        </goals>
-                        <configuration>
-                            <products>
-                                <singleFile>
-                                    <input>
-                                        <include>
-                                            target/dist/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
-                                        </include>
-                                    </input>
-                                    <filters>
-                                        <!-- put any query here -->
-                                        <sparqlSelectFile>
-                                            src/build/srcgen/conversionMultiplier/query.rq
-                                        </sparqlSelectFile>
-                                    </filters>
-                                    <outputFile>target/ignore.txt</outputFile>
-                                </singleFile>
                             </products>
                         </configuration>
                     </execution>
@@ -1049,12 +924,24 @@
                             <goal>check</goal>
                         </goals>
                         <configuration>
+                            <formats>
+                            <!--
+                            does our placeholder replacements using the maven properties
+                            that were set using the groovy plugin
+                            -->
+                                <format>
+                                    <excludes>
+                                        <exclude>target/**/*.*</exclude>
+                                    </excludes>
+                                </format>
+                            </formats>
+
                             <rdf>
                                 <includes>
                                     <include>src/**/*.ttl</include>
                                 </includes>
                                 <excludes>
-                                    <exclude>**/target/**/*.*</exclude>
+                                    <exclude>target/**/*.*</exclude>
                                     <exclude>src/build/srcgen/**/infer.ttl</exclude>
                                     <exclude>src/build/srcgen/**/validate.ttl</exclude>
                                 </excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
                 Here are the phases and the execution ids that are linked to them (executed in the order they appear in this file):
                       validate                 defineAdditionalProperties, preprocess-shacl-files
                       initialize               [Profile -Pfix: reformat-sources]
-                      generate-sources
+                      generate-sources         unitTestPipeline
                       process-sources          check-source-format, shacl-validate-src
                       generate-resources       copy-rdf, copy-docs, copy-root-files, validate-shacl-files
                       process-resources        generate-iec-links
@@ -381,7 +381,7 @@
             <plugin>
                 <groupId>io.github.qudtlib</groupId>
                 <artifactId>rdfio-maven-plugin</artifactId>
-                <version>1.4.1</version>
+                <version>1.4.2</version>
                 <executions>
                     <execution>
                         <id>badness</id>
@@ -430,7 +430,7 @@
                                                         ), xsd:decimal)
                                                     AS ?badness)
                                                 FILTER(BOUND(?badness))
-                                                FILTER(ABS(?badness) > 0.01)
+                                                FILTER(ABS(?badness) > 0.000001)
                                             } order by ABS(?badness)
                                             ]]>
                                         </sparql>
@@ -439,6 +439,88 @@
                             </pipeline>
                         </configuration>
                     </execution>
+                    <execution>
+                        <!-- unit tests for SHACL functions -->
+                        <id>unitTestPipeline</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>pipeline</goal>
+                        </goals>
+                        <configuration>
+                        <pipeline>
+                            <id>unitTestPipeline</id>
+                            <steps>
+                                <!-- make custom shacl functions available in inference and SPARQL-->
+                                <shaclFunctions>
+                                    <file>src/main/rdf/validation/qudt-shacl-functions.ttl</file>
+                                </shaclFunctions>
+                                <assert>
+                                    <message>Test qfn:decimalPrecision()</message>
+                                    <failureMessage>Unit test failed for qfn:decimalPrecision()</failureMessage>
+                                    <sparqlSelect>
+                                        SELECT *
+                                        WHERE {
+                                        VALUES (?input ?expectedOutput) {
+                                        (0            0)
+                                        (0.0          0)
+                                        (1            1)
+                                        (1.0          1)
+                                        (-1           1)
+                                        (-1.0         1)
+                                        (-.1          1)
+                                        (10           1)
+                                        (100          1)
+                                        (100.001      6)
+                                        (100.000      1)
+                                        (00123.456000 6)
+                                        (-0.00000001  1)
+                                        }
+                                        BIND(qfn:decimalPrecision(?input) AS ?precision)
+                                        FILTER(!BOUND(?precision) || ?precision != ?expectedOutput)
+                                        }
+                                    </sparqlSelect>
+                                </assert>
+                                <assert>
+                                    <message>Test qfn:decimalRoundToPrecision()</message>
+                                    <failureMessage>Unit test failed for qfn:decimalRoundToPrecision()</failureMessage>
+                                    <sparqlSelect>
+                                        SELECT *
+                                        WHERE {
+                                        VALUES (?input ?precision ?expectedOutput) {
+                                            (0            1         0.0)
+                                            (0.0          1         0.0)
+                                            (0.1          1         0.1)
+                                            (.1           1         0.1)
+                                            (1            1         1.0)
+                                            (+1           1         1.0)
+                                            (+1.0         1         1.0)
+                                            (+.0          1         0.0)
+                                            (+.1          1         0.1)
+                                            (1.0          1         1.0)
+                                            (-1           1        -1.0)
+                                            (-1.0         1        -1.0)
+                                            (-.1          1        -0.1)
+                                            (10           1        10.0)
+                                            (100          1       100.0)
+                                            (100.001      6       100.001)
+                                            (100.000      1       100.0)
+                                            (00123.456000 6       123.456)
+                                            (-0.00000001  1        -0.00000001)
+                                            (-00123.456000 3     -123.0)
+                                            (00123.456000 3       123.0)
+                                            (0.000000011574074074074074074  10 0.00000001157407407)
+                                            (-0.000000011574074074074074074  10 -0.00000001157407407)
+                                        }
+                                        BIND(qfn:decimalRoundToPrecision(?input, ?precision) AS ?rounded)
+                                        FILTER(!BOUND(?rounded) || ?rounded != ?expectedOutput)
+                                        }
+                                    </sparqlSelect>
+                                </assert>
+                            </steps>
+                            </pipeline>
+                        </configuration>
+                    </execution>
+
                     <execution>
                         <id>mainPipeline</id>
                         <phase>compile</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -316,6 +316,7 @@
                                     <!--skip>true</skip-->
                                     <shapes>
                                         <include>
+                                            src/main/rdf/validation/qudt-shacl-functions.ttl
                                             target/srcgen/factorUnits/validate.ttl
                                         </include>
                                     </shapes>
@@ -332,6 +333,7 @@
                                     <!--skip>true</skip-->
                                     <shapes>
                                         <include>
+                                            src/main/rdf/validation/qudt-shacl-functions.ttl
                                             target/srcgen/scalingOf/validate.ttl
                                         </include>
                                     </shapes>
@@ -340,7 +342,7 @@
                                             target/dist/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
                                         </include>
                                     </data>
-                                    <outputFile>target/validation/validationReport-factorUnits.ttl</outputFile>
+                                    <outputFile>target/validation/validationReport-scalingOf.ttl</outputFile>
                                 </validation>
                             </validations>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -793,6 +793,53 @@
                                         <toFile>target/dist/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL.ttl</toFile>
                                     </write>
                                     <!-- start from here if nothing has changed in the inputs of the earlier steps -->
+
+                                    <clear/>
+                                    <savepoint><id>09-afterClear</id></savepoint>
+                                    <shaclFunctions>
+                                        <file>src/main/rdf/validation/qudt-shacl-functions.ttl</file>
+                                    </shaclFunctions>
+                                    <add>
+                                        <files>
+                                            <include>target/dist/**/*.ttl</include>
+                                        </files>
+                                        <toGraphsPattern>target:${name}</toGraphsPattern>
+                                    </add>
+                                    <sparqlUpdate>
+                                        <message>Limit any xsd:decimal's precision to 34</message>
+                                        <sparql>
+                                        DELETE {
+                                            GRAPH ?g {
+                                                ?s ?p ?oldVal .
+                                                ?s ?pSN ?oldValSN .
+                                            }
+                                        }
+                                        INSERT {
+                                            GRAPH ?g {
+                                                ?s ?p ?newVal .
+                                                ?s ?pSN ?newValSN .
+                                            }
+                                        }
+                                        WHERE {
+                                           GRAPH ?g {
+                                                ?s ?p ?oldVal .
+                                                FILTER (DATATYPE(?oldVal) = xsd:decimal)
+                                                FILTER(qfn:decimalPrecision(?oldVal) > 34)
+                                                BIND(IRI(CONCAT(STR(?p),"SN")) as ?pSN)
+                                                BIND(qfn:decimalRoundToPrecision(?oldVal, 34) AS ?newVal)
+                                                BIND(qfn:decimalToDouble(?newVal) AS ?newValSN)
+                                                OPTIONAL {
+                                                    ?s ?pSN ?oldValSN .
+                                                }
+                                           }
+                                        }
+                                        </sparql>
+                                    </sparqlUpdate>
+                                    <write>
+                                        <graphs>
+                                            <include>target:*</include>
+                                        </graphs>
+                                    </write>
                                     <savepoint><id>99-endOfPipeline</id></savepoint>
                                 </steps>
                             </pipeline>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
                       generate-sources         unitTestPipeline
                       process-sources          check-source-format, shacl-validate-src
                       generate-resources       copy-rdf, copy-docs, copy-root-files, validate-shacl-files
-                      process-resources        generate-iec-links
+                      process-resources
                       process-classes          mainRdfPipeline
                       generate-test-sources
                       process-test-sources
@@ -386,62 +386,6 @@
                 <version>1.4.2</version>
                 <executions>
                     <execution>
-                        <id>badness</id>
-                        <phase>none</phase>
-                        <goals>
-                            <goal>pipeline</goal>
-                        </goals>
-                        <configuration>
-                            <pipeline>
-                                <id>badnessPipeline</id>
-                                <steps>
-                                    <add>
-                                        <files>
-                                            <include>
-                                                target/validation/conversionMultiplier-toDelete*.ttl
-                                            </include>
-                                        </files>
-                                    </add>
-                                    <add>
-                                        <file>src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl</file>
-                                        <toGraph>units:src</toGraph>
-                                    </add>
-                                    <add>
-                                        <file>target/dist/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl</file>
-                                        <toGraph>units:target</toGraph>
-                                    </add>
-                                    <sparqlQuery>
-                                        <sparql>
-                                            <![CDATA[
-                                            SELECT ?focusNode ?badness ?originalConversionMultiplier ?cmCalculated WHERE {
-                                                ?report sh:resultMessage ?message .
-                                                ?report sh:focusNode ?focusNode .
-                                                GRAPH <units:src> {
-                                                    ?focusNode qudt:conversionMultiplier ?originalConversionMultiplier .
-                                                }
-                                                GRAPH <units:target> {
-                                                    ?focusNode qudt:conversionMultiplier ?cmCalculated .
-                                                }
-                                                BIND(
-                                                    STRDT(
-                                                        REPLACE(
-                                                            ?message,
-                                                            "^(.|\\r\\n)*badness\\s+: ([0-9]+\\.[0-9]+)(.|\\r\\n)*$",
-                                                            "$2",
-                                                            "mi"
-                                                        ), xsd:decimal)
-                                                    AS ?badness)
-                                                FILTER(BOUND(?badness))
-                                                FILTER(ABS(?badness) > 0.000001)
-                                            } order by ABS(?badness)
-                                            ]]>
-                                        </sparql>
-                                    </sparqlQuery>
-                                </steps>
-                            </pipeline>
-                        </configuration>
-                    </execution>
-                    <execution>
                         <!-- unit tests for SHACL functions -->
                         <id>unitTestPipeline</id>
                         <phase>generate-sources</phase>
@@ -537,15 +481,45 @@
                                     <shaclFunctions>
                                         <file>src/main/rdf/validation/qudt-shacl-functions.ttl</file>
                                     </shaclFunctions>
+                                    <!-- first, handle the IEC links -->
+                                    <add>
+                                        <!--
+                                            this reads each file in target into a graph named 'target:{filename}'
+                                            in the dataset and remembers the file association (see <write> at the end)
+                                        -->
+                                        <files>
+                                            <include>target/dist/vocab/**/*.ttl</include>
+                                        </files>
+                                        <toGraphsPattern>target:${name}</toGraphsPattern>
+                                    </add>
+                                    <sparqlUpdate>
+                                        <message>Adding IEC links</message>
+                                        <sparql>
+                                            <![CDATA[
+                                            INSERT {
+                                                GRAPH ?g {
+                                                    ?x qudt:informativeReference ?new}
+                                                }
+                                            WHERE {
+                                                GRAPH ?g {
+                                                    ?x a ?type; qudt:iec61360Code ?irdi.
+                                                    VALUES (?type ?prefix) {
+                                                        (qudt:Unit         "https://cdd.iec.ch/cdd/iec62720/iec62720.nsf/Units/")
+                                                        (qudt:QuantityKind "https://cdd.iec.ch/cdd/iec61987/iec61987.nsf/ListsOfUnitsAllVersions/")
+                                                        (qudt:PhysicalConstant "https://cdd.iec.ch/cdd/iec61987/iec61987.nsf/ListsOfUnitsAllVersions/")
+                                                    }
+                                                    OPTIONAL {
+                                                        ?x qudt:informativeReference ?old filter(strstarts(str(?old),"https://cdd.iec.ch"))
+                                                    }
+                                                    BIND(replace(replace(str(?irdi),"/","-"),"#","%23") as ?irdi_new)
+                                                    BIND(strdt(concat(?prefix,?irdi_new),xsd:anyURI) as ?new)
+                                                }
+                                            }
+                                            ]]>
+                                        </sparql>
+                                    </sparqlUpdate>
+                                    <savepoint><id>01-iec-links</id></savepoint>
 
-                                    <add> <!-- load target quantitykinds into <target:quantityKinds> (associating that graph with the file)-->
-                                        <file>src/main/rdf/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL.ttl</file>
-                                        <toGraph>modified:quantityKinds</toGraph>
-                                    </add>
-                                    <add> <!-- load target units into <modified:units>  (associating that graph with the file) -->
-                                        <file>src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl</file>
-                                        <toGraph>modified:units</toGraph>
-                                    </add>
                                     <add> <!-- load applicableUnits shapes (rules) into <shapes:applicableUnits> because we need them twice (see below) -->
                                         <file>src/build/inference/inferApplicableUnits.ttl</file>
                                         <toGraph>shapes:applicableUnits</toGraph>
@@ -557,8 +531,8 @@
                                             <graph>shapes:applicableUnits</graph>
                                         </shapes>
                                         <data>
-                                            <graph>modified:quantityKinds</graph>
-                                            <graph>modified:units</graph>
+                                            <graph>target:VOCAB_QUDT-QUANTITY-KINDS-ALL.ttl</graph>
+                                            <graph>target:VOCAB_QUDT-UNITS-ALL.ttl</graph>
                                         </data>
                                         <inferred>
                                             <graph>inferred:applicableUnits</graph>
@@ -568,31 +542,26 @@
 
                                     <add> <!-- add the results of the quantitykinds inference to the quantityKinds graph -->
                                         <graph>inferred:applicableUnits</graph>
-                                        <toGraph>modified:quantityKinds</toGraph>
+                                        <toGraph>target:VOCAB_QUDT-QUANTITY-KINDS-ALL.ttl</toGraph>
                                     </add>
 
                                     <!-- start from here if nothing has changed in the inputs of the earlier steps -->
-                                    <savepoint><id>01-applicableUnits</id></savepoint>
-                                    <add>
-                                        <file>src/main/rdf/vocab/currency/VOCAB_QUDT-UNITS-CURRENCY.ttl</file>
-                                        <toGraph>target:currencyUnits</toGraph>
-                                    </add>
+                                    <savepoint><id>02-applicableUnits</id></savepoint>
                                     <shaclInfer>  <!-- do the quantitykinds inference for currency units -->
                                         <message>Inferring qudt:applicableUnit triples (currency units)</message>
                                         <shapes><graph>shapes:applicableUnits</graph></shapes>
                                         <data>
-                                            <graph>target:currencyUnits</graph>
+                                            <graph>target:VOCAB_QUDT-UNITS-CURRENCY.ttl</graph>
                                         </data>
                                         <inferred>
                                             <graph>inferred:applicableCurrencyUnits</graph>
                                             <file>target/inferred/applicableUnits-currency.ttl</file>
                                         </inferred>
                                     </shaclInfer>
-                                    <write>
-                                        <graph>target:currencyUnits</graph>
+                                    <add>
                                         <graph>inferred:applicableCurrencyUnits</graph>
-                                        <toFile>target/dist/vocab/currency/VOCAB_QUDT-UNITS-CURRENCY.ttl</toFile>
-                                    </write>
+                                        <toGraph>target:VOCAB_QUDT-UNITS-CURRENCY.ttl</toGraph>
+                                    </add>
 
                                     <!-- start from here if nothing has changed in the inputs of the earlier steps -->
                                     <savepoint><id>02-applicableUnits-currencies</id></savepoint>
@@ -606,9 +575,9 @@
                                             <files>
                                                 <include>
                                                     src/main/rdf/schema/SCHEMA_QUDT.ttl
-                                                    src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
                                                 </include>
                                             </files>
+                                            <graph>target:VOCAB_QUDT-UNITS-ALL.ttl</graph>
                                         </data>
                                         <inferred>
                                             <graph>inferred:owl-subset-units</graph>
@@ -618,7 +587,7 @@
 
                                     <add> <!-- add the inferred triples to the units graph -->
                                         <graph>inferred:owl-subset-units</graph>
-                                        <toGraph>modified:units</toGraph>
+                                        <toGraph>target:VOCAB_QUDT-UNITS-ALL.ttl</toGraph>
                                     </add>
 
                                     <!-- start from here if nothing has changed in the inputs of the earlier steps -->
@@ -626,13 +595,7 @@
 
                                     <add>
                                         <file>src/build/inference/factorUnits/predefined-factors-and-scalings.ttl</file>
-                                        <toGraph>modified:units</toGraph>
-                                    </add>
-                                    <add>
-                                        <files>
-                                            <include>target/dist/vocab/prefixes/*.ttl</include>
-                                        </files>
-                                        <toGraph>target:prefixes</toGraph>
+                                        <toGraph>target:VOCAB_QUDT-UNITS-ALL.ttl</toGraph>
                                     </add>
 
                                     <shaclInfer> <!-- infer ther factor units -->
@@ -643,8 +606,8 @@
                                         <data>
                                             <graphs>
                                                 <include>
-                                                    modified:units
-                                                    target:prefixes
+                                                    target:VOCAB_QUDT-UNITS-ALL.ttl
+                                                    target:VOCAB_QUDT-PREFIXES.ttl
                                                 </include>
                                             </graphs>
                                         </data>
@@ -655,7 +618,7 @@
                                     </shaclInfer>
                                     <add>
                                         <graph>inferred:factorUnits</graph>
-                                        <toGraph>modified:units</toGraph>
+                                        <toGraph>target:VOCAB_QUDT-UNITS-ALL.ttl</toGraph>
                                     </add>
                                     <savepoint><id>04-infer-factor-units</id></savepoint>
                                     <shaclInfer>
@@ -664,8 +627,8 @@
                                             <file>target/srcgen/scalingOf/infer.ttl</file>
                                         </shapes>
                                         <data>
-                                            <graph>modified:units</graph>
-                                            <graph>target:prefixes</graph>
+                                            <graph>target:VOCAB_QUDT-UNITS-ALL.ttl</graph>
+                                            <graph>target:VOCAB_QUDT-PREFIXES.ttl</graph>
                                         </data>
                                         <inferred>
                                             <graph>inferred:scalingOf</graph>
@@ -674,7 +637,7 @@
                                     </shaclInfer>
                                     <add>
                                         <graph>inferred:scalingOf</graph>
-                                        <toGraph>modified:units</toGraph>
+                                        <toGraph>target:VOCAB_QUDT-UNITS-ALL.ttl</toGraph>
                                     </add>
                                     <savepoint><id>05-infer-scalingOf</id></savepoint>
                                     <until>
@@ -699,8 +662,8 @@
                                                     <file>target/srcgen/conversionMultiplier/validate.ttl</file>
                                                 </shapes>
                                                 <data>
-                                                    <graph>modified:units</graph>
-                                                    <graph>target:prefixes</graph>
+                                                    <graph>target:VOCAB_QUDT-UNITS-ALL.ttl</graph>
+                                                    <graph>target:VOCAB_QUDT-PREFIXES.ttl</graph>
                                                 </data>
                                                 <validationReport>
                                                     <graph>inferred:conversionMultiplierToDelete_${index_cm}</graph>
@@ -712,13 +675,13 @@
                                                 <sparql>
                                                     <![CDATA[
                                                 DELETE {
-                                                    GRAPH <modified:units> {
+                                                    GRAPH <target:VOCAB_QUDT-UNITS-ALL.ttl> {
                                                         ?unit qudt:conversionMultiplier ?m .
                                                         ?unit  qudt:conversionMultiplierSN ?mSN .
                                                     }
                                                 }
                                                 WHERE {
-                                                    GRAPH <modified:units> {
+                                                    GRAPH <target:VOCAB_QUDT-UNITS-ALL.ttl> {
                                                         {
                                                             ?unit qudt:conversionMultiplier ?m .
                                                         } UNION {
@@ -746,8 +709,8 @@
                                                     <file>target/srcgen/conversionMultiplier/infer.ttl</file>
                                                 </shapes>
                                                 <data>
-                                                    <graph>modified:units</graph>
-                                                    <graph>target:prefixes</graph>
+                                                    <graph>target:VOCAB_QUDT-UNITS-ALL.ttl</graph>
+                                                    <graph>target:VOCAB_QUDT-PREFIXES.ttl</graph>
                                                 </data>
                                                 <inferred>
                                                     <graph>inferred:conversionMultiplier_${index_cm}</graph>
@@ -756,23 +719,23 @@
                                             </shaclInfer>
                                             <add>
                                                 <graph>inferred:conversionMultiplier_${index_cm}</graph>
-                                                <toGraph>modified:units</toGraph>
+                                                <toGraph>target:VOCAB_QUDT-UNITS-ALL.ttl</toGraph>
                                             </add>
                                         </body>
 
                                     </until>
-                                    <savepoint><id>08-infer-conversionMultiplier</id></savepoint>
+
                                     <sparqlUpdate>
                                         <message>Generate conversion multipliers in xsd:double format where it's missing</message>
                                         <sparql>
                                             <![CDATA[
                                             INSERT {
-                                                GRAPH <modified:units> {
+                                                GRAPH <target:VOCAB_QUDT-UNITS-ALL.ttl> {
                                                     ?unit qudt:conversionMultiplierSN ?cmsn
                                                 }
                                             }
                                             WHERE {
-                                                GRAPH <modified:units> {
+                                                GRAPH <target:VOCAB_QUDT-UNITS-ALL.ttl> {
                                                     ?unit a qudt:Unit ;
                                                           qudt:conversionMultiplier ?cm .
                                                     FILTER NOT EXISTS {
@@ -784,29 +747,8 @@
                                             ]]>
                                         </sparql>
                                     </sparqlUpdate>
-                                    <!-- write the main outputs: units and quantitykinds files (back to the files they were initially read from) -->
-                                    <write>
-                                        <graph>modified:units</graph>
-                                        <toFile>target/dist/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl</toFile>
-                                    </write>
+                                    <savepoint><id>08-infer-conversionMultiplier</id></savepoint>
 
-                                    <write>
-                                        <graph>modified:quantityKinds</graph>
-                                        <toFile>target/dist/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL.ttl</toFile>
-                                    </write>
-                                    <!-- start from here if nothing has changed in the inputs of the earlier steps -->
-
-                                    <clear/>
-                                    <savepoint><id>09-afterClear</id></savepoint>
-                                    <shaclFunctions>
-                                        <file>src/main/rdf/validation/qudt-shacl-functions.ttl</file>
-                                    </shaclFunctions>
-                                    <add>
-                                        <files>
-                                            <include>target/dist/**/*.ttl</include>
-                                        </files>
-                                        <toGraphsPattern>target:${name}</toGraphsPattern>
-                                    </add>
                                     <sparqlUpdate>
                                         <message>Limit any xsd:decimal's precision to 34</message>
                                         <sparql>
@@ -837,6 +779,7 @@
                                         }
                                         </sparql>
                                     </sparqlUpdate>
+
                                     <write>
                                         <graphs>
                                             <include>target:*</include>
@@ -845,46 +788,6 @@
                                     <savepoint><id>99-endOfPipeline</id></savepoint>
                                 </steps>
                             </pipeline>
-                        </configuration>
-                    </execution>
-
-                    <execution>
-                        <!--
-                        generates links to IEC CDD
-                        -->
-                        <id>generate-iec-links</id>
-                        <phase>process-resources</phase>
-                        <goals>
-                            <goal>make</goal>
-                        </goals>
-                        <configuration>
-                            <products>
-                                <eachFile>
-                                    <replaceInputFiles>true</replaceInputFiles>
-                                    <input>
-                                        <include>target/dist/vocab/**/*.ttl</include>
-                                    </input>
-                                    <filters>
-                                        <sparqlUpdate>
-                                            prefix qudt:&lt;http://qudt.org/schema/qudt/&gt;
-                                            prefix xsd:&lt;http://www.w3.org/2001/XMLSchema#&gt;
-
-                                            insert {?x qudt:informativeReference ?new}
-                                            where {
-                                                ?x a ?type; qudt:iec61360Code ?irdi.
-                                                values (?type ?prefix) {
-                                                    (qudt:Unit         "https://cdd.iec.ch/cdd/iec62720/iec62720.nsf/Units/")
-                                                    (qudt:QuantityKind "https://cdd.iec.ch/cdd/iec61987/iec61987.nsf/ListsOfUnitsAllVersions/")
-                                                    (qudt:PhysicalConstant "https://cdd.iec.ch/cdd/iec61987/iec61987.nsf/ListsOfUnitsAllVersions/")
-                                                }
-                                                optional {?x qudt:informativeReference ?old filter(strstarts(str(?old),"https://cdd.iec.ch"))}
-                                                bind(replace(replace(str(?irdi),"/","-"),"#","%23") as ?irdi_new)
-                                                bind(strdt(concat(?prefix,?irdi_new),xsd:anyURI) as ?new)
-                                            }
-                                        </sparqlUpdate>
-                                    </filters>
-                                </eachFile>
-                            </products>
                         </configuration>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -386,6 +386,69 @@
                 <version>1.4.2</version>
                 <executions>
                     <execution>
+                        <!--
+                            interesting inspections,
+
+                            run with:
+                            mvn rdfio:pipeline@inspect
+
+                            writes to target/inspection
+                        -->
+                        <id>inspect</id>
+                        <phase>none</phase>
+                        <goals>
+                            <goal>pipeline</goal>
+                        </goals>
+                        <configuration>
+                            <pipeline>
+                                <id>inspect</id>
+                                <steps>
+                                    <!-- make custom shacl functions available in inference and SPARQL-->
+                                    <shaclFunctions>
+                                        <file>src/main/rdf/validation/qudt-shacl-functions.ttl</file>
+                                    </shaclFunctions>
+                                    <add>
+                                        <!--
+                                            this reads each file in target into a graph named 'target:{filename}'
+                                        -->
+                                        <files>
+                                            <include>target/dist/vocab/**/*.ttl</include>
+                                        </files>
+                                        <toGraphsPattern>target:${name}</toGraphsPattern>
+                                    </add>
+
+                                    <sparqlQuery>
+                                        <sparql>
+                                            <![CDATA[
+                                                SELECT ?unit ?cm ?match ?deprecated
+                                                WHERE {
+                                                    GRAPH <target:VOCAB_QUDT-UNITS-ALL.ttl> {
+                                                        ?unit a qudt:Unit .
+                                                        OPTIONAL {
+                                                            ?unit qudt:deprecated ?deprecated .
+                                                        }
+                                                        OPTIONAL {
+                                                            ?unit qudt:conversionMultiplier ?cm
+                                                        }
+                                                        OPTIONAL {
+                                                            ?unit qudt:exactMatch ?match
+                                                        }
+                                                        FILTER (!BOUND(?cm))
+                                                        FILTER NOT EXISTS {
+                                                            ?unit a qudt:CurrencyUnit
+                                                        }
+                                                    }
+                                                } ORDER BY ?cm ?match ?unit
+                                            ]]>
+                                        </sparql>
+                                        <toFile>target/inspection/units-without-conversionMultiplier.txt</toFile>
+                                    </sparqlQuery>
+
+                                </steps>
+                            </pipeline>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <!-- unit tests for SHACL functions -->
                         <id>unitTestPipeline</id>
                         <phase>generate-sources</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -381,7 +381,7 @@
             <plugin>
                 <groupId>io.github.qudtlib</groupId>
                 <artifactId>rdfio-maven-plugin</artifactId>
-                <version>1.3.3-SNAPSHOT</version>
+                <version>1.4.0</version>
                 <executions>
                     <execution>
                         <id>mainPipeline</id>

--- a/pom.xml
+++ b/pom.xml
@@ -68,264 +68,158 @@
                 Executions with phase 'none' (invocable directly via command line, not bound to lifecycle):
                       none                     infer-and-format, infer-factorUnits, infer-scalingOf, merge-factorUnits-target, query-factorUnits, query-scalingOf, merge-scalingOf-target, reformat-sources
             -->
+
             <plugin>
-                <groupId>io.github.qudtlib</groupId>
-                <artifactId>seq-maven-plugin</artifactId>
-                <version>1.0.0</version>
+                <groupId>org.codehaus.gmavenplus</groupId>
+                <artifactId>gmavenplus-plugin</artifactId>
+                <version>4.1.1</version>
                 <executions>
-                    <execution>
-                        <id>infer-and-format</id>
-                        <phase>compile</phase>
-                        <goals><goal>run</goal></goals>
-                        <configuration>
-                            <label>make all inferences and write to target</label>
-                            <steps>
-                                <step>
-                                    <pluginCoordinates>rdfio:make@merge-predefinedUnits-target</pluginCoordinates>
-                                </step>
-                                <step>
-                                    <pluginCoordinates>shacl:infer@infer-factorUnits</pluginCoordinates>
-                                </step>
-                                <step>
-                                    <pluginCoordinates>rdfio:make@merge-factorUnits-target</pluginCoordinates>
-                                </step>
-                                <step>
-                                    <pluginCoordinates>shacl:infer@infer-scalingOf</pluginCoordinates>
-                                </step>
-                                <step>
-                                    <pluginCoordinates>rdfio:make@merge-scalingOf-target</pluginCoordinates>
-                                </step>
-                                <step>
-                                    <pluginCoordinates>shacl:infer@infer-conversionMultiplier</pluginCoordinates>
-                                </step>
-                                <step>
-                                    <pluginCoordinates>rdfio:make@merge-conversionMultiplier-target</pluginCoordinates>
-                                </step>
-                                <step>
-                                    <pluginCoordinates>shacl:infer@infer-applicableUnits</pluginCoordinates>
-                                </step>
-                                <step>
-                                    <pluginCoordinates>rdfio:make@merge-applicableUnits-target</pluginCoordinates>
-                                </step>
-                                <step>
-                                    <pluginCoordinates>shacl:infer@infer-owlSubset</pluginCoordinates>
-                                </step>
-                                <step>
-                                    <pluginCoordinates>rdfio:make@merge-owlSubset-target</pluginCoordinates>
-                                </step>
-                            </steps>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>infer-factorUnits</id>
-                        <phase>none</phase>
-                        <goals><goal>run</goal></goals>
-                        <configuration>
-                            <label>factor units</label>
-                            <steps>
-                                <step>
-                                    <pluginCoordinates>shacl:infer@infer-factorUnits</pluginCoordinates>
-                                </step>
-                                <step>
-                                    <pluginCoordinates>rdfio:make@merge-factorUnits-target</pluginCoordinates>
-                                </step>
-                                <step>
-                                    <pluginCoordinates>spotless:apply@reformat-sources</pluginCoordinates>
-                                </step>
-                            </steps>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>infer-scalingOf</id>
-                        <phase>none</phase>
-                        <goals><goal>run</goal></goals>
-                        <configuration>
-                            <label>scalingOf</label>
-                            <steps>
-                                <step>
-                                    <pluginCoordinates>shacl:infer@infer-scalingOf</pluginCoordinates>
-                                </step>
-                                <step>
-                                    <pluginCoordinates>rdfio:make@merge-scalingOf-target</pluginCoordinates>
-                                </step>
-                                <step>
-                                    <pluginCoordinates>spotless:apply@reformat-sources</pluginCoordinates>
-                                </step>
-                            </steps>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>infer-derivedUnit-conversionMultiplier</id>
-                        <phase>none</phase>
-                        <goals><goal>run</goal></goals>
-                        <configuration>
-                            <label>derived units multipliers</label>
-                            <steps>
-                                <step>
-                                    <pluginCoordinates>shacl:infer@infer-conversionMultipliers</pluginCoordinates>
-                                </step>
-                                <step>
-                                    <pluginCoordinates>rdfio:make@merge-conversionMultipliers-target</pluginCoordinates>
-                                </step>
-                                <step>
-                                    <pluginCoordinates>spotless:apply@reformat-sources</pluginCoordinates>
-                                </step>
-                            </steps>
+                <!-- Ported execution: defineAdditionalProperties -->
+                <execution>
+                    <id>defineAdditionalProperties</id>
+                    <phase>validate</phase>
+                    <goals>
+                        <goal>execute</goal>
+                    </goals>
+                    <configuration>
+                        <scripts>
+                            <script><![CDATA[
+                                    import java.time.OffsetDateTime
+                                    import java.time.format.DateTimeFormatter
+                                    import java.time.temporal.ChronoField
+
+                                    def majorMinorVersion = "${project.version}".replaceAll('^(\\w+\\.\\w+).*\$', '\$1')
+                                    project.properties.setProperty('project.version.majorminor', majorMinorVersion)
+                                    project.properties.setProperty('qudt.versioned.iri.prefix', "http://qudt.org/${majorMinorVersion}/")
+                                    def now = OffsetDateTime.now().with(ChronoField.MILLI_OF_SECOND, 0)
+                                    project.properties.setProperty('qudt.build.date', "${now}")
+                                    def currentMonth = now.format(DateTimeFormatter.ofPattern("MM"))
+                                    def currentYear = now.format(DateTimeFormatter.ofPattern("YYYY"))
+                                    project.properties.setProperty('qudt.current.month', currentMonth)
+                                    project.properties.setProperty('qudt.current.year', currentYear)
+                                ]]></script>
+                        </scripts>
+                    </configuration>
+                </execution>
+                <!-- New execution: preprocess-shacl-files -->
+                <execution>
+                    <id>preprocess-shacl-files</id>
+                    <phase>validate</phase>
+                    <goals>
+                        <goal>execute</goal>
+                    </goals>
+                    <configuration>
+                        <scripts>
+                            <script><![CDATA[
+                                // Define base directories
+                                def basedir = project.basedir.toString()
+                                def srcgenDir = new File(basedir, "src/build/srcgen")
+                                def targetDir = new File(basedir, "target/srcgen")
+
+                                // Validate source directory
+                                if (!srcgenDir.exists() || !srcgenDir.isDirectory()) {
+                                    throw new Exception("Source generation directory not found: ${srcgenDir}")
+                                }
+
+                                // Ensure target directory exists
+                                targetDir.mkdirs()
+
+                                // Step 1: Collect all aspect directories and their file status
+                                def allAspectDirs = srcgenDir.listFiles().findAll { it.isDirectory() }
+                                def validAspectDirs = []
+                                // Map to store omitted dirs and missing files
+                                def omittedAspectDirsWithReasons = [:]
+
+                                allAspectDirs.each { dir ->
+                                    def aspectName = dir.name
+                                    def queryFile = new File(dir, "query.rq")
+                                    def inferTemplateFile = new File(dir, "infer-template.ttl")
+                                    def validateTemplateFile = new File(dir, "validate-template.ttl")
+
+                                    def requiredFiles = [
+                                        queryFile: queryFile,
+                                        inferTemplateFile: inferTemplateFile,
+                                        validateTemplateFile: validateTemplateFile
+                                    ]
+
+                                    // Find missing files for this directory
+                                    def missingFiles = requiredFiles.findAll { !it.value.exists() }.keySet()
+
+                                    if (missingFiles.isEmpty()) {
+                                        // All files present, add to valid list
+                                        validAspectDirs << dir
+                                        // Record missing files
+                                        } else { omittedAspectDirsWithReasons[dir] = missingFiles
+                                         }
+                                }
+
+                                // Step 2: Process valid directories
+                                validAspectDirs.each { aspectDir ->
+                                    def aspectName = aspectDir.name
+                                    println "Processing aspect: ${aspectName}"
+
+                                    // Load required files
+                                    def queryFile = new File(aspectDir, "query.rq")
+                                    def inferTemplateFile = new File(aspectDir, "infer-template.ttl")
+                                    def validateTemplateFile = new File(aspectDir, "validate-template.ttl")
+
+                                    // Process query file (e.g., remove prefixes)
+                                    def queryText = queryFile.text
+                                    def queryWithoutPrefixes = queryText.replaceAll('(?is)^\\s*(PREFIX\\s+[^\\n]*\\n)*\\s*', '')
+                                                                .replaceAll('(?is)\\s*$', '')
+                                    if (!queryWithoutPrefixes) {
+                                        throw new Exception("No query body found in ${queryFile}")
+                                    }
+                                    queryWithoutPrefixes = queryWithoutPrefixes.replaceAll("\\\\", "\\\\\\\\")
+
+                                    // Create output directory for this aspect
+                                    def aspectOutputDir = new File(targetDir, aspectName)
+                                    aspectOutputDir.mkdirs()
+
+                                    // Define templates to process
+                                    def templates = [
+                                        [source: inferTemplateFile, target: "infer.ttl"],
+                                        [source: validateTemplateFile, target: "validate.ttl"]
+                                    ]
+
+                                    // Generate output files
+                                    templates.each { template ->
+                                        def content = template.source.text
+                                        def outputContent = content.replace('{{QUERY_WITHOUT_PREFIXES}}', queryWithoutPrefixes)
+                                        outputContent = outputContent.replace('{{AUTOGENERATED_WARNING_DO_NOT_EDIT}}',
+                                            " Auto-generated file - ALL EDITS WILL BE LOST! Edit the '-template.ttl' file instead!")
+                                        def outputFile = new File(aspectOutputDir, template.target)
+                                        outputFile.text = outputContent
+                                        println "Generated: ${outputFile}"
+                                    }
+                                }
+
+                                // Step 3: Log omitted directories with missing file details
+                                if (omittedAspectDirsWithReasons) {
+                                    println "The following aspects were omitted due to missing required files:"
+                                    // Simplify to file names
+                                    omittedAspectDirsWithReasons.each { dir, missingFiles ->
+                                        def missingFileNames = missingFiles.collect { it.toString().replaceAll('^.*\\.', '') }
+                                        println " - ${dir.name}: Missing ${missingFileNames.join(', ')}"
+                                    }
+                                } else {
+                                    println "All aspects processed successfully; no missing files detected."
+                                }
+                            ]]>
+                                </script>
+                            </scripts>
                         </configuration>
                     </execution>
                 </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.groovy</groupId>
+                        <artifactId>groovy-ant</artifactId>
+                        <version>4.0.23</version>
+                        <scope>runtime</scope>
+                    </dependency>
+                </dependencies>
             </plugin>
-            <plugin>
-            <groupId>org.codehaus.gmavenplus</groupId>
-            <artifactId>gmavenplus-plugin</artifactId>
-            <version>4.1.1</version>
-            <executions>
-            <!-- Ported execution: defineAdditionalProperties -->
-            <execution>
-                <id>defineAdditionalProperties</id>
-                <phase>validate</phase>
-                <goals>
-                    <goal>execute</goal>
-                </goals>
-                <configuration>
-                    <scripts>
-                        <script><![CDATA[
-                                import java.time.OffsetDateTime
-                                import java.time.format.DateTimeFormatter
-                                import java.time.temporal.ChronoField
-
-                                def majorMinorVersion = "${project.version}".replaceAll('^(\\w+\\.\\w+).*\$', '\$1')
-                                project.properties.setProperty('project.version.majorminor', majorMinorVersion)
-                                project.properties.setProperty('qudt.versioned.iri.prefix', "http://qudt.org/${majorMinorVersion}/")
-                                def now = OffsetDateTime.now().with(ChronoField.MILLI_OF_SECOND, 0)
-                                project.properties.setProperty('qudt.build.date', "${now}")
-                                def currentMonth = now.format(DateTimeFormatter.ofPattern("MM"))
-                                def currentYear = now.format(DateTimeFormatter.ofPattern("YYYY"))
-                                project.properties.setProperty('qudt.current.month', currentMonth)
-                                project.properties.setProperty('qudt.current.year', currentYear)
-                            ]]></script>
-                    </scripts>
-                </configuration>
-            </execution>
-            <!-- New execution: preprocess-shacl-files -->
-            <execution>
-                <id>preprocess-shacl-files</id>
-                <phase>validate</phase>
-                <goals>
-                    <goal>execute</goal>
-                </goals>
-                <configuration>
-                    <scripts>
-                        <script><![CDATA[
-                            // Define base directories
-                            def basedir = project.basedir.toString()
-                            def srcgenDir = new File(basedir, "src/build/srcgen")
-                            def targetDir = new File(basedir, "target/srcgen")
-
-                            // Validate source directory
-                            if (!srcgenDir.exists() || !srcgenDir.isDirectory()) {
-                                throw new Exception("Source generation directory not found: ${srcgenDir}")
-                            }
-
-                            // Ensure target directory exists
-                            targetDir.mkdirs()
-
-                            // Step 1: Collect all aspect directories and their file status
-                            def allAspectDirs = srcgenDir.listFiles().findAll { it.isDirectory() }
-                            def validAspectDirs = []
-                            // Map to store omitted dirs and missing files
-                            def omittedAspectDirsWithReasons = [:]
-
-                            allAspectDirs.each { dir ->
-                                def aspectName = dir.name
-                                def queryFile = new File(dir, "query.rq")
-                                def inferTemplateFile = new File(dir, "infer-template.ttl")
-                                def validateTemplateFile = new File(dir, "validate-template.ttl")
-
-                                def requiredFiles = [
-                                    queryFile: queryFile,
-                                    inferTemplateFile: inferTemplateFile,
-                                    validateTemplateFile: validateTemplateFile
-                                ]
-
-                                // Find missing files for this directory
-                                def missingFiles = requiredFiles.findAll { !it.value.exists() }.keySet()
-
-                                if (missingFiles.isEmpty()) {
-                                    // All files present, add to valid list
-                                    validAspectDirs << dir
-                                    // Record missing files
-                                    } else { omittedAspectDirsWithReasons[dir] = missingFiles
-                                     }
-                            }
-
-                            // Step 2: Process valid directories
-                            validAspectDirs.each { aspectDir ->
-                                def aspectName = aspectDir.name
-                                println "Processing aspect: ${aspectName}"
-
-                                // Load required files
-                                def queryFile = new File(aspectDir, "query.rq")
-                                def inferTemplateFile = new File(aspectDir, "infer-template.ttl")
-                                def validateTemplateFile = new File(aspectDir, "validate-template.ttl")
-
-                                // Process query file (e.g., remove prefixes)
-                                def queryText = queryFile.text
-                                def queryWithoutPrefixes = queryText.replaceAll('(?is)^\\s*(PREFIX\\s+[^\\n]*\\n)*\\s*', '')
-                                                            .replaceAll('(?is)\\s*$', '')
-                                if (!queryWithoutPrefixes) {
-                                    throw new Exception("No query body found in ${queryFile}")
-                                }
-                                queryWithoutPrefixes = queryWithoutPrefixes.replaceAll("\\\\", "\\\\\\\\")
-
-                                // Create output directory for this aspect
-                                def aspectOutputDir = new File(targetDir, aspectName)
-                                aspectOutputDir.mkdirs()
-
-                                // Define templates to process
-                                def templates = [
-                                    [source: inferTemplateFile, target: "infer.ttl"],
-                                    [source: validateTemplateFile, target: "validate.ttl"]
-                                ]
-
-                                // Generate output files
-                                templates.each { template ->
-                                    def content = template.source.text
-                                    def outputContent = content.replace('{{QUERY_WITHOUT_PREFIXES}}', queryWithoutPrefixes)
-                                    outputContent = outputContent.replace('{{AUTOGENERATED_WARNING_DO_NOT_EDIT}}',
-                                        " Auto-generated file - ALL EDITS WILL BE LOST! Edit the '-template.ttl' file instead!")
-                                    def outputFile = new File(aspectOutputDir, template.target)
-                                    outputFile.text = outputContent
-                                    println "Generated: ${outputFile}"
-                                }
-                            }
-
-                            // Step 3: Log omitted directories with missing file details
-                            if (omittedAspectDirsWithReasons) {
-                                println "The following aspects were omitted due to missing required files:"
-                                // Simplify to file names
-                                omittedAspectDirsWithReasons.each { dir, missingFiles ->
-                                    def missingFileNames = missingFiles.collect { it.toString().replaceAll('^.*\\.', '') }
-                                    println " - ${dir.name}: Missing ${missingFileNames.join(', ')}"
-                                }
-                            } else {
-                                println "All aspects processed successfully; no missing files detected."
-                            }
-                        ]]>
-                        </script>
-                    </scripts>
-                </configuration>
-            </execution>
-        </executions>
-        <dependencies>
-            <dependency>
-                <groupId>org.apache.groovy</groupId>
-                <artifactId>groovy-ant</artifactId>
-                <version>4.0.23</version>
-                <scope>runtime</scope>
-            </dependency>
-        </dependencies>
-        </plugin>
 
             <plugin>
                 <groupId>io.github.qudtlib</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -384,6 +384,62 @@
                 <version>1.4.1</version>
                 <executions>
                     <execution>
+                        <id>badness</id>
+                        <phase>none</phase>
+                        <goals>
+                            <goal>pipeline</goal>
+                        </goals>
+                        <configuration>
+                            <pipeline>
+                                <id>badnessPipeline</id>
+                                <steps>
+                                    <add>
+                                        <files>
+                                            <include>
+                                                target/validation/conversionMultiplier-toDelete*.ttl
+                                            </include>
+                                        </files>
+                                    </add>
+                                    <add>
+                                        <file>src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl</file>
+                                        <toGraph>units:src</toGraph>
+                                    </add>
+                                    <add>
+                                        <file>target/dist/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl</file>
+                                        <toGraph>units:target</toGraph>
+                                    </add>
+                                    <sparqlQuery>
+                                        <sparql>
+                                            <![CDATA[
+                                            SELECT ?focusNode ?badness ?originalConversionMultiplier ?cmCalculated WHERE {
+                                                ?report sh:resultMessage ?message .
+                                                ?report sh:focusNode ?focusNode .
+                                                GRAPH <units:src> {
+                                                    ?focusNode qudt:conversionMultiplier ?originalConversionMultiplier .
+                                                }
+                                                GRAPH <units:target> {
+                                                    ?focusNode qudt:conversionMultiplier ?cmCalculated .
+                                                }
+                                                BIND(
+                                                    STRDT(
+                                                        REPLACE(
+                                                            ?message,
+                                                            "^(.|\\r\\n)*badness\\s+: ([0-9]+\\.[0-9]+)(.|\\r\\n)*$",
+                                                            "$2",
+                                                            "mi"
+                                                        ), xsd:decimal)
+                                                    AS ?badness)
+                                                FILTER(BOUND(?badness))
+                                                FILTER(ABS(?badness) > 0.01)
+                                            } order by ABS(?badness)
+                                            ]]>
+                                        </sparql>
+                                    </sparqlQuery>
+                                </steps>
+                            </pipeline>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>mainPipeline</id>
                         <phase>compile</phase>
                         <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -564,7 +564,7 @@
                                     </add>
 
                                     <!-- start from here if nothing has changed in the inputs of the earlier steps -->
-                                    <savepoint><id>02-applicableUnits-currencies</id></savepoint>
+                                    <savepoint><id>03-applicableUnits-currencies</id></savepoint>
 
                                     <shaclInfer> <!-- do the custom OWL subset inference -->
                                         <message>Performing our custom subset of OWL inferences</message>
@@ -591,7 +591,7 @@
                                     </add>
 
                                     <!-- start from here if nothing has changed in the inputs of the earlier steps -->
-                                    <savepoint><id>03-owl-subset-units</id></savepoint>
+                                    <savepoint><id>04-owl-subset-units</id></savepoint>
 
                                     <add>
                                         <file>src/build/inference/factorUnits/predefined-factors-and-scalings.ttl</file>
@@ -620,7 +620,7 @@
                                         <graph>inferred:factorUnits</graph>
                                         <toGraph>target:VOCAB_QUDT-UNITS-ALL.ttl</toGraph>
                                     </add>
-                                    <savepoint><id>04-infer-factor-units</id></savepoint>
+                                    <savepoint><id>05-infer-factor-units</id></savepoint>
                                     <shaclInfer>
                                         <message>Inferring qudt:scalingOf</message>
                                         <shapes>
@@ -639,7 +639,7 @@
                                         <graph>inferred:scalingOf</graph>
                                         <toGraph>target:VOCAB_QUDT-UNITS-ALL.ttl</toGraph>
                                     </add>
-                                    <savepoint><id>05-infer-scalingOf</id></savepoint>
+                                    <savepoint><id>06-infer-scalingOf</id></savepoint>
                                     <until>
                                         <message>Replacing invalid conversionMultipliers iteratively until no more are found</message>
                                         <indexVar>index_cm</indexVar>
@@ -747,7 +747,7 @@
                                             ]]>
                                         </sparql>
                                     </sparqlUpdate>
-                                    <savepoint><id>08-infer-conversionMultiplier</id></savepoint>
+                                    <savepoint><id>07-infer-conversionMultiplier</id></savepoint>
 
                                     <sparqlUpdate>
                                         <message>Limit any xsd:decimal's precision to 34</message>

--- a/pom.xml
+++ b/pom.xml
@@ -780,6 +780,46 @@
                                         </sparql>
                                     </sparqlUpdate>
 
+                                    <sparqlUpdate>
+                                        <message>Copy conversionMultipliers/offsets from qudt:exactMatch unit where not present</message>
+                                        <sparql>
+                                            <![CDATA[
+                                                INSERT {
+                                                    GRAPH <target:VOCAB_QUDT-UNITS-ALL.ttl> {
+                                                        ?unit
+                                                            qudt:conversionMultiplier ?cm ;
+                                                            qudt:conversionMultiplierSN ?cmSN ;
+                                                            qudt:conversionOffset ?co ;
+                                                            qudt:conversionOffset ?coSN .
+                                                    }
+                                                }
+                                                WHERE {
+                                                    GRAPH <target:VOCAB_QUDT-UNITS-ALL.ttl>  {
+                                                        ?unit qudt:exactMatch ?otherUnit .
+                                                        ?otherUnit
+                                                            qudt:conversionMultiplier ?cm ;
+                                                            qudt:conversionMultiplierSN ?cmSN .
+                                                        OPTIONAL {
+                                                            ?otherUnit
+                                                                qudt:conversionOffset ?co ;
+                                                                qudt:conversionOffsetSN ?coSN .
+                                                        }
+                                                        FILTER NOT EXISTS {
+                                                            ?unit
+                                                                qudt:conversionMultiplier ?cm ;
+                                                                qudt:conversionMultiplierSN ?cmSN ;
+                                                            OPTIONAL {
+                                                                ?unit
+                                                                    qudt:conversionOffset ?co ;
+                                                                    qudt:conversionOffsetSN ?coSN .
+                                                            }
+                                                        }
+
+                                                    }
+                                                }
+                                            ]]>
+                                        </sparql>
+                                    </sparqlUpdate>
                                     <write>
                                         <graphs>
                                             <include>target:*</include>

--- a/pom.xml
+++ b/pom.xml
@@ -381,7 +381,7 @@
             <plugin>
                 <groupId>io.github.qudtlib</groupId>
                 <artifactId>rdfio-maven-plugin</artifactId>
-                <version>1.4.0</version>
+                <version>1.4.1</version>
                 <executions>
                     <execution>
                         <id>mainPipeline</id>

--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,12 @@
                                     <pluginCoordinates>rdfio:make@merge-scalingOf-target</pluginCoordinates>
                                 </step>
                                 <step>
+                                    <pluginCoordinates>shacl:infer@infer-conversionMultiplier</pluginCoordinates>
+                                </step>
+                                <step>
+                                    <pluginCoordinates>rdfio:make@merge-conversionMultiplier-target</pluginCoordinates>
+                                </step>
+                                <step>
                                     <pluginCoordinates>shacl:infer@infer-applicableUnits</pluginCoordinates>
                                 </step>
                                 <step>
@@ -142,6 +148,25 @@
                                 </step>
                                 <step>
                                     <pluginCoordinates>rdfio:make@merge-scalingOf-target</pluginCoordinates>
+                                </step>
+                                <step>
+                                    <pluginCoordinates>spotless:apply@reformat-sources</pluginCoordinates>
+                                </step>
+                            </steps>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>infer-derivedUnit-conversionMultiplier</id>
+                        <phase>none</phase>
+                        <goals><goal>run</goal></goals>
+                        <configuration>
+                            <label>derived units multipliers</label>
+                            <steps>
+                                <step>
+                                    <pluginCoordinates>shacl:infer@infer-conversionMultipliers</pluginCoordinates>
+                                </step>
+                                <step>
+                                    <pluginCoordinates>rdfio:make@merge-conversionMultipliers-target</pluginCoordinates>
                                 </step>
                                 <step>
                                     <pluginCoordinates>spotless:apply@reformat-sources</pluginCoordinates>
@@ -438,6 +463,34 @@
                         </configuration>
                     </execution>
                     <execution>
+                        <!-- infers qudt:conversionMultiplier triples and writes them to target/inferred/conversionMultiplier.ttl -->
+                        <id>infer-conversionMultiplier</id>
+                        <phase>none</phase>
+                        <goals>
+                            <goal>infer</goal>
+                        </goals>
+                        <configuration>
+                            <inferences>
+                                <inference>
+                                    <shapes>
+                                        <include>
+                                            target/srcgen/conversionMultiplier/infer.ttl
+                                            src/main/rdf/validation/qudt-shacl-functions.ttl
+                                        </include>
+                                    </shapes>
+                                    <data>
+                                        <include>
+                                            <!-- assuming predefined units and factor units have already been merged into the target units -->
+                                            target/dist/vocab/unit/*.ttl
+                                            target/dist/vocab/prefixes/*.ttl
+                                        </include>
+                                    </data>
+                                    <outputFile>target/inferred/conversionMultiplier.ttl</outputFile>
+                                </inference>
+                            </inferences>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <!--
                         SHACL-validates the union of all ttl files in src/vocab and the No-OWL schema
                         against the union of QA-Tests and No-OWL schema
@@ -484,12 +537,29 @@
                         <configuration>
                             <validations>
                                 <validation>
+                                    <message>Validating QUDT conversionMultiplier</message>
+                                    <failureMessage>Problems found</failureMessage>
+                                    <shapes>
+                                        <include>
+                                            target/srcgen/conversionMultiplier/validate.ttl
+                                            src/main/rdf/validation/qudt-shacl-functions.ttl
+                                        </include>
+                                    </shapes>
+                                    <data>
+                                        <include>
+                                            target/dist/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
+                                        </include>
+                                    </data>
+                                    <outputFile>target/validation/validationReport-conversionMultiplier.ttl</outputFile>
+                                </validation>
+                                <validation>
                                     <message>Validating QUDT build output (target/dist/)</message>
                                     <!--skip>true</skip-->
                                     <shapes>
                                         <include>
                                             src/main/rdf/validation/COLLECTION_QUDT_QA_TESTS_ALL.ttl
                                             src/main/rdf/validation/COLLECTION_QUDT_USER_TESTS.ttl
+                                            src/main/rdf/validation/qudt-shacl-functions.ttl
                                             src/main/rdf/schema/shacl/SCHEMA_QUDT_NoOWL.ttl
                                             src/main/rdf/schema/shacl/SCHEMA_QUDT-DATATYPES_NoOWL.ttl
                                         </include>
@@ -677,6 +747,29 @@
                                     <input>
                                         <include>
                                             target/inferred/factorUnits.ttl
+                                            target/dist/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
+                                        </include>
+                                    </input>
+                                    <outputFile>target/dist/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl</outputFile>
+                                </singleFile>
+                            </products>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <!--
+                        adds the qudt:hasFactorUnit triples we generated with SHACL to the units source file.
+                        -->
+                        <id>merge-conversionMultiplier-target</id>
+                        <phase>none</phase>
+                        <goals>
+                            <goal>make</goal>
+                        </goals>
+                        <configuration>
+                            <products>
+                                <singleFile>
+                                    <input>
+                                        <include>
+                                            target/inferred/conversionMultiplier.ttl
                                             target/dist/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
                                         </include>
                                     </input>

--- a/pom.xml
+++ b/pom.xml
@@ -416,11 +416,10 @@
                                         </files>
                                         <toGraphsPattern>target:${name}</toGraphsPattern>
                                     </add>
-
                                     <sparqlQuery>
                                         <sparql>
                                             <![CDATA[
-                                                SELECT ?unit ?cm ?match ?deprecated
+                                                SELECT ?unit ?cm ?match ?broader ?deprecated
                                                 WHERE {
                                                     GRAPH <target:VOCAB_QUDT-UNITS-ALL.ttl> {
                                                         ?unit a qudt:Unit .
@@ -433,12 +432,15 @@
                                                         OPTIONAL {
                                                             ?unit qudt:exactMatch ?match
                                                         }
+                                                        OPTIONAL {
+                                                            ?unit skos:broader ?broader
+                                                        }
                                                         FILTER (!BOUND(?cm))
                                                         FILTER NOT EXISTS {
                                                             ?unit a qudt:CurrencyUnit
                                                         }
                                                     }
-                                                } ORDER BY ?cm ?match ?unit
+                                                } ORDER BY ?deprecated ?match ?unit
                                             ]]>
                                         </sparql>
                                         <toFile>target/inspection/units-without-conversionMultiplier.txt</toFile>
@@ -703,6 +705,49 @@
                                         <toGraph>target:VOCAB_QUDT-UNITS-ALL.ttl</toGraph>
                                     </add>
                                     <savepoint><id>06-infer-scalingOf</id></savepoint>
+                                    <sparqlUpdate>
+                                        <message>Copy conversionMultipliers/offsets from qudt:exactMatch|skos:broader unit where not present</message>
+                                        <sparql>
+                                            <![CDATA[
+                                                INSERT {
+                                                    GRAPH <target:VOCAB_QUDT-UNITS-ALL.ttl> {
+                                                        ?unit
+                                                            qudt:conversionMultiplier ?cm ;
+                                                            qudt:conversionMultiplierSN ?cmSN ;
+                                                            qudt:conversionOffset ?co ;
+                                                            qudt:conversionOffset ?coSN ;
+                                                            rdfs:comment ?copyComment .
+                                                    }
+                                                }
+                                                WHERE {
+                                                    GRAPH <target:VOCAB_QUDT-UNITS-ALL.ttl>  {
+                                                        ?unit a qudt:Unit .
+                                                        FILTER NOT EXISTS {
+                                                            ?unit
+                                                                qudt:conversionMultiplier [] ;
+                                                                qudt:conversionMultiplierSN [] ;
+                                                            OPTIONAL {
+                                                                ?unit
+                                                                    qudt:conversionOffset [];
+                                                                    qudt:conversionOffsetSN [] .
+                                                            }
+                                                        }
+                                                        ?unit ?rel ?otherUnit .
+                                                        FILTER(?rel IN (qudt:exactMatch,skos:broader))
+                                                        ?otherUnit
+                                                            qudt:conversionMultiplier ?cm ;
+                                                            qudt:conversionMultiplierSN ?cmSN .
+                                                        OPTIONAL {
+                                                            ?otherUnit
+                                                                qudt:conversionOffset ?co ;
+                                                                qudt:conversionOffsetSN ?coSN .
+                                                        }
+                                                        BIND(CONCAT("qudt:conversionMultiplier copied from unit ", STR(?otherUnit), " via relation ", STR(?rel)) AS ?copyComment)
+                                                    }
+                                                }
+                                            ]]>
+                                        </sparql>
+                                    </sparqlUpdate>
                                     <until>
                                         <message>Replacing invalid conversionMultipliers iteratively until no more are found</message>
                                         <indexVar>index_cm</indexVar>
@@ -843,46 +888,7 @@
                                         </sparql>
                                     </sparqlUpdate>
 
-                                    <sparqlUpdate>
-                                        <message>Copy conversionMultipliers/offsets from qudt:exactMatch unit where not present</message>
-                                        <sparql>
-                                            <![CDATA[
-                                                INSERT {
-                                                    GRAPH <target:VOCAB_QUDT-UNITS-ALL.ttl> {
-                                                        ?unit
-                                                            qudt:conversionMultiplier ?cm ;
-                                                            qudt:conversionMultiplierSN ?cmSN ;
-                                                            qudt:conversionOffset ?co ;
-                                                            qudt:conversionOffset ?coSN .
-                                                    }
-                                                }
-                                                WHERE {
-                                                    GRAPH <target:VOCAB_QUDT-UNITS-ALL.ttl>  {
-                                                        ?unit qudt:exactMatch ?otherUnit .
-                                                        ?otherUnit
-                                                            qudt:conversionMultiplier ?cm ;
-                                                            qudt:conversionMultiplierSN ?cmSN .
-                                                        OPTIONAL {
-                                                            ?otherUnit
-                                                                qudt:conversionOffset ?co ;
-                                                                qudt:conversionOffsetSN ?coSN .
-                                                        }
-                                                        FILTER NOT EXISTS {
-                                                            ?unit
-                                                                qudt:conversionMultiplier ?cm ;
-                                                                qudt:conversionMultiplierSN ?cmSN ;
-                                                            OPTIONAL {
-                                                                ?unit
-                                                                    qudt:conversionOffset ?co ;
-                                                                    qudt:conversionOffsetSN ?coSN .
-                                                            }
-                                                        }
 
-                                                    }
-                                                }
-                                            ]]>
-                                        </sparql>
-                                    </sparqlUpdate>
                                     <write>
                                         <graphs>
                                             <include>target:*</include>

--- a/src/build/release/release-body-footer.md
+++ b/src/build/release/release-body-footer.md
@@ -1,2 +1,1 @@
- 
 And as always, a big thank-you to all of you for bringing many of these issues to our attention, and even better, for providing submissions to extend the coverage and capabilities of QUDT!

--- a/src/build/release/release-body-footer.md
+++ b/src/build/release/release-body-footer.md
@@ -1,1 +1,2 @@
+ 
 And as always, a big thank-you to all of you for bringing many of these issues to our attention, and even better, for providing submissions to extend the coverage and capabilities of QUDT!

--- a/src/build/release/release-body-header.md
+++ b/src/build/release/release-body-header.md
@@ -1,0 +1,11 @@
+# Highlights
+
+With this Release we have made our treatment of conversion multipliers more consistent, by:
+
+1. Requiring all units to have a conversion multiplier, even if it is zero. A value of zero is for units with nonlinear or undefined multipliers.
+
+2. Computing conversion multipliers automatically for compound units, based on its components (aka factors).
+
+3. Limiting all conversion multipliers to at most 34 significant digits. Units with exact values for conversion multipliers will typically have fewer digits.
+We plan to treat uncertainty values for conversion multipliers in an upcoming Release.
+

--- a/src/build/release/release-body-header.md
+++ b/src/build/release/release-body-header.md
@@ -7,5 +7,5 @@ With this Release we have made our treatment of conversion multipliers more cons
 2. Computing conversion multipliers automatically for compound units, based on its components (aka factors).
 
 3. Limiting all conversion multipliers to at most 34 significant digits. Units with exact values for conversion multipliers will typically have fewer digits.
-We plan to treat uncertainty values for conversion multipliers in an upcoming Release.
+   We plan to treat uncertainty values for conversion multipliers in an upcoming Release.
 

--- a/src/build/srcgen/conversionMultiplier/infer-template.ttl
+++ b/src/build/srcgen/conversionMultiplier/infer-template.ttl
@@ -1,0 +1,34 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix qfn: <http://qudt.org/shacl/functions#> .
+@prefix qudt: <http://qudt.org/schema/qudt/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+
+qfn:inferConversionMultiplier
+  a owl:Ontology ;
+  owl:imports qfn: .
+
+qfn:conversionMultiplierRule
+  a sh:NodeShape ;
+  sh:rule [
+    a sh:SPARQLRule ;
+    sh:construct """
+        CONSTRUCT {
+            ?this qudt:conversionMultiplier ?calculatedMultiplier .
+        }
+        WHERE
+        {
+            {
+                {{QUERY_WITHOUT_PREFIXES}}
+            }
+            FILTER ( ?relDiff < 0.00001 ) # the lower the threshold, the fewer, less error-prone inferences
+        }
+
+
+        """ ;
+    sh:prefixes qfn: ;
+  ] ;
+  sh:targetClass qudt:Unit .
+
+

--- a/src/build/srcgen/conversionMultiplier/infer-template.ttl
+++ b/src/build/srcgen/conversionMultiplier/infer-template.ttl
@@ -19,13 +19,7 @@ qfn:conversionMultiplierRule
         }
         WHERE
         {
-            {
-                {{QUERY_WITHOUT_PREFIXES}}
-            }
-            #FILTER ( ?relDiff < 0.00001 ) # the lower the threshold, the fewer, less error-prone inferences
-            FILTER NOT EXISTS {
-                ?this qudt:conversionMultiplier ?cm .
-            }
+            {{QUERY_WITHOUT_PREFIXES}}
         }
 
 

--- a/src/build/srcgen/conversionMultiplier/infer-template.ttl
+++ b/src/build/srcgen/conversionMultiplier/infer-template.ttl
@@ -22,7 +22,10 @@ qfn:conversionMultiplierRule
             {
                 {{QUERY_WITHOUT_PREFIXES}}
             }
-            FILTER ( ?relDiff < 0.00001 ) # the lower the threshold, the fewer, less error-prone inferences
+            #FILTER ( ?relDiff < 0.00001 ) # the lower the threshold, the fewer, less error-prone inferences
+            FILTER NOT EXISTS {
+                ?this qudt:conversionMultiplier ?cm .
+            }
         }
 
 

--- a/src/build/srcgen/conversionMultiplier/query.rq
+++ b/src/build/srcgen/conversionMultiplier/query.rq
@@ -1,51 +1,73 @@
-PREFIX qudt: <http://qudt.org/schema/qudt/>
-PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-
-SELECT ?this (xsd:decimal(?m1 * ?m2 * ?m3 * ?m4 * ?m5 * ?m6 * ?m7) AS ?total_multiplier)
+SELECT ?this ?relDiff ?actualMultiplier ?calculatedMultiplier
 WHERE {
-  # Inner query to get concatenated multipliers
+  ?this a qudt:Unit .
+  OPTIONAL { ?this qudt:conversionMultiplier ?actualMultiplier . }
+
+  # Subquery to compute and concatenate factor unit contributions
   {
-    SELECT ?this (GROUP_CONCAT(?fu_multiplier; SEPARATOR="|") AS ?concat)
+    SELECT ?this (GROUP_CONCAT(?factorContribution; SEPARATOR="|") AS ?contributions)
     WHERE {
-      ?this qudt:hasFactorUnit ?fu .
-      ?fu qudt:hasUnit ?baseUnit ;
-          qudt:exponent ?exp .
-      ?baseUnit qudt:conversionMultiplier ?b .
-      BIND(
-        IF(ABS(?exp) = 1, ?b,
-          IF(ABS(?exp) = 2, ?b * ?b,
-          IF(ABS(?exp) = 3, ?b * ?b * ?b,
-          IF(ABS(?exp) = 4, ?b * ?b * ?b * ?b,
-          IF(ABS(?exp) = 5, ?b * ?b * ?b * ?b * ?b,
-          IF(ABS(?exp) = 6, ?b * ?b * ?b * ?b * ?b * ?b,
-          IF(ABS(?exp) = 7, ?b * ?b * ?b * ?b * ?b * ?b * ?b,
-            CONCAT("Error: cannot handle exponent ", ?exp))))))))
-        AS ?m_tmp
-      )
-      BIND(
-        IF(?exp < 0, 1 / ?m_tmp,
-          IF(?exp = 0, 1.0, ?m_tmp))
-        AS ?fu_multiplier
-      )
+      ?this qudt:hasFactorUnit ?factor .
+      ?factor qudt:hasUnit ?baseUnit ;
+              qudt:exponent ?exponent .
+      ?baseUnit qudt:conversionMultiplier ?baseMultiplier .
+      # Compute contribution (exponents 0 to 8)
+      BIND(ABS(?exponent) as ?absoluteExponent)
+            BIND(if (?exponent < 0, 1.0 / ?baseMultiplier, ?baseMultiplier ) as ?multiplier)
+            BIND(
+        IF(?absoluteExponent = 0, 1.1,
+        IF(?absoluteExponent = 1, ?multiplier,
+        IF(?absoluteExponent = 2, ?multiplier * ?multiplier,
+        IF(?absoluteExponent = 3, ?multiplier * ?multiplier * ?multiplier,
+        IF(?absoluteExponent = 4, ?multiplier * ?multiplier * ?multiplier * ?multiplier,
+        IF(?absoluteExponent = 5, ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier,
+        IF(?absoluteExponent = 6, ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier,
+        IF(?absoluteExponent = 7, ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier,
+        IF(?absoluteExponent = 8, ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier,
+                                                            CONCAT("CANNOT HANDLE EXPONENT ", ?exponent)))))))))) AS ?factorContribution )
+
+
     }
     GROUP BY ?this
   }
+    # Disassemble contributions into up to 10 variables
+    BIND(COALESCE(CONCAT("|",?contributions), "|") AS ?contribString)
 
-  # Extract each multiplier using regex, default to "1" if not present
-  BIND( REPLACE(?concat, "^([^|]*).*", "$1") AS ?m1_str )
-  BIND( IF(REGEX(?concat, "\\|"), REPLACE(?concat, "^[^|]*\\|([^|]*).*", "$1"), "1") AS ?m2_str )
-  BIND( IF(REGEX(?concat, "\\|.*\\|"), REPLACE(?concat, "^[^|]*\\|[^|]*\\|([^|]*).*", "$1"), "1") AS ?m3_str )
-  BIND( IF(REGEX(?concat, "\\|.*\\|.*\\|"), REPLACE(?concat, "^[^|]*\\|[^|]*\\|[^|]*\\|([^|]*).*", "$1"), "1") AS ?m4_str )
-  BIND( IF(REGEX(?concat, "\\|.*\\|.*\\|.*\\|"), REPLACE(?concat, "^[^|]*\\|[^|]*\\|[^|]*\\|[^|]*\\|([^|]*).*", "$1"), "1") AS ?m5_str )
-  BIND( IF(REGEX(?concat, "\\|.*\\|.*\\|.*\\|.*\\|"), REPLACE(?concat, "^[^|]*\\|[^|]*\\|[^|]*\\|[^|]*\\|[^|]*\\|([^|]*).*", "$1"), "1") AS ?m6_str )
-  BIND( IF(REGEX(?concat, "\\|.*\\|.*\\|.*\\|.*\\|.*\\|"), REPLACE(?concat, "^[^|]*\\|[^|]*\\|[^|]*\\|[^|]*\\|[^|]*\\|[^|]*\\|([^|]*).*", "$1"), "1") AS ?m7_str )
-
-  # Convert strings to doubles for multiplication
-  BIND( xsd:decimal(?m1_str) AS ?m1 )
-  BIND( xsd:decimal(?m2_str) AS ?m2 )
-  BIND( xsd:decimal(?m3_str) AS ?m3 )
-  BIND( xsd:decimal(?m4_str) AS ?m4 )
-  BIND( xsd:decimal(?m5_str) AS ?m5 )
-  BIND( xsd:decimal(?m6_str) AS ?m6 )
-  BIND( xsd:decimal(?m7_str) AS ?m7 )
+    # Make sure we don't accidentally swallow stuff that isn't made of numbers
+    FILTER(REGEX("[0-9\\-\\.\\|]+", ?contribString))
+    
+    BIND(REPLACE(?contribString, ".*\\|", "") as ?f1)
+    BIND(SUBSTR(?contribString, 0, STRLEN(?contribString) - STRLEN(?f1)) as ?f1removed)
+    BIND(REPLACE(?f1removed, ".*\\|", "") as ?f2)
+    BIND(SUBSTR(?f1removed, 0, STRLEN(?f1removed) - STRLEN(?f2)) as ?f2removed)
+    BIND(REPLACE(?f2removed, ".*\\|", "") as ?f3)
+    BIND(SUBSTR(?f2removed, 0, STRLEN(?f2removed) - STRLEN(?f3)) as ?f3removed)
+    BIND(REPLACE(?f3removed, ".*\\|", "") as ?f4)
+    BIND(SUBSTR(?f3removed, 0, STRLEN(?f3removed) - STRLEN(?f4)) as ?f4removed)
+    BIND(REPLACE(?f4removed, ".*\\|", "") as ?f5)
+    BIND(SUBSTR(?f4removed, 0, STRLEN(?f4removed) - STRLEN(?f5)) as ?f5removed)
+    BIND(REPLACE(?f5removed, ".*\\|", "") as ?f6)
+    BIND(SUBSTR(?f5removed, 0, STRLEN(?f5removed) - STRLEN(?f6)) as ?f6removed)
+    BIND(REPLACE(?f6removed, ".*\\|", "") as ?f7)
+    BIND(SUBSTR(?f6removed, 0, STRLEN(?f6removed) - STRLEN(?f7)) as ?f7removed)
+    BIND(REPLACE(?f7removed, ".*\\|", "") as ?f8)
+    BIND(SUBSTR(?f7removed, 0, STRLEN(?f7removed) - STRLEN(?f8)) as ?f8removed)
+    BIND(REPLACE(?f8removed, ".*\\|", "") as ?f9)
+  # Compute calculatedMultiplier by multiplying all contributions
+    BIND(COALESCE(xsd:decimal(?f1), 1.0)
+        * COALESCE(xsd:decimal(?f2), 1.0)
+        * COALESCE(xsd:decimal(?f3), 1.0)
+        * COALESCE(xsd:decimal(?f4), 1.0)
+        * COALESCE(xsd:decimal(?f5), 1.0)
+        * COALESCE(xsd:decimal(?f6), 1.0)
+        * COALESCE(xsd:decimal(?f7), 1.0)
+        * COALESCE(xsd:decimal(?f8), 1.0)
+        * COALESCE(xsd:decimal(?f9), 1.0) as ?cumMul)
+    BIND(qfn:decimalRoundToPrecision(?cumMul, 34) as ?calculatedMultiplier)
+    BIND (?actualMultiplier - ?calculatedMultiplier as ?diff)
+    BIND (IF (?actualMultiplier = 0 , 0.0, ABS(?diff) / ABS(?actualMultiplier)) as ?relDiffAct)
+    BIND (IF( ?calculatedMultiplier = 0, 0.0, ABS(?diff) / ABS(?calculatedMultiplier)) as ?relDiffCalc)
+    BIND(IF(?relDiffAct > ?relDiffCalc, ?relDiffAct, ?relDiffCalc) as ?relDiff)
+    FILTER(?actualMultiplier != ?calculatedMultiplier)
 }
+ORDER BY DESC(?relDiff)

--- a/src/build/srcgen/conversionMultiplier/query.rq
+++ b/src/build/srcgen/conversionMultiplier/query.rq
@@ -12,67 +12,82 @@ WHERE {
   OPTIONAL { ?this qudt:conversionMultiplier ?actualMultiplier . }
   # Subquery to compute and concatenate factor unit contributions
   {
-    SELECT ?this (GROUP_CONCAT(?factorContribution; SEPARATOR="|") AS ?contributions) (GROUP_CONCAT(?multiplierFound;SEPARATOR="|") AS ?allMultipliersFound)
-    WHERE {
-      ?this qudt:hasFactorUnit ?factor .
-      ?factor qudt:hasUnit ?baseUnit ;
-              qudt:exponent ?exponent .
-      OPTIONAL {              
-        ?baseUnit qudt:conversionMultiplier ?baseMultiplier .
-      }
-      OPTIONAL {
-        ?this qudt:factorUnitScalar ?factorUnitScalar
-      }
-      
-      # did we find the multiplier?
-      BIND(IF(BOUND(?baseMultiplier), "YES", "NO") AS ?multiplierFound)
-      BIND(IF(BOUND(?factorUnitScalar), ?factorUnitScalar, 1.0) AS ?scalar)
-      BIND(?scalar * qfn:exp(?baseMultiplier, ?exponent) AS ?factorContribution)
+      {
+        SELECT
+            ?this
+            (GROUP_CONCAT(?factorContribution; SEPARATOR="|") AS ?contributions)
+            (GROUP_CONCAT(?multiplierFound;SEPARATOR="|") AS ?allMultipliersFound)
+        WHERE {
+          ?this qudt:hasFactorUnit ?factor .
+          ?factor qudt:hasUnit ?baseUnit ;
+                  qudt:exponent ?exponent .
+          OPTIONAL {
+            ?baseUnit qudt:conversionMultiplier ?baseMultiplier .
+          }
 
+
+          # did we find the multiplier?
+          BIND(IF(BOUND(?baseMultiplier), "YES", "NO") AS ?multiplierFound)
+          BIND(qfn:exp(?baseMultiplier, ?exponent) AS ?factorContribution)
+
+        }
+        GROUP BY ?this
+      }
+        # Dont continue if we could not find all multipliers
+        FILTER(!CONTAINS(?allMultipliersFound,"NO"))
+
+        # Disassemble contributions into up to 10 variables
+        BIND(COALESCE(CONCAT("|",?contributions), "|") AS ?contribString)
+
+        # Make sure we don't accidentally swallow stuff that isn't made of numbers
+        FILTER(REGEX("[0-9\\-\\.\\|]+", ?contribString))
+
+        BIND(REPLACE(?contribString, ".*\\|", "") as ?f1)
+        BIND(SUBSTR(?contribString, 0, STRLEN(?contribString) - STRLEN(?f1)) as ?f1removed)
+        BIND(REPLACE(?f1removed, ".*\\|", "") as ?f2)
+        BIND(SUBSTR(?f1removed, 0, STRLEN(?f1removed) - STRLEN(?f2)) as ?f2removed)
+        BIND(REPLACE(?f2removed, ".*\\|", "") as ?f3)
+        BIND(SUBSTR(?f2removed, 0, STRLEN(?f2removed) - STRLEN(?f3)) as ?f3removed)
+        BIND(REPLACE(?f3removed, ".*\\|", "") as ?f4)
+        BIND(SUBSTR(?f3removed, 0, STRLEN(?f3removed) - STRLEN(?f4)) as ?f4removed)
+        BIND(REPLACE(?f4removed, ".*\\|", "") as ?f5)
+        BIND(SUBSTR(?f4removed, 0, STRLEN(?f4removed) - STRLEN(?f5)) as ?f5removed)
+        BIND(REPLACE(?f5removed, ".*\\|", "") as ?f6)
+        BIND(SUBSTR(?f5removed, 0, STRLEN(?f5removed) - STRLEN(?f6)) as ?f6removed)
+        BIND(REPLACE(?f6removed, ".*\\|", "") as ?f7)
+        BIND(SUBSTR(?f6removed, 0, STRLEN(?f6removed) - STRLEN(?f7)) as ?f7removed)
+        BIND(REPLACE(?f7removed, ".*\\|", "") as ?f8)
+        BIND(SUBSTR(?f7removed, 0, STRLEN(?f7removed) - STRLEN(?f8)) as ?f8removed)
+        BIND(REPLACE(?f8removed, ".*\\|", "") as ?f9)
+      # Compute calculatedMultiplier by multiplying all contributions
+        OPTIONAL {
+            ?this qudt:factorUnitScalar ?factorUnitScalar
+        }
+        BIND(IF(BOUND(?factorUnitScalar), ?factorUnitScalar, 1.0) AS ?scalar)
+        BIND( ?scalar
+            * COALESCE(xsd:decimal(?f1), 1.0)
+            * COALESCE(xsd:decimal(?f2), 1.0)
+            * COALESCE(xsd:decimal(?f3), 1.0)
+            * COALESCE(xsd:decimal(?f4), 1.0)
+            * COALESCE(xsd:decimal(?f5), 1.0)
+            * COALESCE(xsd:decimal(?f6), 1.0)
+            * COALESCE(xsd:decimal(?f7), 1.0)
+            * COALESCE(xsd:decimal(?f8), 1.0)
+            * COALESCE(xsd:decimal(?f9), 1.0) as ?rawCalculatedMultiplier)
+    } UNION {
+        ?this
+            qudt:scalingOf/qudt:conversionMultiplier ?baseCM ;
+            qudt:prefix/qudt:conversionMultiplier ?prefixCM .
+        BIND (?baseCM * ?prefixCM as ?rawCalculatedMultiplier)
     }
-    GROUP BY ?this
-  }
-    # Dont continue if we could not find all multipliers
-    FILTER(!CONTAINS(?allMultipliersFound,"NO"))
-  
-    # Disassemble contributions into up to 10 variables
-    BIND(COALESCE(CONCAT("|",?contributions), "|") AS ?contribString)
-
-    # Make sure we don't accidentally swallow stuff that isn't made of numbers
-    FILTER(REGEX("[0-9\\-\\.\\|]+", ?contribString))
-    
-    BIND(REPLACE(?contribString, ".*\\|", "") as ?f1)
-    BIND(SUBSTR(?contribString, 0, STRLEN(?contribString) - STRLEN(?f1)) as ?f1removed)
-    BIND(REPLACE(?f1removed, ".*\\|", "") as ?f2)
-    BIND(SUBSTR(?f1removed, 0, STRLEN(?f1removed) - STRLEN(?f2)) as ?f2removed)
-    BIND(REPLACE(?f2removed, ".*\\|", "") as ?f3)
-    BIND(SUBSTR(?f2removed, 0, STRLEN(?f2removed) - STRLEN(?f3)) as ?f3removed)
-    BIND(REPLACE(?f3removed, ".*\\|", "") as ?f4)
-    BIND(SUBSTR(?f3removed, 0, STRLEN(?f3removed) - STRLEN(?f4)) as ?f4removed)
-    BIND(REPLACE(?f4removed, ".*\\|", "") as ?f5)
-    BIND(SUBSTR(?f4removed, 0, STRLEN(?f4removed) - STRLEN(?f5)) as ?f5removed)
-    BIND(REPLACE(?f5removed, ".*\\|", "") as ?f6)
-    BIND(SUBSTR(?f5removed, 0, STRLEN(?f5removed) - STRLEN(?f6)) as ?f6removed)
-    BIND(REPLACE(?f6removed, ".*\\|", "") as ?f7)
-    BIND(SUBSTR(?f6removed, 0, STRLEN(?f6removed) - STRLEN(?f7)) as ?f7removed)
-    BIND(REPLACE(?f7removed, ".*\\|", "") as ?f8)
-    BIND(SUBSTR(?f7removed, 0, STRLEN(?f7removed) - STRLEN(?f8)) as ?f8removed)
-    BIND(REPLACE(?f8removed, ".*\\|", "") as ?f9)
-  # Compute calculatedMultiplier by multiplying all contributions
-    BIND(COALESCE(xsd:decimal(?f1), 1.0)
-        * COALESCE(xsd:decimal(?f2), 1.0)
-        * COALESCE(xsd:decimal(?f3), 1.0)
-        * COALESCE(xsd:decimal(?f4), 1.0)
-        * COALESCE(xsd:decimal(?f5), 1.0)
-        * COALESCE(xsd:decimal(?f6), 1.0)
-        * COALESCE(xsd:decimal(?f7), 1.0)
-        * COALESCE(xsd:decimal(?f8), 1.0)
-        * COALESCE(xsd:decimal(?f9), 1.0) as ?cumMul)
-    BIND(qfn:decimalRoundToPrecision(?cumMul, 34) as ?calculatedMultiplier)
+    BIND (qfn:decimalRoundToPrecision(?rawCalculatedMultiplier, 34) as ?calculatedMultiplier)
     BIND (?actualMultiplier - ?calculatedMultiplier as ?diff)
     BIND (IF (?actualMultiplier = 0 , 0.0, ABS(?diff) / ABS(?actualMultiplier)) as ?relDiffAct)
     BIND (IF( ?calculatedMultiplier = 0, 0.0, ABS(?diff) / ABS(?calculatedMultiplier)) as ?relDiffCalc)
     BIND(IF(?relDiffAct > ?relDiffCalc, ?relDiffAct, ?relDiffCalc) as ?relDiff)
-    FILTER(!BOUND(?actualMultiplier) || ?actualMultiplier != ?calculatedMultiplier)
+    FILTER(
+        !BOUND(?actualMultiplier)                               # no actual multiplier? use calculated!
+        || (?actualMultiplier != 0.0                            # actual multiplier is 0? skip!!
+            && ?actualMultiplier != ?calculatedMultiplier))     # no result if calculated == actual
 }
 ORDER BY DESC(?relDiff)

--- a/src/build/srcgen/conversionMultiplier/query.rq
+++ b/src/build/srcgen/conversionMultiplier/query.rq
@@ -77,7 +77,7 @@ WHERE {
     } UNION {
         ?this
             qudt:scalingOf/qudt:conversionMultiplier ?baseCM ;
-            qudt:prefix/qudt:conversionMultiplier ?prefixCM .
+            qudt:prefix/qudt:prefixMultiplier ?prefixCM .
         BIND (?baseCM * ?prefixCM as ?rawCalculatedMultiplier)
     }
     BIND (qfn:decimalRoundToPrecision(?rawCalculatedMultiplier, 34) as ?calculatedMultiplier)

--- a/src/build/srcgen/conversionMultiplier/query.rq
+++ b/src/build/srcgen/conversionMultiplier/query.rq
@@ -1,35 +1,40 @@
-SELECT ?this ?relDiff ?actualMultiplier ?calculatedMultiplier
+prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+prefix xsd: <http://www.w3.org/2001/XMLSchema#>
+prefix owl: <http://www.w3.org/2002/07/owl#>
+prefix qfn: <http://qudt.org/shacl/functions#>
+prefix qudt: <http://qudt.org/schema/qudt/>
+prefix sh: <http://www.w3.org/ns/shacl#>
+
+SELECT ?this (qudt:conversionMultiplier as ?path) ?relDiff ?actualMultiplier ?calculatedMultiplier
 WHERE {
   ?this a qudt:Unit .
   OPTIONAL { ?this qudt:conversionMultiplier ?actualMultiplier . }
-
   # Subquery to compute and concatenate factor unit contributions
   {
-    SELECT ?this (GROUP_CONCAT(?factorContribution; SEPARATOR="|") AS ?contributions)
+    SELECT ?this (GROUP_CONCAT(?factorContribution; SEPARATOR="|") AS ?contributions) (GROUP_CONCAT(?multiplierFound;SEPARATOR="|") AS ?allMultipliersFound)
     WHERE {
       ?this qudt:hasFactorUnit ?factor .
       ?factor qudt:hasUnit ?baseUnit ;
               qudt:exponent ?exponent .
-      ?baseUnit qudt:conversionMultiplier ?baseMultiplier .
-      # Compute contribution (exponents 0 to 8)
-      BIND(ABS(?exponent) as ?absoluteExponent)
-            BIND(if (?exponent < 0, 1.0 / ?baseMultiplier, ?baseMultiplier ) as ?multiplier)
-            BIND(
-        IF(?absoluteExponent = 0, 1.1,
-        IF(?absoluteExponent = 1, ?multiplier,
-        IF(?absoluteExponent = 2, ?multiplier * ?multiplier,
-        IF(?absoluteExponent = 3, ?multiplier * ?multiplier * ?multiplier,
-        IF(?absoluteExponent = 4, ?multiplier * ?multiplier * ?multiplier * ?multiplier,
-        IF(?absoluteExponent = 5, ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier,
-        IF(?absoluteExponent = 6, ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier,
-        IF(?absoluteExponent = 7, ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier,
-        IF(?absoluteExponent = 8, ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier,
-                                                            CONCAT("CANNOT HANDLE EXPONENT ", ?exponent)))))))))) AS ?factorContribution )
-
+      OPTIONAL {              
+        ?baseUnit qudt:conversionMultiplier ?baseMultiplier .
+      }
+      OPTIONAL {
+        ?this qudt:factorUnitScalar ?factorUnitScalar
+      }
+      
+      # did we find the multiplier?
+      BIND(IF(BOUND(?baseMultiplier), "YES", "NO") AS ?multiplierFound)
+      BIND(IF(BOUND(?factorUnitScalar), ?factorUnitScalar, 1.0) AS ?scalar)
+      BIND(?scalar * qfn:exp(?baseMultiplier, ?exponent) AS ?factorContribution)
 
     }
     GROUP BY ?this
   }
+    # Dont continue if we could not find all multipliers
+    FILTER(!CONTAINS(?allMultipliersFound,"NO"))
+  
     # Disassemble contributions into up to 10 variables
     BIND(COALESCE(CONCAT("|",?contributions), "|") AS ?contribString)
 
@@ -68,6 +73,6 @@ WHERE {
     BIND (IF (?actualMultiplier = 0 , 0.0, ABS(?diff) / ABS(?actualMultiplier)) as ?relDiffAct)
     BIND (IF( ?calculatedMultiplier = 0, 0.0, ABS(?diff) / ABS(?calculatedMultiplier)) as ?relDiffCalc)
     BIND(IF(?relDiffAct > ?relDiffCalc, ?relDiffAct, ?relDiffCalc) as ?relDiff)
-    FILTER(?actualMultiplier != ?calculatedMultiplier)
+    FILTER(!BOUND(?actualMultiplier) || ?actualMultiplier != ?calculatedMultiplier)
 }
 ORDER BY DESC(?relDiff)

--- a/src/build/srcgen/conversionMultiplier/validate-template.ttl
+++ b/src/build/srcgen/conversionMultiplier/validate-template.ttl
@@ -5,7 +5,7 @@
 @prefix qudt: <http://qudt.org/schema/qudt/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 
-qfn:inferConversionMultiplier
+qfn:ValidateConversionMultiplier
   a owl:Ontology ;
   owl:imports qfn: .
 

--- a/src/build/srcgen/conversionMultiplier/validate-template.ttl
+++ b/src/build/srcgen/conversionMultiplier/validate-template.ttl
@@ -1,0 +1,35 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix qfn: <http://qudt.org/shacl/functions#> .
+@prefix qudt: <http://qudt.org/schema/qudt/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+
+qfn:inferConversionMultiplier
+  a owl:Ontology ;
+  owl:imports qfn: .
+
+qfn:conversionMultiplierRule
+  a sh:NodeShape ;
+  sh:severity sh:Violation ;
+  sh:sparql [
+    a sh:SPARQLConstraint ;
+    sh:message """
+        {$this}
+        Multiplier differs from the multiplier calculated from its factor units.
+        actual multiplier : {?actualMultiplier}
+        calculated        : {?calculatedMultiplier}
+        badness           : {?relDiff}
+        The badness is the relative difference of the difference and the actual or calculated multiplier, whichever is bigger. A badness >> 0 is a real issue to look at. A badness ~ 0 is usually due to a difference in precision and should be resolved by using the calculated value.
+        A
+        """ ;
+    sh:prefixes qfn: ;
+    sh:select """
+
+    {{QUERY_WITHOUT_PREFIXES}}
+
+    """ ;
+  ] ;
+  sh:targetClass qudt:Unit .
+
+

--- a/src/build/srcgen/factorUnits/infer-template.ttl
+++ b/src/build/srcgen/factorUnits/infer-template.ttl
@@ -1,37 +1,15 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix qk: <http://qudt.org/schema/quantitykind/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix qfn: <http://qudt.org/shacl/functions#> .
 @prefix qudt: <http://qudt.org/schema/qudt/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix sq: <http://qudt.org/2.1/shacl/infer/applicableUnits> .
 
-qk:
-  sh:declare [
-    sh:namespace "http://qudt.org/vocab/quantitykind/"^^xsd:anyURI ;
-    sh:prefix "qk" ;
-  ] .
+qfn:inferFactorUnits
+  a owl:Ontology ;
+  owl:imports qfn: .
 
-qudt:
-  sh:declare [
-    sh:namespace "http://qudt.org/schema/qudt/"^^xsd:anyURI ;
-    sh:prefix "qudt" ;
-  ] .
-
-rdfs:
-  sh:declare [
-    sh:namespace "http://www.w3.org/2000/01/rdf-schema#" ;
-    sh:prefix "rdfs" ;
-  ] .
-
-skos:
-  sh:declare [
-    sh:namespace "http://www.w3.org/2004/02/skos/core#"^^xsd:anyURI ;
-    sh:prefix "skos" ;
-  ] .
-
-sq:qkRule
+qfn:qkRule
   a sh:NodeShape ;
   sh:rule [
     a sh:SPARQLRule ;
@@ -49,18 +27,8 @@ sq:qkRule
         }
 
         """ ;
-    sh:prefixes qk: ;
-    sh:prefixes qudt: ;
-    sh:prefixes rdfs: ;
-    sh:prefixes skos: ;
-    sh:prefixes xsd: ;
+    sh:prefixes qfn: ;
   ] ;
   sh:targetClass qudt:Unit .
-
-xsd:
-  sh:declare [
-    sh:namespace "http://www.w3.org/2001/XMLSchema#"^^xsd:anyURI ;
-    sh:prefix "xsd" ;
-  ] .
 
 

--- a/src/build/srcgen/factorUnits/validate-template.ttl
+++ b/src/build/srcgen/factorUnits/validate-template.ttl
@@ -1,47 +1,21 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix qk: <http://qudt.org/schema/quantitykind/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix qfn: <http://qudt.org/shacl/functions#> .
 @prefix qudt: <http://qudt.org/schema/qudt/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix sq: <http://qudt.org/2.1/shacl/infer/applicableUnits> .
 
-qk:
-  sh:declare [
-    sh:namespace "http://qudt.org/vocab/quantitykind/"^^xsd:anyURI ;
-    sh:prefix "qk" ;
-  ] .
+qfn:ValidateFactorUnits
+  a owl:Ontology ;
+  owl:imports qfn: .
 
-qudt:
-  sh:declare [
-    sh:namespace "http://qudt.org/schema/qudt/"^^xsd:anyURI ;
-    sh:prefix "qudt" ;
-  ] .
-
-rdfs:
-  sh:declare [
-    sh:namespace "http://www.w3.org/2000/01/rdf-schema#" ;
-    sh:prefix "rdfs" ;
-  ] .
-
-skos:
-  sh:declare [
-    sh:namespace "http://www.w3.org/2004/02/skos/core#"^^xsd:anyURI ;
-    sh:prefix "skos" ;
-  ] .
-
-sq:qkRule
+qfn:qkRule
   a sh:NodeShape ;
   sh:severity sh:Violation ;
   sh:sparql [
     a sh:SPARQLConstraint ;
     sh:message "Unit {?this} does not have required qudt:hasFactorUnit reference to {?baseUnit}." ;
-    sh:prefixes qk: ;
-    sh:prefixes qudt: ;
-    sh:prefixes rdfs: ;
-    sh:prefixes skos: ;
-    sh:prefixes xsd: ;
+    sh:prefixes qfn: ;
     sh:select """
 
     {{QUERY_WITHOUT_PREFIXES}}
@@ -49,11 +23,5 @@ sq:qkRule
     """ ;
   ] ;
   sh:targetClass qudt:Unit .
-
-xsd:
-  sh:declare [
-    sh:namespace "http://www.w3.org/2001/XMLSchema#"^^xsd:anyURI ;
-    sh:prefix "xsd" ;
-  ] .
 
 

--- a/src/build/srcgen/scalingOf/infer-template.ttl
+++ b/src/build/srcgen/scalingOf/infer-template.ttl
@@ -1,37 +1,15 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix qk: <http://qudt.org/schema/quantitykind/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix qfn: <http://qudt.org/shacl/functions#> .
 @prefix qudt: <http://qudt.org/schema/qudt/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix sq: <http://qudt.org/2.1/shacl/infer/applicableUnits> .
 
-qk:
-  sh:declare [
-    sh:namespace "http://qudt.org/vocab/quantitykind/"^^xsd:anyURI ;
-    sh:prefix "qk" ;
-  ] .
+qfn:inferFactorUnits
+  a owl:Ontology ;
+  owl:imports qfn: .
 
-qudt:
-  sh:declare [
-    sh:namespace "http://qudt.org/schema/qudt/"^^xsd:anyURI ;
-    sh:prefix "qudt" ;
-  ] .
-
-rdfs:
-  sh:declare [
-    sh:namespace "http://www.w3.org/2000/01/rdf-schema#" ;
-    sh:prefix "rdfs" ;
-  ] .
-
-skos:
-  sh:declare [
-    sh:namespace "http://www.w3.org/2004/02/skos/core#"^^xsd:anyURI ;
-    sh:prefix "skos" ;
-  ] .
-
-sq:qkRule
+qfn:qkRule
   a sh:NodeShape ;
   sh:rule [
     a sh:SPARQLRule ;
@@ -50,18 +28,8 @@ sq:qkRule
         }
 
         """ ;
-    sh:prefixes qk: ;
-    sh:prefixes qudt: ;
-    sh:prefixes rdfs: ;
-    sh:prefixes skos: ;
-    sh:prefixes xsd: ;
+    sh:prefixes qfn: ;
   ] ;
   sh:targetClass qudt:Unit .
-
-xsd:
-  sh:declare [
-    sh:namespace "http://www.w3.org/2001/XMLSchema#"^^xsd:anyURI ;
-    sh:prefix "xsd" ;
-  ] .
 
 

--- a/src/build/srcgen/scalingOf/infer-template.ttl
+++ b/src/build/srcgen/scalingOf/infer-template.ttl
@@ -17,8 +17,6 @@ qfn:qkRule
         CONSTRUCT {
                  ?this
                     qudt:scalingOf ?baseUnit ;
-                    qudt:conversionMultiplier ?scaledUnitConversionMultiplier ;
-                    qudt:conversionOffset ?scaledUnitConversionOffset ;
                     qudt:prefix ?prefix .
                 }
         WHERE

--- a/src/build/srcgen/scalingOf/query.rq
+++ b/src/build/srcgen/scalingOf/query.rq
@@ -91,5 +91,6 @@ where
             ?this qudt:hasFactorUnit ?x . # for derived units, we don't generate a prefix.
         }
     }
+    FILTER(?this != unit:KiloGM)
 }
 order by ?baseUnit ?this

--- a/src/build/srcgen/scalingOf/query.rq
+++ b/src/build/srcgen/scalingOf/query.rq
@@ -4,7 +4,7 @@ PREFIX prefix: <http://qudt.org/vocab/prefix/>
 PREFIX kind: <http://qudt.org/vocab/quantitykind/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
-SELECT ?this ?baseUnit ?prefix ?scaledUnitConversionMultiplier ?scaledUnitConversionOffset
+SELECT ?this ?baseUnit ?prefix
 where
 {
     {
@@ -62,23 +62,9 @@ where
             FILTER (!CONTAINS(?baseUnitLocalName, "-"))
             FILTER (CONTAINS(?scaledUnitLocalName, STR(?prefixLabel)))
     }
-    OPTIONAL {
-        # if the scaled unit does not have a conversionMultiplier, generate it
-        FILTER NOT EXISTS {
-            ?this qudt:conversionMultiplier ?any .
-        }
-        ?baseUnit qudt:conversionMultiplier ?cm .
-        optional {
-            ?baseUnit qudt:conversionOffset ?co
-        }
-        ?prefix a qudt:Prefix ;
-            qudt:prefixMultiplier ?prefixMultiplier ;
-            rdfs:label ?prefixLabel ;
-            FILTER (!CONTAINS(?baseUnitLocalName, "-"))
-            FILTER (CONTAINS(?scaledUnitLocalName, STR(?prefixLabel)))
-        BIND (?cm * ?prefixMultiplier as ?scaledUnitConversionMultiplier )
-        BIND (?co as ?scaledUnitConversionOffset )
-    }
+
+    # NOTE: conversion multiplier calcluation for scaled units
+    # is done in src/build/srcgen/conversionMultiplier
 
     OPTIONAL {
         ?baseUnit qudt:dimensionVector ?dv .

--- a/src/build/srcgen/scalingOf/validate-template.ttl
+++ b/src/build/srcgen/scalingOf/validate-template.ttl
@@ -1,47 +1,21 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix qk: <http://qudt.org/schema/quantitykind/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix qfn: <http://qudt.org/shacl/functions#> .
 @prefix qudt: <http://qudt.org/schema/qudt/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix sq: <http://qudt.org/2.1/shacl/infer/applicableUnits> .
 
-qk:
-  sh:declare [
-    sh:namespace "http://qudt.org/vocab/quantitykind/"^^xsd:anyURI ;
-    sh:prefix "qk" ;
-  ] .
+qfn:inferFactorUnits
+  a owl:Ontology ;
+  owl:imports qfn: .
 
-qudt:
-  sh:declare [
-    sh:namespace "http://qudt.org/schema/qudt/"^^xsd:anyURI ;
-    sh:prefix "qudt" ;
-  ] .
-
-rdfs:
-  sh:declare [
-    sh:namespace "http://www.w3.org/2000/01/rdf-schema#" ;
-    sh:prefix "rdfs" ;
-  ] .
-
-skos:
-  sh:declare [
-    sh:namespace "http://www.w3.org/2004/02/skos/core#"^^xsd:anyURI ;
-    sh:prefix "skos" ;
-  ] .
-
-sq:qkRule
+qfn:qkRule
   a sh:NodeShape ;
   sh:severity sh:Violation ;
   sh:sparql [
     a sh:SPARQLConstraint ;
     sh:message "Unit {?this} does not have required qudt:scalingOf reference to {?baseUnit}" ;
-    sh:prefixes qk: ;
-    sh:prefixes qudt: ;
-    sh:prefixes rdfs: ;
-    sh:prefixes skos: ;
-    sh:prefixes xsd: ;
+    sh:prefixes qfn: ;
     sh:select """
 
     {{QUERY_WITHOUT_PREFIXES}}
@@ -49,11 +23,5 @@ sq:qkRule
     """ ;
   ] ;
   sh:targetClass qudt:Unit .
-
-xsd:
-  sh:declare [
-    sh:namespace "http://www.w3.org/2001/XMLSchema#"^^xsd:anyURI ;
-    sh:prefix "xsd" ;
-  ] .
 
 

--- a/src/build/validation/factorUnits/decimalRoundToPrecision.rq
+++ b/src/build/validation/factorUnits/decimalRoundToPrecision.rq
@@ -1,0 +1,68 @@
+    PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+    SELECT *
+    WHERE {
+        # rounds input decimal v to precision p
+        #
+        # unscaled number: significant digits
+        # precision: number of significant digits
+        # scale: (value = unscaled * 10^(-scale) ) eg: 123.45: unscaled: 12345 scale = 2;  110 = unscaled: 11, scale = -1; 0.000123 = unscaled: 123, scale = 6
+        #
+        # Algorithm:
+        #
+        # 1. val = normalized v (strip leading 0s, don't add trailing 0 if it has no dot)
+        # 2. find the dot position dVal (dVal = length(val) if no dot)
+        # 3. find the unscaled number uVal as the digits without the dot, leading 0s removed, trailing 0s kept
+        # 4. length of uVal is the precision of our value, pVal = length(uVal)
+        # 5. find the position eVal in val at which the unscaled number ends
+        # 6. scale sVal = eVal - dVal (e.g 123.456: dVal = 3, eVal = 6, sVal = 3, pVal = 6; 123: dVal = 0; 12345: dVal = 5, eVal = 5, sVal = 0, pVal = 5; 12000: dVal = 5, eVal = 2, sVal = -3, pVal = 2; 0.00123: dVal = 1, eVal=6, sVal= 5, pVal=3 )
+        # 7. precision to use pNew = min (p, pVal)
+        # 8. New unscaled number uNew with given precision. if pNew == pVal: uNew = uVal . otherwise, make tmp value from unscaled, inserting a dot at position pNew and use ROUND on it, ie uNew = ROUND(tmp)
+        # 9. New scale sNew = sVal - (pVal - pNew)
+        # 10. if sNew = 0 : newVal = CONCAT(uVal)
+        #     if sNew < 0 : newVal = CONCAT(uNew, SUBSTR(zeros,1,- sNew) ) - append zeros for each negative scale point
+        #     if sNew > 0 : newVal = CONCAT("0.", SUBSTR(zeros, 1, - sNew - pNew), uNew) - insert zeros to fill if needed
+        # 11. result = xsd:decimal(newVal)
+        #
+        # for testing:
+    VALUES (?value ?precision) { ( 438735434.18234027234132943816725522054055902409299111398204019161729399005 7 )(12345678 4) (0.00123456 3) (.00123456 4) (000123.456000 2) (123456789.0123456789 14) (0.123 5) (12345 3) (2 10) (3 1) (7 0) }
+        #
+    	BIND(IF(bound(?precision), ?precision, 34) as ?p)
+        BIND("0000000000000000000000000000000000000000000000000000000000000000000000000000000000000" as ?zeroPad)
+        # 1: normalize
+        BIND(STR(?value) as ?tmpValueStr)
+        # leading 0 before the dot are insignificant. strip.
+        BIND(REPLACE(?tmpValueStr, "^0*(0\\.|[1-9])","$1") as ?tmpValueStrNoLeading0)
+        # if the number starts with '.', prepend '0'
+        BIND(IF(STRSTARTS(?tmpValueStrNoLeading0, "."), CONCAT("0", ?tmpValueStrNoLeading0), ?tmpValueStrNoLeading0) as ?val)
+        # 2. dVal
+        BIND(STRLEN(STRBEFORE(?val,".")) as ?tmp0)
+        BIND(IF(?tmp0 = 0, STRLEN(?val), ?tmp0) as ?dVal)
+        # 3. uVal
+        BIND(REPLACE(REPLACE(?val,"\\.",""), "^0+","") as ?uVal)
+        # 4. pVal
+        BIND(STRLEN(?uVal) as ?pVal)
+        # 5. eVal
+        BIND(REPLACE(?val,"\\.","") as ?tmp1)
+        BIND(STRLEN(?tmp1) - STRLEN(STRAFTER(?tmp1,?uVal)) as ?eVal)
+        # 6. sVal
+        BIND(?eVal - ?dVal as ?sVal)
+        # 7. pNew
+        BIND(IF(?p < ?pVal, ?p, ?pVal) as ?pNew)
+        # 8. uNew
+        BIND(CONCAT(SUBSTR(?uVal,1,?pNew),".", SUBSTR(?uVal, ?pNew+1) ) as ?tmp2)
+        BIND(IF(?pNew = ?pVal, ?uVal, REPlACE(STR(ROUND(xsd:decimal(?tmp2))), ".0$","")) as ?uNew)
+        # 9. sNew
+        BIND(?sVal - (?pVal - ?pNew) as ?sNew)
+        # 10. newVal
+        BIND(IF(?sNew = 0, ?uNew,
+                IF (?sNew < 0 ,
+                    CONCAT(?uNew, SUBSTR(?zeroPad, 1, - ?sNew)),
+                    CONCAT(SUBSTR(?zeroPad, 1, ?sNew - ?pNew), ?uNew)
+                )) as ?tmp3)
+        BIND(IF(?sNew <= 0, ?tmp3,
+                CONCAT(SUBSTR(?tmp3,1,STRLEN(?tmp3) - ?sNew), ".", SUBSTR(?tmp3, STRLEN(?tmp3) - ?sNew + 1))
+            ) as ?tmp4)
+        BIND(IF(STRSTARTS(?tmp4, "."), CONCAT("0",?tmp4), ?tmp4) as ?newVal)
+        # 11. result
+        BIND(xsd:decimal(?newVal) as ?result)
+    }

--- a/src/build/validation/factorUnits/identifyMultiplierProblems.rq
+++ b/src/build/validation/factorUnits/identifyMultiplierProblems.rq
@@ -1,0 +1,79 @@
+PREFIX qudt: <http://qudt.org/schema/qudt/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+SELECT ?this ?relDiff
+       (IF(?actualMultiplier = ?calculatedMultiplier, "Equal", "Not Equal") AS ?equalityFlag)
+       ?actualMultiplier ?calculatedMultiplier
+WHERE {
+  ?this a qudt:Unit .
+  OPTIONAL { ?this qudt:conversionMultiplier ?actualMultiplier . }
+
+  # Subquery to compute and concatenate factor unit contributions
+  {
+    SELECT ?this (GROUP_CONCAT(?factorContribution; SEPARATOR="|") AS ?contributions)
+    WHERE {
+      ?this qudt:hasFactorUnit ?factor .
+      ?factor qudt:hasUnit ?baseUnit ;
+              qudt:exponent ?exponent .
+      ?baseUnit qudt:conversionMultiplier ?baseMultiplier .
+      # Compute contribution (exponents 0 to 8)
+      BIND(ABS(?exponent) as ?absoluteExponent)
+            BIND(if (?exponent < 0, 1.0 / ?baseMultiplier, ?baseMultiplier ) as ?multiplier)
+            BIND(
+        IF(?absoluteExponent = 0, 1.0,
+        IF(?absoluteExponent = 1, ?multiplier,
+        IF(?absoluteExponent = 2, ?multiplier * ?multiplier,
+        IF(?absoluteExponent = 3, ?multiplier * ?multiplier * ?multiplier,
+        IF(?absoluteExponent = 4, ?multiplier * ?multiplier * ?multiplier * ?multiplier,
+        IF(?absoluteExponent = 5, ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier,
+        IF(?absoluteExponent = 6, ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier,
+        IF(?absoluteExponent = 7, ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier,
+        IF(?absoluteExponent = 8, ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier,
+                                                            CONCAT("CANNOT HANDLE EXPONENT ", ?exponent)))))))))) AS ?factorContribution )
+
+
+    }
+    GROUP BY ?this
+  }
+    # Disassemble contributions into up to 10 variables
+    BIND(COALESCE(CONCAT("|",?contributions), "|") AS ?contribString)
+
+    # Make sure we don't accidentally swallow stuff that isn't made of numbers
+    FILTER(REGEX("[0-9\\-.|]+", ?contribString))
+
+    BIND(REPLACE(?contribString, ".*\\|", "") as ?f1)
+    BIND(SUBSTR(?contribString, 0, STRLEN(?contribString) - STRLEN(?f1)) as ?f1removed)
+    BIND(REPLACE(?f1removed, ".*\\|", "") as ?f2)
+    BIND(SUBSTR(?f1removed, 0, STRLEN(?f1removed) - STRLEN(?f2)) as ?f2removed)
+    BIND(REPLACE(?f2removed, ".*\\|", "") as ?f3)
+  	BIND(SUBSTR(?f2removed, 0, STRLEN(?f2removed) - STRLEN(?f3)) as ?f3removed)
+    BIND(REPLACE(?f3removed, ".*\\|", "") as ?f4)
+    BIND(SUBSTR(?f3removed, 0, STRLEN(?f3removed) - STRLEN(?f4)) as ?f4removed)
+    BIND(REPLACE(?f4removed, ".*\\|", "") as ?f5)
+    BIND(SUBSTR(?f4removed, 0, STRLEN(?f4removed) - STRLEN(?f5)) as ?f5removed)
+    BIND(REPLACE(?f5removed, ".*\\|", "") as ?f6)
+    BIND(SUBSTR(?f5removed, 0, STRLEN(?f5removed) - STRLEN(?f6)) as ?f6removed)
+    BIND(REPLACE(?f6removed, ".*\\|", "") as ?f7)
+    BIND(SUBSTR(?f6removed, 0, STRLEN(?f6removed) - STRLEN(?f7)) as ?f7removed)
+    BIND(REPLACE(?f7removed, ".*\\|", "") as ?f8)
+    BIND(SUBSTR(?f7removed, 0, STRLEN(?f7removed) - STRLEN(?f8)) as ?f8removed)
+    BIND(REPLACE(?f8removed, ".*\\|", "") as ?f9)
+  # Compute calculatedMultiplier by multiplying all contributions
+    BIND(COALESCE(xsd:decimal(?f1), 1.0)
+        * COALESCE(xsd:decimal(?f2), 1.0)
+        * COALESCE(xsd:decimal(?f3), 1.0)
+        * COALESCE(xsd:decimal(?f4), 1.0)
+        * COALESCE(xsd:decimal(?f5), 1.0)
+        * COALESCE(xsd:decimal(?f6), 1.0)
+        * COALESCE(xsd:decimal(?f7), 1.0)
+        * COALESCE(xsd:decimal(?f8), 1.0)
+        * COALESCE(xsd:decimal(?f9), 1.0) as ?calculatedMultiplier)
+
+    BIND (?actualMultiplier - ?calculatedMultiplier as ?diff)
+    BIND (ABS(?diff) / ABS(?actualMultiplier) as ?relDiffAct)
+    BIND (ABS(?diff) / ABS(?calculatedMultiplier) as ?relDiffCalc)
+    BIND(IF(?relDiffAct > ?relDiffCalc, ?relDiffAct, ?relDiffCalc) as ?relDiff)
+    FILTER(?actualMultiplier != ?calculatedMultiplier)
+}
+ORDER BY DESC(?relDiff)

--- a/src/build/validation/factorUnits/identifyMultiplierProblemsMoreVars.rq
+++ b/src/build/validation/factorUnits/identifyMultiplierProblemsMoreVars.rq
@@ -1,0 +1,77 @@
+PREFIX qudt: <http://qudt.org/schema/qudt/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+SELECT *
+WHERE {
+  ?this a qudt:Unit .
+  OPTIONAL { ?this qudt:conversionMultiplier ?actualMultiplier . }
+
+  # Subquery to compute and concatenate factor unit contributions
+  {
+    SELECT ?this (GROUP_CONCAT(?factorContribution; SEPARATOR="|") AS ?contributions)
+    WHERE {
+      ?this qudt:hasFactorUnit ?factor .
+      ?factor qudt:hasUnit ?baseUnit ;
+              qudt:exponent ?exponent .
+      ?baseUnit qudt:conversionMultiplier ?baseMultiplier .
+      # Compute contribution (exponents 0 to 8)
+      BIND(ABS(?exponent) as ?absoluteExponent)
+            BIND(if (?exponent < 0, 1.0 / ?baseMultiplier, ?baseMultiplier ) as ?multiplier)
+            BIND(
+        IF(?absoluteExponent = 0, 1.0,
+        IF(?absoluteExponent = 1, ?multiplier,
+        IF(?absoluteExponent = 2, ?multiplier * ?multiplier,
+        IF(?absoluteExponent = 3, ?multiplier * ?multiplier * ?multiplier,
+        IF(?absoluteExponent = 4, ?multiplier * ?multiplier * ?multiplier * ?multiplier,
+        IF(?absoluteExponent = 5, ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier,
+        IF(?absoluteExponent = 6, ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier,
+        IF(?absoluteExponent = 7, ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier,
+        IF(?absoluteExponent = 8, ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier,
+                                                            CONCAT("CANNOT HANDLE EXPONENT ", ?exponent)))))))))) AS ?factorContribution )
+
+
+    }
+    GROUP BY ?this
+  }
+    # Disassemble contributions into up to 10 variables
+    BIND(COALESCE(CONCAT("|",?contributions), "|") AS ?contribString)
+
+    # Make sure we don't accidentally swallow stuff that isn't made of numbers
+    FILTER(REGEX("[0-9\\-.|]+", ?contribString))
+
+    BIND(REPLACE(?contribString, ".*\\|", "") as ?f1)
+    BIND(SUBSTR(?contribString, 0, STRLEN(?contribString) - STRLEN(?f1)) as ?f1removed)
+    BIND(REPLACE(?f1removed, ".*\\|", "") as ?f2)
+    BIND(SUBSTR(?f1removed, 0, STRLEN(?f1removed) - STRLEN(?f2)) as ?f2removed)
+    BIND(REPLACE(?f2removed, ".*\\|", "") as ?f3)
+  	BIND(SUBSTR(?f2removed, 0, STRLEN(?f2removed) - STRLEN(?f3)) as ?f3removed)
+    BIND(REPLACE(?f3removed, ".*\\|", "") as ?f4)
+    BIND(SUBSTR(?f3removed, 0, STRLEN(?f3removed) - STRLEN(?f4)) as ?f4removed)
+    BIND(REPLACE(?f4removed, ".*\\|", "") as ?f5)
+    BIND(SUBSTR(?f4removed, 0, STRLEN(?f4removed) - STRLEN(?f5)) as ?f5removed)
+    BIND(REPLACE(?f5removed, ".*\\|", "") as ?f6)
+    BIND(SUBSTR(?f5removed, 0, STRLEN(?f5removed) - STRLEN(?f6)) as ?f6removed)
+    BIND(REPLACE(?f6removed, ".*\\|", "") as ?f7)
+    BIND(SUBSTR(?f6removed, 0, STRLEN(?f6removed) - STRLEN(?f7)) as ?f7removed)
+    BIND(REPLACE(?f7removed, ".*\\|", "") as ?f8)
+    BIND(SUBSTR(?f7removed, 0, STRLEN(?f7removed) - STRLEN(?f8)) as ?f8removed)
+    BIND(REPLACE(?f8removed, ".*\\|", "") as ?f9)
+  # Compute calculatedMultiplier by multiplying all contributions
+    BIND(COALESCE(xsd:decimal(?f1), 1.0)
+        * COALESCE(xsd:decimal(?f2), 1.0)
+        * COALESCE(xsd:decimal(?f3), 1.0)
+        * COALESCE(xsd:decimal(?f4), 1.0)
+        * COALESCE(xsd:decimal(?f5), 1.0)
+        * COALESCE(xsd:decimal(?f6), 1.0)
+        * COALESCE(xsd:decimal(?f7), 1.0)
+        * COALESCE(xsd:decimal(?f8), 1.0)
+        * COALESCE(xsd:decimal(?f9), 1.0) as ?calculatedMultiplier)
+
+    BIND (?actualMultiplier - ?calculatedMultiplier as ?diff)
+    BIND (ABS(?diff) / ABS(?actualMultiplier) as ?relDiffAct)
+    BIND (ABS(?diff) / ABS(?calculatedMultiplier) as ?relDiffCalc)
+    BIND(IF(?relDiffAct > ?relDiffCalc, ?relDiffAct, ?relDiffCalc) as ?relDiff)
+    FILTER(?actualMultiplier != ?calculatedMultiplier)
+}
+ORDER BY DESC(?relDiff)

--- a/src/main/rdf/validation/COLLECTION_QUDT_QA_TESTS_ALL.ttl
+++ b/src/main/rdf/validation/COLLECTION_QUDT_QA_TESTS_ALL.ttl
@@ -2,15 +2,16 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix qfn: <http://qudt.org/shacl/functions#> .
 @prefix qudt: <http://qudt.org/schema/qudt/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix qfn: <http://qudt.org/schema/qudt/fn#> .
 
 <http://qudt.org/$$QUDT_VERSION$$/collection/qa/all>
   a owl:Ontology ;
   owl:imports <http://qudt.org/$$QUDT_VERSION$$/collection/usertest> ;
   owl:imports <http://qudt.org/$$QUDT_VERSION$$/vocab/constant> ;
   owl:imports <http://qudt.org/$$QUDT_VERSION$$/vocab/soqk> ;
+  owl:imports qfn: ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/collection/qa/all> ;
   rdfs:label "QUDT Collection - QA TESTS - ALL - v $$QUDT_VERSION$$" ;
   sh:declare [
@@ -62,11 +63,6 @@
     a sh:PrefixDeclaration ;
     sh:namespace "http://www.w3.org/2004/02/skos/core#"^^xsd:anyURI ;
     sh:prefix "skos" ;
-  ] ;
-  sh:declare [
-   a sh:PrefixDeclaration ;
-   sh:namespace "http://qudt.org/schema/qudt/fn#"^^xsd:anyURI ;
-   sh:prefix "qfn" ;
   ] ;
   sh:declare [
     a sh:PrefixDeclaration ;
@@ -555,203 +551,6 @@ qudt:prefixMultiplierSnShape
         """ ;
   ] ;
   sh:targetClass qudt:Prefix .
-
-
-qfn:decimalRoundToPrecision a sh:SPARQLFunction ;
-  sh:parameter [
-    sh:path qfn:value ;
-    sh:order 0 ;
-    sh:datatype xsd:decimal ;
-    sh:description "The decimal value to normalize" ;
-  ] ;
-  sh:parameter [
-    sh:path qfn:precision ;
-    sh:order 1 ;
-    sh:datatype xsd:integer ;
-    sh:description "Number of significant digits" ;
-  ] ;
-  sh:returnType xsd:decimal ;
-  sh:prefixes <http://qudt.org/$$QUDT_VERSION$$/collection/qa/all> ;
-  sh:select """
-        PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-        SELECT ?result
-        WHERE {
-            # rounds input decimal v to precision p
-            #
-            # unscaled number: significant digits
-            # precision: number of significant digits
-            # scale: (value = unscaled * 10^(-scale) ) eg: 123.45: unscaled: 12345 scale = 2;  110 = unscaled: 11, scale = -1; 0.000123 = unscaled: 123, scale = 6
-            #
-            # Algorithm:
-            #
-            # 1. val = normalized v (strip leading 0s, don't add trailing 0 if it has no dot)
-            # 2. find the dot position dVal (dVal = length(val) if no dot)
-            # 3. find the unscaled number uVal as the digits without the dot, leading 0s removed, trailing 0s kept
-            # 4. length of uVal is the precision of our value, pVal = length(uVal)
-            # 5. find the position eVal in val at which the unscaled number ends
-            # 6. scale sVal = eVal - dVal (e.g 123.456: dVal = 3, eVal = 6, sVal = 3, pVal = 6; 123: dVal = 0; 12345: dVal = 5, eVal = 5, sVal = 0, pVal = 5; 12000: dVal = 5, eVal = 2, sVal = -3, pVal = 2; 0.00123: dVal = 1, eVal=6, sVal= 5, pVal=3 )
-            # 7. precision to use pNew = min (p, pVal)
-            # 8. New unscaled number uNew with given precision. if pNew == pVal: uNew = uVal . otherwise, make tmp value from unscaled, inserting a dot at position pNew and use ROUND on it, ie uNew = ROUND(tmp)
-            # 9. New scale sNew = sVal - (pVal - pNew)
-            # 10. if sNew = 0 : newVal = CONCAT(uVal)
-            #     if sNew < 0 : newVal = CONCAT(uNew, SUBSTR(zeros,1,- sNew) ) - append zeros for each negative scale point
-            #     if sNew > 0 : newVal = CONCAT("0.", SUBSTR(zeros, 1, - sNew - pNew), uNew) - insert zeros to fill if needed
-            # 11. result = xsd:decimal(newVal)
-            #
-            # for testing:
-            # VALUES (?value ?precision) { (12345678 4) (0.00123456 3) (.00123456 4) (000123.456000 2) (123456789.0123456789 14) (0.123 5) (12345 3) (2 10) (3 1) (7 0) }
-            #
-        	BIND(IF(bound(?precision), ?precision, 34) as ?p)
-            BIND("0000000000000000000000000000000000000000000000000000000000000000000000000000000000000" as ?zeroPad)
-            # 1: normalize
-            BIND(STR(?value) as ?tmpValueStr)
-            # leading 0 before the dot are insignificant. strip.
-            BIND(REPLACE(?tmpValueStr, "^0*(0\\\\.|[1-9])","$1") as ?tmpValueStrNoLeading0)
-            # if the number starts with '.', prepend '0'
-            BIND(IF(STRSTARTS(?tmpValueStrNoLeading0, "."), CONCAT("0", ?tmpValueStrNoLeading0), ?tmpValueStrNoLeading0) as ?val)
-            # 2. dVal
-            BIND(STRLEN(STRBEFORE(?val,".")) as ?tmp0)
-            BIND(IF(?tmp0 = 0, STRLEN(?val), ?tmp0) as ?dVal)
-            # 3. uVal
-            BIND(REPLACE(REPLACE(?val,"\\\\.",""), "^0+","") as ?uVal)
-            # 4. pVal
-            BIND(STRLEN(?uVal) as ?pVal)
-            # 5. eVal
-            BIND(REPLACE(?val,"\\\\.","") as ?tmp1)
-            BIND(STRLEN(?tmp1) - STRLEN(STRAFTER(?tmp1,?uVal)) as ?eVal)
-            # 6. sVal
-            BIND(?eVal - ?dVal as ?sVal)
-            # 7. pNew
-            BIND(IF(?p < ?pVal, ?p, ?pVal) as ?pNew)
-            # 8. uNew
-            BIND(CONCAT(SUBSTR(?uVal,1,?pNew),".", SUBSTR(?uVal, ?pNew+1) ) as ?tmp2)
-            BIND(IF(?pNew = ?pVal, ?uVal, REPlACE(STR(ROUND(xsd:decimal(?tmp2))), ".0$","")) as ?uNew)
-            # 9. sNew
-            BIND(?sVal - (?pVal - ?pNew) as ?sNew)
-            # 10. newVal
-            BIND(IF(?sNew = 0, ?uNew,
-                    IF (?sNew < 0 ,
-                        CONCAT(?uNew, SUBSTR(?zeroPad, 1, - ?sNew)),
-                        CONCAT(SUBSTR(?zeroPad, 1, ?sNew - ?pNew), ?uNew)
-                    )) as ?tmp3)
-            BIND(IF(?sNew <= 0, ?tmp3,
-                    CONCAT(SUBSTR(?tmp3,1,STRLEN(?tmp3) - ?sNew), ".", SUBSTR(?tmp3, STRLEN(?tmp3) - ?sNew + 1))
-                ) as ?tmp4)
-            BIND(IF(STRSTARTS(?tmp4, "."), CONCAT("0",?tmp4), ?tmp4) as ?newVal)
-            # 11. result
-            BIND(xsd:decimal(?newVal) as ?result)
-        }
-    """
-  .
-
-qudt:scaledUnitMultiplierShape
-  a sh:NodeShape ;
-  rdfs:isDefinedBy <http://qudt.org/2.1/collection/qa/all> ;
-  sh:severity sh:Violation ;
-  sh:sparql [
-    a sh:SPARQLConstraint ;
-    rdfs:comment """
-       Ensure that
-         - if unit u has factor units f_1, ..., f_n (n <= 10!)
-         - and if u has a mulitipler m_u
-         - and if all f_i have a multiplier m_i and an exponent e_i
-      then
-         m_u = (Product over all i:) m_i ^ e_i
-    """ ;
-    sh:message """
-    {$this}
-    Multiplier differs from the multiplier calculated from its factor units.
-    actual multiplier : {?actualMultiplier}
-    calculated        : {?calculatedMultiplier}
-    badness           : {?relDiff}
-    The badness is the relative difference of the difference and the actual or calculated multiplier, whichever is bigger. A badness >> 0 is a real issue to look at. A badness ~ 0 is usually due to a difference in precision and should be resolved by using the calculated value.
-    A
-    """ ;
-    sh:prefixes <http://qudt.org/$$QUDT_VERSION$$/collection/qa/all> ;
-    sh:select """
-
-PREFIX qudt: <http://qudt.org/schema/qudt/>
-PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-
-SELECT ?this ?relDiff
-       (IF(?actualMultiplier = ?calculatedMultiplier, "Equal", "Not Equal") AS ?equalityFlag)
-       ?actualMultiplier ?calculatedMultiplier
-WHERE {
-  ?this a qudt:Unit .
-  OPTIONAL { ?this qudt:conversionMultiplier ?actualMultiplier . }
-
-  # Subquery to compute and concatenate factor unit contributions
-  {
-    SELECT ?this (GROUP_CONCAT(?factorContribution; SEPARATOR="|") AS ?contributions)
-    WHERE {
-      ?this qudt:hasFactorUnit ?factor .
-      ?factor qudt:hasUnit ?baseUnit ;
-              qudt:exponent ?exponent .
-      ?baseUnit qudt:conversionMultiplier ?baseMultiplier .
-      # Compute contribution (exponents 0 to 8)
-      BIND(ABS(?exponent) as ?absoluteExponent)
-            BIND(if (?exponent < 0, 1.0 / ?baseMultiplier, ?baseMultiplier ) as ?multiplier)
-            BIND(
-        IF(?absoluteExponent = 0, 1.0,
-        IF(?absoluteExponent = 1, ?multiplier,
-        IF(?absoluteExponent = 2, ?multiplier * ?multiplier,
-        IF(?absoluteExponent = 3, ?multiplier * ?multiplier * ?multiplier,
-        IF(?absoluteExponent = 4, ?multiplier * ?multiplier * ?multiplier * ?multiplier,
-        IF(?absoluteExponent = 5, ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier,
-        IF(?absoluteExponent = 6, ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier,
-        IF(?absoluteExponent = 7, ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier,
-        IF(?absoluteExponent = 8, ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier,
-                                                            CONCAT("CANNOT HANDLE EXPONENT ", ?exponent)))))))))) AS ?factorContribution )
-
-
-    }
-    GROUP BY ?this
-  }
-    # Disassemble contributions into up to 10 variables
-    BIND(COALESCE(CONCAT("|",?contributions), "|") AS ?contribString)
-
-    # Make sure we don't accidentally swallow stuff that isn't made of numbers
-    FILTER(REGEX("[0-9\\\\-\\\\.\\\\|]+", ?contribString))
-
-    BIND(REPLACE(?contribString, ".*\\\\|", "") as ?f1)
-    BIND(SUBSTR(?contribString, 0, STRLEN(?contribString) - STRLEN(?f1)) as ?f1removed)
-    BIND(REPLACE(?f1removed, ".*\\\\|", "") as ?f2)
-    BIND(SUBSTR(?f1removed, 0, STRLEN(?f1removed) - STRLEN(?f2)) as ?f2removed)
-    BIND(REPLACE(?f2removed, ".*\\\\|", "") as ?f3)
-  \tBIND(SUBSTR(?f2removed, 0, STRLEN(?f2removed) - STRLEN(?f3)) as ?f3removed)
-    BIND(REPLACE(?f3removed, ".*\\\\|", "") as ?f4)
-    BIND(SUBSTR(?f3removed, 0, STRLEN(?f3removed) - STRLEN(?f4)) as ?f4removed)
-    BIND(REPLACE(?f4removed, ".*\\\\|", "") as ?f5)
-    BIND(SUBSTR(?f4removed, 0, STRLEN(?f4removed) - STRLEN(?f5)) as ?f5removed)
-    BIND(REPLACE(?f5removed, ".*\\\\|", "") as ?f6)
-    BIND(SUBSTR(?f5removed, 0, STRLEN(?f5removed) - STRLEN(?f6)) as ?f6removed)
-    BIND(REPLACE(?f6removed, ".*\\\\|", "") as ?f7)
-    BIND(SUBSTR(?f6removed, 0, STRLEN(?f6removed) - STRLEN(?f7)) as ?f7removed)
-    BIND(REPLACE(?f7removed, ".*\\\\|", "") as ?f8)
-    BIND(SUBSTR(?f7removed, 0, STRLEN(?f7removed) - STRLEN(?f8)) as ?f8removed)
-    BIND(REPLACE(?f8removed, ".*\\\\|", "") as ?f9)
-  # Compute calculatedMultiplier by multiplying all contributions
-    BIND(COALESCE(xsd:decimal(?f1), 1.0)
-        * COALESCE(xsd:decimal(?f2), 1.0)
-        * COALESCE(xsd:decimal(?f3), 1.0)
-        * COALESCE(xsd:decimal(?f4), 1.0)
-        * COALESCE(xsd:decimal(?f5), 1.0)
-        * COALESCE(xsd:decimal(?f6), 1.0)
-        * COALESCE(xsd:decimal(?f7), 1.0)
-        * COALESCE(xsd:decimal(?f8), 1.0)
-        * COALESCE(xsd:decimal(?f9), 1.0) as ?cumMul)
-    BIND(qfn:decimalRoundToPrecision(?cumMul, 34) as ?calculatedMultiplier)
-    BIND (?actualMultiplier - ?calculatedMultiplier as ?diff)
-    BIND (IF (?actualMultiplier = 0 , 0.0, ABS(?diff) / ABS(?actualMultiplier)) as ?relDiffAct)
-    BIND (IF( ?calculatedMultiplier = 0, 0.0, ABS(?diff) / ABS(?calculatedMultiplier)) as ?relDiffCalc)
-    BIND(IF(?relDiffAct > ?relDiffCalc, ?relDiffAct, ?relDiffCalc) as ?relDiff)
-    FILTER(?actualMultiplier != ?calculatedMultiplier)
-}
-ORDER BY DESC(?relDiff)
-""" ;
-  ] ;
-  sh:targetClass qudt:Unit .
 
 qudt:standardUncertaintySnShape
   rdfs:comment "qudt:standardUncertainty must match qudt:standardUncertaintySN if present" ;

--- a/src/main/rdf/validation/COLLECTION_QUDT_QA_TESTS_ALL.ttl
+++ b/src/main/rdf/validation/COLLECTION_QUDT_QA_TESTS_ALL.ttl
@@ -550,6 +550,115 @@ qudt:prefixMultiplierSnShape
   ] ;
   sh:targetClass qudt:Prefix .
 
+qudt:scaledUnitMultiplierShape
+  a sh:NodeShape ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/collection/qa/all> ;
+  sh:severity sh:Violation ;
+  sh:sparql [
+    a sh:SPARQLConstraint ;
+    rdfs:comment """
+       Ensure that
+         - if unit u has factor units f_1, ..., f_n (n <= 10!)
+         - and if u has a mulitipler m_u
+         - and if all f_i have a multiplier m_i and an exponent e_i
+      then
+         m_u = (Product over all i:) m_i ^ e_i
+    """ ;
+    sh:message """
+    {$this}
+    Multiplier differs from the multiplier calculated from its factor units.
+    actual multiplier : {?actualMultiplier}
+    calculated        : {?calculatedMultiplier}
+    badness           : {?relDiff}
+    The badness is the relative difference of the difference and the actual or calculated multiplier, whichever is bigger. A badness >> 0 is a real issue to look at. A badness ~ 0 is usually due to a difference in precision and should be resolved by using the calculated value.
+    A
+    """ ;
+    sh:prefixes <http://qudt.org/$$QUDT_VERSION$$/collection/qa/all> ;
+    sh:select """
+
+PREFIX qudt: <http://qudt.org/schema/qudt/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+SELECT ?this ?relDiff
+       (IF(?actualMultiplier = ?calculatedMultiplier, "Equal", "Not Equal") AS ?equalityFlag)
+       ?actualMultiplier ?calculatedMultiplier
+WHERE {
+  ?this a qudt:Unit .
+  OPTIONAL { ?this qudt:conversionMultiplier ?actualMultiplier . }
+
+  # Subquery to compute and concatenate factor unit contributions
+  {
+    SELECT ?this (GROUP_CONCAT(?factorContribution; SEPARATOR="|") AS ?contributions)
+    WHERE {
+      ?this qudt:hasFactorUnit ?factor .
+      ?factor qudt:hasUnit ?baseUnit ;
+              qudt:exponent ?exponent .
+      ?baseUnit qudt:conversionMultiplier ?baseMultiplier .
+      # Compute contribution (exponents 0 to 8)
+      BIND(ABS(?exponent) as ?absoluteExponent)
+            BIND(if (?exponent < 0, 1.0 / ?baseMultiplier, ?baseMultiplier ) as ?multiplier)
+            BIND(
+        IF(?absoluteExponent = 0, 1.0,
+        IF(?absoluteExponent = 1, ?multiplier,
+        IF(?absoluteExponent = 2, ?multiplier * ?multiplier,
+        IF(?absoluteExponent = 3, ?multiplier * ?multiplier * ?multiplier,
+        IF(?absoluteExponent = 4, ?multiplier * ?multiplier * ?multiplier * ?multiplier,
+        IF(?absoluteExponent = 5, ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier,
+        IF(?absoluteExponent = 6, ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier,
+        IF(?absoluteExponent = 7, ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier,
+        IF(?absoluteExponent = 8, ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier,
+                                                            CONCAT("CANNOT HANDLE EXPONENT ", ?exponent)))))))))) AS ?factorContribution )
+
+
+    }
+    GROUP BY ?this
+  }
+    # Disassemble contributions into up to 10 variables
+    BIND(COALESCE(CONCAT("|",?contributions), "|") AS ?contribString)
+
+    # Make sure we don't accidentally swallow stuff that isn't made of numbers
+    FILTER(REGEX("[0-9\\\\-\\\\.\\\\|]+", ?contribString))
+
+    BIND(REPLACE(?contribString, ".*\\\\|", "") as ?f1)
+    BIND(SUBSTR(?contribString, 0, STRLEN(?contribString) - STRLEN(?f1)) as ?f1removed)
+    BIND(REPLACE(?f1removed, ".*\\\\|", "") as ?f2)
+    BIND(SUBSTR(?f1removed, 0, STRLEN(?f1removed) - STRLEN(?f2)) as ?f2removed)
+    BIND(REPLACE(?f2removed, ".*\\\\|", "") as ?f3)
+  \tBIND(SUBSTR(?f2removed, 0, STRLEN(?f2removed) - STRLEN(?f3)) as ?f3removed)
+    BIND(REPLACE(?f3removed, ".*\\\\|", "") as ?f4)
+    BIND(SUBSTR(?f3removed, 0, STRLEN(?f3removed) - STRLEN(?f4)) as ?f4removed)
+    BIND(REPLACE(?f4removed, ".*\\\\|", "") as ?f5)
+    BIND(SUBSTR(?f4removed, 0, STRLEN(?f4removed) - STRLEN(?f5)) as ?f5removed)
+    BIND(REPLACE(?f5removed, ".*\\\\|", "") as ?f6)
+    BIND(SUBSTR(?f5removed, 0, STRLEN(?f5removed) - STRLEN(?f6)) as ?f6removed)
+    BIND(REPLACE(?f6removed, ".*\\\\|", "") as ?f7)
+    BIND(SUBSTR(?f6removed, 0, STRLEN(?f6removed) - STRLEN(?f7)) as ?f7removed)
+    BIND(REPLACE(?f7removed, ".*\\\\|", "") as ?f8)
+    BIND(SUBSTR(?f7removed, 0, STRLEN(?f7removed) - STRLEN(?f8)) as ?f8removed)
+    BIND(REPLACE(?f8removed, ".*\\\\|", "") as ?f9)
+  # Compute calculatedMultiplier by multiplying all contributions
+    BIND(COALESCE(xsd:decimal(?f1), 1.0)
+        * COALESCE(xsd:decimal(?f2), 1.0)
+        * COALESCE(xsd:decimal(?f3), 1.0)
+        * COALESCE(xsd:decimal(?f4), 1.0)
+        * COALESCE(xsd:decimal(?f5), 1.0)
+        * COALESCE(xsd:decimal(?f6), 1.0)
+        * COALESCE(xsd:decimal(?f7), 1.0)
+        * COALESCE(xsd:decimal(?f8), 1.0)
+        * COALESCE(xsd:decimal(?f9), 1.0) as ?calculatedMultiplier)
+
+    BIND (?actualMultiplier - ?calculatedMultiplier as ?diff)
+    BIND (IF (?actualMultiplier = 0 , 0.0, ABS(?diff) / ABS(?actualMultiplier)) as ?relDiffAct)
+    BIND (IF( ?calculatedMultiplier = 0, 0.0, ABS(?diff) / ABS(?calculatedMultiplier)) as ?relDiffCalc)
+    BIND(IF(?relDiffAct > ?relDiffCalc, ?relDiffAct, ?relDiffCalc) as ?relDiff)
+    FILTER(?actualMultiplier != ?calculatedMultiplier)
+}
+ORDER BY DESC(?relDiff)
+""" ;
+  ] ;
+  sh:targetClass qudt:Unit .
+
 qudt:standardUncertaintySnShape
   rdfs:comment "qudt:standardUncertainty must match qudt:standardUncertaintySN if present" ;
   sh:sparql [

--- a/src/main/rdf/validation/COLLECTION_QUDT_QA_TESTS_ALL.ttl
+++ b/src/main/rdf/validation/COLLECTION_QUDT_QA_TESTS_ALL.ttl
@@ -4,6 +4,7 @@
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix qudt: <http://qudt.org/schema/qudt/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix qfn: <http://qudt.org/schema/qudt/fn#> .
 
 <http://qudt.org/$$QUDT_VERSION$$/collection/qa/all>
   a owl:Ontology ;
@@ -61,6 +62,11 @@
     a sh:PrefixDeclaration ;
     sh:namespace "http://www.w3.org/2004/02/skos/core#"^^xsd:anyURI ;
     sh:prefix "skos" ;
+  ] ;
+  sh:declare [
+   a sh:PrefixDeclaration ;
+   sh:namespace "http://qudt.org/schema/qudt/fn#"^^xsd:anyURI ;
+   sh:prefix "qfn" ;
   ] ;
   sh:declare [
     a sh:PrefixDeclaration ;
@@ -550,6 +556,94 @@ qudt:prefixMultiplierSnShape
   ] ;
   sh:targetClass qudt:Prefix .
 
+
+qfn:decimalRoundToPrecision a sh:SPARQLFunction ;
+  sh:parameter [
+    sh:path qfn:value ;
+    sh:order 0 ;
+    sh:datatype xsd:decimal ;
+    sh:description "The decimal value to normalize" ;
+  ] ;
+  sh:parameter [
+    sh:path qfn:precision ;
+    sh:order 1 ;
+    sh:datatype xsd:integer ;
+    sh:description "Number of significant digits" ;
+  ] ;
+  sh:returnType xsd:decimal ;
+  sh:prefixes <http://qudt.org/$$QUDT_VERSION$$/collection/qa/all> ;
+  sh:select """
+        PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+        SELECT ?result
+        WHERE {
+            # rounds input decimal v to precision p
+            #
+            # unscaled number: significant digits
+            # precision: number of significant digits
+            # scale: (value = unscaled * 10^(-scale) ) eg: 123.45: unscaled: 12345 scale = 2;  110 = unscaled: 11, scale = -1; 0.000123 = unscaled: 123, scale = 6
+            #
+            # Algorithm:
+            #
+            # 1. val = normalized v (strip leading 0s, don't add trailing 0 if it has no dot)
+            # 2. find the dot position dVal (dVal = length(val) if no dot)
+            # 3. find the unscaled number uVal as the digits without the dot, leading 0s removed, trailing 0s kept
+            # 4. length of uVal is the precision of our value, pVal = length(uVal)
+            # 5. find the position eVal in val at which the unscaled number ends
+            # 6. scale sVal = eVal - dVal (e.g 123.456: dVal = 3, eVal = 6, sVal = 3, pVal = 6; 123: dVal = 0; 12345: dVal = 5, eVal = 5, sVal = 0, pVal = 5; 12000: dVal = 5, eVal = 2, sVal = -3, pVal = 2; 0.00123: dVal = 1, eVal=6, sVal= 5, pVal=3 )
+            # 7. precision to use pNew = min (p, pVal)
+            # 8. New unscaled number uNew with given precision. if pNew == pVal: uNew = uVal . otherwise, make tmp value from unscaled, inserting a dot at position pNew and use ROUND on it, ie uNew = ROUND(tmp)
+            # 9. New scale sNew = sVal - (pVal - pNew)
+            # 10. if sNew = 0 : newVal = CONCAT(uVal)
+            #     if sNew < 0 : newVal = CONCAT(uNew, SUBSTR(zeros,1,- sNew) ) - append zeros for each negative scale point
+            #     if sNew > 0 : newVal = CONCAT("0.", SUBSTR(zeros, 1, - sNew - pNew), uNew) - insert zeros to fill if needed
+            # 11. result = xsd:decimal(newVal)
+            #
+            # for testing:
+            # VALUES (?value ?precision) { (12345678 4) (0.00123456 3) (.00123456 4) (000123.456000 2) (123456789.0123456789 14) (0.123 5) (12345 3) (2 10) (3 1) (7 0) }
+            #
+        	BIND(IF(bound(?precision), ?precision, 34) as ?p)
+            BIND("0000000000000000000000000000000000000000000000000000000000000000000000000000000000000" as ?zeroPad)
+            # 1: normalize
+            BIND(STR(?value) as ?tmpValueStr)
+            # leading 0 before the dot are insignificant. strip.
+            BIND(REPLACE(?tmpValueStr, "^0*(0\\\\.|[1-9])","$1") as ?tmpValueStrNoLeading0)
+            # if the number starts with '.', prepend '0'
+            BIND(IF(STRSTARTS(?tmpValueStrNoLeading0, "."), CONCAT("0", ?tmpValueStrNoLeading0), ?tmpValueStrNoLeading0) as ?val)
+            # 2. dVal
+            BIND(STRLEN(STRBEFORE(?val,".")) as ?tmp0)
+            BIND(IF(?tmp0 = 0, STRLEN(?val), ?tmp0) as ?dVal)
+            # 3. uVal
+            BIND(REPLACE(REPLACE(?val,"\\\\.",""), "^0+","") as ?uVal)
+            # 4. pVal
+            BIND(STRLEN(?uVal) as ?pVal)
+            # 5. eVal
+            BIND(REPLACE(?val,"\\\\.","") as ?tmp1)
+            BIND(STRLEN(?tmp1) - STRLEN(STRAFTER(?tmp1,?uVal)) as ?eVal)
+            # 6. sVal
+            BIND(?eVal - ?dVal as ?sVal)
+            # 7. pNew
+            BIND(IF(?p < ?pVal, ?p, ?pVal) as ?pNew)
+            # 8. uNew
+            BIND(CONCAT(SUBSTR(?uVal,1,?pNew),".", SUBSTR(?uVal, ?pNew+1) ) as ?tmp2)
+            BIND(IF(?pNew = ?pVal, ?uVal, REPlACE(STR(ROUND(xsd:decimal(?tmp2))), ".0$","")) as ?uNew)
+            # 9. sNew
+            BIND(?sVal - (?pVal - ?pNew) as ?sNew)
+            # 10. newVal
+            BIND(IF(?sNew = 0, ?uNew,
+                    IF (?sNew < 0 ,
+                        CONCAT(?uNew, SUBSTR(?zeroPad, 1, - ?sNew)),
+                        CONCAT(SUBSTR(?zeroPad, 1, ?sNew - ?pNew), ?uNew)
+                    )) as ?tmp3)
+            BIND(IF(?sNew <= 0, ?tmp3,
+                    CONCAT(SUBSTR(?tmp3,1,STRLEN(?tmp3) - ?sNew), ".", SUBSTR(?tmp3, STRLEN(?tmp3) - ?sNew + 1))
+                ) as ?tmp4)
+            BIND(IF(STRSTARTS(?tmp4, "."), CONCAT("0",?tmp4), ?tmp4) as ?newVal)
+            # 11. result
+            BIND(xsd:decimal(?newVal) as ?result)
+        }
+    """
+  .
+
 qudt:scaledUnitMultiplierShape
   a sh:NodeShape ;
   rdfs:isDefinedBy <http://qudt.org/2.1/collection/qa/all> ;
@@ -646,8 +740,8 @@ WHERE {
         * COALESCE(xsd:decimal(?f6), 1.0)
         * COALESCE(xsd:decimal(?f7), 1.0)
         * COALESCE(xsd:decimal(?f8), 1.0)
-        * COALESCE(xsd:decimal(?f9), 1.0) as ?calculatedMultiplier)
-
+        * COALESCE(xsd:decimal(?f9), 1.0) as ?cumMul)
+    BIND(qfn:decimalRoundToPrecision(?cumMul, 34) as ?calculatedMultiplier)
     BIND (?actualMultiplier - ?calculatedMultiplier as ?diff)
     BIND (IF (?actualMultiplier = 0 , 0.0, ABS(?diff) / ABS(?actualMultiplier)) as ?relDiffAct)
     BIND (IF( ?calculatedMultiplier = 0, 0.0, ABS(?diff) / ABS(?calculatedMultiplier)) as ?relDiffCalc)

--- a/src/main/rdf/validation/qudt-shacl-functions.ttl
+++ b/src/main/rdf/validation/qudt-shacl-functions.ttl
@@ -75,7 +75,7 @@ qfn:decimalRoundToPrecision
   ] ;
   sh:parameter [
     sh:datatype xsd:integer ;
-    sh:description "Number of significant digits" ;
+    sh:description "Number of significant digits (default: 34)" ;
     sh:order 1 ;
     sh:path qfn:precision ;
   ] ;
@@ -145,10 +145,144 @@ qfn:decimalRoundToPrecision
             BIND(IF(?sNew <= 0, ?tmp3,
                     CONCAT(SUBSTR(?tmp3,1,STRLEN(?tmp3) - ?sNew), ".", SUBSTR(?tmp3, STRLEN(?tmp3) - ?sNew + 1))
                 ) as ?tmp4)
-            BIND(IF(STRSTARTS(?tmp4, "."), CONCAT("0",?tmp4), ?tmp4) as ?newVal)
+            BIND(IF(STRSTARTS(?tmp4, "."), CONCAT("0",?tmp4), ?tmp4) as ?tmp5)
             # 11. result
+            # 12. append '.0' if there is no '.' in the string
+            BIND(IF(CONTAINS(?tmp5,"."), ?tmp5, CONCAT(?tmp5,".0")) AS ?tmp6)
+            BIND(REPLACE(?tmp6, "^0*([1-9][0-9]*.[0-9][1-9]*)0*$", "$1", "") AS ?newVal)
             BIND(xsd:decimal(?newVal) as ?result)
         }
+    """ .
+
+qfn:decimalToDouble
+  a sh:SPARQLFunction ;
+  sh:parameter [
+    sh:datatype xsd:decimal ;
+    sh:description "The decimal value to expess as double" ;
+    sh:order 0 ;
+    sh:path qfn:input ;
+  ] ;
+  sh:prefixes qfn: ;
+  sh:returnType xsd:decimal ;
+  sh:select """
+    SELECT ?result
+    WHERE {
+      BIND(IF(?input = 0.0, "0.0", "") AS ?zeroCheck)
+      BIND(STR(?input) AS ?str)
+      BIND(STRSTARTS(?str, "-") AS ?isNegative)
+      BIND(IF(?isNegative, SUBSTR(?str, 2), ?str) AS ?absStr)
+      BIND(CONTAINS(?absStr, ".") AS ?hasDecimal)
+      BIND(IF(?hasDecimal, STRBEFORE(?absStr, "."), ?absStr) AS ?intPart)
+      BIND(IF(?hasDecimal, STRAFTER(?absStr, "."), "") AS ?fracPart)
+      BIND(IF(?intPart = "", "", REPLACE(?intPart, "^0+", "", "")) AS ?trimmedInt)
+      BIND(IF(?fracPart = "", "", REPLACE(?fracPart, "^0+", "", "")) AS ?trimmedFrac)  # Only trim leading zeros
+      BIND(IF(?fracPart = "", "", REPLACE(?fracPart, "0+$","","")) AS ?fracTrimmedAtEnd) # only trim trailing zeros
+      BIND(STRLEN(?trimmedInt) AS ?trimmedIntLen)
+      BIND(STRLEN(?trimmedFrac) AS ?trimmedFracLen)
+      BIND(STRLEN(?fracPart) AS ?fracLen)
+      BIND(IF(
+        ?trimmedIntLen > 0,
+        ?trimmedIntLen - 1,
+        IF(
+          ?trimmedFracLen > 0,
+          -(?fracLen - ?trimmedFracLen + 1),
+          0
+        )
+      ) AS ?exp)
+      BIND(IF(
+        ?trimmedIntLen > 0,
+        CONCAT(
+          SUBSTR(?trimmedInt, 1, 1),
+          IF(?trimmedIntLen > 1 || ?trimmedFracLen > 0, ".", ""),
+          SUBSTR(?trimmedInt, 2),
+          ?fracTrimmedAtEnd
+        ),
+        IF(
+          ?trimmedFracLen > 0,
+          CONCAT(
+            SUBSTR(?trimmedFrac, 1, 1),
+            IF(?trimmedFracLen > 1, ".", ""),
+            SUBSTR(?trimmedFrac, 2)
+          ),
+          "0.0"
+        )
+      ) AS ?mantissaTmpStr)
+      BIND(REPLACE(?mantissaTmpStr, "^0*([0-9]+(\\\\.[0-9][1-9]*)?)0*$", "$1","") AS ?mantissaStr)
+      BIND(STRDT(IF(
+        ?zeroCheck = "0.0",
+        "0E0",
+        CONCAT(
+          IF(?isNegative, "-", ""),
+          ?mantissaStr,
+          "E",
+          STR(?exp)
+        )
+      ), xsd:double) AS ?result)
+    }
+    """ .
+
+qfn:defaultValue
+  a sh:SPARQLFunction ;
+  sh:parameter [
+    sh:description "Any value, may also be unbound" ;
+    sh:order 0 ;
+    sh:path qfn:value ;
+  ] ;
+  sh:parameter [
+    sh:description "The default value to return if value is unbound" ;
+    sh:order 1 ;
+    sh:path qfn:defaultValue ;
+  ] ;
+  sh:prefixes qfn: ;
+  sh:select """
+    SELECT
+        (IF(BOUND(?value), ?value, ?defaultValue) AS ?result)
+    WHERE {}
+    """ .
+
+qfn:exp
+  a sh:SPARQLFunction ;
+  sh:parameter [
+    sh:datatype xsd:decimal ;
+    sh:description "The decimal value to exponentiate" ;
+    sh:order 0 ;
+    sh:path qfn:value ;
+  ] ;
+  sh:parameter [
+    sh:datatype xsd:integer ;
+    sh:description "The exponent - an integer between 0 and 8 (inclusive)" ;
+    sh:order 1 ;
+    sh:path qfn:exponent ;
+  ] ;
+  sh:prefixes qfn: ;
+  sh:returnType xsd:decimal ;
+  sh:select """
+    SELECT ?result
+    WHERE {
+        # supports exponents 0 to 8
+        BIND(ABS(?exponent) as ?absoluteExponent)
+        BIND(if (?exponent < 0, 1.0 / ?value, ?value ) as ?multiplier)
+        BIND(
+            IF(?absoluteExponent = 0, 1.1,
+                IF(?absoluteExponent = 1,
+                    ?multiplier,
+                    IF(?absoluteExponent = 2,
+                        ?multiplier * ?multiplier,
+                        IF(?absoluteExponent = 3,
+                            ?multiplier * ?multiplier * ?multiplier,
+                            IF(?absoluteExponent = 4,
+                                ?multiplier * ?multiplier * ?multiplier * ?multiplier,
+                                IF(?absoluteExponent = 5,
+                                    ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier,
+                                    IF(?absoluteExponent = 6,
+                                        ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier,
+                                        IF(?absoluteExponent = 7,
+                                            ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier,
+                                            IF(?absoluteExponent = 8,
+                                                ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier * ?multiplier,
+                                                CONCAT("CANNOT HANDLE EXPONENT ", ?exponent))))))))))
+        AS ?result )
+    }
     """ .
 
 

--- a/src/main/rdf/validation/qudt-shacl-functions.ttl
+++ b/src/main/rdf/validation/qudt-shacl-functions.ttl
@@ -65,6 +65,37 @@ qfn:
     sh:prefix "sh" ;
   ] .
 
+qfn:decimalPrecision
+  a sh:SPARQLFunction ;
+  rdfs:comment "Determines the precision (number of significant digits) of the decimal number provided as its first argument" ;
+  sh:parameter [
+    sh:datatype xsd:decimal ;
+    sh:description "The decimal value of which to determine the precision " ;
+    sh:order 0 ;
+    sh:path qfn:value ;
+  ] ;
+  sh:prefixes qfn: ;
+  sh:returnType xsd:decimal ;
+  sh:select """
+        SELECT ?result
+        WHERE {
+            # determines precision of input
+            # simple: remove any '.' if present
+            BIND(STR(?value) as ?tmpVal)
+            BIND(REPLACE(?tmpVal, "([^.]*)\\\\.([^.]*)", "$1$2") as ?tmpVal1)
+            # leading 0 before the dot are insignificant, trailing 0 after the dot are insignificant. strip.
+            BIND(REPLACE(?tmpVal1, "^\\\\s*[+-]?\\\\s*0*([1-9]([0-9]*[1-9])?)0*$","$1") as ?val)
+            # 2. dVal
+            BIND(STRLEN(STRBEFORE(?val,".")) as ?tmp0)
+            BIND(IF(?tmp0 = 0, STRLEN(?val), ?tmp0) as ?dVal)
+            # 3. uVal
+            BIND(REPLACE(REPLACE(?val,"\\\\.",""), "^0+","") as ?uVal)
+            # 4. pVal
+            BIND(STRLEN(?uVal) as ?pVal)
+            BIND(xsd:integer(?pVal) as ?result)
+        }
+    """ .
+
 qfn:decimalRoundToPrecision
   a sh:SPARQLFunction ;
   sh:parameter [
@@ -109,12 +140,15 @@ qfn:decimalRoundToPrecision
             # for testing:
             # VALUES (?value ?precision) { (12345678 4) (0.00123456 3) (.00123456 4) (000123.456000 2) (123456789.0123456789 14) (0.123 5) (12345 3) (2 10) (3 1) (7 0) }
             #
-        \tBIND(IF(bound(?precision), ?precision, 34) as ?p)
+            BIND(IF(bound(?precision), ?precision, 34) as ?p)
             BIND("0000000000000000000000000000000000000000000000000000000000000000000000000000000000000" as ?zeroPad)
+
             # 1: normalize
             BIND(STR(?value) as ?tmpValueStr)
             # leading 0 before the dot are insignificant. strip.
-            BIND(REPLACE(?tmpValueStr, "^0*(0\\\\.|[1-9])","$1") as ?tmpValueStrNoLeading0)
+            BIND(REPLACE(?tmpValueStr, "^[+-]?0*(0?\\\\.|[1-9])","$1") as ?tmpValueStrNoLeading0)
+            # remember sign if negative
+            BIND(IF(REGEX(?tmpValueStr, "^-"), "-","") AS ?sign)
             # if the number starts with '.', prepend '0'
             BIND(IF(STRSTARTS(?tmpValueStrNoLeading0, "."), CONCAT("0", ?tmpValueStrNoLeading0), ?tmpValueStrNoLeading0) as ?val)
             # 2. dVal
@@ -149,7 +183,8 @@ qfn:decimalRoundToPrecision
             # 11. result
             # 12. append '.0' if there is no '.' in the string
             BIND(IF(CONTAINS(?tmp5,"."), ?tmp5, CONCAT(?tmp5,".0")) AS ?tmp6)
-            BIND(REPLACE(?tmp6, "^0*([1-9][0-9]*.[0-9][1-9]*)0*$", "$1", "") AS ?newVal)
+            BIND(REPLACE(?tmp6, "^0*([1-9][0-9]*.[0-9][1-9]*)0*$", "$1", "") AS ?tmp7)
+            BIND(CONCAT(?sign, ?tmp7) AS ?newVal)
             BIND(xsd:decimal(?newVal) as ?result)
         }
     """ .

--- a/src/main/rdf/validation/qudt-shacl-functions.ttl
+++ b/src/main/rdf/validation/qudt-shacl-functions.ttl
@@ -1,0 +1,154 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix qfn: <http://qudt.org/shacl/functions#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+
+qfn:
+  a owl:Ontology ;
+  rdfs:isDefinedBy qfn: ;
+  rdfs:label "QUDT SHACL FUNCTIONS" ;
+  sh:declare [
+    a sh:PrefixDeclaration ;
+    sh:namespace "http://qudt.org/shacl/functions#"^^xsd:anyURI ;
+    sh:prefix "qfn" ;
+  ] ;
+  sh:declare [
+    a sh:PrefixDeclaration ;
+    sh:namespace "http://qudt.org/schema/qudt/"^^xsd:anyURI ;
+    sh:prefix "qudt" ;
+  ] ;
+  sh:declare [
+    a sh:PrefixDeclaration ;
+    sh:namespace "http://qudt.org/vocab/dimensionvector/"^^xsd:anyURI ;
+    sh:prefix "qkdv" ;
+  ] ;
+  sh:declare [
+    a sh:PrefixDeclaration ;
+    sh:namespace "http://qudt.org/vocab/quantitykind/"^^xsd:anyURI ;
+    sh:prefix "quantitykind" ;
+  ] ;
+  sh:declare [
+    a sh:PrefixDeclaration ;
+    sh:namespace "http://qudt.org/vocab/unit/"^^xsd:anyURI ;
+    sh:prefix "unit" ;
+  ] ;
+  sh:declare [
+    a sh:PrefixDeclaration ;
+    sh:namespace "http://www.w3.org/1999/02/22-rdf-syntax-ns#"^^xsd:anyURI ;
+    sh:prefix "rdf" ;
+  ] ;
+  sh:declare [
+    a sh:PrefixDeclaration ;
+    sh:namespace "http://www.w3.org/2000/01/rdf-schema#"^^xsd:anyURI ;
+    sh:prefix "rdfs" ;
+  ] ;
+  sh:declare [
+    a sh:PrefixDeclaration ;
+    sh:namespace "http://www.w3.org/2001/XMLSchema#"^^xsd:anyURI ;
+    sh:prefix "xsd" ;
+  ] ;
+  sh:declare [
+    a sh:PrefixDeclaration ;
+    sh:namespace "http://www.w3.org/2002/07/owl#"^^xsd:anyURI ;
+    sh:prefix "owl" ;
+  ] ;
+  sh:declare [
+    a sh:PrefixDeclaration ;
+    sh:namespace "http://www.w3.org/2004/02/skos/core#"^^xsd:anyURI ;
+    sh:prefix "skos" ;
+  ] ;
+  sh:declare [
+    a sh:PrefixDeclaration ;
+    sh:namespace "http://www.w3.org/ns/shacl#"^^xsd:anyURI ;
+    sh:prefix "sh" ;
+  ] .
+
+qfn:decimalRoundToPrecision
+  a sh:SPARQLFunction ;
+  sh:parameter [
+    sh:datatype xsd:decimal ;
+    sh:description "The decimal value to normalize" ;
+    sh:order 0 ;
+    sh:path qfn:value ;
+  ] ;
+  sh:parameter [
+    sh:datatype xsd:integer ;
+    sh:description "Number of significant digits" ;
+    sh:order 1 ;
+    sh:path qfn:precision ;
+  ] ;
+  sh:prefixes qfn: ;
+  sh:returnType xsd:decimal ;
+  sh:select """
+        SELECT ?result
+        WHERE {
+            # rounds input decimal v to precision p
+            #
+            # unscaled number: significant digits
+            # precision: number of significant digits
+            # scale: (value = unscaled * 10^(-scale) ) eg: 123.45: unscaled: 12345 scale = 2;  110 = unscaled: 11, scale = -1; 0.000123 = unscaled: 123, scale = 6
+            #
+            # Algorithm:
+            #
+            # 1. val = normalized v (strip leading 0s, don't add trailing 0 if it has no dot)
+            # 2. find the dot position dVal (dVal = length(val) if no dot)
+            # 3. find the unscaled number uVal as the digits without the dot, leading 0s removed, trailing 0s kept
+            # 4. length of uVal is the precision of our value, pVal = length(uVal)
+            # 5. find the position eVal in val at which the unscaled number ends
+            # 6. scale sVal = eVal - dVal (e.g 123.456: dVal = 3, eVal = 6, sVal = 3, pVal = 6; 123: dVal = 0; 12345: dVal = 5, eVal = 5, sVal = 0, pVal = 5; 12000: dVal = 5, eVal = 2, sVal = -3, pVal = 2; 0.00123: dVal = 1, eVal=6, sVal= 5, pVal=3 )
+            # 7. precision to use pNew = min (p, pVal)
+            # 8. New unscaled number uNew with given precision. if pNew == pVal: uNew = uVal . otherwise, make tmp value from unscaled, inserting a dot at position pNew and use ROUND on it, ie uNew = ROUND(tmp)
+            # 9. New scale sNew = sVal - (pVal - pNew)
+            # 10. if sNew = 0 : newVal = CONCAT(uVal)
+            #     if sNew < 0 : newVal = CONCAT(uNew, SUBSTR(zeros,1,- sNew) ) - append zeros for each negative scale point
+            #     if sNew > 0 : newVal = CONCAT("0.", SUBSTR(zeros, 1, - sNew - pNew), uNew) - insert zeros to fill if needed
+            # 11. result = xsd:decimal(newVal)
+            #
+            # for testing:
+            # VALUES (?value ?precision) { (12345678 4) (0.00123456 3) (.00123456 4) (000123.456000 2) (123456789.0123456789 14) (0.123 5) (12345 3) (2 10) (3 1) (7 0) }
+            #
+        \tBIND(IF(bound(?precision), ?precision, 34) as ?p)
+            BIND("0000000000000000000000000000000000000000000000000000000000000000000000000000000000000" as ?zeroPad)
+            # 1: normalize
+            BIND(STR(?value) as ?tmpValueStr)
+            # leading 0 before the dot are insignificant. strip.
+            BIND(REPLACE(?tmpValueStr, "^0*(0\\\\.|[1-9])","$1") as ?tmpValueStrNoLeading0)
+            # if the number starts with '.', prepend '0'
+            BIND(IF(STRSTARTS(?tmpValueStrNoLeading0, "."), CONCAT("0", ?tmpValueStrNoLeading0), ?tmpValueStrNoLeading0) as ?val)
+            # 2. dVal
+            BIND(STRLEN(STRBEFORE(?val,".")) as ?tmp0)
+            BIND(IF(?tmp0 = 0, STRLEN(?val), ?tmp0) as ?dVal)
+            # 3. uVal
+            BIND(REPLACE(REPLACE(?val,"\\\\.",""), "^0+","") as ?uVal)
+            # 4. pVal
+            BIND(STRLEN(?uVal) as ?pVal)
+            # 5. eVal
+            BIND(REPLACE(?val,"\\\\.","") as ?tmp1)
+            BIND(STRLEN(?tmp1) - STRLEN(STRAFTER(?tmp1,?uVal)) as ?eVal)
+            # 6. sVal
+            BIND(?eVal - ?dVal as ?sVal)
+            # 7. pNew
+            BIND(IF(?p < ?pVal, ?p, ?pVal) as ?pNew)
+            # 8. uNew
+            BIND(CONCAT(SUBSTR(?uVal,1,?pNew),".", SUBSTR(?uVal, ?pNew+1) ) as ?tmp2)
+            BIND(IF(?pNew = ?pVal, ?uVal, REPlACE(STR(ROUND(xsd:decimal(?tmp2))), ".0$","")) as ?uNew)
+            # 9. sNew
+            BIND(?sVal - (?pVal - ?pNew) as ?sNew)
+            # 10. newVal
+            BIND(IF(?sNew = 0, ?uNew,
+                    IF (?sNew < 0 ,
+                        CONCAT(?uNew, SUBSTR(?zeroPad, 1, - ?sNew)),
+                        CONCAT(SUBSTR(?zeroPad, 1, ?sNew - ?pNew), ?uNew)
+                    )) as ?tmp3)
+            BIND(IF(?sNew <= 0, ?tmp3,
+                    CONCAT(SUBSTR(?tmp3,1,STRLEN(?tmp3) - ?sNew), ".", SUBSTR(?tmp3, STRLEN(?tmp3) - ?sNew + 1))
+                ) as ?tmp4)
+            BIND(IF(STRSTARTS(?tmp4, "."), CONCAT("0",?tmp4), ?tmp4) as ?newVal)
+            # 11. result
+            BIND(xsd:decimal(?newVal) as ?result)
+        }
+    """ .
+
+

--- a/src/main/rdf/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL.ttl
+++ b/src/main/rdf/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL.ttl
@@ -14577,6 +14577,8 @@ quantitykind:VacuumThrust
 quantitykind:VaporPermeability
   a qudt:QuantityKind ;
   dcterms:description "The moisture transmission rate of a material is referred to as its \"permeability\"."^^qudt:LatexString ;
+  dcterms:isReplacedBy quantitykind:VapourPermeability ;
+  qudt:deprecated true ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T1D0 ;
   qudt:informativeReference "https://users.encs.concordia.ca/~raojw/crd/essay/essay000287.html"^^xsd:anyURI ;
   qudt:informativeReference "https://www.designingbuildings.co.uk/wiki/Vapour_Permeability"^^xsd:anyURI ;
@@ -14587,12 +14589,14 @@ quantitykind:VaporPermeability
 quantitykind:VaporPermeance
   a qudt:QuantityKind ;
   dcterms:description "A material's \"permeance\", is dependent on thickness much like the R-value in heat transmission. Dividing the permeability of a material by its thickness gives the material's permeance. Permeance is the number that should be used to compare various products in regard to moisture transmission resistance."^^qudt:LatexString ;
+  dcterms:isReplacedBy quantitykind:VapourPermeance ;
+  qudt:deprecated true ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T1D0 ;
   qudt:informativeReference "https://users.encs.concordia.ca/~raojw/crd/essay/essay000287.html"^^xsd:anyURI ;
   qudt:informativeReference "https://www.designingbuildings.co.uk/wiki/Vapour_Permeability"^^xsd:anyURI ;
   qudt:plainTextDescription "A material's \"permeance\", is dependent on thickness much like the R-value in heat transmission. Dividing the permeability of a material by its thickness gives the material's permeance. Permeance is the number that should be used to compare various products in regard to moisture transmission resistance." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Vapor Permeability"@en .
+  rdfs:label "Vapor Permeance"@en .
 
 quantitykind:VaporPressure
   a qudt:QuantityKind ;
@@ -14602,6 +14606,26 @@ quantitykind:VaporPressure
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Vapor Pressure"@en ;
   skos:broader quantitykind:Pressure .
+
+quantitykind:VapourPermeability
+  a qudt:QuantityKind ;
+  dcterms:description "The moisture transmission rate of a material is referred to as its \"permeability\"."^^qudt:LatexString ;
+  qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T1D0 ;
+  qudt:informativeReference "https://users.encs.concordia.ca/~raojw/crd/essay/essay000287.html"^^xsd:anyURI ;
+  qudt:informativeReference "https://www.designingbuildings.co.uk/wiki/Vapour_Permeability"^^xsd:anyURI ;
+  qudt:plainTextDescription "The moisture transmission rate of a material is referred to as its \"permeability\"." ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
+  rdfs:label "Vapour Permeability"@en .
+
+quantitykind:VapourPermeance
+  a qudt:QuantityKind ;
+  dcterms:description "A material's \"permeance\", is dependent on thickness much like the R-value in heat transmission. Dividing the permeability of a material by its thickness gives the material's permeance. Permeance is the number that should be used to compare various products in regard to moisture transmission resistance."^^qudt:LatexString ;
+  qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T1D0 ;
+  qudt:informativeReference "https://users.encs.concordia.ca/~raojw/crd/essay/essay000287.html"^^xsd:anyURI ;
+  qudt:informativeReference "https://www.designingbuildings.co.uk/wiki/Vapour_Permeability"^^xsd:anyURI ;
+  qudt:plainTextDescription "A material's \"permeance\", is dependent on thickness much like the R-value in heat transmission. Dividing the permeability of a material by its thickness gives the material's permeance. Permeance is the number that should be used to compare various products in regard to moisture transmission resistance." ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
+  rdfs:label "Vapour Permeance"@en .
 
 quantitykind:VehicleVelocity
   a qudt:QuantityKind ;
@@ -15047,7 +15071,7 @@ quantitykind:WaterVaporDiffusionCoefficient
 quantitykind:WaterVapourPermeability
   a qudt:QuantityKind ;
   dcterms:description "mass of water vapour passing a surface divided by the area of this surface, the pressure difference, and the corresponding time"@en ;
-  qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T1D0 ;
+  qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T1D0 ;
   qudt:iec61360Code "0112/2///62720#UAD244" ;
   qudt:plainTextDescription "Masse des durch eine Fläche hindurchtretenden Wasserdampfes, dividiert durch den Flächeninhalt dieser Fläche, die Druckdifferenz und die dazugehörige Zeit"@de ;
   qudt:symbol "0173-1#Z4-BAJ446#001" ;

--- a/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
+++ b/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
@@ -970,6 +970,8 @@ unit:AWG
   dcterms:description """
   The unit for $\\textit{American Wire Gage}$, symbol $AWG$, is for the standard nominal diameters and cross-sectional areas of American Wire Gage sizes of solid round wires used as electrical conductors.
   """^^qudt:LatexString ;
+  qudt:conversionMultiplier 0.0 ;
+  qudt:conversionMultiplierSN 0.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAD909" ;
@@ -1234,6 +1236,8 @@ unit:B
   qudt:applicableSystem sou:IMPERIAL ;
   qudt:applicableSystem sou:PLANCK ;
   qudt:applicableSystem sou:SI ;
+  qudt:conversionMultiplier 0.0 ;
+  qudt:conversionMultiplierSN 0.0E0 ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Bel"^^xsd:anyURI ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:SoundExposureLevel ;
@@ -2095,6 +2099,8 @@ unit:BQ-SEC-PER-M3
 unit:BREATH-PER-MIN
   a qudt:ContextualUnit, qudt:DerivedUnit, qudt:Unit ;
   dcterms:description "A unit of respiratory rate."^^rdf:HTML ;
+  qudt:conversionMultiplier 0.01666666666666666666666666666666667 ;
+  qudt:conversionMultiplierSN 1.666666666666666666666666666666667E-2 ;
   qudt:expression "$breaths/min$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:RespiratoryRate ;
@@ -2124,6 +2130,8 @@ unit:BREWSTER
 unit:BTU_39DEG_F
   a qudt:ContextualUnit, qudt:Unit ;
   dcterms:description "unit of heat energy according to the Imperial system of units in a reference temperature of 39 °F" ;
+  qudt:conversionMultiplier 1059.67 ;
+  qudt:conversionMultiplierSN 1.05967E3 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ThermalEnergy ;
   qudt:iec61360Code "0112/2///62720#UAB216" ;
@@ -2134,6 +2142,8 @@ unit:BTU_39DEG_F
 unit:BTU_59DEG_F
   a qudt:ContextualUnit, qudt:Unit ;
   dcterms:description "unit of heat energy according to the Imperial system of units in a reference temperature of 59 °F" ;
+  qudt:conversionMultiplier 1054.80 ;
+  qudt:conversionMultiplierSN 1.05480E3 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ThermalEnergy ;
   qudt:iec61360Code "0112/2///62720#UAB217" ;
@@ -2145,6 +2155,8 @@ unit:BTU_59DEG_F
 unit:BTU_60DEG_F
   a qudt:ContextualUnit, qudt:Unit ;
   dcterms:description "unit of head energy according to the Imperial system of units at a reference temperature of 60 °F" ;
+  qudt:conversionMultiplier 1054.68 ;
+  qudt:conversionMultiplierSN 1.05468E3 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ThermalEnergy ;
   qudt:iec61360Code "0112/2///62720#UAB218" ;
@@ -3411,6 +3423,7 @@ unit:BYTE
   qudt:conversionMultiplier 5.5451774444795624753378569716654 ;
   qudt:conversionMultiplierSN 5.5451774444795624753378569716654E0 ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Byte"^^xsd:anyURI ;
+  qudt:exactMatch unit:OCTET ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:InformationEntropy ;
   qudt:iec61360Code "0112/2///62720#UAA354" ;
@@ -3891,11 +3904,12 @@ unit:CAL_15_DEG_C
   qudt:applicableSystem sou:CGS ;
   qudt:applicableSystem sou:IMPERIAL ;
   qudt:applicableSystem sou:USCS ;
-  qudt:conversionMultiplier 4.1855 ;
-  qudt:conversionMultiplierSN 4.1855E0 ;
+  qudt:conversionMultiplier 4.18580 ;
+  qudt:conversionMultiplierSN 4.18580E0 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ThermalEnergy ;
   qudt:iec61360Code "0112/2///62720#UAB139" ;
+  qudt:informativeReference "https://physics.nist.gov/cuu/pdf/sp811.pdf"^^xsd:anyURI ;
   qudt:plainTextDescription "unit for the quantity of heat which is required to warm up 1 g  of water, which is free of air, at a constant pressure of 101.325 kPa (the pressure of the standard atmosphere on sea level) from 14.5 degrees Celsius to 15.5 degrees Celsius" ;
   qudt:symbol "cal{15 °C}" ;
   qudt:ucumCode "cal_[15]"^^qudt:UCUMcs ;
@@ -3906,9 +3920,12 @@ unit:CAL_15_DEG_C
 unit:CAL_20DEG_C
   a qudt:ContextualUnit, qudt:Unit ;
   dcterms:description "unit for quantity of heat, which is to be required for 1 g air free water at a constant pressure from 101,325 kPa, to warm up the pressure of standard atmosphere at sea level, from 19.5 °C on 20.5 °C" ;
+  qudt:conversionMultiplier 4.18190 ;
+  qudt:conversionMultiplierSN 4.18190E0 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ThermalEnergy ;
   qudt:iec61360Code "0112/2///62720#UAB219" ;
+  qudt:informativeReference "https://physics.nist.gov/cuu/pdf/sp811.pdf"^^xsd:anyURI ;
   qudt:symbol "cal₂₀" ;
   qudt:uneceCommonCode "N69" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -6990,13 +7007,16 @@ unit:CD-PER-M2
 unit:CD_IN
   a qudt:Unit ;
   dcterms:description "obsolete, non-legal unit of the power in Germany relating to DIN 1301-3:1979" ;
+  qudt:conversionMultiplier 0.920 ;
+  qudt:conversionMultiplierSN 9.20E-1 ;
   qudt:hasDimensionVector qkdv:A0E0L0I1M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:LuminousIntensity ;
   qudt:iec61360Code "0112/2///62720#UAB440" ;
   qudt:symbol "international candle" ;
   qudt:uneceCommonCode "P36" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
-  rdfs:label "international candle" .
+  rdfs:label "international candle" ;
+  rdfs:seeAlso unit:HK .
 
 unit:CH
   a qudt:DerivedUnit, qudt:Unit ;
@@ -7023,6 +7043,8 @@ unit:CH
 unit:CHAIN_US
   a qudt:Unit ;
   dcterms:description "unit of the length according the Anglo-American system of units" ;
+  qudt:conversionMultiplier 20.1168 ;
+  qudt:conversionMultiplierSN 2.01168E1 ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Length ;
   qudt:iec61360Code "0112/2///62720#UAA372" ;
@@ -8204,6 +8226,7 @@ unit:CentiM_H2O
   qudt:conversionMultiplier 98.0665 ;
   qudt:conversionMultiplierSN 9.80665E1 ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Centimetre_of_water"^^xsd:anyURI ;
+  qudt:exactMatch unit:CentiM_H2O_4DEG_C ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerArea ;
   qudt:hasQuantityKind quantitykind:VaporPressure ;
@@ -8221,7 +8244,10 @@ unit:CentiM_H2O
 
 unit:CentiM_H2O_4DEG_C
   a qudt:ContextualUnit, qudt:Unit ;
-  dcterms:description "non SI-conform unit of pressure, at which a value of 1 cmH₂O meets the static pressure, which is generated by a head of water at a temperature of 4 °C with a height of 1 centimetre" ;
+  dcterms:description "non SI-conforming unit of pressure, at which a value of 1 cmH₂O means the static pressure which is generated by a head of water at a temperature of 4 °C with a height of 1 centimetre" ;
+  qudt:conversionMultiplier 98.0665 ;
+  qudt:conversionMultiplierSN 9.80665E1 ;
+  qudt:exactMatch unit:CentiM_H2O ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerArea ;
   qudt:hasQuantityKind quantitykind:VaporPressure ;
@@ -8236,6 +8262,7 @@ unit:CentiM_HG
   dcterms:description "A non-SI-conforming unit of pressure, that corresponds with the static pressure generated by a mercury column with the height of 1 centimetre"^^rdf:HTML ;
   qudt:conversionMultiplier 1333.224 ;
   qudt:conversionMultiplierSN 1.333224E3 ;
+  qudt:exactMatch unit:CentiM_HG_0DEG_C ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerArea ;
   qudt:hasQuantityKind quantitykind:VaporPressure ;
@@ -8253,6 +8280,9 @@ unit:CentiM_HG
 unit:CentiM_HG_0DEG_C
   a qudt:ContextualUnit, qudt:Unit ;
   dcterms:description "non SI-conform unit of pressure, at which a value of 1 cmHg meets the static pressure, which is generated by a mercury at a temperature of 0 °C with a height of 1 centimetre" ;
+  qudt:conversionMultiplier 1333.224 ;
+  qudt:conversionMultiplierSN 1.333224E3 ;
+  qudt:exactMatch unit:CentiM_HG ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerArea ;
   qudt:hasQuantityKind quantitykind:VaporPressure ;
@@ -8515,6 +8545,8 @@ unit:DECADE
   qudt:applicableSystem sou:IMPERIAL ;
   qudt:applicableSystem sou:PLANCK ;
   qudt:applicableSystem sou:SI ;
+  qudt:conversionMultiplier 0.0 ;
+  qudt:conversionMultiplierSN 0.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Dimensionless ;
   qudt:iec61360Code "0112/2///62720#UAB338" ;
@@ -10610,7 +10642,9 @@ unit:E
 
 unit:ENZ
   a qudt:Unit ;
-  dcterms:description "unit to express the catalytic activity of a specified chemical redation" ;
+  dcterms:description "unit to express the catalytic activity of a specified chemical reaction" ;
+  qudt:conversionMultiplier 0.000000016667 ;
+  qudt:conversionMultiplierSN 1.6667E-8 ;
   qudt:hasDimensionVector qkdv:A1E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:CatalyticActivity ;
   qudt:iec61360Code "0112/2///62720#UAB600" ;
@@ -10621,6 +10655,8 @@ unit:ENZ
 unit:ENZ-PER-L
   a qudt:Unit ;
   dcterms:description "amount of enzyme units divided by litre" ;
+  qudt:conversionMultiplier 0.000016667 ;
+  qudt:conversionMultiplierSN 1.6667E-5 ;
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:CatalyticActivityConcentration ;
   qudt:iec61360Code "0112/2///62720#UAB601" ;
@@ -11515,7 +11551,7 @@ unit:FC
   rdfs:label "Foot Candle"@en .
 
 unit:FLIGHT
-  a qudt:Unit ;
+  a qudt:ContextualUnit, qudt:CountingUnit, qudt:Unit ;
   qudt:applicableSystem sou:ASU ;
   qudt:applicableSystem sou:CGS ;
   qudt:applicableSystem sou:CGS-EMU ;
@@ -11528,7 +11564,8 @@ unit:FLIGHT
   qudt:hasQuantityKind quantitykind:Dimensionless ;
   qudt:symbol "flight" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
-  rdfs:label "Flight"@en .
+  rdfs:label "Flight"@en ;
+  skos:broader unit:NUM .
 
 unit:FM
   a qudt:Unit ;
@@ -11594,6 +11631,8 @@ unit:FRACTION
 unit:FRAME-PER-SEC
   a qudt:ContextualUnit, qudt:DerivedUnit, qudt:Unit ;
   dcterms:description "\"Frame per Second\" is a unit for  'Video Frame Rate' expressed as $fps$."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0 ;
+  qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VideoFrameRate ;
   qudt:symbol "fps" ;
@@ -12362,6 +12401,7 @@ unit:FT_H2O
   dcterms:description "\"Foot of Water\" is a unit for  'Force Per Area' expressed as $ftH2O$."^^qudt:LatexString ;
   qudt:conversionMultiplier 2989.067 ;
   qudt:conversionMultiplierSN 2.989067E3 ;
+  qudt:exactMatch unit:FT_H2O_39dot2DEG_F ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerArea ;
   qudt:hasQuantityKind quantitykind:VaporPressure ;
@@ -12376,7 +12416,10 @@ unit:FT_H2O
 
 unit:FT_H2O_39dot2DEG_F
   a qudt:Unit ;
-  dcterms:description "non SI-conform unit of pressure according to the Anglo-American and Imperial system for units, whereas the value of 1 ftH₂O is equivalent to the static pressure, which is generated by a head of water at a temperature 39.2°F with a height of 1 foot" ;
+  dcterms:description "non SI-conforming unit of pressure according to the Anglo-American and Imperial system for units, whereas the value of 1 ftH₂O is equivalent to the static pressure generated by a head of water at a temperature 39.2°F with a height of 1 foot" ;
+  qudt:conversionMultiplier 2989.067 ;
+  qudt:conversionMultiplierSN 2.989067E3 ;
+  qudt:exactMatch unit:FT_H2O ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerArea ;
   qudt:hasQuantityKind quantitykind:VaporPressure ;
@@ -12441,6 +12484,8 @@ unit:FUR
 
 unit:FUR_Long
   a qudt:Unit ;
+  dcterms:isReplacedBy unit:FUR ;
+  qudt:deprecated true ;
   qudt:expression "$longfur$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Length ;
@@ -12984,6 +13029,8 @@ unit:GAUSS
 unit:GA_Charriere
   a qudt:Unit ;
   dcterms:description "unit for the diameter of urological instruments and catheters for different purposes corresponding to: 1 Ch = 0,333 333 333 10 ⁻ ³ m" ;
+  qudt:conversionMultiplier 0.0003333333 ;
+  qudt:conversionMultiplierSN 3.333333E-4 ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Length ;
   qudt:iec61360Code "0112/2///62720#UAB382" ;
@@ -14508,6 +14555,8 @@ unit:GR
   qudt:applicableSystem sou:IMPERIAL ;
   qudt:applicableSystem sou:PLANCK ;
   qudt:applicableSystem sou:SI ;
+  qudt:conversionMultiplier 0.0 ;
+  qudt:conversionMultiplierSN 0.0E0 ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Grade"^^xsd:anyURI ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:DimensionlessRatio ;
@@ -15588,13 +15637,16 @@ unit:HART-PER-SEC
 unit:HK
   a qudt:Unit ;
   dcterms:description "obsolete, non-legal unit of the power in Germany relating to DIN 1301-3:1979" ;
+  qudt:conversionMultiplier 0.920 ;
+  qudt:conversionMultiplierSN 9.20E-1 ;
   qudt:hasDimensionVector qkdv:A0E0L0I1M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:LuminousIntensity ;
   qudt:iec61360Code "0112/2///62720#UAB439" ;
   qudt:symbol "HK" ;
   qudt:uneceCommonCode "P35" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
-  rdfs:label "Hefner-Kerze" .
+  rdfs:label "Hefner-Kerze" ;
+  rdfs:seeAlso unit:CD_IN .
 
 unit:HP
   a qudt:Unit ;
@@ -15614,7 +15666,8 @@ unit:HP
   qudt:udunitsCode "hp" ;
   qudt:uneceCommonCode "K43" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
-  rdfs:label "Horsepower"@en .
+  rdfs:label "Horsepower"@en ;
+  rdfs:seeAlso unit:PFERDESTARKE .
 
 unit:HP_Boiler
   a qudt:Unit ;
@@ -16002,7 +16055,11 @@ unit:H_Stat-PER-CentiM
   rdfs:label "Stathenry per Centimetre"@en .
 
 unit:HeartBeat
-  a qudt:Unit ;
+  a qudt:ContextualUnit, qudt:CountingUnit, qudt:Unit ;
+  dcterms:description """A heart beat is a single contraction of the heart muscle,
+  which pumps blood through the circulatory system. The heart rate is the number of heart beats
+  per unit of time, typically measured in beats per minute (bpm). A normal resting 
+  heart rate for adults ranges from 60 to 100 beats per minute."""^^rdf:HTML ;
   qudt:applicableSystem sou:ASU ;
   qudt:applicableSystem sou:CGS ;
   qudt:applicableSystem sou:CGS-EMU ;
@@ -16011,11 +16068,14 @@ unit:HeartBeat
   qudt:applicableSystem sou:IMPERIAL ;
   qudt:applicableSystem sou:PLANCK ;
   qudt:applicableSystem sou:SI ;
+  qudt:conversionMultiplier 0.0 ;
+  qudt:conversionMultiplierSN 0.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Dimensionless ;
   qudt:symbol "heartbeat" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
-  rdfs:label "Heart Beat"@en .
+  rdfs:label "Heart Beat"@en ;
+  skos:broader unit:NUM .
 
 unit:HectoBAR
   a qudt:Unit ;
@@ -16281,6 +16341,7 @@ unit:IN
   qudt:dbpediaMatch "http://dbpedia.org/resource/Inch"^^xsd:anyURI ;
   qudt:definedUnitOfSystem sou:IMPERIAL ;
   qudt:definedUnitOfSystem sou:USCS ;
+  qudt:exactMatch unit:ZOLL ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Length ;
   qudt:iec61360Code "0112/2///62720#UAA539" ;
@@ -16627,14 +16688,15 @@ unit:IN_H2O
   a qudt:Unit ;
   dcterms:description "Inches of water, wc, inch water column (inch WC), inAq, Aq, or inH2O is a non-SI unit for pressure. The units are by convention and due to the historical measurement of certain pressure differentials. It is used for measuring small pressure differences across an orifice, or in a pipeline or shaft. Inches of water can be converted to a pressure unit using the formula for pressure head. It is defined as the pressure exerted by a column of water of 1 inch in height at defined conditions for example $39 ^\\circ F$ at the standard acceleration of gravity; 1 inAq is approximately equal to 249 pascals at $0 ^\\circ C$."^^qudt:LatexString ;
   qudt:applicableSystem sou:USCS ;
-  qudt:conversionMultiplier 249.080024 ;
-  qudt:conversionMultiplierSN 2.49080024E2 ;
+  qudt:conversionMultiplier 249.0889 ;
+  qudt:conversionMultiplierSN 2.490889E2 ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Inch_of_water"^^xsd:anyURI ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerArea ;
   qudt:hasQuantityKind quantitykind:VaporPressure ;
   qudt:iec61360Code "0112/2///62720#UAA553" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Inch_of_water?oldid=466175519"^^xsd:anyURI ;
+  qudt:informativeReference "https://physics.nist.gov/cuu/pdf/sp811.pdf"^^xsd:anyURI ;
   qudt:symbol "inH₂O" ;
   qudt:ucumCode "[in_i'H2O]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F78" ;
@@ -16644,10 +16706,13 @@ unit:IN_H2O
 unit:IN_H2O_39dot2DEG_F
   a qudt:Unit ;
   dcterms:description "non SI-conform unit of pressure according to the Anglo-American and Imperial system for units, whereas the value of 1 inH₂O meets the static pressure, which is generated by a head of water at a temperature of 39.2°F with a height of 1 inch" ;
+  qudt:conversionMultiplier 249.082 ;
+  qudt:conversionMultiplierSN 2.49082E2 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerArea ;
   qudt:hasQuantityKind quantitykind:VaporPressure ;
   qudt:iec61360Code "0112/2///62720#UAB240" ;
+  qudt:informativeReference "https://physics.nist.gov/cuu/pdf/sp811.pdf"^^xsd:anyURI ;
   qudt:symbol "inH₂O (39.2 °F)" ;
   qudt:uneceCommonCode "N18" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -16656,10 +16721,13 @@ unit:IN_H2O_39dot2DEG_F
 unit:IN_H2O_60DEG_F
   a qudt:Unit ;
   dcterms:description "non SI-conform unit of pressure according to the Anglo-American and Imperial system for units, whereas the value of 1 inH₂O meets the static pressure, which is generated by a head of water at a temperature of 60°F with a height of 1 inch" ;
+  qudt:conversionMultiplier 248.84 ;
+  qudt:conversionMultiplierSN 2.4884E2 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerArea ;
   qudt:hasQuantityKind quantitykind:VaporPressure ;
   qudt:iec61360Code "0112/2///62720#UAB241" ;
+  qudt:informativeReference "https://physics.nist.gov/cuu/pdf/sp811.pdf"^^xsd:anyURI ;
   qudt:symbol "inH₂O (60 °F)" ;
   qudt:uneceCommonCode "N19" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -16688,6 +16756,8 @@ unit:IN_HG
 unit:IN_HG_32DEG_F
   a qudt:Unit ;
   dcterms:description "non SI-conform unit of pressure according to the Anglo-American and Imperial system for units, whereas the value of 1 inHg meets the static pressure, which is generated by a mercury at a temperature of 32°F with a height of 1 inch" ;
+  qudt:conversionMultiplier 3386.38 ;
+  qudt:conversionMultiplierSN 3.38638E3 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerArea ;
   qudt:hasQuantityKind quantitykind:VaporPressure ;
@@ -16700,6 +16770,8 @@ unit:IN_HG_32DEG_F
 unit:IN_HG_60DEG_F
   a qudt:Unit ;
   dcterms:description "non SI-conform unit of pressure according to the Anglo-American and Imperial system for units, whereas the value of 1 inHg meets the static pressure, which is generated by a mercury at a temperature of 60°F with a height of 1 inch" ;
+  qudt:conversionMultiplier 3376.85 ;
+  qudt:conversionMultiplierSN 3.37685E3 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerArea ;
   qudt:hasQuantityKind quantitykind:VaporPressure ;
@@ -16715,6 +16787,8 @@ unit:IU
   The $\\textit{International Unit}$ is a unit for $\\textit{Amount Of Substance}$ expressed as $IU$.
   Note that the magnitude depends on the substance, thus there is no fixed conversion multiplier.
   """^^qudt:LatexString ;
+  qudt:conversionMultiplier 0.0 ;
+  qudt:conversionMultiplierSN 0.0E0 ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/International_unit"^^xsd:anyURI ;
   qudt:hasDimensionVector qkdv:A1E0L0I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:AmountOfSubstance ;
@@ -22401,7 +22475,9 @@ unit:LA
 
 unit:LANGLEY
   a qudt:Unit ;
-  dcterms:description "[CGS] unit of the areal-related energy transmission (as a measure of the incendent quantity of heat of solar radiation on the earth's surface)" ;
+  dcterms:description "[CGS] unit of the areal-related energy transmission (as a measure of the incident quantity of heat of solar radiation on the earth's surface)" ;
+  qudt:conversionMultiplier 41840.0 ;
+  qudt:conversionMultiplierSN 4.184E04 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:EnergyFluence ;
   qudt:hasQuantityKind quantitykind:EnergyPerArea ;
@@ -26286,7 +26362,7 @@ unit:M6
 
 unit:MACH
   a qudt:DimensionlessUnit, qudt:Unit ;
-  dcterms:description "\"Mach\" is a unit for  'Dimensionless Ratio' expressed as $mach$."^^qudt:LatexString ;
+  dcterms:description "\"Mach\" is a unit for speed as a multiple of the ambient speed of sound, expressed as $mach$."^^qudt:LatexString ;
   qudt:applicableSystem sou:ASU ;
   qudt:applicableSystem sou:CGS ;
   qudt:applicableSystem sou:CGS-EMU ;
@@ -26295,6 +26371,8 @@ unit:MACH
   qudt:applicableSystem sou:IMPERIAL ;
   qudt:applicableSystem sou:PLANCK ;
   qudt:applicableSystem sou:SI ;
+  qudt:conversionMultiplier 0.0 ;
+  qudt:conversionMultiplierSN 0.0E0 ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Mach"^^xsd:anyURI ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:MachNumber ;
@@ -26655,6 +26733,8 @@ unit:MI_N-PER-MIN
 unit:MI_UK3
   a qudt:Unit ;
   dcterms:description "unit of volume according to the Imperial system of units" ;
+  qudt:conversionMultiplier 4168181825.44057958 ;
+  qudt:conversionMultiplierSN 4.16818182544057958E9 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:SectionModulus ;
   qudt:hasQuantityKind quantitykind:Volume ;
@@ -27299,9 +27379,12 @@ unit:MOL_LB-PER-SEC
 unit:MOMME_Pearl
   a qudt:Unit ;
   dcterms:description "unit momme (pearl) specifically expresses the mass of cultured pearls" ;
+  qudt:conversionMultiplier 3.750 ;
+  qudt:conversionMultiplierSN 3.750E0 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Mass ;
   qudt:iec61360Code "0112/2///62720#UAB598" ;
+  qudt:informativeReference "https://en.wikipedia.org/wiki/Pearl#Momme_weight"^^xsd:anyURI ;
   qudt:symbol "momme (pearl)" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Momme (pearl)" .
@@ -27309,6 +27392,8 @@ unit:MOMME_Pearl
 unit:MOMME_Textile
   a qudt:Unit ;
   dcterms:description "unit momme (textile) specifically express the weight of one square metre of silk" ;
+  qudt:conversionMultiplier 0.004340 ;
+  qudt:conversionMultiplierSN 4.340E-3 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Mass ;
   qudt:iec61360Code "0112/2///62720#UAB599" ;
@@ -27318,6 +27403,8 @@ unit:MOMME_Textile
 
 unit:MO_MeanGREGORIAN
   a qudt:Unit ;
+  qudt:conversionMultiplier 2629746.0 ;
+  qudt:conversionMultiplierSN 2.629746E6 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Time ;
   qudt:informativeReference "https://conversion.org/time/month-gregorian-average/"^^xsd:anyURI ;
@@ -27329,6 +27416,8 @@ unit:MO_MeanGREGORIAN
 
 unit:MO_MeanJulian
   a qudt:Unit ;
+  qudt:conversionMultiplier 2629800.0 ;
+  qudt:conversionMultiplierSN 2.6298E6 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Time ;
   qudt:informativeReference "https://www.convertunits.com/info/Julian+month"^^xsd:anyURI ;
@@ -27340,6 +27429,8 @@ unit:MO_MeanJulian
 unit:MO_Synodic
   a qudt:Unit ;
   dcterms:description "A unit of time corresponding approximately to one cycle of the moon's phases, or about 30 days or 4 weeks and calculated as 29.53059 days."^^rdf:HTML ;
+  qudt:conversionMultiplier 2551442.976 ;
+  qudt:conversionMultiplierSN 2.551442976E6 ;
   qudt:exactMatch unit:MO ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Time ;
@@ -27369,7 +27460,9 @@ unit:MX
 
 unit:M_H2O
   a qudt:Unit ;
-  dcterms:description "not SI-conform unit of pressure, whereas a value of 1 mH₂O is equivalent to the static pressure, which is produced by one metre high watercolumn" ;
+  dcterms:description "not SI-conforming unit of pressure, whereas a value of 1 mH₂O is equivalent to the static pressure produced by one metre high watercolumn" ;
+  qudt:conversionMultiplier 9806.65 ;
+  qudt:conversionMultiplierSN 9.80665E3 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerArea ;
   qudt:hasQuantityKind quantitykind:VaporPressure ;
@@ -27822,6 +27915,8 @@ unit:MegaEV-PER-CentiM
 unit:MegaEV-PER-SpeedOfLight
   a qudt:Unit ;
   dcterms:description "\"Mega Electron Volt per Speed of Light\" is a unit for  'Linear Momentum' expressed as $MeV/c$."^^qudt:LatexString ;
+  qudt:conversionMultiplier 0.000000000000000000000534369681 ;
+  qudt:conversionMultiplierSN 5.34369681E-22 ;
   qudt:expression "$MeV/c$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:LinearMomentum ;
@@ -27834,6 +27929,8 @@ unit:MegaEV-PER-SpeedOfLight
 unit:MegaFLOPS
   a qudt:Unit ;
   dcterms:description "1,000,000-fold of the unit floating point operations divided by the SI base unit second" ;
+  qudt:conversionMultiplier 1000000.0 ;
+  qudt:conversionMultiplierSN 1.0E6 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:FloatingPointCalculationCapability ;
   qudt:iec61360Code "0112/2///62720#UAB591" ;
@@ -35254,6 +35351,8 @@ unit:NP
   a qudt:DimensionlessUnit, qudt:LogarithmicUnit, qudt:Unit ;
   dcterms:description "The neper is a logarithmic unit for ratios of measurements of physical field and power quantities, such as gain and loss of electronic signals. It has the unit symbol Np. The unit's name is derived from the name of John Napier, the inventor of logarithms. As is the case for the decibel and bel, the neper is not a unit in the International System of Units (SI), but it is accepted for use alongside the SI. Like the decibel, the neper is a unit in a logarithmic scale. While the bel uses the decadic (base-10) logarithm to compute ratios, the neper uses the natural logarithm, based on Euler's number"^^rdf:HTML ;
   qudt:applicableSystem sou:SI ;
+  qudt:conversionMultiplier 0.0 ;
+  qudt:conversionMultiplierSN 0.0E0 ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Neper"^^xsd:anyURI ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Dimensionless ;
@@ -35269,8 +35368,8 @@ unit:NP
 unit:NP-PER-SEC
   a qudt:Unit ;
   dcterms:description "unit neper divided by the SI base unit second" ;
-  qudt:conversionMultiplier 1.0 ;
-  qudt:conversionMultiplierSN 1.0E0 ;
+  qudt:conversionMultiplier 0.0 ;
+  qudt:conversionMultiplierSN 0.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA254" ;
@@ -35303,6 +35402,8 @@ unit:NTU
   a qudt:Unit ;
   dcterms:description "\"Nephelometry Turbidity Unit\" is a C.G.S System unit for  'Turbidity' expressed as $NTU$."^^qudt:LatexString ;
   qudt:applicableSystem sou:CGS ;
+  qudt:conversionMultiplier 0.0 ;
+  qudt:conversionMultiplierSN 0.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Turbidity ;
   qudt:symbol "NTU" ;
@@ -36722,6 +36823,8 @@ unit:OCT
   qudt:applicableSystem sou:IMPERIAL ;
   qudt:applicableSystem sou:PLANCK ;
   qudt:applicableSystem sou:SI ;
+  qudt:conversionMultiplier 0.0 ;
+  qudt:conversionMultiplierSN 0.0E0 ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Octave"^^xsd:anyURI ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Dimensionless ;
@@ -36736,6 +36839,9 @@ unit:OCT
 unit:OCTET
   a qudt:Unit ;
   dcterms:description "synonym for byte: 1 octet = 8 bit = 1 byte" ;
+  qudt:conversionMultiplier 5.5451774444795624753378569716654 ;
+  qudt:conversionMultiplierSN 5.5451774444795624753378569716654E0 ;
+  qudt:exactMatch unit:BYTE ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:DatasetOfBits ;
   qudt:iec61360Code "0112/2///62720#UAB341" ;
@@ -37019,6 +37125,8 @@ unit:OHM_Ab
 unit:OHM_CIRC-MIL-PER-FT
   a qudt:Unit ;
   dcterms:description "unit of resistivity" ;
+  qudt:conversionMultiplier 0.000000001662426113 ;
+  qudt:conversionMultiplierSN 1.662426113E-9 ;
   qudt:hasDimensionVector qkdv:A0E-2L3I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:Resistivity ;
   qudt:iec61360Code "0112/2///62720#UAB215" ;
@@ -37060,6 +37168,8 @@ unit:OKTA
   9: Sky obscured by fog and/or other meteorological phenomena;
   /: Cloud cover is indiscernible for reasons other than fog or other meteorological phenomena, or observation is not made.
   """^^rdf:HTML ;
+  qudt:conversionMultiplier 0.0 ;
+  qudt:conversionMultiplierSN 0.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:AmountOfCloudCover ;
   qudt:informativeReference "https://windy.app/blog/okta-cloud-cover.html"^^xsd:anyURI ;
@@ -41029,17 +41139,22 @@ unit:PERM_US
 unit:PFERDESTAERKE
   a qudt:Unit ;
   dcterms:description "obsolete, non-legal unit of the power in Germany relating to DIN 1301-3:1979" ;
+  qudt:conversionMultiplier 735.49875 ;
+  qudt:conversionMultiplierSN 7.3549875E2 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAB438" ;
   qudt:symbol "PS" ;
   qudt:uneceCommonCode "N12" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
-  rdfs:label "Pferdestaerke" .
+  rdfs:label "Pferdestaerke" ;
+  rdfs:seeAlso unit:HP .
 
 unit:PFUND
   a qudt:Unit ;
   dcterms:description "outdated unit of the mass in Germany" ;
+  qudt:conversionMultiplier 0.5 ;
+  qudt:conversionMultiplierSN 5.0E-1 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Mass ;
   qudt:iec61360Code "0112/2///62720#UAB387" ;
@@ -41096,6 +41211,8 @@ unit:PH
   qudt:applicableSystem sou:IMPERIAL ;
   qudt:applicableSystem sou:PLANCK ;
   qudt:applicableSystem sou:SI ;
+  qudt:conversionMultiplier 0.0 ;
+  qudt:conversionMultiplierSN 0.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Acidity ;
   qudt:hasQuantityKind quantitykind:Basicity ;
@@ -42000,6 +42117,8 @@ unit:PSU
   qudt:applicableSystem sou:IMPERIAL ;
   qudt:applicableSystem sou:PLANCK ;
   qudt:applicableSystem sou:SI ;
+  qudt:conversionMultiplier 0.0 ;
+  qudt:conversionMultiplierSN 0.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:DimensionlessRatio ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Salinity#PSU"^^xsd:anyURI ;
@@ -43941,6 +44060,8 @@ unit:REV-PER-SEC2
 unit:RHE
   a qudt:Unit ;
   dcterms:description "non SI-conforming unit of fluidity of dynamic viscosity" ;
+  qudt:conversionMultiplier 10.0 ;
+  qudt:conversionMultiplierSN 1.0E1 ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M-1H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Fluidity ;
   qudt:iec61360Code "0112/2///62720#UAB228" ;
@@ -44004,6 +44125,8 @@ unit:R_man
 unit:RichterMagnitude
   a qudt:Unit ;
   dcterms:description "unit Richter magnitude expressing size of an earthquake in accordance to a specific scale" ;
+  qudt:conversionMultiplier 0.0 ;
+  qudt:conversionMultiplierSN 0.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:EarthquakeMagnitude ;
   qudt:iec61360Code "0112/2///62720#UAB596" ;
@@ -44648,6 +44771,8 @@ unit:SON
 unit:SPF
   a qudt:Unit ;
   dcterms:description "the sunprotection factor is a dimensionless value expressing the required amount of protection against solar radiation" ;
+  qudt:conversionMultiplier 0.0 ;
+  qudt:conversionMultiplierSN 0.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:SunProtectionFactorOfAProduct ;
   qudt:iec61360Code "0112/2///62720#UAB597" ;
@@ -44658,6 +44783,8 @@ unit:SPF
 unit:SPIN_QUANTUM_NUMBER
   a qudt:Unit ;
   dcterms:description "dimensionless atomic value expressing a system’s spin" ;
+  qudt:conversionMultiplier 0.0 ;
+  qudt:conversionMultiplierSN 0.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAB604" ;
@@ -46137,10 +46264,13 @@ unit:TON_Metric-PER-SEC-K
 unit:TON_Register
   a qudt:Unit ;
   dcterms:description "traditional unit of the cargo capacity" ;
+  qudt:conversionMultiplier 2.830 ;
+  qudt:conversionMultiplierSN 2.830E0 ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:SectionModulus ;
   qudt:hasQuantityKind quantitykind:Volume ;
   qudt:iec61360Code "0112/2///62720#UAB291" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Register_ton"^^xsd:anyURI ;
   qudt:symbol "RT" ;
   qudt:uneceCommonCode "M70" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -46996,6 +47126,8 @@ unit:UNITLESS
 unit:UNKNOWN
   a qudt:Unit ;
   dcterms:description "Placeholder unit for abstract quantities" ;
+  qudt:conversionMultiplier 0.0 ;
+  qudt:conversionMultiplierSN 0.0E0 ;
   qudt:hasDimensionVector qkdv:NotApplicable ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:symbol "Unknown" ;
@@ -48783,6 +48915,8 @@ unit:YR_Common
 unit:YR_Metrology
   a qudt:Unit ;
   dcterms:description "31,557,600-fold of the SI base unit second according to one year with 365.25 days as physical quantity in the metrology" ;
+  qudt:conversionMultiplier 31557600.0 ;
+  qudt:conversionMultiplierSN 3.15576E7 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Time ;
   qudt:iec61360Code "0112/2///62720#UAD922" ;
@@ -48869,9 +49003,11 @@ unit:YottaC
   rdfs:label "YottaCoulomb"@en .
 
 unit:Z
-  a qudt:Unit ;
+  a qudt:CountingUnit, qudt:Unit ;
   dcterms:description "In chemistry and physics, the atomic number (also known as the proton number) is the number of protons found in the nucleus of an atom and therefore identical to the charge number of the nucleus. It is conventionally represented by the symbol Z. The atomic number uniquely identifies a chemical element. In an atom of neutral charge, the atomic number is also equal to the number of electrons."^^rdf:HTML ;
   qudt:applicableSystem sou:CGS ;
+  qudt:conversionMultiplier 0.0 ;
+  qudt:conversionMultiplierSN 0.0E0 ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Atomic_number"^^xsd:anyURI ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:AtomicNumber ;
@@ -48883,6 +49019,9 @@ unit:Z
 unit:ZOLL
   a qudt:Unit ;
   dcterms:description "length measure corresponding to the imperial unit \"inch\"" ;
+  qudt:conversionMultiplier 0.0254 ;
+  qudt:conversionMultiplierSN 2.54E-2 ;
+  qudt:exactMatch unit:IN ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Length ;
   qudt:iec61360Code "0112/2///62720#UAB837" ;

--- a/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
+++ b/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
@@ -29659,8 +29659,6 @@ unit:MicroKAT-PER-L
   a qudt:DerivedUnit, qudt:Unit ;
   dcterms:description "A unit of catalytic activity used especially in the chemistry of enzymes. A catalyst is a substance that starts or speeds a chemical reaction. Enzymes are proteins that act as catalysts within the bodies of living plants and animals. A catalyst has an activity of one katal if it enables a reaction to proceed at the rate of one mole per second. "^^rdf:HTML ;
   qudt:applicableSystem sou:SI ;
-  qudt:conversionMultiplier 0.000000001 ;
-  qudt:conversionMultiplierSN 1.0E-9 ;
   qudt:definedUnitOfSystem sou:SI ;
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:CatalyticActivityConcentration ;
@@ -32560,8 +32558,6 @@ unit:MilliKAT-PER-L
   a qudt:DerivedUnit, qudt:Unit ;
   dcterms:description "A unit of catalytic activity used especially in the chemistry of enzymes. A catalyst is a substance that starts or speeds a chemical reaction. Enzymes are proteins that act as catalysts within the bodies of living plants and animals. A catalyst has an activity of one katal if it enables a reaction to proceed at the rate of one mole per second. "^^rdf:HTML ;
   qudt:applicableSystem sou:SI ;
-  qudt:conversionMultiplier 0.000001 ;
-  qudt:conversionMultiplierSN 1.0E-6 ;
   qudt:definedUnitOfSystem sou:SI ;
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:CatalyticActivityConcentration ;
@@ -33721,8 +33717,6 @@ unit:MilliOSM
 unit:MilliOSM-PER-KiloGM
   a qudt:Unit ;
   dcterms:description "0.001-fold of the unit Osmol divided by the SI base unit kilogram" ;
-  qudt:conversionMultiplier 0.001 ;
-  qudt:conversionMultiplierSN 1.0E-3 ;
   qudt:hasDimensionVector qkdv:A1E0L0I0M-1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:AmountOfSubstancePerMass ;
   qudt:symbol "mOsmol/kg" ;
@@ -36124,8 +36118,6 @@ unit:NanoKAT-PER-L
   a qudt:DerivedUnit, qudt:Unit ;
   dcterms:description "A unit of catalytic activity used especially in the chemistry of enzymes. A catalyst is a substance that starts or speeds a chemical reaction. Enzymes are proteins that act as catalysts within the bodies of living plants and animals. A catalyst has an activity of one katal if it enables a reaction to proceed at the rate of one mole per second. "^^rdf:HTML ;
   qudt:applicableSystem sou:SI ;
-  qudt:conversionMultiplier 0.000000000001 ;
-  qudt:conversionMultiplierSN 1.0E-12 ;
   qudt:definedUnitOfSystem sou:SI ;
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:CatalyticActivityConcentration ;
@@ -42607,8 +42599,6 @@ unit:PicoKAT-PER-L
   a qudt:DerivedUnit, qudt:Unit ;
   dcterms:description "A unit of catalytic activity used especially in the chemistry of enzymes. A catalyst is a substance that starts or speeds a chemical reaction. Enzymes are proteins that act as catalysts within the bodies of living plants and animals. A catalyst has an activity of one katal if it enables a reaction to proceed at the rate of one mole per second. "^^rdf:HTML ;
   qudt:applicableSystem sou:SI ;
-  qudt:conversionMultiplier 0.000000000000001 ;
-  qudt:conversionMultiplierSN 1.0E-15 ;
   qudt:definedUnitOfSystem sou:SI ;
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:CatalyticActivityConcentration ;

--- a/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
+++ b/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
@@ -16068,8 +16068,8 @@ unit:HeartBeat
   qudt:applicableSystem sou:IMPERIAL ;
   qudt:applicableSystem sou:PLANCK ;
   qudt:applicableSystem sou:SI ;
-  qudt:conversionMultiplier 0.0 ;
-  qudt:conversionMultiplierSN 0.0E0 ;
+  qudt:conversionMultiplier 1.0 ;
+  qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Dimensionless ;
   qudt:symbol "heartbeat" ;

--- a/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
+++ b/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
@@ -10014,6 +10014,8 @@ unit:DeciB
   qudt:applicableSystem sou:IMPERIAL ;
   qudt:applicableSystem sou:PLANCK ;
   qudt:applicableSystem sou:SI ;
+  qudt:conversionMultiplier 0.0 ;
+  qudt:conversionMultiplierSN 0.0E0 ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Decibel"^^xsd:anyURI ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:SoundExposureLevel ;
@@ -10122,7 +10124,9 @@ unit:DeciBAR-PER-YR
 
 unit:DeciB_A
   a qudt:Unit ;
-  dcterms:description "unit of sound pressure level with frequency weighting A" ;
+  dcterms:description "Logarithmic unit of sound pressure level with frequency weighting A" ;
+  qudt:conversionMultiplier 0.0 ;
+  qudt:conversionMultiplierSN 0.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:SoundExposureLevel ;
   qudt:hasQuantityKind quantitykind:SoundPowerLevel ;
@@ -10135,7 +10139,7 @@ unit:DeciB_A
 
 unit:DeciB_C
   a qudt:Unit ;
-  dcterms:description "\"Decibel Carrier Unit\" is a unit for  'Signal Detection Threshold' expressed as $dBc$."^^qudt:LatexString ;
+  dcterms:description "\"Decibel Carrier Unit\" is a logarithmic unit for  'Signal Detection Threshold' expressed as $dBc$."^^qudt:LatexString ;
   qudt:applicableSystem sou:ASU ;
   qudt:applicableSystem sou:CGS ;
   qudt:applicableSystem sou:CGS-EMU ;
@@ -10144,6 +10148,8 @@ unit:DeciB_C
   qudt:applicableSystem sou:IMPERIAL ;
   qudt:applicableSystem sou:PLANCK ;
   qudt:applicableSystem sou:SI ;
+  qudt:conversionMultiplier 0.0 ;
+  qudt:conversionMultiplierSN 0.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:SignalDetectionThreshold ;
   qudt:iec61360Code "0112/2///62720#UAD894" ;
@@ -10153,7 +10159,9 @@ unit:DeciB_C
 
 unit:DeciB_ISO
   a qudt:Unit ;
-  dcterms:description "antenna gain of a transmitted or received signal" ;
+  dcterms:description "Logarithmic antenna gain of a transmitted or received signal" ;
+  qudt:conversionMultiplier 0.0 ;
+  qudt:conversionMultiplierSN 0.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:SoundExposureLevel ;
   qudt:hasQuantityKind quantitykind:SoundPowerLevel ;
@@ -10166,7 +10174,7 @@ unit:DeciB_ISO
 
 unit:DeciB_M
   a qudt:DimensionlessUnit, qudt:Unit ;
-  dcterms:description "\"Decibel Referred to 1mw\" is a 'Dimensionless Ratio' expressed as $dBm$."^^qudt:LatexString ;
+  dcterms:description "\"Decibel Referred to 1mw\" is a 'Logarithmic Dimensionless Ratio' expressed as $dBm$."^^qudt:LatexString ;
   qudt:applicableSystem sou:ASU ;
   qudt:applicableSystem sou:CGS ;
   qudt:applicableSystem sou:CGS-EMU ;
@@ -10175,6 +10183,8 @@ unit:DeciB_M
   qudt:applicableSystem sou:IMPERIAL ;
   qudt:applicableSystem sou:PLANCK ;
   qudt:applicableSystem sou:SI ;
+  qudt:conversionMultiplier 0.0 ;
+  qudt:conversionMultiplierSN 0.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:SoundExposureLevel ;
   qudt:hasQuantityKind quantitykind:SoundPowerLevel ;
@@ -10188,7 +10198,9 @@ unit:DeciB_M
 
 unit:DeciB_Z
   a qudt:Unit ;
-  dcterms:description "unit of sound pressure level with frequency weighting Z (ZERO or linear weighting)" ;
+  dcterms:description "Logarithmic unit of sound pressure level with frequency weighting Z (ZERO or linear weighting)" ;
+  qudt:conversionMultiplier 0.0 ;
+  qudt:conversionMultiplierSN 0.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:SoundExposureLevel ;
   qudt:hasQuantityKind quantitykind:SoundPowerLevel ;

--- a/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
+++ b/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
@@ -19843,7 +19843,7 @@ unit:KiloGM-PER-M2-PA-SEC
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:exactMatch unit:S-PER-M ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T1D0 ;
-  qudt:hasQuantityKind quantitykind:VaporPermeance ;
+  qudt:hasQuantityKind quantitykind:VapourPermeance ;
   qudt:iec61360Code "0112/2///62720#UAB481" ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Perm_(unit)"^^xsd:anyURI ;
   qudt:symbol "kg/(m²·Pa·s)" ;
@@ -20119,7 +20119,7 @@ unit:KiloGM-PER-PA-SEC-M
   qudt:conversionMultiplier 1.0 ;
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T1D0 ;
-  qudt:hasQuantityKind quantitykind:VaporPermeability ;
+  qudt:hasQuantityKind quantitykind:VapourPermeability ;
   qudt:hasQuantityKind quantitykind:WaterVaporDiffusionCoefficient ;
   qudt:plainTextDescription "Common unit for the Water vapour diffusion coefficient" ;
   qudt:symbol "kg/(Pa·s·m)" ;
@@ -36006,7 +36006,7 @@ unit:NanoGM-PER-M2-PA-SEC
   qudt:conversionMultiplier 0.000000000001 ;
   qudt:conversionMultiplierSN 1.0E-12 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T1D0 ;
-  qudt:hasQuantityKind quantitykind:VaporPermeance ;
+  qudt:hasQuantityKind quantitykind:VapourPermeance ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Perm_(unit)"^^xsd:anyURI ;
   qudt:symbol "ng/(m²·Pa·s)" ;
   qudt:ucumCode "ng.m-2.Pa-1.s-1"^^qudt:UCUMcs ;
@@ -41065,10 +41065,10 @@ unit:PERMITTIVITY_REL
 
 unit:PERM_0DEG_C
   a qudt:Unit ;
-  dcterms:description "traditional unit for the ability of a material to allow the transition of the steam, defined at a temperature of 0 °C as steam transmittance, where the mass of one grain steam penetrates an area of one foot squared at a pressure from one inch mercury per hour" ;
-  qudt:exactMatch unit:PERM_Metric_0DEG_C ;
+  dcterms:description "The rate of water vapor transmission through a specific thickness of a material—i.e., the permeability divided by the thickness." ;
+  qudt:deprecated true ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T1D0 ;
-  qudt:hasQuantityKind quantitykind:WaterVapourPermeability ;
+  qudt:hasQuantityKind quantitykind:VapourPermeance ;
   qudt:iec61360Code "0112/2///62720#UAB294" ;
   qudt:symbol "perm (0 °C)" ;
   qudt:uneceCommonCode "P91" ;
@@ -41077,10 +41077,10 @@ unit:PERM_0DEG_C
 
 unit:PERM_23DEG_C
   a qudt:Unit ;
-  dcterms:description "traditional unit for the ability of a material to allow the transition of the steam, defined at a temperature of 23 °C as steam transmittance at which the mass of one grain of steam penetrates an area of one square foot at a pressure of one inch mercury per hour" ;
-  qudt:exactMatch unit:PERM_Metric_23DEG_C ;
+  dcterms:description "The rate of water vapor transmission through a specific thickness of a material—i.e., the permeability divided by the thickness." ;
+  qudt:deprecated true ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T1D0 ;
-  qudt:hasQuantityKind quantitykind:WaterVapourPermeability ;
+  qudt:hasQuantityKind quantitykind:VapourPermeance ;
   qudt:iec61360Code "0112/2///62720#UAB295" ;
   qudt:symbol "perm (23 °C)" ;
   qudt:uneceCommonCode "P92" ;
@@ -41089,12 +41089,13 @@ unit:PERM_23DEG_C
 
 unit:PERM_Metric
   a qudt:Unit ;
-  dcterms:description "A perm is a unit of permeance or \"water vapor transmission\" given a certain differential in partial pressures on either side of a material or membrane. The metric perm (not an SI unit) is defined as 1 gram of water vapor per day, per square metre, per millimeter of mercury."@en ;
-  qudt:conversionMultiplier 0.0000000000868127 ;
-  qudt:conversionMultiplierSN 8.68127E-11 ;
+  dcterms:description "The rate of water vapor transmission through a specific thickness of a material—i.e., the permeability divided by the thickness." ;
+  qudt:conversionMultiplier 0.000000000001 ;
+  qudt:conversionMultiplierSN 1.0E-12 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T1D0 ;
-  qudt:hasQuantityKind quantitykind:VaporPermeance ;
+  qudt:hasQuantityKind quantitykind:VapourPermeance ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Perm_(unit)"^^xsd:anyURI ;
+  qudt:latexDefinition "\\frac{ng}{s \\cdot m^2 \\cdot Pa}"^^qudt:LatexString ;
   qudt:symbol "perm{Metric}" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Metric Perm"@en .
@@ -41102,9 +41103,9 @@ unit:PERM_Metric
 unit:PERM_Metric_0DEG_C
   a qudt:Unit ;
   dcterms:description "traditional unit for the ability of a material to allow the transition of the steam, defined at a temperature of 0 °C as steam transmittance, where the mass of one grain steam penetrates an area of one foot squared at a pressure from one inch mercury per hour" ;
-  qudt:exactMatch unit:PERM_0DEG_C ;
+  qudt:deprecated true ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T1D0 ;
-  qudt:hasQuantityKind quantitykind:VaporPermeance ;
+  qudt:hasQuantityKind quantitykind:VapourPermeance ;
   qudt:iec61360Code "0112/2///62720#UAB294" ;
   qudt:symbol "perm (0 °C)" ;
   qudt:uneceCommonCode "P91" ;
@@ -41114,9 +41115,9 @@ unit:PERM_Metric_0DEG_C
 unit:PERM_Metric_23DEG_C
   a qudt:Unit ;
   dcterms:description "traditional unit for the ability of a material to allow the transition of the steam, defined at a temperature of 23 °C as steam transmittance at which the mass of one grain of steam penetrates an area of one square foot at a pressure of one inch mercury per hour" ;
-  qudt:exactMatch unit:PERM_23DEG_C ;
+  qudt:deprecated true ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T1D0 ;
-  qudt:hasQuantityKind quantitykind:VaporPermeance ;
+  qudt:hasQuantityKind quantitykind:VapourPermeance ;
   qudt:iec61360Code "0112/2///62720#UAB295" ;
   qudt:symbol "perm (23 °C)" ;
   qudt:uneceCommonCode "P92" ;
@@ -41125,13 +41126,14 @@ unit:PERM_Metric_23DEG_C
 
 unit:PERM_US
   a qudt:Unit ;
-  dcterms:description "A perm is a unit of permeance or \"water vapor transmission\" given a certain differential in partial pressures on either side of a material or membrane. The U.S. perm is defined as 1 grain of water vapor per hour, per square foot, per inch of mercury."@en ;
+  dcterms:description "The rate of water vapor transmission through a specific thickness of a material—i.e., the permeability divided by the thickness." ;
   qudt:applicableSystem sou:USCS ;
   qudt:conversionMultiplier 0.0000000000572135 ;
   qudt:conversionMultiplierSN 5.72135E-11 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T1D0 ;
-  qudt:hasQuantityKind quantitykind:VaporPermeance ;
+  qudt:hasQuantityKind quantitykind:VapourPermeance ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Perm_(unit)"^^xsd:anyURI ;
+  qudt:latexDefinition "\\frac{grain}{hour \\cdot ft^2 \\cdot in\\,Hg}"^^qudt:LatexString ;
   qudt:symbol "perm{US}" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "U.S. Perm"@en .
@@ -45333,6 +45335,8 @@ unit:TEX
 unit:THERM_EC
   a qudt:Unit ;
   dcterms:description "unit of heat energy in commercial use, within the EU defined: 1 thm (EC) = 100 000 BtuIT" ;
+  qudt:conversionMultiplier 1055055852.62 ;
+  qudt:conversionMultiplierSN 1.05505585262E9 ;
   qudt:exactMatch unit:THM_EEC ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Energy ;
@@ -45358,6 +45362,8 @@ unit:THERM_US
 
 unit:THM_EEC
   a qudt:Unit ;
+  qudt:conversionMultiplier 1055055852.62 ;
+  qudt:conversionMultiplierSN 1.05505585262E9 ;
   qudt:exactMatch unit:THERM_EC ;
   qudt:expression "$therm-eec$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;

--- a/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
+++ b/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
@@ -42345,6 +42345,8 @@ unit:PetaC
 unit:PetaFLOPS
   a qudt:Unit ;
   dcterms:description "1,000,000,000,000,000-fold of the unit floating point operations divided by the SI base unit second" ;
+  qudt:conversionMultiplier 1000000000000000.0 ;
+  qudt:conversionMultiplierSN 1.0E15 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:FloatingPointCalculationCapability ;
   qudt:iec61360Code "0112/2///62720#UAB594" ;
@@ -46783,6 +46785,8 @@ unit:TeraC
 unit:TeraFLOPS
   a qudt:Unit ;
   dcterms:description "1,000,000,000,000-fold of the unit floating point operations divided by the SI base unit second" ;
+  qudt:conversionMultiplier 1000000000000.0 ;
+  qudt:conversionMultiplierSN 1.0E12 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:FloatingPointCalculationCapability ;
   qudt:iec61360Code "0112/2///62720#UAB593" ;


### PR DESCRIPTION
Replaces a number of plugin executions with the mainPipeline execution that centralizes most of the RDF processing.

The main change to the output is that conversion multipliers of derived units recalculated based on their factor units using 34 digit precision.

A number of unit multipliers were deleted and added in src.
