### PR TITLE
Improve consistency checks and fix identified issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,7 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
 - Cleaned up some confusion regarding unit:PERM_US and unit:PERM_Metric, resulting in the deprecation of some related units. The summary
   is that the magnitude of a PERM does not change with temperature, but measurements made on materials will have different measured values
   at different temperatures.
-- Deprecated scaled units of `unit:Ci`, which had do be added (with deprecation in place) for consistency. All these units are being replaced by `unit:CI` and its scaled units. 
+- Deprecated scaled units of `unit:Ci`, which had do be added (with deprecation in place) for consistency. All these units are being replaced by `unit:CI` and its scaled units.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,12 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
   - dist/QUDT-all-in-one-OWL.ttl: the union of all vocab files and the OWL schema.
   - Users can load just one of these files as a convenience, without needing to follow transitive owl:imports.
 - New Units
-  - M2-PER-HR to support the Netherlands water pumping sector
+  - `M2-PER-HR` to support the Netherlands water pumping sector
+  - `unit:BAR_A` which is implied by `unit:MilliBar_A`
+  - `unit:BasePair` which is implied by `unit:GigaBasePair`
+  - `unit:FLOPS` which is implied by e.g `unit:TeraFLOPS`
+- New Details
+  - new `unit:KiloCubicFT qudt:scalingOf unit:FT3`
 
 ### Changed
 
@@ -22,10 +27,14 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
 
 ### Changed
 
-- Improved consistency checks
-  - Checks for dimension vectors based on factors / scalingOf
-  - Checks for missing deprecation triples
-  - Checks for mixing of factors and scalingOf
+- Build process
+  - Improved consistency checks
+    - Checks for dimension vectors based on factors / scalingOf
+    - Checks for missing deprecation triples
+    - Checks for mixing of factors and scalingOf
+  - Inference calculations during the build process were sped up by an order of magnitude
+  - Dimension vectors for scaled units and derived units can now be inferred
+- Prefixes and scalingOf are now always consistent: all units with scaling prefix (e.g. `KiloM`) now have `qudt:scalingOf`
 
 ### Fixed
 
@@ -39,13 +48,18 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
   - `unit:W-PER-M2-MicroM` (also required using a different QuantityKind)
 - Add factor units to ´unit:VAR`
 - Corrected mixing factors and scalingOf in `unit:DEG_C`
-- Replaced some units:
 
-  |       Deprecated       |         New Unit          |
-  |------------------------|---------------------------|
-  | `unit:MicroGAL-PER-M`  | `unit:MicroGALILEO-PER-M` |
-  | `unit:MilliGAL`        | `unit:MilliGALILEO`       |
-  | `unit:MilliGAL-PER-MO` | `MilliGALILEO-PER-MO`     |
+### Deprecated
+
+|            Deprecated             |         New Unit          |
+|-----------------------------------|---------------------------|
+| `unit:MicroGAL-PER-M`             | `unit:MicroGALILEO-PER-M` |
+| `unit:MilliGAL`                   | `unit:MilliGALILEO`       |
+| `unit:MilliGAL-PER-MO`            | `MilliGALILEO-PER-MO`     |
+| `unit:Ci` (added for consistency) | `unit:CI`                 |
+| `unit:KiloCi`                     | `unit:KiloCI`             |
+| `unit:MicroCi`                    | `unit:MicroCI`            |
+| `unit:MilliCi`                    | `unit:MilliCI`            |
 
 ## [3.1.3] - 2025-06-26
 
@@ -54,11 +68,6 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
 - Added an updated intro slide deck in the doc folder
 - New Units
   - `unit:CCY_CHF-PER-HA`
-  - `unit:BAR_A` which is implied by `unit:MilliBar_A`
-  - `unit:BasePair` which is implied by `unit:GigaBasePair`
-  - `unit:FLOPS` which is implied by e.g `unit:TeraFLOPS`
-- New Details
-  - new `unit:KiloCubicFT qudt:scalingOf unit:FT3`
 
 ### Changed
 
@@ -68,9 +77,6 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
   - New `src/main/rdf/validation/qudt-shacl-functions.ttl` to make some intricate functionality
     available to SPARQL and SHACL
   - New `unitTestPipeline` for unit testing the SHACL functions
-  - Inference calculations during the build process were sped up by an order of magnitude
-  - Dimension vectors for scaled units and derived units can now be inferred
-- Prefixes and scalingOf are now always consistent: all units with scaling prefix (e.g. `KiloM`) now have `qudt:scalingOf`
 - All instances of `xsd:decimal` are limited to a maximum precision of 34 significant digits
 - Derived units: recalculation of `qudt:conversionMultiplier` and `qudt:conversionMultiplierSN`
   - During the build, all derived units' conversion multipliers are checked based on their `qudt:factorUnits`
@@ -85,7 +91,6 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
 - Cleaned up some confusion regarding unit:PERM_US and unit:PERM_Metric, resulting in the deprecation of some related units. The summary
   is that the magnitude of a PERM does not change with temperature, but measurements made on materials will have different measured values
   at different temperatures.
-- Deprecated scaled units of `unit:Ci`, which had do be added (with deprecation in place) for consistency. All these units are being replaced by `unit:CI` and its scaled units.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,6 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
   - `unit:BasePair` which is implied by `unit:GigaBasePair`
   - `unit:FLOPS` which is implied by e.g `unit:TeraFLOPS`
   - `unit:Ci` (deprecated) which is implied by e.g. now-deprecated `unit:KiloCi`
-- New Details
-  - new `unit:KiloCubicFT qudt:scalingOf unit:FT3`
 
 ### Changed
 
@@ -43,9 +41,10 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
   - `unit:MilliVAR-PER-K`
   - `unit:W-PER-M2-MicroM` (also required using a different QuantityKind)
 - Add factor units to ´unit:VAR`
+- Add `unit:KiloCubicFT qudt:scalingOf unit:FT3
 - Corrected mixing factors and scalingOf in `unit:DEG_C`
 - Prefixes and scalingOf are now always consistent: all units with scaling prefix (e.g. `KiloM`) now have `qudt:scalingOf`
-- Make rdfs:labels treatment of Titlecase more consistent for units
+- Make `rdfs:label`s treatment of Titlecase more consistent for units
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,12 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
 
 - Added an updated intro slide deck in the doc folder
 - New Units
-  - unit:CCY_CHF-PER-HA
+  - `unit:CCY_CHF-PER-HA`
+  - `unit:BAR_A` which is implied by `unit:MilliBar_A`
+  - `unit:BasePair` which is implied by `unit:GigaBasePair`
+  - `unit:FLOPS` which is implied by e.g `unit:TeraFLOPS`
+- New Details
+  - new `unit:KiloCubicFT qudt:scalingOf unit:FT3`
 
 ### Changed
 
@@ -63,6 +68,9 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
   - New `src/main/rdf/validation/qudt-shacl-functions.ttl` to make some intricate functionality
     available to SPARQL and SHACL
   - New `unitTestPipeline` for unit testing the SHACL functions
+  - Inference calculations during the build process were sped up by an order of magnitude
+  - Dimension vectors for scaled units and derived units can now be inferred
+- Prefixes and scalingOf are now always consistent: all units with scaling prefix (e.g. `KiloM`) now have `qudt:scalingOf`
 - All instances of `xsd:decimal` are limited to a maximum precision of 34 significant digits
 - Derived units: recalculation of `qudt:conversionMultiplier` and `qudt:conversionMultiplierSN`
   - During the build, all derived units' conversion multipliers are checked based on their `qudt:factorUnits`
@@ -77,6 +85,7 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
 - Cleaned up some confusion regarding unit:PERM_US and unit:PERM_Metric, resulting in the deprecation of some related units. The summary
   is that the magnitude of a PERM does not change with temperature, but measurements made on materials will have different measured values
   at different temperatures.
+- Deprecated scaled units of `unit:Ci`, which had do be added (with deprecation in place) for consistency. All these units are being replaced by `unit:CI` and its scaled units. 
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
   - `unit:BAR_A` which is implied by `unit:MilliBar_A`
   - `unit:BasePair` which is implied by `unit:GigaBasePair`
   - `unit:FLOPS` which is implied by e.g `unit:TeraFLOPS`
+  - `unit:Ci` (deprecated) which is implied by e.g. now-deprecated `unit:KiloCi`
 - New Details
   - new `unit:KiloCubicFT qudt:scalingOf unit:FT3`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,32 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
 
 - Make rdfs:labels treatment of Titlecase more consistent for units'
 
+### Changed
+
+- Improved consistency checks
+  - Checks for dimension vectors based on factors / scalingOf
+  - Checks for missing deprecation triples
+  - Checks for mixing of factors and scalingOf
+
 ### Fixed
 
 - Fix wrong `qudt:isReplacedBy CCY_CCY_AED` statement in old currency units file `src/main/rdf/vocab/currency/VOCAB_QUDT-UNITS-CURRENCY.ttl`.
+- Corrected dimension vectors of units
+  - `unit:VAR`
+  - `unit:VAR-PER-K`
+  - `unit:KiloVAR-PER-K`
+  - `unit:MicroVAR-PER-K`
+  - `unit:MilliVAR-PER-K`
+  - `unit:W-PER-M2-MicroM` (also required using a different QuantityKind)
+- Add factor units to ´unit:VAR`
+- Corrected mixing factors and scalingOf in `unit:DEG_C`
+- Replaced some units:
+
+  |       Deprecated       |         New Unit          |
+  |------------------------|---------------------------|
+  | `unit:MicroGAL-PER-M`  | `unit:MicroGALILEO-PER-M` |
+  | `unit:MilliGAL`        | `unit:MilliGALILEO`       |
+  | `unit:MilliGAL-PER-MO` | `MilliGALILEO-PER-MO`     |
 
 ## [3.1.3] - 2025-06-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,16 +67,16 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
 
 ### Changed
 
