### PR TITLE
Improve SHACL validation log output

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -297,7 +297,7 @@
             <plugin>
                 <groupId>io.github.qudtlib</groupId>
                 <artifactId>rdfio-maven-plugin</artifactId>
-                <version>1.5.3</version>
+                <version>1.5.5</version>
                 <executions>
                     <execution>
                         <!--


### PR DESCRIPTION
Bumps rdfio-maven-plugin version, which improves the SHACL validation log output (only shows results above the specified threshold, which is sh:Violation by default)