-- Build process
+- All instances of `xsd:decimal` are limited to a maximum precision of 34 significant digits
+- Build process by [Florian Kleedorfer](https://github.com/fkleedorfer)
   - New maven goal `rdfio:pipeline` that allows for fine-grained rdf file manipulation
   - New `mainPipeline` execution for the bulk of rdf munging
   - New `src/main/rdf/validation/qudt-shacl-functions.ttl` to make some intricate functionality
     available to SPARQL and SHACL
   - New `unitTestPipeline` for unit testing the SHACL functions
-- All instances of `xsd:decimal` are limited to a maximum precision of 34 significant digits
-- Derived units: recalculation of `qudt:conversionMultiplier` and `qudt:conversionMultiplierSN`
-  - During the build, all derived units' conversion multipliers are checked based on their `qudt:factorUnits`
-    and replaced with the calculated result if necessary
+  - Derived units: recalculation of `qudt:conversionMultiplier` and `qudt:conversionMultiplierSN`
+    - During the build, all derived units' conversion multipliers are checked based on their `qudt:factorUnits`
+      and replaced with the calculated result if necessary
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,6 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
 
 ### Changed
 
-- Make rdfs:labels treatment of Titlecase more consistent for units'
-
-### Changed
-
 - Build process
   - Improved consistency checks
     - Checks for dimension vectors based on factors / scalingOf
@@ -35,7 +31,6 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
     - Checks for mixing of factors and scalingOf
   - Inference calculations during the build process were sped up by an order of magnitude
   - Dimension vectors for scaled units and derived units can now be inferred
-- Prefixes and scalingOf are now always consistent: all units with scaling prefix (e.g. `KiloM`) now have `qudt:scalingOf`
 
 ### Fixed
 
@@ -49,18 +44,18 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
   - `unit:W-PER-M2-MicroM` (also required using a different QuantityKind)
 - Add factor units to ´unit:VAR`
 - Corrected mixing factors and scalingOf in `unit:DEG_C`
+- Prefixes and scalingOf are now always consistent: all units with scaling prefix (e.g. `KiloM`) now have `qudt:scalingOf`
+- Make rdfs:labels treatment of Titlecase more consistent for units
 
 ### Deprecated
 
-|            Deprecated             |         New Unit          |
-|-----------------------------------|---------------------------|
-| `unit:MicroGAL-PER-M`             | `unit:MicroGALILEO-PER-M` |
-| `unit:MilliGAL`                   | `unit:MilliGALILEO`       |
-| `unit:MilliGAL-PER-MO`            | `MilliGALILEO-PER-MO`     |
-| `unit:Ci` (added for consistency) | `unit:CI`                 |
-| `unit:KiloCi`                     | `unit:KiloCI`             |
-| `unit:MicroCi`                    | `unit:MicroCI`            |
-| `unit:MilliCi`                    | `unit:MilliCI`            |
+- `unit:MicroGAL-PER-M` (new unit: `unit:MicroGALILEO-PER-M`)
+- `unit:MilliGAL` (new unit: `unit:MilliGALILEO`)
+- `unit:MilliGAL-PER-MO` (new unit: `unit:MilliGALILEO-PER-MO`)
+- `unit:Ci` (added for consistency, new unit: `unit:CI`)
+- `unit:KiloCi` (new unit: `unit:KiloCI`)
+- `unit:MicroCi` (new unit: `unit:MicroCI`)
+- `unit:MilliCi` (new unit: `unit:MilliCI`)
 
 ## [3.1.3] - 2025-06-26
 

--- a/pom.xml
+++ b/pom.xml
@@ -1016,11 +1016,11 @@
                                     </until>
 
                                     <until>
-                                        <message>Replacing invalid conversionMultipliers iteratively until no more are found</message>
+                                        <message>Replacing invalid conversionMultipliers and missing dimension vectors iteratively until no more are found</message>
                                         <indexVar>index_cm</indexVar>
                                         <sparqlAsk>
                                             ASK {
-                                                BIND(IRI(CONCAT("inferred:conversionMultiplierToDelete_",STR(?index_cm))) as ?graph)
+                                                BIND(IRI(CONCAT("validation:conversionMultiplierToDelete_",STR(?index_cm))) as ?graph)
                                                 GRAPH ?graph {
                                                     ?report
                                                         a               sh:ValidationReport;
@@ -1041,7 +1041,7 @@
                                                     <graph>target:VOCAB_QUDT-PREFIXES.ttl</graph>
                                                 </data>
                                                 <validationReport>
-                                                    <graph>inferred:conversionMultiplierToDelete_${index_cm}</graph>
+                                                    <graph>validation:conversionMultiplierToDelete_${index_cm}</graph>
                                                     <file>target/validation/conversionMultiplier-toDelete_${index_cm}.ttl</file>
                                                 </validationReport>
                                             </shaclValidate>
@@ -1063,7 +1063,7 @@
                                                             ?unit qudt:conversionMultiplierSN ?mSN .
                                                         }
                                                     }
-                                                    BIND(IRI(CONCAT("inferred:conversionMultiplierToDelete_",STR(?index_cm))) as ?graph)
+                                                    BIND(IRI(CONCAT("validation:conversionMultiplierToDelete_",STR(?index_cm))) as ?graph)
                                                     GRAPH ?graph {
                                                         ?res
                                                             rdf:type                      sh:ValidationResult;

--- a/pom.xml
+++ b/pom.xml
@@ -537,27 +537,33 @@
                                 <shaclFunctions>
                                     <file>src/main/rdf/validation/qudt-shacl-functions.ttl</file>
                                 </shaclFunctions>
+                                <add>
+                                    <!-- for testing, we need units and some factor units -->
+                                    <file>src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl</file>
+                                    <file>src/build/inference/factorUnits/predefined-factors-and-scalings.ttl</file>
+                                </add>
+
                                 <assert>
                                     <message>Test qfn:decimalPrecision()</message>
                                     <failureMessage>Unit test failed for qfn:decimalPrecision()</failureMessage>
                                     <sparqlSelect>
                                         SELECT *
                                         WHERE {
-                                        VALUES (?input ?expectedOutput) {
-                                        (0            0)
-                                        (0.0          0)
-                                        (1            1)
-                                        (1.0          1)
-                                        (-1           1)
-                                        (-1.0         1)
-                                        (-.1          1)
-                                        (10           1)
-                                        (100          1)
-                                        (100.001      6)
-                                        (100.000      1)
-                                        (00123.456000 6)
-                                        (-0.00000001  1)
-                                        }
+                                            VALUES (?input ?expectedOutput) {
+                                                (0            0)
+                                                (0.0          0)
+                                                (1            1)
+                                                (1.0          1)
+                                                (-1           1)
+                                                (-1.0         1)
+                                                (-.1          1)
+                                                (10           1)
+                                                (100          1)
+                                                (100.001      6)
+                                                (100.000      1)
+                                                (00123.456000 6)
+                                                (-0.00000001  1)
+                                            }
                                         BIND(qfn:decimalPrecision(?input) AS ?precision)
                                         FILTER(!BOUND(?precision) || ?precision != ?expectedOutput)
                                         }
@@ -569,36 +575,174 @@
                                     <sparqlSelect>
                                         SELECT *
                                         WHERE {
-                                        VALUES (?input ?precision ?expectedOutput) {
-                                            (0            1         0.0)
-                                            (0.0          1         0.0)
-                                            (0.1          1         0.1)
-                                            (.1           1         0.1)
-                                            (1            1         1.0)
-                                            (+1           1         1.0)
-                                            (+1.0         1         1.0)
-                                            (+.0          1         0.0)
-                                            (+.1          1         0.1)
-                                            (1.0          1         1.0)
-                                            (-1           1        -1.0)
-                                            (-1.0         1        -1.0)
-                                            (-.1          1        -0.1)
-                                            (10           1        10.0)
-                                            (100          1       100.0)
-                                            (100.001      6       100.001)
-                                            (100.000      1       100.0)
-                                            (00123.456000 6       123.456)
-                                            (-0.00000001  1        -0.00000001)
-                                            (-00123.456000 3     -123.0)
-                                            (00123.456000 3       123.0)
-                                            (0.000000011574074074074074074  10 0.00000001157407407)
-                                            (-0.000000011574074074074074074  10 -0.00000001157407407)
-                                        }
+                                            VALUES (?input ?precision ?expectedOutput) {
+                                                (0            1         0.0)
+                                                (0.0          1         0.0)
+                                                (0.1          1         0.1)
+                                                (.1           1         0.1)
+                                                (1            1         1.0)
+                                                (+1           1         1.0)
+                                                (+1.0         1         1.0)
+                                                (+.0          1         0.0)
+                                                (+.1          1         0.1)
+                                                (1.0          1         1.0)
+                                                (-1           1        -1.0)
+                                                (-1.0         1        -1.0)
+                                                (-.1          1        -0.1)
+                                                (10           1        10.0)
+                                                (100          1       100.0)
+                                                (100.001      6       100.001)
+                                                (100.000      1       100.0)
+                                                (00123.456000 6       123.456)
+                                                (-0.00000001  1        -0.00000001)
+                                                (-00123.456000 3     -123.0)
+                                                (00123.456000 3       123.0)
+                                                (0.000000011574074074074074074  10 0.00000001157407407)
+                                                (-0.000000011574074074074074074  10 -0.00000001157407407)
+                                            }
                                         BIND(qfn:decimalRoundToPrecision(?input, ?precision) AS ?rounded)
                                         FILTER(!BOUND(?rounded) || ?rounded != ?expectedOutput)
                                         }
                                     </sparqlSelect>
                                 </assert>
+                                <add>
+                                    <file>src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl</file>
+                                </add>
+                                <assert>
+                                    <message>Test qfn:localname()</message>
+                                    <failureMessage>Unit test failed for qfn:localname()</failureMessage>
+                                    <sparqlSelect>
+                                        SELECT *
+                                        WHERE {
+                                            VALUES (?input ?expectedOutput) {
+                                                (xsd:int            "int")
+                                                (unit:M          "M")
+                                            }
+                                        BIND(qfn:localname(?input) AS ?actualOutput)
+                                        FILTER(BOUND(?actualOutput) != BOUND(?expectedOutput) || ?actualOutput != ?expectedOutput)
+                                        }
+                                    </sparqlSelect>
+                                </assert>
+                                <assert>
+                                    <message>Test qfn:dimVec.getDimensionExponentFromLocalname()</message>
+                                    <failureMessage>Unit test failed for qfn:dimVec.getDimensionExponentFromLocalname()</failureMessage>
+                                    <sparqlSelect>
+                                        <![CDATA[
+                                        SELECT *
+                                        WHERE {
+                                            VALUES (?dimVecLocalname ?dimension ?expectedOutput) {
+                                                ("A0E0L1I0M0H0T0D0"  "A"  0)
+                                                ("A0E0L1I0M0H3T0D0"  "L"  1)
+                                                ("A0E0L1I0M0H3T0D0"  "H"  3)
+                                            }
+                                        BIND(qfn:dimVec.getDimensionExponentFromLocalname(?dimVecLocalname, ?dimension) AS ?actualOutput)
+                                        FILTER(BOUND(?actualOutput) != BOUND(?expectedOutput) || ?actualOutput != ?expectedOutput)
+                                        }
+                                        ]]>
+                                    </sparqlSelect>
+                                </assert>
+                                <assert>
+                                    <message>Test qfn:dimVec.getDimensionExponent()</message>
+                                    <failureMessage>Unit test failed for qfn:dimVec.getDimensionExponent()</failureMessage>
+                                    <sparqlSelect>
+                                        <![CDATA[
+                                        SELECT *
+                                        WHERE {
+                                            VALUES (?dimVec ?dimension ?expectedOutput) {
+                                                (qkdv:A0E0L1I0M0H0T0D0  "A"  0)
+                                                (qkdv:A0E0L1I0M0H3T0D0  "L"  1)
+                                                (qkdv:A0E0L1I0M0H3T0D0  "H"  3)
+                                            }
+                                        BIND(qfn:dimVec.getDimensionExponent(?dimVec, ?dimension) AS ?actualOutput)
+                                        FILTER(BOUND(?actualOutput) != BOUND(?expectedOutput) || ?actualOutput != ?expectedOutput)
+                                        }
+                                        ]]>
+                                    </sparqlSelect>
+                                </assert>
+                                <assert>
+                                    <message>Test qfn:dimVec.pow()</message>
+                                    <failureMessage>Unit test failed for qfn:dimVec.pow()</failureMessage>
+                                    <sparqlSelect>
+                                        <![CDATA[
+                                        SELECT *
+                                        WHERE {
+                                            VALUES (?dimVec ?exp ?expectedOutput) {
+                                                (qkdv:A0E0L1I0M0H0T0D0  1 qkdv:A0E0L1I0M0H0T0D0  )
+                                                (qkdv:A0E0L1I0M0H0T0D0  2 qkdv:A0E0L2I0M0H0T0D0  )
+                                                (qkdv:A0E0L1I0M0H0T0D0 -2 qkdv:A0E0L-2I0M0H0T0D0 )
+                                                (qkdv:A0E0L1I0M0H0T0D0 -1 qkdv:A0E0L-1I0M0H0T0D0 )
+                                            }
+                                        BIND(qfn:dimVec.pow(?dimVec, ?exp) AS ?actualOutput)
+                                        FILTER(BOUND(?actualOutput) != BOUND(?expectedOutput) || ?actualOutput != ?expectedOutput)
+                                        }
+                                        ]]>
+                                    </sparqlSelect>
+                                </assert>
+                                <assert>
+                                    <message>Test qfn:dimVec.fromLocalname()</message>
+                                    <failureMessage>Unit test failed for qfn:dimVec.fromLocalname()</failureMessage>
+                                    <sparqlSelect>
+                                        <![CDATA[
+                                        SELECT *
+                                        WHERE {
+                                            VALUES (?dimVecLocalname ?expectedOutput) {
+                                                ("A0E0L1I0M0H0T0D0" qkdv:A0E0L1I0M0H0T0D0)
+                                                ("A1E0L1I0M0H0T0D0" qkdv:A1E0L1I0M0H0T0D0)
+                                                ("A1E0L1I0M0H0T0D1" qkdv:A1E0L1I0M0H0T0D0)
+                                                ("A0E0L0I0M0H0T0D1" qkdv:A0E0L0I0M0H0T0D1)
+                                                ("A0E0L0I0M0H0T0D0" qkdv:A0E0L0I0M0H0T0D1)
+                                            }
+                                            BIND(qfn:dimVec.fromLocalname(?dimVecLocalname) AS ?actualOutput)
+                                            FILTER(BOUND(?actualOutput) != BOUND(?expectedOutput) || ?actualOutput != ?expectedOutput)
+                                        }
+                                        ]]>
+                                    </sparqlSelect>
+                                </assert>
+                                <assert>
+                                    <message>Test qfn:dimVec.multiply()</message>
+                                    <failureMessage>Unit test failed for qfn:dimVec.multiply()</failureMessage>
+                                    <sparqlSelect>
+                                        <![CDATA[
+                                        SELECT *
+                                        WHERE {
+                                            VALUES (?leftDimVec ?rightDimVec ?expectedOutput) {
+                                                (qkdv:A0E0L1I0M0H0T0D0 qkdv:A0E0L0I0M0H1T0D0  qkdv:A0E0L1I0M0H1T0D0)
+                                                (qkdv:A0E0L1I0M0H0T0D0 qkdv:A0E0L0I0M1H1T0D0  qkdv:A0E0L1I0M1H1T0D0)
+                                                (qkdv:A0E0L1I0M1H0T0D0 qkdv:A0E0L0I0M1H1T0D0  qkdv:A0E0L1I0M2H1T0D0)
+                                                (qkdv:A0E0L1I0M0H0T0D0 qkdv:A0E0L1I0M0H0T0D0  qkdv:A0E0L2I0M0H0T0D0)
+                                                (qkdv:A0E0L1I0M0H0T0D0 qkdv:A0E0L-3I0M0H0T0D0 qkdv:A0E0L-2I0M0H0T0D0)
+                                                (qkdv:A0E0L1I0M0H0T0D0 qkdv:A0E0L-1I0M0H0T0D0 qkdv:A0E0L0I0M0H0T0D1)
+                                                (qkdv:A0E0L1I0M0H0T0D0 qkdv:A0E0L0I0M0H0T0D1  qkdv:A0E0L1I0M0H0T0D0)
+                                                (qkdv:A0E0L1I0M0H0T0D0 undef                  qkdv:A0E0L1I0M0H0T0D0)
+                                                (undef                 qkdv:A0E0L1I0M0H0T0D0  qkdv:A0E0L1I0M0H0T0D0)
+                                                (undef                 undef                  qfn:Unbound)
+                                            }
+                                            BIND(qfn:dimVec.multiply(?leftDimVec, ?rightDimVec) AS ?actualOutput)
+                                            FILTER(BOUND(?actualOutput) != BOUND(?expectedOutput) || ?actualOutput != ?expectedOutput)
+                                        }
+                                        ]]>
+                                    </sparqlSelect>
+                                </assert>
+                                <assert>
+                                    <message>Test qfn:unit.dimVec.calculate()</message>
+                                    <failureMessage>Unit test failed for qfn:unit.dimVec.calculate()</failureMessage>
+                                    <sparqlSelect>
+                                        <![CDATA[
+                                        SELECT *
+                                        WHERE {
+                                            VALUES (?unit ?expectedOutput) {
+                                                (unit:J             qkdv:A0E0L2I0M1H0T-2D0  )
+                                                (unit:W             qkdv:A0E0L2I0M1H0T-3D0  )
+                                                (unit:IN            qkdv:A0E0L1I0M0H0T0D0  )
+                                                (unit:M             qfn:Unbound )
+                                            }
+                                            BIND(qfn:unit.dimVec.calculate(?unit) AS ?actualOutput)
+                                            FILTER(BOUND(?actualOutput) != BOUND(?expectedOutput) || ?actualOutput != ?expectedOutput)
+                                        }
+                                        ]]>
+                                    </sparqlSelect>
+                                </assert>
+
                             </steps>
                             </pipeline>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -381,7 +381,7 @@
             <plugin>
                 <groupId>io.github.qudtlib</groupId>
                 <artifactId>rdfio-maven-plugin</artifactId>
-                <version>1.4.2</version>
+                <version>1.4.3</version>
                 <executions>
                     <execution>
                         <!--

--- a/pom.xml
+++ b/pom.xml
@@ -964,6 +964,57 @@
                                             ]]>
                                         </sparql>
                                     </sparqlUpdate>
+                                    <shaclValidate>
+                                        <message>Validating qudt:hasDimensionVector (making sure none are missing that cannot be derived)</message>
+                                        <shapes>
+                                            <file>src/build/srcgen/dimensionVector/prerequisite.ttl</file>
+                                        </shapes>
+                                        <data>
+                                            <graph>target:VOCAB_QUDT-UNITS-ALL.ttl</graph>
+                                            <graph>target:VOCAB_QUDT-PREFIXES.ttl</graph>
+                                        </data>
+                                        <validationReport>
+                                            <graph>validation:dimensionVector-underivable.ttl</graph>
+                                            <file>target/validation/dimensionVector-underivable.ttl.ttl</file>
+                                        </validationReport>
+                                    </shaclValidate>
+                                    <until>
+                                        <message>Add missing dimension vectors that can be inferred</message>
+                                        <indexVar>index_dv</indexVar>
+                                        <body>
+                                            <shaclInfer>
+                                                <message>Inferring missing qudt:dimensionVector</message>
+                                                <iterateUntilStable>true</iterateUntilStable>
+                                                <iterationOutputFilePattern>target/inferred/dimensionVector-${index_dv}_${index}.ttl</iterationOutputFilePattern>
+                                                <shapes>
+                                                    <file>target/srcgen/dimensionVector/infer.ttl</file>
+                                                </shapes>
+                                                <data>
+                                                    <graph>target:VOCAB_QUDT-UNITS-ALL.ttl</graph>
+                                                    <graph>target:VOCAB_QUDT-PREFIXES.ttl</graph>
+                                                </data>
+                                                <inferred>
+                                                    <graph>inferred:dimensionVector_${index_dv}</graph>
+                                                    <file>target/inferred/dimensionVector_${index_dv}.ttl</file>
+                                                </inferred>
+                                            </shaclInfer>
+                                            <add>
+                                                <graph>inferred:dimensionVector_${index_dv}</graph>
+                                                <toGraph>target:VOCAB_QUDT-UNITS-ALL.ttl</toGraph>
+                                            </add>
+                                        </body>
+                                        <sparqlAsk>
+                                            ASK {
+                                                BIND(IRI(CONCAT("inferred:dimensionVector_",STR(?index_dv))) as ?graph)
+                                                FILTER NOT EXISTS {
+                                                    GRAPH ?graph {
+                                                        ?s ?p ?o
+                                                    }
+                                                }
+                                            }
+                                        </sparqlAsk>
+                                    </until>
+
                                     <until>
                                         <message>Replacing invalid conversionMultipliers iteratively until no more are found</message>
                                         <indexVar>index_cm</indexVar>

--- a/src/build/inference/factorUnits/predefined-factors-and-scalings.ttl
+++ b/src/build/inference/factorUnits/predefined-factors-and-scalings.ttl
@@ -497,6 +497,9 @@ unit:KiloCAL
 unit:KiloCAL_Mean
   qudt:scalingOf unit:J .
 
+unit:KiloCubicFT
+  qudt:scalingOf unit:FT3 .
+
 unit:KiloPA_A
   qudt:scalingOf unit:PA .
 

--- a/src/build/inference/factorUnits/predefined-factors-and-scalings.ttl
+++ b/src/build/inference/factorUnits/predefined-factors-and-scalings.ttl
@@ -175,10 +175,6 @@ unit:DEG
   qudt:scalingOf unit:RAD .
 
 unit:DEG_C
-  qudt:hasFactorUnit [
-    qudt:exponent 1 ;
-    qudt:hasUnit unit:K ;
-  ] ;
   qudt:scalingOf unit:K .
 
 unit:DEG_F

--- a/src/build/inference/factorUnits/predefined-factors-and-scalings.ttl
+++ b/src/build/inference/factorUnits/predefined-factors-and-scalings.ttl
@@ -1044,6 +1044,16 @@ unit:V
     qudt:hasUnit unit:A ;
   ] .
 
+unit:VAR
+  qudt:hasFactorUnit [
+    qudt:exponent 1 ;
+    qudt:hasUnit unit:J ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent -1 ;
+    qudt:hasUnit unit:SEC ;
+  ] .
+
 unit:V_Ab
   qudt:scalingOf unit:V .
 

--- a/src/build/srcgen/conversionMultiplier/query.rq
+++ b/src/build/srcgen/conversionMultiplier/query.rq
@@ -8,86 +8,92 @@ prefix sh: <http://www.w3.org/ns/shacl#>
 
 SELECT ?this (qudt:conversionMultiplier as ?path) ?relDiff ?actualMultiplier ?calculatedMultiplier
 WHERE {
-  ?this a qudt:Unit .
-  OPTIONAL { ?this qudt:conversionMultiplier ?actualMultiplier . }
+
   # Subquery to compute and concatenate factor unit contributions
   {
-      {
-        SELECT
-            ?this
-            (GROUP_CONCAT(?factorContribution; SEPARATOR="|") AS ?contributions)
-            (GROUP_CONCAT(?multiplierFound;SEPARATOR="|") AS ?allMultipliersFound)
-        WHERE {
-          ?this qudt:hasFactorUnit ?factor .
-          ?factor qudt:hasUnit ?baseUnit ;
-                  qudt:exponent ?exponent .
-          OPTIONAL {
-            ?baseUnit qudt:conversionMultiplier ?baseMultiplier .
+     {
+          {
+            SELECT
+                ?this
+                (GROUP_CONCAT(?factorContribution; SEPARATOR="|") AS ?contributions)
+                (GROUP_CONCAT(?multiplierFound;SEPARATOR="|") AS ?allMultipliersFound)
+            WHERE {
+              ?this a qudt:Unit .
+              OPTIONAL { ?this qudt:conversionMultiplier ?actualMultiplier . }
+              FILTER(!BOUND(?actualMultiplier)                               # no actual multiplier? use calculated!
+                     || (?actualMultiplier != 0.0))                          # actual multiplier is 0? skip!!
+              ?this qudt:hasFactorUnit ?factor .
+              ?factor qudt:hasUnit ?baseUnit ;
+                      qudt:exponent ?exponent .
+              OPTIONAL {
+                ?baseUnit qudt:conversionMultiplier ?baseMultiplier .
+              }
+
+
+              # did we find the multiplier?
+              BIND(IF(BOUND(?baseMultiplier), "YES", "NO") AS ?multiplierFound)
+              BIND(qfn:exp(?baseMultiplier, ?exponent) AS ?factorContribution)
+
+            }
+            GROUP BY ?this
           }
+            # Dont continue if we could not find all multipliers
+            FILTER(!CONTAINS(?allMultipliersFound,"NO"))
 
+            # Disassemble contributions into up to 10 variables
+            BIND(COALESCE(CONCAT("|",?contributions), "|") AS ?contribString)
 
-          # did we find the multiplier?
-          BIND(IF(BOUND(?baseMultiplier), "YES", "NO") AS ?multiplierFound)
-          BIND(qfn:exp(?baseMultiplier, ?exponent) AS ?factorContribution)
+            # Make sure we don't accidentally swallow stuff that isn't made of numbers
+            FILTER(REGEX("[0-9\\-\\.\\|]+", ?contribString))
 
+            BIND(REPLACE(?contribString, ".*\\|", "") as ?f1)
+            BIND(SUBSTR(?contribString, 0, STRLEN(?contribString) - STRLEN(?f1)) as ?f1removed)
+            BIND(REPLACE(?f1removed, ".*\\|", "") as ?f2)
+            BIND(SUBSTR(?f1removed, 0, STRLEN(?f1removed) - STRLEN(?f2)) as ?f2removed)
+            BIND(REPLACE(?f2removed, ".*\\|", "") as ?f3)
+            BIND(SUBSTR(?f2removed, 0, STRLEN(?f2removed) - STRLEN(?f3)) as ?f3removed)
+            BIND(REPLACE(?f3removed, ".*\\|", "") as ?f4)
+            BIND(SUBSTR(?f3removed, 0, STRLEN(?f3removed) - STRLEN(?f4)) as ?f4removed)
+            BIND(REPLACE(?f4removed, ".*\\|", "") as ?f5)
+            BIND(SUBSTR(?f4removed, 0, STRLEN(?f4removed) - STRLEN(?f5)) as ?f5removed)
+            BIND(REPLACE(?f5removed, ".*\\|", "") as ?f6)
+            BIND(SUBSTR(?f5removed, 0, STRLEN(?f5removed) - STRLEN(?f6)) as ?f6removed)
+            BIND(REPLACE(?f6removed, ".*\\|", "") as ?f7)
+            BIND(SUBSTR(?f6removed, 0, STRLEN(?f6removed) - STRLEN(?f7)) as ?f7removed)
+            BIND(REPLACE(?f7removed, ".*\\|", "") as ?f8)
+            BIND(SUBSTR(?f7removed, 0, STRLEN(?f7removed) - STRLEN(?f8)) as ?f8removed)
+            BIND(REPLACE(?f8removed, ".*\\|", "") as ?f9)
+          # Compute calculatedMultiplier by multiplying all contributions
+            OPTIONAL {
+                ?this qudt:factorUnitScalar ?factorUnitScalar
+            }
+            BIND(IF(BOUND(?factorUnitScalar), ?factorUnitScalar, 1.0) AS ?scalar)
+            BIND( ?scalar
+                * COALESCE(xsd:decimal(?f1), 1.0)
+                * COALESCE(xsd:decimal(?f2), 1.0)
+                * COALESCE(xsd:decimal(?f3), 1.0)
+                * COALESCE(xsd:decimal(?f4), 1.0)
+                * COALESCE(xsd:decimal(?f5), 1.0)
+                * COALESCE(xsd:decimal(?f6), 1.0)
+                * COALESCE(xsd:decimal(?f7), 1.0)
+                * COALESCE(xsd:decimal(?f8), 1.0)
+                * COALESCE(xsd:decimal(?f9), 1.0) as ?rawCalculatedMultiplier)
+        } UNION {
+            ?this a qudt:Unit .
+            ?this
+                qudt:scalingOf/qudt:conversionMultiplier ?baseCM ;
+                qudt:prefix/qudt:prefixMultiplier ?prefixCM .
+            OPTIONAL { ?this qudt:conversionMultiplier ?actualMultiplier . }
+            FILTER(!BOUND(?actualMultiplier)                               # no actual multiplier? use calculated!
+                   || (?actualMultiplier != 0.0))                          # actual multiplier is 0? skip!!
+            BIND (?baseCM * ?prefixCM as ?rawCalculatedMultiplier)
         }
-        GROUP BY ?this
-      }
-        # Dont continue if we could not find all multipliers
-        FILTER(!CONTAINS(?allMultipliersFound,"NO"))
-
-        # Disassemble contributions into up to 10 variables
-        BIND(COALESCE(CONCAT("|",?contributions), "|") AS ?contribString)
-
-        # Make sure we don't accidentally swallow stuff that isn't made of numbers
-        FILTER(REGEX("[0-9\\-\\.\\|]+", ?contribString))
-
-        BIND(REPLACE(?contribString, ".*\\|", "") as ?f1)
-        BIND(SUBSTR(?contribString, 0, STRLEN(?contribString) - STRLEN(?f1)) as ?f1removed)
-        BIND(REPLACE(?f1removed, ".*\\|", "") as ?f2)
-        BIND(SUBSTR(?f1removed, 0, STRLEN(?f1removed) - STRLEN(?f2)) as ?f2removed)
-        BIND(REPLACE(?f2removed, ".*\\|", "") as ?f3)
-        BIND(SUBSTR(?f2removed, 0, STRLEN(?f2removed) - STRLEN(?f3)) as ?f3removed)
-        BIND(REPLACE(?f3removed, ".*\\|", "") as ?f4)
-        BIND(SUBSTR(?f3removed, 0, STRLEN(?f3removed) - STRLEN(?f4)) as ?f4removed)
-        BIND(REPLACE(?f4removed, ".*\\|", "") as ?f5)
-        BIND(SUBSTR(?f4removed, 0, STRLEN(?f4removed) - STRLEN(?f5)) as ?f5removed)
-        BIND(REPLACE(?f5removed, ".*\\|", "") as ?f6)
-        BIND(SUBSTR(?f5removed, 0, STRLEN(?f5removed) - STRLEN(?f6)) as ?f6removed)
-        BIND(REPLACE(?f6removed, ".*\\|", "") as ?f7)
-        BIND(SUBSTR(?f6removed, 0, STRLEN(?f6removed) - STRLEN(?f7)) as ?f7removed)
-        BIND(REPLACE(?f7removed, ".*\\|", "") as ?f8)
-        BIND(SUBSTR(?f7removed, 0, STRLEN(?f7removed) - STRLEN(?f8)) as ?f8removed)
-        BIND(REPLACE(?f8removed, ".*\\|", "") as ?f9)
-      # Compute calculatedMultiplier by multiplying all contributions
-        OPTIONAL {
-            ?this qudt:factorUnitScalar ?factorUnitScalar
-        }
-        BIND(IF(BOUND(?factorUnitScalar), ?factorUnitScalar, 1.0) AS ?scalar)
-        BIND( ?scalar
-            * COALESCE(xsd:decimal(?f1), 1.0)
-            * COALESCE(xsd:decimal(?f2), 1.0)
-            * COALESCE(xsd:decimal(?f3), 1.0)
-            * COALESCE(xsd:decimal(?f4), 1.0)
-            * COALESCE(xsd:decimal(?f5), 1.0)
-            * COALESCE(xsd:decimal(?f6), 1.0)
-            * COALESCE(xsd:decimal(?f7), 1.0)
-            * COALESCE(xsd:decimal(?f8), 1.0)
-            * COALESCE(xsd:decimal(?f9), 1.0) as ?rawCalculatedMultiplier)
-    } UNION {
-        ?this
-            qudt:scalingOf/qudt:conversionMultiplier ?baseCM ;
-            qudt:prefix/qudt:prefixMultiplier ?prefixCM .
-        BIND (?baseCM * ?prefixCM as ?rawCalculatedMultiplier)
     }
     BIND (qfn:decimalRoundToPrecision(?rawCalculatedMultiplier, 34) as ?calculatedMultiplier)
     BIND (?actualMultiplier - ?calculatedMultiplier as ?diff)
     BIND (IF (?actualMultiplier = 0 , 0.0, ABS(?diff) / ABS(?actualMultiplier)) as ?relDiffAct)
     BIND (IF( ?calculatedMultiplier = 0, 0.0, ABS(?diff) / ABS(?calculatedMultiplier)) as ?relDiffCalc)
     BIND(IF(?relDiffAct > ?relDiffCalc, ?relDiffAct, ?relDiffCalc) as ?relDiff)
-    FILTER(
-        !BOUND(?actualMultiplier)                               # no actual multiplier? use calculated!
-        || (?actualMultiplier != 0.0                            # actual multiplier is 0? skip!!
-            && ?actualMultiplier != ?calculatedMultiplier))     # no result if calculated == actual
+    FILTER(?actualMultiplier != ?calculatedMultiplier)    # no result if calculated == actual
 }
 ORDER BY DESC(?relDiff)

--- a/src/build/srcgen/dimensionVector/infer-template.ttl
+++ b/src/build/srcgen/dimensionVector/infer-template.ttl
@@ -1,0 +1,31 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix qfn: <http://qudt.org/shacl/functions#> .
+@prefix qudt: <http://qudt.org/schema/qudt/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+
+qfn:inferDerivableDimensionvector
+  a owl:Ontology ;
+  owl:imports qfn: .
+
+qfn:inferDerivableDimensionvectorRule
+  a sh:NodeShape ;
+  sh:rule [
+    a sh:SPARQLRule ;
+    sh:construct """
+        CONSTRUCT {
+            ?this qudt:hasDimensionVector ?calculatedDimVec .
+        }
+        WHERE
+        {
+            {{QUERY_WITHOUT_PREFIXES}}
+        }
+
+
+        """ ;
+    sh:prefixes qfn: ;
+  ] ;
+  sh:targetClass qudt:Unit .
+
+

--- a/src/build/srcgen/dimensionVector/prerequisite.ttl
+++ b/src/build/srcgen/dimensionVector/prerequisite.ttl
@@ -1,0 +1,41 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix qfn: <http://qudt.org/shacl/functions#> .
+@prefix qudt: <http://qudt.org/schema/qudt/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+
+qfn:DerivableDimensionVectorMissing
+  a owl:Ontology ;
+  owl:imports qfn: .
+
+qfn:DerivableDimensionVectorMissingRule
+  a sh:NodeShape ;
+  sh:severity sh:Violation ;
+  sh:sparql [
+    a sh:SPARQLConstraint ;
+    sh:message "{?this}: dimension vector is missing and no way to derive it (no qudt:scalingOf, no qudt:hasFactorUnit present)" ;
+    sh:prefixes qfn: ;
+    sh:select """
+    SELECT $this
+    WHERE {
+        {
+            ?this a qudt:Unit .
+            FILTER NOT EXISTS {
+                ?this qudt:hasDimensionVector ?actualDimVec
+            }
+            FILTER NOT EXISTS {
+                {
+                    $this qudt:hasFactorUnit ?fu
+                } union {
+                    ?this qudt:scalingOf ?base
+                }
+            }
+        }
+    }
+
+    """ ;
+  ] ;
+  sh:targetClass qudt:Unit .
+
+

--- a/src/build/srcgen/dimensionVector/query.rq
+++ b/src/build/srcgen/dimensionVector/query.rq
@@ -1,0 +1,23 @@
+prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+prefix qfn: <http://qudt.org/shacl/functions#>
+prefix qudt: <http://qudt.org/schema/qudt/>
+
+SELECT $this ?calculatedDimVec
+WHERE {
+    {
+        ?this a qudt:Unit .
+        FILTER NOT EXISTS {
+            ?this qudt:hasDimensionVector ?actualDimVec
+        }
+        FILTER EXISTS {
+            {
+                $this qudt:hasFactorUnit ?fu
+            } union {
+                ?this qudt:scalingOf ?base
+            }
+        }
+    }
+    BIND(qfn:unit.dimVec.calculate(?this) AS ?calculatedDimVec)
+    FILTER(qfn:bound(?calculatedDimVec))
+
+}

--- a/src/build/srcgen/dimensionVector/validate-template.ttl
+++ b/src/build/srcgen/dimensionVector/validate-template.ttl
@@ -1,0 +1,27 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix qfn: <http://qudt.org/shacl/functions#> .
+@prefix qudt: <http://qudt.org/schema/qudt/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+
+qfn:DerivableDimensionVectorMissing
+  a owl:Ontology ;
+  owl:imports qfn: .
+
+qfn:DerivableDimensionVectorMissingRule
+  a sh:NodeShape ;
+  sh:severity sh:Violation ;
+  sh:sparql [
+    a sh:SPARQLConstraint ;
+    sh:message "{?this}: dimension vector is missing but can be derived to be {?calculatedDimVec}" ;
+    sh:prefixes qfn: ;
+    sh:select """
+
+    {{QUERY_WITHOUT_PREFIXES}}
+
+    """ ;
+  ] ;
+  sh:targetClass qudt:Unit .
+
+

--- a/src/build/srcgen/factorUnits/query.rq
+++ b/src/build/srcgen/factorUnits/query.rq
@@ -5,71 +5,56 @@ PREFIX kind: <http://qudt.org/vocab/quantitykind/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-SELECT DISTINCT ?this ?baseUnit ?exponent
-{
-    SELECT DISTINCT ?this ?baseUnit ?exponent WHERE
+    SELECT DISTINCT ?this ?baseUnit ?exponent
+    WHERE
     {
-    {
-        ?this a qudt:Unit ;
-            BIND(REPLACE(STR(?this), "^.+/", "") as ?derivedUnitLocalName)
-        FILTER(REPLACE(?derivedUnitLocalName, "(PER|2|3|4|5|6|-)\\b", "") != ?derivedUnitLocalName)
-        FILTER(?derivedUnitLocalName NOT IN (
-            "Gold-OunceTroy",
-            "Palladium-OunceTroy",
-            "Silver-OunceTroy",
-            "Platinum-OunceTroy",
-            "failures-in-time",
-            "USDollar-NextDay",
-            "Kilo-FT3"
-        ))
+        {
+            {
+                {
+                    ?this a qudt:Unit ;
+                    FILTER NOT EXISTS {
+                        ?this qudt:hasFactorUnit [
+                                qudt:hasUnit ?baseUnit ;
+                                qudt:exponent ?exponent
+                            ] .
+                    }
 
-        VALUES ?skipUnits { 0 1 2 3 4 5 6 }
-        BIND("(\\w+(_\\w+)?\\d?)" as ?baseUnitRegex)
-        BIND("(\\w+(_\\w+)?\\d?|PER)" as ?skipUnitRegex)
-        BIND(CONCAT("^(",?skipUnitRegex,"-){", STR(?skipUnits), "}", ?baseUnitRegex, "(-" ,?skipUnitRegex, ")*$") as ?selectUnitRegex )
-        BIND(REPLACE(?derivedUnitLocalName, ?selectUnitRegex, "$4") as ?baseUnitLocalNameExtractedTmp)
-        BIND(REPLACE(?baseUnitLocalNameExtractedTmp, "^(\\w*[^\\d])(\\d?)$", "$1") as ?baseUnitLocalNameExtracted)
-        BIND(REPLACE(?baseUnitLocalNameExtractedTmp, "^(\\w*[^\\d])(\\d?)$", "$2") as ?exponentTmpStr)
-        BIND(IF(?exponentTmpStr = "", STRDT("1",xsd:integer), STRDT(?exponentTmpStr,xsd:integer)) as ?exponentTmp)
-        VALUES ( ?matchString ?dontMatchString ?expFactor) {
-            ( "^.*PER-.*\\b@@UNIT@@\\b.*$" "dontfindthis" -1 )
-            ( "^.*\\b@@UNIT@@\\b.*PER.*$" "dontfindthis"  1 )
-            ( ".+" "\\bPER\\b" 1 )
+                    FILTER NOT EXISTS {
+                        ?this qudt:scalingOf ?someOtherUnit
+                    }
+                }
+                BIND(REPLACE(STR(?this), "^.+/", "") as ?derivedUnitLocalName)
+                FILTER(REPLACE(?derivedUnitLocalName, "(PER|2|3|4|5|6|-)\\b", "") != ?derivedUnitLocalName)
+                FILTER(?derivedUnitLocalName NOT IN (
+                    "Gold-OunceTroy",
+                    "Palladium-OunceTroy",
+                    "Silver-OunceTroy",
+                    "Platinum-OunceTroy",
+                    "failures-in-time",
+                    "USDollar-NextDay",
+                    "Kilo-FT3"
+                ))
+            }
+
+            VALUES ?skipUnits { 0 1 2 3 4 5 6 }
+            BIND("(\\w+(_\\w+)?\\d?)" as ?baseUnitRegex)
+            BIND("(\\w+(_\\w+)?\\d?|PER)" as ?skipUnitRegex)
+            BIND(CONCAT("^(",?skipUnitRegex,"-){", STR(?skipUnits), "}", ?baseUnitRegex, "(-" ,?skipUnitRegex, ")*$") as ?selectUnitRegex )
+            BIND(REPLACE(?derivedUnitLocalName, ?selectUnitRegex, "$4") as ?baseUnitLocalNameExtractedTmp)
+            BIND(REPLACE(?baseUnitLocalNameExtractedTmp, "^(\\w*[^\\d])(\\d?)$", "$1") as ?baseUnitLocalNameExtracted)
+            BIND(REPLACE(?baseUnitLocalNameExtractedTmp, "^(\\w*[^\\d])(\\d?)$", "$2") as ?exponentTmpStr)
+            BIND(IF(?exponentTmpStr = "", STRDT("1",xsd:integer), STRDT(?exponentTmpStr,xsd:integer)) as ?exponentTmp)
+            VALUES ( ?matchString ?dontMatchString ?expFactor) {
+                ( "^.*PER-.*\\b@@UNIT@@\\b.*$" "dontfindthis" -1 )
+                ( "^.*\\b@@UNIT@@\\b.*PER.*$" "dontfindthis"  1 )
+                ( ".+" "\\bPER\\b" 1 )
+            }
+            FILTER(REPLACE(?derivedUnitLocalName, REPLACE(?matchString, "@@UNIT@@", ?baseUnitLocalNameExtractedTmp), "") != ?derivedUnitLocalName)
+            FILTER(REPLACE(?derivedUnitLocalName, ?dontMatchString, "") = ?derivedUnitLocalName)
         }
-        FILTER(REPLACE(?derivedUnitLocalName, REPLACE(?matchString, "@@UNIT@@", ?baseUnitLocalNameExtractedTmp), "") != ?derivedUnitLocalName)
-        FILTER(REPLACE(?derivedUnitLocalName, ?dontMatchString, "") = ?derivedUnitLocalName)
         BIND(?exponentTmp * ?expFactor as ?exponent)
         FILTER( ?baseUnitLocalNameExtractedTmp != "PER" )
         FILTER( ! CONTAINS(?baseUnitLocalNameExtractedTmp, "-") )
-        BIND(IRI(CONCAT("http://qudt.org/vocab/unit/", ?baseUnitLocalNameExtracted)) as ?newlyMintedBaseUnit)
-        # find an existing unit or currencyunit with the localname we have determined. if we find none, we will
-        # assume that the factor unit is a normal unit and that it is missing.
-        OPTIONAL {
-            {
-                ?existingBaseUnit a qudt:Unit
-                BIND(REPLACE(STR(?existingBaseUnit), "^.+/", "")  AS ?existingBaseUnitLocalName)
-            }
-            UNION
-            {
-                ?existingBaseUnit a qudt:CurrencyUnit
-                BIND(REPLACE(STR(?existingBaseUnit), "^.+/", "")  AS ?existingBaseUnitLocalName)
-            }
-            FILTER(?existingBaseUnitLocalName = ?baseUnitLocalNameExtracted)
-        }
-        # did we find an existing unit/currencyunit with that localname? use it. Otherwise: use newly minted unit iri.
-        BIND(IF(BOUND(?existingBaseUnit), ?existingBaseUnit, ?newlyMintedBaseUnit) as ?baseUnit)
+        BIND(IRI(CONCAT("http://qudt.org/vocab/unit/", ?baseUnitLocalNameExtracted)) as ?baseUnit)
     }
-
-    FILTER NOT EXISTS {
-        ?this qudt:hasFactorUnit [
-                qudt:hasUnit ?baseUnit ;
-                qudt:exponent ?exponent
-            ] .
-    }
-
-    FILTER NOT EXISTS {
-        ?this qudt:isScalingOf ?someOtherUnit
-    }
-    }
-}
 order by ?this ?baseUnit

--- a/src/build/srcgen/scalingOf/query.rq
+++ b/src/build/srcgen/scalingOf/query.rq
@@ -21,7 +21,18 @@ where
                         ?this a qudt:Unit .
                     }
                 }
+                FILTER NOT EXISTS {
+                    {
+                        ?this qudt:scalingOf ?baseUnit .
+                    } UNION {
+                        ?this qudt:prefix ?prefix
+                    } UNION {
+                        ?this qudt:hasFactorUnit ?x . # for derived units, we don't generate a prefix.
+                    }
+                }
+                FILTER(?this != unit:KiloGM)
                 BIND(REPLACE(STR(?this), "^.+/", "") as ?scaledUnitLocalName)
+                FILTER(!CONTAINS(?scaledUnitLocalName,"DeciB"))
                 FILTER(REPLACE(?scaledUnitLocalName, ?prefixRegex, "") != ?scaledUnitLocalName)
                 {
                     SELECT (CONCAT("\\b(",GROUP_CONCAT(STR(?prefixLabel); separator ="|"), ")") as ?prefixRegex) where
@@ -37,46 +48,39 @@ where
         # select all base units (not using prefixes)
         # special handling for prefix + time, e.g.
         # 'unit:MegaYR qudt:scalingOf unit:YR', not unit:SEC
-
-        ?baseUnit a qudt:Unit ;
-        BIND(REPLACE(STR(?baseUnit), "^.+/", "") as ?baseUnitLocalName)
+        #{
+        #    ?baseUnit a qudt:Unit ;
+        #    BIND(REPLACE(STR(?baseUnit), "^.+/", "") as ?baseUnitLocalName)
+        #    # we don't generate scalingOf for bases that are derived units
+        #    FILTER(! CONTAINS(?baseUnitLocalName, "-"))
+        #    # we don't generate scalingOf for bases with a non-1 exponent (because then we cannot use the existing factor as would have to be exponentiated)
+        #    FILTER(! REGEX(?baseUnitLocalName,".+\\d+"))
+        #}
+        BIND("(YR|MO|DAY|HR|MIN)\\b" as ?timeRegex)
+       # special handling for prefix scaling or unprefixed time scaling to SEC
+        BIND(
+            IF(
+                #special case for scaling via time expression
+                ?scaledUnitLocalName = REPLACE(?scaledUnitLocalName, CONCAT(?prefixRegex, ?timeRegex), ""),           # scaled NOT unit:[prefix][timeparticle] (e.g. unit:KiloM or also unit:HR)
+                REPLACE(REPLACE(?scaledUnitLocalName, ?prefixRegex, ""), ?timeRegex, "SEC"),                           # base = scaled without the prefix, and time replaced by SEC (e.g unitM or also unit:SEC)
+                # normal case for scaling via prefix
+                REPLACE(?scaledUnitLocalName, ?prefixRegex, ""))                                                                                         # none of the above - not a scaled unit
+             AS ?baseUnitLocalName)
         # we don't generate scalingOf for bases that are derived units
         FILTER(! CONTAINS(?baseUnitLocalName, "-"))
         # we don't generate scalingOf for bases with a non-1 exponent (because then we cannot use the existing factor as would have to be exponentiated)
         FILTER(! REGEX(?baseUnitLocalName,".+\\d+"))
-        BIND("(YR|MO|DAY|HR|MIN)\\b" as ?timeRegex)
-        FILTER (
-                    (
-                        REPLACE(?scaledUnitLocalName, CONCAT(?prefixRegex, ?timeRegex), "") = ?scaledUnitLocalName
-                        && ?baseUnitLocalName = REPLACE(REPLACE(?scaledUnitLocalName, ?prefixRegex, ""), ?timeRegex, "SEC")
-                    ) || (
-                        REPLACE(?scaledUnitLocalName, CONCAT(?prefixRegex, ?timeRegex), "") != ?scaledUnitLocalName
-                        && ?baseUnitLocalName = REPLACE(?scaledUnitLocalName, ?prefixRegex, "")
-                    )
-        )
+        BIND(IRI(CONCAT(STR(unit:),?baseUnitLocalName)) as ?baseUnit)
     }
     OPTIONAL {
         # if the scaled unit has a prefix, match it so we can add the triple
         ?prefix a qudt:Prefix ;
             rdfs:label ?prefixLabel ;
-            FILTER (!CONTAINS(?baseUnitLocalName, "-"))
             FILTER (CONTAINS(?scaledUnitLocalName, STR(?prefixLabel)))
     }
 
     # NOTE: conversion multiplier calcluation for scaled units
     # is done in src/build/srcgen/conversionMultiplier
 
-    OPTIONAL {
-        ?baseUnit qudt:dimensionVector ?dv .
-    }
-    FILTER NOT EXISTS {
-        ?this qudt:scalingOf ?baseUnit .
-        {
-            ?this qudt:prefix ?prefix
-        } UNION {
-            ?this qudt:hasFactorUnit ?x . # for derived units, we don't generate a prefix.
-        }
-    }
-    FILTER(?this != unit:KiloGM)
 }
 order by ?baseUnit ?this

--- a/src/main/rdf/validation/COLLECTION_QUDT_QA_TESTS_ALL.ttl
+++ b/src/main/rdf/validation/COLLECTION_QUDT_QA_TESTS_ALL.ttl
@@ -70,6 +70,11 @@
     a sh:PrefixDeclaration ;
     sh:namespace "http://www.w3.org/ns/shacl#"^^xsd:anyURI ;
     sh:prefix "sh" ;
+  ] ;
+  sh:declare [
+    a sh:PrefixDeclaration ;
+    sh:namespace "http://qudt.org/shacl/functions#"^^xsd:anyURI ;
+    sh:prefix "qfn" ;
   ] .
 
 qudt:ClosedWorldShape
@@ -243,6 +248,33 @@ FILTER NOT EXISTS {$this qudt:deprecated true} .
 FILTER NOT EXISTS {?t qudt:exactMatch $this } .
 }
 """ ;
+  ] ;
+  sh:targetClass qudt:Concept .
+
+qudt:InconsistentDimensionVector
+  a sh:NodeShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/collection/usertest> ;
+  rdfs:label "Ensures that dimension vectors of derived units are consistent with their factors" ;
+  sh:severity sh:Violation ;
+  sh:sparql [
+    a sh:SPARQLConstraint ;
+    rdfs:comment "Ensures that dimension vectors of derived units are consistent with their factors" ;
+    sh:message """{?this}: dimension vector 
+    {?actualDimVec} is inconsistent with the dimension vector calculated from its factor units
+    {?calculatedDimVec}""" ;
+    sh:prefixes <http://qudt.org/$$QUDT_VERSION$$/collection/qa/allPrefixes> ;
+    sh:select """
+    SELECT $this ?calculatedDimVec ?actualDimVec
+    WHERE {
+        ?this qudt:hasDimensionVector ?actualDimVec
+        BIND(qfn:unit.dimVec.calculate(?this) AS ?calculatedDimVec)
+        FILTER(qfn:bound(?calculatedDimVec))
+        FILTER(?actualDimVec != ?calculatedDimVec)
+        FILTER NOT EXISTS {
+            ?this qudt:deprecated true
+        }
+    }
+    """ ;
   ] ;
   sh:targetClass qudt:Concept .
 

--- a/src/main/rdf/validation/COLLECTION_QUDT_QA_TESTS_ALL.ttl
+++ b/src/main/rdf/validation/COLLECTION_QUDT_QA_TESTS_ALL.ttl
@@ -231,6 +231,33 @@ qudt:DeprecatedTripleMissing
   ] ;
   sh:targetClass qudt:Concept .
 
+qudt:DerivableDimensionVectorMissing
+  a sh:NodeShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/collection/usertest> ;
+  rdfs:label "Ensures that no derivable dimension vectors are omitted" ;
+  sh:severity sh:Violation ;
+  sh:sparql [
+    a sh:SPARQLConstraint ;
+    rdfs:comment "Ensures that no derivable dimension vectors are omitted" ;
+    sh:message """{?this}: dimension vector is missing but can be derived to be
+    {?calculatedDimVec}""" ;
+    sh:prefixes <http://qudt.org/$$QUDT_VERSION$$/collection/qa/allPrefixes> ;
+    sh:select """
+    SELECT $this ?calculatedDimVec ?actualDimVec
+    WHERE {
+        BIND(qfn:unit.dimVec.calculate(?this) AS ?calculatedDimVec)
+        FILTER(qfn:bound(?calculatedDimVec))
+        FILTER NOT EXISTS {
+            ?this qudt:deprecated true
+        }
+        FILTER NOT EXISTS {
+            ?this qudt:hasDimensionVector ?actualDimVec
+        }
+    }
+    """ ;
+  ] ;
+  sh:targetClass qudt:Unit .
+
 qudt:ExactMatchGoesBothWaysConstraint
   a sh:NodeShape ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/collection/qa/all> ;

--- a/src/main/rdf/validation/COLLECTION_QUDT_QA_TESTS_ALL.ttl
+++ b/src/main/rdf/validation/COLLECTION_QUDT_QA_TESTS_ALL.ttl
@@ -243,16 +243,18 @@ qudt:DerivableDimensionVectorMissing
     {?calculatedDimVec}""" ;
     sh:prefixes <http://qudt.org/$$QUDT_VERSION$$/collection/qa/allPrefixes> ;
     sh:select """
-    SELECT $this ?calculatedDimVec ?actualDimVec
+    SELECT $this ?calculatedDimVec
     WHERE {
+        {
+            FILTER NOT EXISTS {
+                ?this qudt:deprecated true
+            }
+            FILTER NOT EXISTS {
+                ?this qudt:hasDimensionVector ?actualDimVec
+            }
+        }
         BIND(qfn:unit.dimVec.calculate(?this) AS ?calculatedDimVec)
         FILTER(qfn:bound(?calculatedDimVec))
-        FILTER NOT EXISTS {
-            ?this qudt:deprecated true
-        }
-        FILTER NOT EXISTS {
-            ?this qudt:hasDimensionVector ?actualDimVec
-        }
     }
     """ ;
   ] ;

--- a/src/main/rdf/validation/COLLECTION_QUDT_QA_TESTS_ALL.ttl
+++ b/src/main/rdf/validation/COLLECTION_QUDT_QA_TESTS_ALL.ttl
@@ -409,6 +409,38 @@ qudt:QuantityKindShape
   ] ;
   sh:targetClass qudt:QuantityKind .
 
+qudt:ScalingOfAndFactorUnitsPresent
+  a sh:NodeShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/collection/usertest> ;
+  rdfs:label "Ensures that no unit has both qudt:scalingOf and qudt:hasFactorUnits" ;
+  sh:severity sh:Violation ;
+  sh:sparql [
+    a sh:SPARQLConstraint ;
+    rdfs:comment "Ensures that no unit has both qudt:scalingOf and qudt:hasFactorUnits" ;
+    sh:message "{?this} has factor units {?factorUnits} as well as scalingOf {?scalingOf} - that's not allowed" ;
+    sh:prefixes <http://qudt.org/$$QUDT_VERSION$$/collection/qa/allPrefixes> ;
+    sh:select """
+      SELECT $this ?factorUnits ?scalingOf
+      WHERE {
+          ?this qudt:scalingOf ?scalingOf
+          {
+            SELECT (GROUP_CONCAT(?fuString; separator=", ") AS ?factorUnits)
+            WHERE {
+                ?this qudt:hasFactorUnit ?fun .
+                ?fun qudt:hasUnit ?fu ;
+                     qudt:exponent ?exp .
+                BIND(CONCAT(qfn:localname(?fu),"^",STR(?exp)) AS ?fuString)
+            }
+          }
+          FILTER(STRLEN(?factorUnits) > 0)
+          FILTER NOT EXISTS {
+              ?this qudt:deprecated true
+          }
+      }
+      """ ;
+  ] ;
+  sh:targetClass qudt:Concept .
+
 qudt:UniqueSymbolTypeRestrictedPropertyConstraint
   a sh:NodeShape ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/collection/qa/all> ;

--- a/src/main/rdf/validation/COLLECTION_QUDT_QA_TESTS_ALL.ttl
+++ b/src/main/rdf/validation/COLLECTION_QUDT_QA_TESTS_ALL.ttl
@@ -203,6 +203,29 @@ qudt:DeprecatedPropertyInfoShape
   ] ;
   sh:targetClass rdf:Property .
 
+qudt:DeprecatedTripleMissing
+  a sh:NodeShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/collection/usertest> ;
+  rdfs:label "Ensures that objects depending on deprecated objects are themselves also deprecated" ;
+  sh:severity sh:Violation ;
+  sh:sparql [
+    a sh:SPARQLConstraint ;
+    rdfs:comment "Informs whether a resource that depends on a deprecated resource is itself not deprecated." ;
+    sh:message "Resource {?this} depends on deprecated resource {?dep} and must therefore also be deprecated or be changed to depend on a different resource" ;
+    sh:prefixes <http://qudt.org/$$QUDT_VERSION$$/collection/qa/allPrefixes> ;
+    sh:select """
+    SELECT $this ?dep ?replacementMessage
+    WHERE {
+        ?dep qudt:deprecated true .
+        ?this ( ( qudt:hasFactorUnit/qudt:hasUnit ) | qudt:scalingOf ) + ?dep .
+        FILTER NOT EXISTS {
+            ?this qudt:deprecated true
+        }
+    }
+    """ ;
+  ] ;
+  sh:targetClass qudt:Concept .
+
 qudt:ExactMatchGoesBothWaysConstraint
   a sh:NodeShape ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/collection/qa/all> ;

--- a/src/main/rdf/validation/qudt-shacl-functions.ttl
+++ b/src/main/rdf/validation/qudt-shacl-functions.ttl
@@ -65,6 +65,20 @@ qfn:
     sh:prefix "sh" ;
   ] .
 
+qfn:bound
+  a sh:SPARQLFunction ;
+  rdfs:comment "returns true iff the value is bound and not equal to qfn:Unbound" ;
+  sh:parameter [
+    sh:description "anything" ;
+    sh:order 0 ;
+    sh:path qfn:value ;
+  ] ;
+  sh:prefixes qfn: ;
+  sh:returnType xsd:boolean ;
+  sh:select """
+        SELECT (BOUND(?value) && ?value != qfn:Unbound) WHERE {}
+      """ .
+
 qfn:decimalPrecision
   a sh:SPARQLFunction ;
   rdfs:comment "Determines the precision (number of significant digits) of the decimal number provided as its first argument" ;
@@ -275,6 +289,151 @@ qfn:defaultValue
     WHERE {}
     """ .
 
+qfn:dimVec.fromLocalname
+  a sh:SPARQLFunction ;
+  rdfs:comment "Constructs a valid dimension vector IRI from the specified localname. If necessary, the localname is replaced by 'A0E0L0I0M0H0T0D1'. " ;
+  sh:parameter [
+    sh:datatype xsd:string ;
+    sh:description "the dimension vector localname" ;
+    sh:order 0 ;
+    sh:path qfn:dimVecLocalname ;
+  ] ;
+  sh:prefixes qfn: ;
+  sh:returnType xsd:anyURI ;
+  sh:select """
+            SELECT (IRI(CONCAT(STR(qkdv:), ?finalLocalname)) as ?result)
+            WHERE {
+                BIND ( IF(
+                          STRSTARTS(?dimVecLocalname, "A0E0L0I0M0H0T0"),
+                          "A0E0L0I0M0H0T0D1",
+                          REPLACE(?dimVecLocalname,"^(.+)D.+$","$1D0") # apparently, we explicitly set D0 if any other dimension is != 0
+                    ) AS ?finalLocalname)
+            }
+        """ .
+
+qfn:dimVec.getDimensionExponent
+  a sh:SPARQLFunction ;
+  rdfs:comment "Gets the exponent of the specified dimension indicator (ie, letter) in the specified dimension vector" ;
+  sh:parameter [
+    sh:datatype xsd:anyURI ;
+    sh:description "the dimension vector IRI" ;
+    sh:order 0 ;
+    sh:path qfn:dimVec ;
+  ] ;
+  sh:parameter [
+    sh:datatype xsd:string ;
+    sh:description "dimensionIndicator" ;
+    sh:order 1 ;
+    sh:path qfn:dimensionIndicator ;
+  ] ;
+  sh:prefixes qfn: ;
+  sh:returnType xsd:number ;
+  sh:select """
+            SELECT (qfn:dimVec.getDimensionExponentFromLocalname(qfn:localname(?dimVec), ?dimensionIndicator) as ?result)
+            WHERE{}
+        """ .
+
+qfn:dimVec.getDimensionExponentFromLocalname
+  a sh:SPARQLFunction ;
+  rdfs:comment "Gets the exponent of the specified dimension indicator (ie, letter) in the specified dimension vector's localname" ;
+  sh:parameter [
+    sh:datatype xsd:string ;
+    sh:description "the dimension vector localname" ;
+    sh:order 0 ;
+    sh:path qfn:dimVecLocalname ;
+  ] ;
+  sh:parameter [
+    sh:datatype xsd:string ;
+    sh:description "dimensionIndicator" ;
+    sh:order 1 ;
+    sh:path qfn:dimensionIndicator ;
+  ] ;
+  sh:prefixes qfn: ;
+  sh:returnType xsd:number ;
+  sh:select """
+            SELECT (
+                    xsd:integer(
+                        REPLACE(
+                            ?dimVecLocalname,
+                            CONCAT("^[^",?dimensionIndicator,"]*",?dimensionIndicator,"(-?\\\\d+(\\\\.\\\\d+)?)($|\\\\w.+)$"),"$1"))
+                        as ?result)
+            WHERE {}
+        """ .
+
+qfn:dimVec.multiply
+  a sh:SPARQLFunction ;
+  rdfs:comment "Combines two dimension vectors by multiplication. if one argument is unbound, the other is returned as-is" ;
+  sh:parameter [
+    sh:datatype xsd:anyURI ;
+    sh:description "an IRI" ;
+    sh:order 0 ;
+    sh:path qfn:leftDimVec ;
+  ] ;
+  sh:parameter [
+    sh:datatype xsd:anyURI ;
+    sh:description "an IRI" ;
+    sh:order 1 ;
+    sh:path qfn:rightDimVec ;
+  ] ;
+  sh:prefixes qfn: ;
+  sh:returnType xsd:anyURI ;
+  sh:select """
+                SELECT (
+                        IF(qfn:bound(?leftDimVec),
+                            IF (qfn:bound(?rightDimVec),
+                                qfn:dimVec.fromLocalname(?rawLocalname),
+                                ?leftDimVec),
+                            IF (qfn:bound(?rightDimVec),
+                                ?rightDimVec,
+                                qfn:Unbound))
+                    AS ?result )
+                {
+                    {
+                        SELECT (COALESCE(GROUP_CONCAT(?dimResult; separator=""),"") AS ?rawLocalname)
+                        WHERE {
+                            # a dim vector looks like this: qkdv:A0E0L1I0M0H0T0D0 ;
+                            VALUES ?dim { "A" "E" "L" "I" "M" "H" "T" "D" }
+                            BIND(COALESCE(qfn:dimVec.getDimensionExponent(?leftDimVec, ?dim) + qfn:dimVec.getDimensionExponent(?rightDimVec, ?dim), 0) as ?dimExp)
+                            BIND(CONCAT(?dim, STR(?dimExp)) AS ?dimResult)
+                        }
+                    }
+                }
+        """ .
+
+qfn:dimVec.pow
+  a sh:SPARQLFunction ;
+  rdfs:comment "Raises the specified dimension vector, provided as an IRI, to the specified power and returns its IRI" ;
+  sh:parameter [
+    sh:datatype xsd:anyURI ;
+    sh:description "an IRI" ;
+    sh:order 0 ;
+    sh:path qfn:dimVec ;
+  ] ;
+  sh:parameter [
+    sh:datatype xsd:decimal ;
+    sh:description "exponent" ;
+    sh:order 1 ;
+    sh:path qfn:exponent ;
+  ] ;
+  sh:prefixes qfn: ;
+  sh:returnType xsd:anyURI ;
+  sh:select """
+            SELECT ( qfn:dimVec.fromLocalname(?localname) as ?result)
+            WHERE {
+                SELECT (GROUP_CONCAT(?dimResult; separator="") as ?localname)
+                WHERE {
+                    # a dim vector looks like this: qkdv:A0E0L1I0M0H0T0D0 ;
+                    VALUES ?dim { "A" "E" "L" "I" "M" "H" "T" "D" }
+                    {
+                        BIND(qfn:localname(?dimVec) as ?dimVecLocalname)
+                    }
+                    BIND(qfn:dimVec.getDimensionExponentFromLocalname(?dimVecLocalname, ?dim) * ?exponent as ?dimExp)
+                    BIND(CONCAT(?dim, STR(?dimExp)) AS ?dimResult)
+                }
+
+            }
+        """ .
+
 qfn:exp
   a sh:SPARQLFunction ;
   sh:parameter [
@@ -319,5 +478,104 @@ qfn:exp
         AS ?result )
     }
     """ .
+
+qfn:localname
+  a sh:SPARQLFunction ;
+  rdfs:comment "Extracts the localname part of an IRI" ;
+  sh:parameter [
+    sh:datatype xsd:anyURI ;
+    sh:description "an IRI" ;
+    sh:order 0 ;
+    sh:path qfn:input ;
+  ] ;
+  sh:prefixes qfn: ;
+  sh:returnType xsd:string ;
+  sh:select """
+        SELECT (REPLACE(STR(?input), "^.+[/#]", "") as ?result) WHERE {}
+    """ .
+
+qfn:unit.dimVec.calculate
+  a sh:SPARQLFunction ;
+  rdfs:comment "Calculates the dimension vector of a unit if that unit has factor units or is a scaled unit" ;
+  sh:parameter [
+    sh:datatype xsd:anyURI ;
+    sh:description "a unit IRI" ;
+    sh:order 0 ;
+    sh:path qfn:unit ;
+  ] ;
+  sh:prefixes qfn: ;
+  sh:returnType xsd:anyURI ;
+  sh:select """
+            SELECT ?result
+                WHERE {
+                    {
+                        SELECT (GROUP_CONCAT(?factorDimVecResult) AS ?allDimVecs)
+                        WHERE
+                        {
+                            {
+                                ?unit qudt:hasFactorUnit ?fu .
+                                ?fu
+                                    qudt:hasUnit ?base;
+                                    qudt:exponent ?exponent ;
+                            } UNION {
+                                ?unit qudt:scalingOf ?base .
+                                BIND(1 as ?exponent)
+                            }
+                            OPTIONAL {
+                                ?base qudt:hasDimensionVector ?dimVector .
+                            }
+                            BIND(qfn:dimVec.pow(?dimVector, ?exponent) AS ?factorDimVec)
+                            BIND(COALESCE(?factorDimVec, qfn:Unbound) AS ?factorDimVecResult)
+                        }
+                    }
+                    BIND(REPLACE(?allDimVecs,"^([^ ]+)( .+)?$", "$1") AS ?dv0)
+                    BIND(SUBSTR(?allDimVecs,STRLEN(STR(?dv0)) + 2) AS ?rest0)
+                    BIND(REPLACE(?rest0,"^([^ ]+)( .+)?$", "$1") AS ?dv1)
+                    BIND(SUBSTR(?rest0,STRLEN(STR(?dv1)) + 2) AS ?rest1)
+                    BIND(REPLACE(?rest1,"^([^ ]+)( .+)?$", "$1") AS ?dv2)
+                    BIND(SUBSTR(?rest1,STRLEN(STR(?dv2)) + 2) AS ?rest2)
+                    BIND(REPLACE(?rest2,"^([^ ]+)( .+)?$", "$1") AS ?dv3)
+                    BIND(SUBSTR(?rest2,STRLEN(STR(?dv3)) + 2) AS ?rest3)
+                    BIND(REPLACE(?rest3,"^([^ ]+)( .+)?$", "$1") AS ?dv4)
+                    BIND(SUBSTR(?rest3,STRLEN(STR(?dv4)) + 2) AS ?rest4)
+                    BIND(REPLACE(?rest4,"^([^ ]+)( .+)?$", "$1") AS ?dv5)
+                    BIND(SUBSTR(?rest4,STRLEN(STR(?dv5)) + 2) AS ?rest5)
+                    BIND(REPLACE(?rest5,"^([^ ]+)( .+)?$", "$1") AS ?dv6)
+                    BIND(SUBSTR(?rest5,STRLEN(STR(?dv6)) + 2) AS ?rest6)
+                    BIND(REPLACE(?rest6,"^([^ ]+)( .+)?$", "$1") AS ?dv7)
+                    BIND(SUBSTR(?rest6,STRLEN(STR(?dv7)) + 2) AS ?rest7)
+                    BIND(IF(?dv0 = "", ?undefined, IRI(?dv0)) AS ?dvIri0)
+                    BIND(IF(?dv1 = "", ?undefined, IRI(?dv1)) AS ?dvIri1)
+                    BIND(IF(?dv2 = "", ?undefined, IRI(?dv2)) AS ?dvIri2)
+                    BIND(IF(?dv3 = "", ?undefined, IRI(?dv3)) AS ?dvIri3)
+                    BIND(IF(?dv4 = "", ?undefined, IRI(?dv4)) AS ?dvIri4)
+                    BIND(IF(?dv5 = "", ?undefined, IRI(?dv5)) AS ?dvIri5)
+                    BIND(IF(?dv6 = "", ?undefined, IRI(?dv6)) AS ?dvIri6)
+                    BIND(IF(?dv7 = "", ?undefined, IRI(?dv7)) AS ?dvIri7)
+                    BIND(IF(
+                        # check if we found all factors' dimvecs and if the unit has no more than 8 of them
+                        CONTAINS(?allDimVecs,STR(qfn:Unbound)) || (BOUND(?rest7) && ?rest7 != "") ,
+                        qfn:Unbound, # unbound if the above did not hold
+                        qfn:dimVec.multiply(?dvIri0,
+                            qfn:dimVec.multiply(?dvIri1,
+                                qfn:dimVec.multiply(?dvIri2,
+                                    qfn:dimVec.multiply(?dvIri3,
+                                        qfn:dimVec.multiply(?dvIri4,
+                                            qfn:dimVec.multiply(?dvIri5,
+                                                qfn:dimVec.multiply(?dvIri6,?dvIri7))))))))
+                        AS ?result)
+                    #BIND(CONCAT(
+                    #IF(BOUND(?dvIri0),STR(?dvIri0),"unbound"),
+                    #"-0----",
+                    #IF(BOUND(?dvIri1),STR(?dvIri1),"unbound"),
+                    #"-1----",
+                    #IF(BOUND(?dvIri2),STR(?dvIri2),"unbound"),
+                    #"-2----",
+                    #IF(BOUND(?dvIri3),STR(?dvIri3),"unbound"),
+                    #"-3----",
+                    #IF(BOUND(?dvIri4),STR(?dvIri4),"unbound"),
+                    #"-4----") AS ?result)
+                }
+        """ .
 
 

--- a/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
+++ b/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
@@ -29229,6 +29229,21 @@ unit:MicroG
 unit:MicroGAL-PER-M
   a qudt:Unit ;
   dcterms:description "A rate of change of one millionth part of a unit of gravitational acceleration equal to one centimetre per second per second over a distance of one metre."@en ;
+  dcterms:isReplacedBy unit:MicroGALILEO-PER-M ;
+  qudt:conversionMultiplier 0.00000001 ;
+  qudt:conversionMultiplierSN 1.0E-8 ;
+  qudt:deprecated true ;
+  qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-2D0 ;
+  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:symbol "µGal/m" ;
+  qudt:ucumCode "uGal.m-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "uGal/m"^^qudt:UCUMcs ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
+  rdfs:label "MicroGals per Metre"@en .
+
+unit:MicroGALILEO-PER-M
+  a qudt:Unit ;
+  dcterms:description "A rate of change of one millionth part of a unit of gravitational acceleration equal to one centimetre per second per second over a distance of one metre."@en ;
   qudt:conversionMultiplier 0.00000001 ;
   qudt:conversionMultiplierSN 1.0E-8 ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-2D0 ;
@@ -29237,7 +29252,7 @@ unit:MicroGAL-PER-M
   qudt:ucumCode "uGal.m-1"^^qudt:UCUMcs ;
   qudt:ucumCode "uGal/m"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
-  rdfs:label "MicroGals per Metre"@en .
+  rdfs:label "Microgalileo per metre"@en .
 
 unit:MicroGM
   a qudt:Unit ;
@@ -31417,8 +31432,10 @@ unit:MilliG
 unit:MilliGAL
   a qudt:Unit ;
   dcterms:description "0.001-fold of the unit of acceleration called gal according to the CGS system of units"^^rdf:HTML ;
+  dcterms:isReplacedBy unit:MilliGALILEO ;
   qudt:conversionMultiplier 0.00001 ;
   qudt:conversionMultiplierSN 1.0E-5 ;
+  qudt:deprecated true ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Acceleration ;
   qudt:hasQuantityKind quantitykind:LinearAcceleration ;
@@ -31433,6 +31450,37 @@ unit:MilliGAL
 unit:MilliGAL-PER-MO
   a qudt:Unit ;
   dcterms:description "A rate of change of one millionth part of a unit of gravitational acceleration equal to one centimetre per second per second over a time duration of 30.4375 days or 2629800 seconds."@en ;
+  dcterms:isReplacedBy unit:MilliGALILEO-PER-MO ;
+  qudt:conversionMultiplier 0.000000000003919350772901616281311709002114104 ;
+  qudt:conversionMultiplierSN 3.919350772901616281311709002114104E-12 ;
+  qudt:deprecated true ;
+  qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T-3D0 ;
+  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:symbol "mgal/mo" ;
+  qudt:ucumCode "mGal.mo-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "mGal/mo"^^qudt:UCUMcs ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
+  rdfs:label "MilliGals per Month"@en .
+
+unit:MilliGALILEO
+  a qudt:Unit ;
+  dcterms:description "0.001-fold of the unit of acceleration called gal according to the CGS system of units"^^rdf:HTML ;
+  qudt:conversionMultiplier 0.00001 ;
+  qudt:conversionMultiplierSN 1.0E-5 ;
+  qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T-2D0 ;
+  qudt:hasQuantityKind quantitykind:Acceleration ;
+  qudt:hasQuantityKind quantitykind:LinearAcceleration ;
+  qudt:iec61360Code "0112/2///62720#UAB043" ;
+  qudt:plainTextDescription "0.001-fold of the unit of acceleration called gal according to the CGS system of units" ;
+  qudt:symbol "mgal" ;
+  qudt:ucumCode "mGal"^^qudt:UCUMcs ;
+  qudt:uneceCommonCode "C11" ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
+  rdfs:label "Milligalileo"@en .
+
+unit:MilliGALILEO-PER-MO
+  a qudt:Unit ;
+  dcterms:description "A rate of change of one millionth part of a unit of gravitational acceleration equal to one centimetre per second per second over a time duration of 30.4375 days or 2629800 seconds."@en ;
   qudt:conversionMultiplier 0.000000000003919350772901616281311709002114104 ;
   qudt:conversionMultiplierSN 3.919350772901616281311709002114104E-12 ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T-3D0 ;
@@ -31441,7 +31489,7 @@ unit:MilliGAL-PER-MO
   qudt:ucumCode "mGal.mo-1"^^qudt:UCUMcs ;
   qudt:ucumCode "mGal/mo"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
-  rdfs:label "MilliGals per Month"@en .
+  rdfs:label "Milligalileo per month"@en .
 
 unit:MilliGM
   a qudt:Unit ;

--- a/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
+++ b/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
@@ -3468,6 +3468,27 @@ unit:BYTE-PER-SEC
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Byte per Second" .
 
+unit:BasePair
+  a qudt:Unit ;
+  dcterms:description "DNA sequence length in numbers of base pairs. One bp corresponds to approximately 3.4 Å (340 pm)[23] of length along the strand, and to roughly 618 or 643 daltons for DNA and RNA respectively."^^rdf:HTML ;
+  qudt:applicableSystem sou:ASU ;
+  qudt:applicableSystem sou:CGS ;
+  qudt:applicableSystem sou:CGS-EMU ;
+  qudt:applicableSystem sou:CGS-ESU ;
+  qudt:applicableSystem sou:CGS-GAUSS ;
+  qudt:applicableSystem sou:IMPERIAL ;
+  qudt:applicableSystem sou:PLANCK ;
+  qudt:applicableSystem sou:SI ;
+  qudt:conversionMultiplier 1.0 ;
+  qudt:conversionMultiplierSN 1.0E0 ;
+  qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
+  qudt:hasQuantityKind quantitykind:Dimensionless ;
+  qudt:informativeReference "https://en.wikipedia.org/wiki/Base_pair#As_a_unit_of_length"^^xsd:anyURI ;
+  qudt:plainTextDescription "One bp corresponds to approximately 3.4 Å (340 pm)[23] of length along the strand, and to roughly 618 or 643 daltons for DNA and RNA respectively." ;
+  qudt:symbol "bp" ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
+  rdfs:label "Base Pair"@en .
+
 unit:C
   a qudt:DerivedUnit, qudt:Unit ;
   dcterms:description "The SI unit of electric charge. One coulomb is the amount of charge accumulated in one second by a current of one ampere. Electricity is actually a flow of charged particles, such as electrons, protons, or ions. The charge on one of these particles is a whole-number multiple of the charge e on a single electron, and one coulomb represents a charge of approximately 6.241 506 x 1018 e. The coulomb is named for a French physicist, Charles-Augustin de Coulomb (1736-1806), who was the first to measure accurately the forces exerted between electric charges."^^rdf:HTML ;

--- a/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
+++ b/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
@@ -1531,6 +1531,24 @@ unit:BARYE
   skos:altLabel "baryd" ;
   skos:altLabel "baryed" .
 
+unit:BAR_A
+  a qudt:Unit ;
+  dcterms:description "The same as a Bar, however the Absolute is added when there is a mixture of gauge and absolute measurements to ensure there is a clear distinction"^^qudt:LatexString ;
+  qudt:applicableSystem sou:CGS ;
+  qudt:conversionMultiplier 100000.0 ;
+  qudt:conversionMultiplierSN 1.0E5 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Bar"^^xsd:anyURI ;
+  qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
+  qudt:hasQuantityKind quantitykind:ForcePerArea ;
+  qudt:hasQuantityKind quantitykind:VaporPressure ;
+  qudt:iec61360Code "0112/2///62720#UAA323" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Bar?oldid=493875987"^^xsd:anyURI ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Bar_(unit)"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/bar> ;
+  qudt:symbol "bar abs" ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
+  rdfs:label "Bar Absolute"@en .
+
 unit:BAUD
   a qudt:Unit ;
   dcterms:description "unit for the symbol rate in communications engineering and telecommunication, at which 1 baud corresponds to the speed, at which 1 symbol (defined measurable signal change in the physical exchange medium) will be exchanged per second" ;

--- a/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
+++ b/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
@@ -21914,7 +21914,7 @@ unit:KiloVAR-HR
 unit:KiloVAR-PER-K
   a qudt:Unit ;
   dcterms:description "1,000-fold of the unit volt ampere reactive divided by the SI base unit kelvin" ;
-  qudt:hasDimensionVector qkdv:A0E-1L-2I0M1H-1T-3D0 ;
+  qudt:hasDimensionVector qkdv:A0E0L2I0M1H-1T-3D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAD904" ;
   qudt:symbol "kVA{Reactive}/K" ;
@@ -30789,7 +30789,7 @@ unit:MicroVAR
 unit:MicroVAR-PER-K
   a qudt:Unit ;
   dcterms:description "0.000001-fold of the unit volt ampere reactive divided by the SI base unit kelvin" ;
-  qudt:hasDimensionVector qkdv:A0E-1L-2I0M1H-1T-3D0 ;
+  qudt:hasDimensionVector qkdv:A0E0L2I0M1H-1T-3D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAD903" ;
   qudt:symbol "µvar/K" ;
@@ -34369,7 +34369,7 @@ unit:MilliVAR
 unit:MilliVAR-PER-K
   a qudt:Unit ;
   dcterms:description "0.001-fold of the unit volt ampere reactive divided by the SI base unit kelvin" ;
-  qudt:hasDimensionVector qkdv:A0E-1L-2I0M1H-1T-3D0 ;
+  qudt:hasDimensionVector qkdv:A0E0L2I0M1H-1T-3D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAD902" ;
   qudt:symbol "mvar/K" ;
@@ -47748,7 +47748,7 @@ unit:VAR-HR
 unit:VAR-PER-K
   a qudt:Unit ;
   dcterms:description "unit volt ampere reactive divided by the SI base unit kelvin" ;
-  qudt:hasDimensionVector qkdv:A0E-1L-2I0M1H-1T-3D0 ;
+  qudt:hasDimensionVector qkdv:A0E0L2I0M1H-1T-3D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAD901" ;
   qudt:symbol "var/K" ;

--- a/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
+++ b/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
@@ -48375,14 +48375,12 @@ unit:W-PER-M2-MicroM
   qudt:applicableSystem sou:SI ;
   qudt:conversionMultiplier 1000000.0 ;
   qudt:conversionMultiplierSN 1.0E6 ;
-  qudt:hasDimensionVector qkdv:A0E0L-4I0M1H0T-3D0 ;
-  qudt:hasQuantityKind quantitykind:SpectralEmittance ;
-  qudt:hasQuantityKind quantitykind:SpectralIrradiance ;
-  qudt:plainTextDescription "A unit of spectral emittance or spectral irradiance, which is the emittance or irradiance per unit of wavelength. It is watts per square meter per micrometer" ;
+  qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-3D0 ;
+  qudt:hasQuantityKind quantitykind:SpectralRadiance ;
+  qudt:plainTextDescription "A unit of spectral radiance, which is the radiance per unit of wavelength. It is watts per square meter per micrometer" ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Watts per Meter Squared MicroMeter" ;
-  rdfs:seeAlso quantitykind:Emittance ;
-  rdfs:seeAlso quantitykind:Irradiance .
+  rdfs:seeAlso quantitykind:Radiance .
 
 unit:W-PER-M2-MicroM-SR
   a qudt:Unit ;

--- a/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
+++ b/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
@@ -11639,6 +11639,18 @@ unit:FLIGHT
   rdfs:label "Flight"@en ;
   skos:broader unit:NUM .
 
+unit:FLOPS
+  a qudt:Unit ;
+  dcterms:description "Floating point operations divided by the SI base unit second" ;
+  qudt:conversionMultiplier 1.0 ;
+  qudt:conversionMultiplierSN 1.0E0 ;
+  qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
+  qudt:hasQuantityKind quantitykind:FloatingPointCalculationCapability ;
+  qudt:iec61360Code "0112/2///62720#UAB593" ;
+  qudt:symbol "FLOPS" ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
+  rdfs:label "Floating Point Operations per Second" .
+
 unit:FM
   a qudt:Unit ;
   dcterms:description "The $\\textit{fermi}$, or $\\textit{femtometer}$ (other spelling $femtometre$, symbol $fm$) is an SI unit of length equal to $10^{-15} metre$. This distance is often encountered in nuclear physics as a characteristic of this scale. The symbol for the fermi is also $fm$."^^qudt:LatexString ;

--- a/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
+++ b/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
@@ -8447,6 +8447,27 @@ unit:CentiST
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "CentiStokes"@en .
 
+unit:Ci
+  a qudt:Unit ;
+  dcterms:description "The curie (symbol Ci) is a non-SI unit of radioactivity, named after Marie and Pierre Curie. It is defined as $1Ci = 3.7 \\times 10^{10} decays\\ per\\ second$. Its continued use is discouraged. One Curie is roughly the activity of 1 gram of the radium isotope Ra, a substance studied by the Curies. The SI derived unit of radioactivity is the becquerel (Bq), which equates to one decay per second. Therefore: $1Ci = 3.7 \\times 10^{10} Bq= 37 GBq$ and $1Bq \\equiv 2.703 \\times 10^{-11}Ci $."^^qudt:LatexString ;
+  dcterms:isReplacedBy unit:CI ;
+  qudt:applicableSystem sou:CGS ;
+  qudt:conversionMultiplier 37000000000.0 ;
+  qudt:conversionMultiplierSN 3.7E10 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Curie"^^xsd:anyURI ;
+  qudt:deprecated true ;
+  qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
+  qudt:hasQuantityKind quantitykind:Activity ;
+  qudt:iec61360Code "0112/2///62720#UAA138" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Curie?oldid=495080313"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/curie> ;
+  qudt:symbol "Ci" ;
+  qudt:ucumCode "Ci"^^qudt:UCUMcs ;
+  qudt:udunitsCode "Ci" ;
+  qudt:uneceCommonCode "CUR" ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
+  rdfs:label "Curie"@en .
+
 unit:DA
   a qudt:Unit ;
   dcterms:description "The unified atomic mass unit (symbol: $\\mu$) or dalton (symbol: Da) is a unit that is used for indicating mass on an atomic or molecular scale. It is defined as one twelfth of the rest mass of an unbound atom of carbon-12 in its nuclear and electronic ground state, and has a value of $1.660538782(83) \\times 10^{-27} kg$. One $Da$ is approximately equal to the mass of one proton or one neutron. The CIPM have categorised it as a \"non-SI unit whose values in SI units must be obtained experimentally\"."^^qudt:LatexString ;
@@ -18950,12 +18971,31 @@ unit:KiloCD
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "KiloCandela" .
 
-unit:KiloCi
+unit:KiloCI
   a qudt:Unit ;
   dcterms:description "1,000-fold of the unit curie"^^rdf:HTML ;
   qudt:applicableSystem sou:CGS ;
   qudt:conversionMultiplier 37000000000000.0 ;
   qudt:conversionMultiplierSN 3.7E13 ;
+  qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
+  qudt:hasQuantityKind quantitykind:Activity ;
+  qudt:hasQuantityKind quantitykind:DecayConstant ;
+  qudt:iec61360Code "0112/2///62720#UAB046" ;
+  qudt:plainTextDescription "1 000-fold of the unit curie" ;
+  qudt:symbol "kCi" ;
+  qudt:ucumCode "kCi"^^qudt:UCUMcs ;
+  qudt:uneceCommonCode "2R" ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
+  rdfs:label "KiloCurie"@en .
+
+unit:KiloCi
+  a qudt:Unit ;
+  dcterms:description "1,000-fold of the unit curie"^^rdf:HTML ;
+  dcterms:isReplacedBy unit:KiloCI ;
+  qudt:applicableSystem sou:CGS ;
+  qudt:conversionMultiplier 37000000000000.0 ;
+  qudt:conversionMultiplierSN 3.7E13 ;
+  qudt:deprecated true ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Activity ;
   qudt:hasQuantityKind quantitykind:DecayConstant ;
@@ -29175,13 +29215,32 @@ unit:MicroC-PER-M3
   rdfs:label "MicroCoulomb per Cubic Meter"@en-US ;
   rdfs:label "MicroCoulomb per Cubic Metre"@en .
 
-unit:MicroCi
+unit:MicroCI
   a qudt:Unit ;
   dcterms:description "Another commonly used measure of radioactivity, the microcurie: $1 \\micro Ci = 3.7 \\times 10 disintegrations per second = 2.22 \\times 10 disintegrations per minute$. A radiotherapy machine may have roughly 1000 Ci of a radioisotope such as caesium-137 or cobalt-60. This quantity of radioactivity can produce serious health effects with only a few minutes of close-range, un-shielded exposure. The typical human body contains roughly $0.1\\micro Ci$ of naturally occurring potassium-40. "^^qudt:LatexString ;
   qudt:applicableSystem sou:CGS ;
   qudt:conversionMultiplier 37000.0 ;
   qudt:conversionMultiplierSN 3.7E4 ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Curie"^^xsd:anyURI ;
+  qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
+  qudt:hasQuantityKind quantitykind:Activity ;
+  qudt:iec61360Code "0112/2///62720#UAA062" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Curie?oldid=495080313"^^xsd:anyURI ;
+  qudt:symbol "μCi" ;
+  qudt:ucumCode "uCi"^^qudt:UCUMcs ;
+  qudt:uneceCommonCode "M5" ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
+  rdfs:label "MicroCurie"@en .
+
+unit:MicroCi
+  a qudt:Unit ;
+  dcterms:description "Another commonly used measure of radioactivity, the microcurie: $1 \\micro Ci = 3.7 \\times 10 disintegrations per second = 2.22 \\times 10 disintegrations per minute$. A radiotherapy machine may have roughly 1000 Ci of a radioisotope such as caesium-137 or cobalt-60. This quantity of radioactivity can produce serious health effects with only a few minutes of close-range, un-shielded exposure. The typical human body contains roughly $0.1\\micro Ci$ of naturally occurring potassium-40. "^^qudt:LatexString ;
+  dcterms:isReplacedBy unit:MicroCI ;
+  qudt:applicableSystem sou:CGS ;
+  qudt:conversionMultiplier 37000.0 ;
+  qudt:conversionMultiplierSN 3.7E4 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Curie"^^xsd:anyURI ;
+  qudt:deprecated true ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Activity ;
   qudt:iec61360Code "0112/2///62720#UAA062" ;
@@ -31373,12 +31432,30 @@ unit:MilliCD
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "MilliCandela" .
 
-unit:MilliCi
+unit:MilliCI
   a qudt:Unit ;
   dcterms:description "0.001-fold of the SI derived unit curie"^^rdf:HTML ;
   qudt:applicableSystem sou:CGS ;
   qudt:conversionMultiplier 37000000.0 ;
   qudt:conversionMultiplierSN 3.7E7 ;
+  qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
+  qudt:hasQuantityKind quantitykind:Activity ;
+  qudt:iec61360Code "0112/2///62720#UAA786" ;
+  qudt:plainTextDescription "0.001-fold of the SI derived unit curie" ;
+  qudt:symbol "mCi" ;
+  qudt:ucumCode "mCi"^^qudt:UCUMcs ;
+  qudt:uneceCommonCode "MCU" ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
+  rdfs:label "MilliCurie"@en .
+
+unit:MilliCi
+  a qudt:Unit ;
+  dcterms:description "0.001-fold of the SI derived unit curie"^^rdf:HTML ;
+  dcterms:isReplacedBy unit:MilliCI ;
+  qudt:applicableSystem sou:CGS ;
+  qudt:conversionMultiplier 37000000.0 ;
+  qudt:conversionMultiplierSN 3.7E7 ;
+  qudt:deprecated true ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Activity ;
   qudt:iec61360Code "0112/2///62720#UAA786" ;


### PR DESCRIPTION
New consistency checks:
 - prevent `qudt:hasDimensionVector` to differ from the combined dimension vectors of the `qudt:hasFactorUnit`s if present
 - prevent `qudt:hasDimensionVector` to differ from the `qudt:scalingOf` if present
 - prevent mixing `qudt:scalingOf` and `qudt:hasFactorUnit`
 - prevent missing `qudt:deprecated`
 - if a dimension vector is missing and can be derived, there is an (additional) violation message containing the derived dimension vector
 - prevent a scaled unit (eg unit:MegaXYZ) from not having a base unit (eg. unit:XYZ)

Inferences have been sped up by an order of magnitude