### PR TITLE
Fix spotless config

### DIFF
--- a/.github/workflows/fix.yml
+++ b/.github/workflows/fix.yml
@@ -34,21 +34,11 @@ jobs:
           git config user.name ${{ github.actor }}
           git config user.email "<>"
 
-      # Check formatting and exit early (with success) if format is ok
-      - name: Check formatting
-        run: |
-          if mvn spotless:check; then
-            echo "Source was already formatted, nothing was touched." >> $GITHUB_STEP_SUMMARY
-            exit 0
-          else
-            echo "Sources need formatting, we'll do that now"
-          fi
-
       # run mvn install,
       # if there are problems, try mvn -Pfix install
       # then run mvn install again
       # try that up to three times
-      - name: Apply formatting
+      - name: Apply formatting and fix recoverable data errors in src
         run: |
           attempt=0
           while true; do

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
 - Corrected `quantitykind:BohrMagneton` to `constant:BohrMagneton`
 - Corrected `quantitykind:MagneticFluxQuantum` to `constant:MagneticFluxQuantum`
 - Fixed some typos
+- Fixed source formatting with `mvn spotless:apply`, which was broken by a recent change.
 
 ## [3.1.4] - 2025-07-18
 

--- a/pom.xml
+++ b/pom.xml
@@ -2233,16 +2233,16 @@
                 <groupId>com.diffplug.spotless</groupId>
                 <artifactId>spotless-maven-plugin</artifactId>
                 <version>2.44.0.BETA3</version>
+                <!-- DO NOT specify multiple formats for the same file! The results are unpredictable! -->
                 <configuration>
                         <!-- default configuration - this is the one that is used if the plugin is
                         invoked directly using `mvn spotless:apply` or `mvn spotless:check`
+                        only formats src
                         -->
                         <rdf>
                             <includes>
                                 <include>src/main/rdf/**/*.ttl</include>
                                 <include>src/build/**/*.ttl</include>
-                                <include>target/dist/**/*.ttl</include>
-                                <exclude>target/validation/</exclude>
                             </includes>
                             <format>
                                 <failOnWarning>false</failOnWarning>
@@ -2253,26 +2253,22 @@
                                     <firstPredicateInNewLine>true</firstPredicateInNewLine>
                                 </turtle>
                             </format>
+                            <replaceRegex>
+                                <name>fix turtle-formatter newlines on windows and mac</name>
+                                <searchRegex>(\\r)+$</searchRegex>
+                                <replacement></replacement>
+                            </replaceRegex>
                         </rdf>
                     <markdown>
                         <includes>
                             <include>**/*.md</include>
                         </includes>
+                        <excludes>
+                            <include>target/**/*.*</include>
+                        </excludes>
                         <flexmark />
                     </markdown>
-
                     <formats>
-                        <format>
-                            <includes>
-                                <include>src/main/rdf/**/*.ttl</include>
-                                <include>target/dist/**/*.ttl</include>
-                            </includes>
-                            <replaceRegex>
-                                <name>fix turtle-formatter newlines on windows and mac</name>
-                                <searchRegex>(\\r)+$</searchRegex>
-                                <replacement />
-                            </replaceRegex>
-                        </format>
                         <!--
                         does our placeholder replacements using the maven properties
                         that were set using the groovy plugin
@@ -2282,6 +2278,7 @@
                                 <include>target/dist/**/*.*</include>
                             </includes>
                             <excludes>
+                                <include>target/**/*.ttl</include>
                                 <include>target/**/*.xlsx</include>
                                 <include>target/**/*.xls</include>
                                 <include>target/**/*.gif</include>
@@ -2412,6 +2409,54 @@
                                 <includes>
                                     <include>target/dist/**/*.ttl</include>
                                 </includes>
+                                <excludes>
+                                    <include>src/**/*.*</include>
+                                </excludes>
+                                <replaceRegex>
+                                    <name>fix turtle-formatter newlines on windows and mac</name>
+                                    <searchRegex>(\\r)+$</searchRegex>
+                                    <replacement></replacement>
+                                </replaceRegex>
+                                <replaceRegex>
+                                    <name>full version replacement</name>
+                                    <searchRegex>\$\$QUDT_VERSION\$\$</searchRegex>
+                                    <replacement>${project.version}</replacement>
+                                </replaceRegex>
+                                <replaceRegex>
+                                    <name>major.minor version replacement</name>
+                                    <searchRegex>\$\$QUDT_MAJOR_MINOR_VERSION\$\$</searchRegex>
+                                    <replacement>${project.version.majorminor}</replacement>
+                                </replaceRegex>
+                                <replace>
+                                    <name>publish date replacement</name>
+                                    <search>1234-12-12T12:34:56Z</search>
+                                    <replacement>${qudt.build.date}</replacement>
+                                </replace>
+                                <replaceRegex>
+                                    <name>versioned IRI replacement</name>
+                                    <searchRegex>http://qudt.org/\d+.\d+/</searchRegex>
+                                    <replacement>${qudt.versioned.iri.prefix}</replacement>
+                                </replaceRegex>
+                                <replace>
+                                    <name>current year</name>
+                                    <search>$$$$CURRENT_YEAR$$$$</search>
+                                    <replacement>${qudt.current.year}</replacement>
+                                </replace>
+                                <replace>
+                                    <name>current month</name>
+                                    <search>$$$$CURRENT_MONTH$$$$</search>
+                                    <replacement>${qudt.current.month}</replacement>
+                                </replace>
+                                <replace>
+                                    <name>current year</name>
+                                    <search>$$$$QUDT_PREV_RELEASE_YEAR$$$$</search>
+                                    <replacement>${qudtPrevReleaseYear}</replacement>
+                                </replace>
+                                <replace>
+                                    <name>current month</name>
+                                    <search>$$$$QUDT_PREV_RELEASE_MONTH$$$$</search>
+                                    <replacement>${qudtPrevReleaseMonth}</replacement>
+                                </replace>
                             </rdf>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -43,9 +43,9 @@
                 Each plugin has an <execution> section that binds its execution to a lifecycle phase (or it has a default lifecycle phase in which it runs, or 'none' for direct invocation).
                 Here are the phases and the execution ids that are linked to them (executed in the order they appear in this file):
                       validate                 defineAdditionalProperties, preprocess-shacl-files
-                      initialize
+                      initialize               check-src-format
                       generate-sources         unit-test
-                      process-sources          check-src-format, shacl-validate-src
+                      process-sources          shacl-validate-src
                       generate-resources       copy-rdf-to-dist, copy-rdf-to-work, copy-docs, copy-root-files, validate-shacl-files
                       process-resources
                       process-classes          main
@@ -2345,7 +2345,7 @@
                             the main branch.
                         -->
                         <id>check-src-format</id>
-                        <phase>process-sources</phase>
+                        <phase>initialize</phase>
                         <goals>
                             <goal>check</goal>
                         </goals>

--- a/src/main/rdf/schema/shacl/SCHEMA_QUDT-DATATYPES_NoOWL.ttl
+++ b/src/main/rdf/schema/shacl/SCHEMA_QUDT-DATATYPES_NoOWL.ttl
@@ -1,109 +1,57 @@
-# baseURI: http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype
-# imports: http://qudt.org/shacl/functions#
-# imports: http://www.linkedmodel.org/schema/dtype
-# imports: http://www.linkedmodel.org/schema/vaem
-# imports: http://www.w3.org/2004/02/skos/core
-# imports: http://www.w3.org/ns/shacl#
-
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix dtype: <http://www.linkedmodel.org/schema/dtype#> .
-@prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
 @prefix qfn: <http://qudt.org/shacl/functions#> .
 @prefix qudt: <http://qudt.org/schema/qudt/> .
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix vaem: <http://www.linkedmodel.org/schema/vaem#> .
 @prefix voag: <http://voag.linkedmodel.org/schema/voag#> .
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-dcterms:contributor
-  a rdf:Property ;
-  rdfs:label "contributor" ;
-.
-dcterms:creator
-  a rdf:Property ;
-  rdfs:label "creator" ;
-.
-dcterms:description
-  a rdf:Property ;
-  rdfs:label "description" ;
-.
-dcterms:rights
-  a rdf:Property ;
-  rdfs:label "rights" ;
-.
-dcterms:subject
-  a rdf:Property ;
-  rdfs:label "subject" ;
-.
-dcterms:title
-  a rdf:Property ;
-  rdfs:label "title" ;
-.
 <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype>
   a owl:Ontology ;
+  owl:imports <http://www.linkedmodel.org/schema/dtype> ;
+  owl:imports <http://www.linkedmodel.org/schema/vaem> ;
+  owl:imports <http://www.w3.org/2004/02/skos/core> ;
+  owl:imports qfn: ;
+  owl:imports sh: ;
+  rdfs:label "QUDT SHACL SCHEMA Datatypes Version $$QUDT_VERSION$$" ;
   vaem:hasCatalogEntry voag:QUDT-SchemaCatalogEntry ;
   vaem:hasGraphMetadata <http://qudt.org/schema/shacl/datatype/GMD_datatype> ;
   vaem:hasGraphRole vaem:SchemaGraph ;
   vaem:intent "This ontology is to be used by other ontologies that need datatype definitions." ;
   vaem:specificity 1 ;
-  vaem:url "http://qudt.org/$$QUDT_VERSION$$/schema/dtype"^^xsd:anyURI ;
-  rdfs:label "QUDT SHACL SCHEMA Datatypes Version $$QUDT_VERSION$$" ;
-  owl:imports qfn: ;
-  owl:imports <http://www.linkedmodel.org/schema/dtype> ;
-  owl:imports <http://www.linkedmodel.org/schema/vaem> ;
-  owl:imports <http://www.w3.org/2004/02/skos/core> ;
-  owl:imports sh: ;
-.
-<http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatypePrefixes>
-  sh:declare [
-      sh:namespace "http://qudt.org/schema/qudt/"^^xsd:anyURI ;
-      sh:prefix "qudt" ;
-    ] ;
-  sh:declare [
-      sh:namespace "http://qudt.org/vocab/quantitykind/"^^xsd:anyURI ;
-      sh:prefix "quantitykind" ;
-    ] ;
-  sh:declare [
-      sh:namespace "http://qudt.org/vocab/unit/"^^xsd:anyURI ;
-      sh:prefix "unit" ;
-    ] ;
-  sh:declare [
-      sh:namespace "http://www.w3.org/1999/02/22-rdf-syntax-ns#"^^xsd:anyURI ;
-      sh:prefix "rdf" ;
-    ] ;
-.
+  vaem:url "http://qudt.org/$$QUDT_VERSION$$/schema/dtype"^^xsd:anyURI .
+
 qudt:AbstractDatatype
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
-  <p>An \"Abstract Datatype\" (ADT) is a specification of a set of data and the set of operations that can be performed on the data. 
+  <p>An "Abstract Datatype" (ADT) is a specification of a set of data and the set of operations that can be performed on the data. 
   Such a data type is abstract in the sense that it is independent of various concrete implementations. 
   The definition can be mathematical, or it can be programmed as an interface. 
   A first class ADT supports the creation of multiple instances of the ADT, and the interface normally provides a constructor,
    which returns an abstract handle to new data, and several operations, 
    which are functions accepting the abstract handle as an argument.</p>
   """^^rdf:HTML ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "Abstract Datatype" ;
-  rdfs:subClassOf qudt:StructuredDatatype ;
   prov:wasInfluencedBy <http://en.wikipedia.org/wiki/Abstract_data_type> ;
   prov:wasInfluencedBy <http://xlinux.nist.gov/dads/HTML/abstractDataType.html> ;
-.
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  rdfs:label "Abstract Datatype" ;
+  rdfs:subClassOf qudt:StructuredDatatype .
+
 qudt:AerospaceCoordinateSystem
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description "A sub-type of 'Coordinate system'." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Aerospace Coordinate system" ;
-  rdfs:subClassOf qudt:CoordinateSystem ;
-.
+  rdfs:subClassOf qudt:CoordinateSystem .
+
 qudt:AlgebraicDatatype
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """<p>An <em>Algebraic Datatype</em> is a datatype each of whose values are data from other data types wrapped in one of the constructors of the data type. 
 Any wrapped datum is an argument to the constructor. 
 In contrast to other data types, the constructor is not executed and the only way to operate on the data is to unwrap the constructor using pattern matching.
@@ -117,15 +65,14 @@ Algebraic types are one kind of composite type (i.e. a type formed by combining 
 <p>An algebraic data type may also be an abstract data type (ADT) if it is exported from a module without its constructors. 
 Values of such a type can only be manipulated using functions defined in the same module as the type itself.
 </p>"""^^rdf:HTML ;
+  prov:wasInfluencedBy <http://en.wikipedia.org/wiki/Algebraic_data_type> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Algebraic Datatype" ;
   rdfs:seeAlso qudt:AbstractDatatype ;
-  rdfs:subClassOf qudt:StructuredDatatype ;
-  prov:wasInfluencedBy <http://en.wikipedia.org/wiki/Algebraic_data_type> ;
-.
+  rdfs:subClassOf qudt:StructuredDatatype .
+
 qudt:AlignmentType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   Specifies how a physical data field is aligned. 
   The alignment could be at a bit, byte or word boundary.
@@ -133,36 +80,10 @@ qudt:AlignmentType
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Alignment type" ;
   rdfs:subClassOf qudt:EnumeratedValue ;
-  sh:in (
-      qudt:BitAligned
-      qudt:ByteAligned
-      qudt:WordAligned
-    ) ;
-.
-qudt:AllValuesMustHaveSameDataTypeShape
-  a sh:NodeShape ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "All Values must have same DataType Shape" ;
-  sh:severity sh:Violation ;
-  sh:sparql [
-      sh:message "Data Item {$this} has type {?valueType}." ;
-      sh:prefixes <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatypePrefixes> ;
-      sh:select """
-        SELECT $this ?valueType
-        WHERE {
-              $this qudt:datatype/qudt:rdfsDatatype ?datatype .
-              $this qudt:value ?valueList.
-              ?valueList rdf:rest*/rdf:first ?value .
-              BIND(datatype(?value) as ?valueType) .
-              FILTER(?valueType != ?datatype)
-        }
-        """ ;
-    ] ;
-  sh:targetClass qudt:HomogeneousArray ;
-.
+  sh:in ( qudt:BitAligned qudt:ByteAligned qudt:WordAligned ) .
+
 qudt:Array
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   <p>An <em>Array></em> is a data structure that stores a collection of elements, typically of the same type, in a contiguous block of memory. 
   Each element in an array is identified by an index or key, which is typically a numerical identifier, either starting at '0' or '1'.
@@ -193,55 +114,18 @@ qudt:Array
   sh:property qudt:Array-value ;
   sh:property qudt:DatatypePropertyShape ;
   sh:property qudt:DimensionalityPropertyShape ;
-  sh:property qudt:DimensionsPropertyShape ;
-.
-qudt:Array-isHeterogeneous
-  a sh:PropertyShape ;
-  sh:path qudt:isHeterogeneous ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:boolean ;
-  sh:maxCount 1 ;
-.
-qudt:Array-value
-  a sh:PropertyShape ;
-  sh:path qudt:value ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:node qudt:NumericListShape ;
-.
-qudt:Array2DvalueList
-  a rdfs:Resource ;
-  dcterms:description """
-  An rdf:List for a 2D array.
-  For example \"[[1,2], [3,4], [5,6]]\"
-  """ ;
-  rdf:first [
-      sh:datatype qudt:List ;
-    ] ;
-  rdf:rest (
-      [
-        sh:datatype qudt:List ;
-      ]
-    ) ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "2D Array Value List" ;
-  rdfs:subClassOf rdf:List ;
-.
+  sh:property qudt:DimensionsPropertyShape .
+
 qudt:ArrayDataOrder
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description "A sub-type of 'Enumerated Value'. Detailed description to be provided in a future version." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Array data order" ;
   rdfs:subClassOf qudt:EnumeratedValue ;
-  sh:oneOf (
-      qudt:ByColumn
-      qudt:ByRow
-      qudt:ByLeftMostIndex
-    ) ;
-.
+  sh:oneOf ( qudt:ByColumn qudt:ByRow qudt:ByLeftMostIndex ) .
+
 qudt:ArrayType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   <p>An <em>Array Type</em> is a type specification for ordered entries of values arranged according to the dimensions given. 
   The dimensions are given as a list of integers where each integer is the cardinality of each dimension. 
@@ -258,11 +142,10 @@ qudt:ArrayType
   </p>"""^^rdf:HTML ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Array Type" ;
-  rdfs:subClassOf qudt:CompositeDatatype ;
-.
+  rdfs:subClassOf qudt:CompositeDatatype .
+
 qudt:AssociativeArray
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   <p>An <em>Associative Array</em> (or <em>Map</em>) is an abstract data type composed of a collection of keys and a collection of values,
    where each key is associated with one value. 
@@ -274,79 +157,41 @@ qudt:AssociativeArray
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Associative Array" ;
   rdfs:seeAlso qudt:Map ;
-  rdfs:subClassOf qudt:Array ;
-.
+  rdfs:subClassOf qudt:Array .
+
 qudt:AuralCue
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   rdfs:comment """
   <p>An aural cue is a sound produced by a device or a system that is used to alert personnel of of an advisory, cautionary, warning, or emergency state.
   </p>"""^^rdf:HTML ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Aural Cue" ;
   rdfs:subClassOf qudt:ModalCue ;
-  sh:property qudt:AuralCue-sound ;
-.
-qudt:AuralCue-sound
-  a sh:PropertyShape ;
-  sh:path qudt:sound ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:anyURI ;
-  sh:maxCount 1 ;
-  sh:minCount 1 ;
-.
-qudt:AuralCueEnumeration-defaultValue
-  a sh:PropertyShape ;
-  sh:path qudt:defaultValue ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:AuralCue ;
-.
+  sh:property qudt:AuralCue-sound .
+
 qudt:AxialOrientationType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description "The axial orientation of a coordinate system frame axis." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Axial Orientation Type" ;
   rdfs:subClassOf qudt:EnumeratedValue ;
-  sh:in (
-      qudt:PositiveZ
-      qudt:PositiveY
-      qudt:NegativeY
-      qudt:NegativeZ
-      qudt:PositiveX
-      qudt:NegativeX
-    ) ;
-.
+  sh:in ( qudt:PositiveZ qudt:PositiveY qudt:NegativeY qudt:NegativeZ qudt:PositiveX qudt:NegativeX ) .
+
 qudt:BalancedTree
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   <p>A <em>Balanced Tree</em> is a data type that defines the properties of data structures that represent balanced trees. 
   A balanced tree is a tree where no leaf is much farther away from the root than any other leaf. 
-  Different balancing schemes allow different definitions of \"much farther\" and different amounts of work to keep them balanced.
+  Different balancing schemes allow different definitions of "much farther" and different amounts of work to keep them balanced.
   </p>
   """^^rdf:HTML ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Balanced Tree Type" ;
   rdfs:subClassOf qudt:Tree ;
-  sh:property qudt:BalancedTree-maxDepth ;
-.
-qudt:BalancedTree-maxDepth
-  a sh:PropertyShape ;
-  sh:path qudt:maxDepth ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:integer ;
-  sh:maxCount 1 ;
-.
-qudt:BigEndian
-  a qudt:EndianType ;
-  dtype:literal "big" ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "Big Endian" ;
-.
+  sh:property qudt:BalancedTree-maxDepth .
+
 qudt:BigIntegerType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   <p>A <em>Big Integer</em> is an integer that can be represented in eight octets (64 bits) of machine memory. 
   Big integers may be signed or unsigned.
@@ -354,28 +199,20 @@ qudt:BigIntegerType
   """^^rdf:HTML ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Big Integer Type" ;
-  rdfs:subClassOf qudt:IntegerDatatype ;
-.
+  rdfs:subClassOf qudt:IntegerDatatype .
+
 qudt:BinaryTree
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   <p>A <em>Binary Tree</em> is a data type that defines the properties of data structures that represent binary trees. 
   A binary tree is a tree in which each node has at most 2 children.
   </p>"""^^rdf:HTML ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Binary Tree Type" ;
-  rdfs:subClassOf qudt:Tree ;
-.
-qudt:BitAligned
-  a qudt:AlignmentType ;
-  dtype:literal "bit" ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "Bit Aligned" ;
-.
+  rdfs:subClassOf qudt:Tree .
+
 qudt:BitEncodingType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   <p>A <em>Bit Encoding Type</em> is an encoding type for the correspondence between the two possible values of a bit, 0 or 1, and some interpretation. 
   For example, in a boolean encoding, a bit denotes a truth value, where 0 corresponds to False and 1 corresponds to True.
@@ -384,216 +221,89 @@ qudt:BitEncodingType
   rdfs:label "Bit Encoding" ;
   rdfs:subClassOf qudt:Encoding ;
   sh:property [
-      a sh:PropertyShape ;
-      sh:path [
-          sh:inversePath rdf:type ;
-        ] ;
-      rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-      sh:in (
-          qudt:BitEncoding
-        ) ;
+    a sh:PropertyShape ;
+    rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+    sh:in ( qudt:BitEncoding ) ;
+    sh:path [
+      sh:inversePath rdf:type ;
     ] ;
-.
-qudt:BitField
-  a rdfs:Datatype ;
-  dcterms:description """
-  <p>A bit field is a common idiom used in computer programming to store a set of Boolean datatype flags compactly, as a series of bits. 
-  The bit field is stored in an integral type of known, fixed bit-width. 
-  Each Boolean flag is stored in a separate bit. 
-  Usually the source code will define a set of constants, each a power of two, that semantically associate each individual bit with its respective Boolean flag. 
-  The bitwise operators and, or, and not are used in combination to set, reset and test the flags.
-  </p>"""^^rdf:HTML ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:subClassOf xsd:string ;
-.
-qudt:BooleanEncoding
-  a qudt:BooleanEncodingType ;
-  qudt:bits 1 ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "Boolean Encoding" ;
-.
+  ] .
+
 qudt:BooleanEncodingType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Boolean Encoding Type" ;
   rdfs:subClassOf qudt:Encoding ;
   sh:property [
-      a sh:PropertyShape ;
-      sh:path [
-          sh:inversePath rdf:type ;
-        ] ;
-      rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-      sh:in (
-          qudt:BooleanEncoding
-          qudt:BitEncoding
-          qudt:OctetEncoding
-        ) ;
+    a sh:PropertyShape ;
+    rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+    sh:in ( qudt:BooleanEncoding qudt:BitEncoding qudt:OctetEncoding ) ;
+    sh:path [
+      sh:inversePath rdf:type ;
     ] ;
-.
+  ] .
+
 qudt:BooleanType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description "A boolean data type can take on only two values." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Boolean Type" ;
   rdfs:subClassOf qudt:OrdinalType ;
-  sh:property qudt:BooleanType-encoding ;
-.
-qudt:BooleanType-encoding
-  a sh:PropertyShape ;
-  sh:path qudt:encoding ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:BooleanEncodingType ;
-.
+  sh:property qudt:BooleanType-encoding .
+
 qudt:BooleanTypeEnumeratedValue
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description "Specifies how a boolean value is expressed" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "boolean value" ;
-  rdfs:subClassOf qudt:EnumeratedValue ;
-.
-qudt:ByColumn
-  a qudt:ArrayDataOrder ;
-  dtype:literal "byColumn" ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "By Column" ;
-.
-qudt:ByLeftMostIndex
-  a qudt:ArrayDataOrder ;
-  dtype:literal "byLeftMostIndex" ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "By Left Most Index" ;
-.
-qudt:ByRow
-  a qudt:ArrayDataOrder ;
-  dtype:literal "byRow" ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "By row" ;
-.
-qudt:ByteAligned
-  a qudt:AlignmentType ;
-  dtype:literal "byte" ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "Byte Aligned" ;
-.
+  rdfs:subClassOf qudt:EnumeratedValue .
+
 qudt:ByteEncodingType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description "This class contains the various ways that information may be encoded into bytes." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Byte Encoding" ;
-  rdfs:subClassOf qudt:Encoding ;
-.
-qudt:CRC32
-  a rdfs:Datatype ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "CRC-32" ;
-  rdfs:subClassOf xsd:integer ;
-.
-qudt:CT_COUNTABLY-INFINITE
-  a qudt:CardinalityType ;
-  dcterms:description """
-  A set of numbers is called countably infinite if there is a way to enumerate them.
-  Formally this is done with a bijection function that associates each number in the set with exactly one of the positive integers.
-  The set of all fractions is also countably infinite.
-  In other words, any set $X$ that has the same cardinality as the set of the natural numbers,
-   or $| X | \\; =  \\; | \\mathbb N | \\; = \\; \\aleph0$, is said to be a countably infinite set.
-  """^^qudt:LatexString ;
-  qudt:informativeReference "http://www.math.vanderbilt.edu/~schectex/courses/infinity.pdf"^^xsd:anyURI ;
-  dtype:literal "countable" ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "Countably Infinite Cardinality Type" ;
-.
-qudt:CT_FINITE
-  a qudt:CardinalityType ;
-  dcterms:description """
-  Any set $X$ with cardinality less than that of the natural numbers, or
-  $$| X | \\; <  \\; | \\mathbb N | $$
-  is said to be a finite set.
-  """^^qudt:LatexString ;
-  dtype:literal "finite" ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "Finite Cardinality Type" ;
-.
-qudt:CT_UNCOUNTABLE
-  a qudt:CardinalityType ;
-  dcterms:description """
-  Any set with cardinality greater than that of the natural numbers, or 
-  $$| X | \\; >  \\; | \\mathbb N | $$
-  
-  For example $| R| \\; =  \\;  c  \\; > |\\mathbb N |$, is said to be uncountable.
-  """^^qudt:LatexString ;
-  dtype:literal "uncountable" ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "Uncountable Cardinality Type" ;
-.
+  rdfs:subClassOf qudt:Encoding .
+
 qudt:CardinalityType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   In mathematics, the cardinality of a set is a measure of the number of elements of the set.
   For example, the set $A = {2, 4, 6}$ contains 3 elements, and therefore $A$ has a cardinality of 3. 
   There are two approaches to cardinality: one which compares sets directly using bijections and injections,
    and another which uses cardinal numbers.
   """^^qudt:LatexString ;
+  prov:wasInfluencedBy <http://en.wikipedia.org/wiki/Cardinal_number> ;
+  prov:wasInfluencedBy <http://en.wikipedia.org/wiki/Cardinality> ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Cardinal_number"^^xsd:anyURI ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Cardinality"^^xsd:anyURI ;
   qudt:plainTextDescription "In mathematics, the cardinality of a set is a measure of the number of elements of the set.  For example, the set 'A = {2, 4, 6}' contains 3 elements, and therefore 'A' has a cardinality of 3. There are two approaches to cardinality – one which compares sets directly using bijections and injections, and another which uses cardinal numbers." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Cardinality Type" ;
   rdfs:subClassOf qudt:EnumeratedValue ;
-  prov:wasInfluencedBy <http://en.wikipedia.org/wiki/Cardinal_number> ;
-  prov:wasInfluencedBy <http://en.wikipedia.org/wiki/Cardinality> ;
-  sh:in (
-      qudt:CT_COUNTABLY-INFINITE
-      qudt:CT_UNCOUNTABLE
-      qudt:CT_FINITE
-    ) ;
+  sh:in ( qudt:CT_COUNTABLY-INFINITE qudt:CT_UNCOUNTABLE qudt:CT_FINITE ) ;
   sh:property qudt:CardinalityType-literal ;
   sh:property [
-      a sh:PropertyShape ;
-      sh:path [
-          sh:inversePath rdf:type ;
-        ] ;
-      rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-      sh:in (
-          qudt:CT_COUNTABLY-INFINITE
-          qudt:CT_FINITE
-          qudt:CT_UNCOUNTABLE
-        ) ;
+    a sh:PropertyShape ;
+    rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+    sh:in ( qudt:CT_COUNTABLY-INFINITE qudt:CT_FINITE qudt:CT_UNCOUNTABLE ) ;
+    sh:path [
+      sh:inversePath rdf:type ;
     ] ;
-.
-qudt:CardinalityType-literal
-  a sh:PropertyShape ;
-  sh:path dtype:literal ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:string ;
-  sh:maxCount 1 ;
-.
+  ] .
+
 qudt:CartesianCoordinates
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   A set of  variables which fix a geometric object.
   If the coordinates are distances measured along perpendicular axes, they are known as Cartesian coordinates.
   """ ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Cartesian Coordinate Type" ;
-  rdfs:subClassOf qudt:Coordinates ;
-.
-qudt:CharEncoding
-  a qudt:BooleanEncodingType ;
-  a qudt:CharEncodingType ;
-  dcterms:description "7 bits of 1 octet" ;
-  qudt:bytes 1 ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "Char Encoding" ;
-.
+  rdfs:subClassOf qudt:Coordinates .
+
 qudt:CharEncodingType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   <p>The class of all character encoding schemes.
   Each defines a rule or algorithm for encoding character data as a sequence of bits or bytes.
@@ -603,54 +313,35 @@ qudt:CharEncodingType
   rdfs:label "Char Encoding Type" ;
   rdfs:subClassOf qudt:Encoding ;
   sh:property [
-      a sh:PropertyShape ;
-      sh:path [
-          sh:inversePath rdf:type ;
-        ] ;
-      rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-      sh:in (
-          qudt:CharEncoding
-        ) ;
+    a sh:PropertyShape ;
+    rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+    sh:in ( qudt:CharEncoding ) ;
+    sh:path [
+      sh:inversePath rdf:type ;
     ] ;
-.
+  ] .
+
 qudt:CharacterType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   A <em>Character Type</em> is a data type that defines the type and encoding of single characters.
   """ ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Character Type" ;
-  rdfs:subClassOf qudt:OrdinalType ;
-.
+  rdfs:subClassOf qudt:OrdinalType .
+
 qudt:Collection
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   <p>A collection is a grouping of some variable number of zero or more data items that need to be operated upon together in some controlled fashion. 
   Generally, the data items will all share the same data type or are derived from some common ancestor data type.
   </p>"""^^rdf:HTML ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Collection Type" ;
-  rdfs:subClassOf qudt:StructuredDatatype ;
-.
-qudt:Collection-memberQuantity
-  a sh:PropertyShape ;
-  sh:path qudt:quantify ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:Quantity ;
-  sh:maxCount 1 ;
-.
-qudt:Collection-memberUnit
-  a sh:PropertyShape ;
-  sh:path qudt:hasUnit ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:Unit ;
-  sh:maxCount 1 ;
-.
+  rdfs:subClassOf qudt:StructuredDatatype .
+
 qudt:ColorCue
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   rdfs:comment """
   <p>A visual cue that uses color to distinguish it from other cues. 
   Each color cue has exactly one corresponding coordinate point in the RGB space.
@@ -658,19 +349,12 @@ qudt:ColorCue
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Color Cue" ;
   rdfs:subClassOf qudt:VisualCue ;
-  sh:property qudt:ColorCue-rgbCode ;
-.
-qudt:ColorCue-rgbCode
-  a sh:PropertyShape ;
-  sh:path qudt:rgbCode ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:string ;
-  sh:maxCount 1 ;
-  sh:minCount 1 ;
-.
+  sh:property qudt:ColorCue-rgbCode .
+
 qudt:CompositeDataStructure
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
+  prov:wasInfluencedBy <https://en.wikipedia.org/wiki/List_of_data_structures> ;
+  prov:wasInfluencedBy <https://en.wikipedia.org/wiki/Record_(computer_science)> ;
   rdfs:comment """
   <p>A <em>Composite Data Structure</em>, also referred to as <em>Data Record</em> is a datatype that aggregates element of possibly different types. 
   The aggregated items are called fields or members and are usually identified or indexed by field labels.
@@ -678,113 +362,64 @@ qudt:CompositeDataStructure
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Composite Data Structure" ;
   rdfs:subClassOf qudt:CompositeDatatype ;
-  prov:wasInfluencedBy <https://en.wikipedia.org/wiki/List_of_data_structures> ;
-  prov:wasInfluencedBy <https://en.wikipedia.org/wiki/Record_(computer_science)> ;
-  sh:property qudt:CompositeDataStructure-dataElement ;
-.
-qudt:CompositeDataStructure-dataElement
-  a sh:PropertyShape ;
-  sh:path qudt:field ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:DataSetElement ;
-.
+  sh:property qudt:CompositeDataStructure-dataElement .
+
 qudt:CompositeDatatype
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   <p>A <em>Composite Datatype</em> is a datatype that is constructed from basic primitive types and other composite types. 
   </p>"""^^rdf:HTML ;
+  prov:wasInfluencedBy <https://en.wikipedia.org/wiki/List_of_data_structures> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Composite Data Type" ;
   rdfs:subClassOf qudt:StructuredDatatype ;
-  prov:wasInfluencedBy <https://en.wikipedia.org/wiki/List_of_data_structures> ;
   sh:property qudt:CompositeDatatype-alignment ;
-  sh:property qudt:CompositeDatatype-padding ;
-.
-qudt:CompositeDatatype-alignment
-  a sh:PropertyShape ;
-  sh:path qudt:alignment ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:AlignmentType ;
-.
-qudt:CompositeDatatype-elementType
-  a sh:PropertyShape ;
-  sh:path qudt:hasQuantityKind ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:QuantityKind ;
-  sh:maxCount 1 ;
-  sh:minCount 1 ;
-.
-qudt:CompositeDatatype-padding
-  a sh:PropertyShape ;
-  sh:path qudt:padding ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:PaddingType ;
-  sh:maxCount 1 ;
-.
+  sh:property qudt:CompositeDatatype-padding .
+
 qudt:CompositeTable
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description "A sub-type of 'Table Type'." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Composite Table Type" ;
-  rdfs:subClassOf qudt:Table ;
-.
+  rdfs:subClassOf qudt:Table .
+
 qudt:CompositionFunction
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Composition function" ;
-  rdfs:subClassOf qudt:Function ;
-.
+  rdfs:subClassOf qudt:Function .
+
 qudt:CompositionTree
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Composition Tree" ;
   rdfs:subClassOf qudt:Tree ;
-  sh:property qudt:CompositionTree-compositionFunction ;
-.
-qudt:CompositionTree-compositionFunction
-  a sh:PropertyShape ;
-  sh:path qudt:function ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:CompositionFunction ;
-  sh:maxCount 1 ;
-  sh:minCount 1 ;
-.
+  sh:property qudt:CompositionTree-compositionFunction .
+
 qudt:CoordinateCenterKind
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   <p>An enumeration of coordinate centers for coordinate systems, such as:
-   \"Earth centered\", \"Mars centered\", \"Moon centered\", \"Sun centered\",  and \"Vehicle centered\".
+   "Earth centered", "Mars centered", "Moon centered", "Sun centered",  and "Vehicle centered".
   </p>"""^^rdf:HTML ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Coordinate Center Kind" ;
   rdfs:subClassOf qudt:EnumeratedValue ;
   rdfs:subClassOf qudt:NominalScale ;
-  sh:in (
-      qudt:CCT_MarsCentered
-      qudt:CCT_EarthCentered
-      qudt:CCT_MoonCentered
-      qudt:CCT_VehicleCentered
-      qudt:CCT_SunCentered
-    ) ;
-.
+  sh:in ( qudt:CCT_MarsCentered qudt:CCT_EarthCentered qudt:CCT_MoonCentered
+    qudt:CCT_VehicleCentered qudt:CCT_SunCentered ) .
+
 qudt:CoordinateMember
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   <p>A <em>Coordinate Member</em> is a data type that defines the properties of a coordinate in a coordinate system.
   </p>"""^^rdf:HTML ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Coordinate Member" ;
-  rdfs:subClassOf qudt:TupleMember ;
-.
+  rdfs:subClassOf qudt:TupleMember .
+
 qudt:CoordinateSystem
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   <p>A <em>Coordinate System</em> is a mathematical structure for assigning a unique n-tuple of numbers or scalars to each point in an n-dimensional space. 
   A Coordinate System Type is a data type that defines the properties of data structures that represent coordinate systems.
@@ -820,44 +455,10 @@ qudt:CoordinateSystem
   sh:property qudt:CoordinateSystem-acronym ;
   sh:property qudt:CoordinateSystem-coordinateCenter ;
   sh:property qudt:CoordinateSystem-originDefinition ;
-  sh:property qudt:CoordinateSystem-referenceFrame ;
-.
-qudt:CoordinateSystem-abbreviation
-  a sh:PropertyShape ;
-  sh:path qudt:abbreviation ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:maxCount 1 ;
-.
-qudt:CoordinateSystem-acronym
-  a sh:PropertyShape ;
-  sh:path vaem:acronym ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:maxCount 1 ;
-.
-qudt:CoordinateSystem-coordinateCenter
-  a sh:PropertyShape ;
-  sh:path qudt:coordinateCenter ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:CoordinateCenterKind ;
-  sh:maxCount 1 ;
-.
-qudt:CoordinateSystem-originDefinition
-  a sh:PropertyShape ;
-  sh:path qudt:originDefinition ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:string ;
-  sh:maxCount 1 ;
-.
-qudt:CoordinateSystem-referenceFrame
-  a sh:PropertyShape ;
-  sh:path qudt:referenceFrame ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:ReferenceFrame ;
-  sh:maxCount 1 ;
-.
+  sh:property qudt:CoordinateSystem-referenceFrame .
+
 qudt:Coordinates
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   <p>A coordinate system is a mathematical structure for assigning a unique n-tuple of numbers or scalars to each point in an n-dimensional space. 
   A Coordinate System Type is a data type that defines the properties of data structures that represent coordinate systems.
@@ -870,11 +471,10 @@ qudt:Coordinates
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Coordinates" ;
   rdfs:subClassOf qudt:Tuple ;
-  sh:property qudt:Coordinates-elementType ;
-.
+  sh:property qudt:Coordinates-elementType .
+
 qudt:Coordinates-2D
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   <p>A 2D coordinate system is a system for assigning a two-tuple of numbers or scalars to each point in an 2-dimensional space. 
   A corresponding 2D Coordinate Type is a data type that defines the data type for each coordinate (tuple member) in a 2D coordinate system.
@@ -882,11 +482,10 @@ qudt:Coordinates-2D
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "2D Coordinate Type" ;
   rdfs:subClassOf qudt:CartesianCoordinates ;
-  rdfs:subClassOf qudt:TwoTuple ;
-.
+  rdfs:subClassOf qudt:TwoTuple .
+
 qudt:Coordinates-2D-DoublePrecision
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   <p>A 2D coordinates in double floating point precision for locating a point in physical space.
   </p>"""^^rdf:HTML ;
@@ -895,27 +494,10 @@ qudt:Coordinates-2D-DoublePrecision
   rdfs:label "Coordinates-2D-Double precision" ;
   rdfs:subClassOf qudt:Coordinates-2D ;
   sh:property qudt:Coordinates-2D-DoublePrecision-double_X ;
-  sh:property qudt:Coordinates-2D-DoublePrecision-double_Y ;
-.
-qudt:Coordinates-2D-DoublePrecision-double_X
-  a sh:PropertyShape ;
-  sh:path qudt:double_X ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:double ;
-  sh:maxCount 1 ;
-  sh:minCount 1 ;
-.
-qudt:Coordinates-2D-DoublePrecision-double_Y
-  a sh:PropertyShape ;
-  sh:path qudt:double_Y ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:double ;
-  sh:maxCount 1 ;
-  sh:minCount 1 ;
-.
+  sh:property qudt:Coordinates-2D-DoublePrecision-double_Y .
+
 qudt:Coordinates-2D-SinglePrecision
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   <p>A 2D coordinates in single floating point precision for locating a point in physical space.
   </p>"""^^rdf:HTML ;
@@ -924,27 +506,10 @@ qudt:Coordinates-2D-SinglePrecision
   rdfs:label "Cartesian Coordinates 2D Single Precision" ;
   rdfs:subClassOf qudt:Coordinates-2D ;
   sh:property qudt:Coordinates-2D-DoublePrecision-double_X ;
-  sh:property qudt:Coordinates-2D-DoublePrecision-double_Y ;
-.
-qudt:Coordinates-2D-SinglePrecision-float_X
-  a sh:PropertyShape ;
-  sh:path qudt:float_X ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:float ;
-  sh:maxCount 1 ;
-  sh:minCount 1 ;
-.
-qudt:Coordinates-2D-SinglePrecision-float_Y
-  a sh:PropertyShape ;
-  sh:path qudt:float_Y ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:float ;
-  sh:maxCount 1 ;
-  sh:minCount 1 ;
-.
+  sh:property qudt:Coordinates-2D-DoublePrecision-double_Y .
+
 qudt:Coordinates-3D
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   <p>A 3D coordinate system is a system for assigning a three-tuple of numbers or scalars to each point in an 3-dimensional space.
   A corresponding 3D Coordinate Type is a data type that defines the data type for each coordinate (tuple member) in a 3D coordinate system.
@@ -952,11 +517,10 @@ qudt:Coordinates-3D
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "3D Coordinate Type" ;
   rdfs:subClassOf qudt:CartesianCoordinates ;
-  rdfs:subClassOf qudt:ThreeTuple ;
-.
+  rdfs:subClassOf qudt:ThreeTuple .
+
 qudt:Coordinates-3D-DoublePrecision
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   <p>A 3D coordinates in double floating point precision for locating a point in physical space.
   </p>"""^^rdf:HTML ;
@@ -965,35 +529,10 @@ qudt:Coordinates-3D-DoublePrecision
   rdfs:subClassOf qudt:Coordinates-3D ;
   sh:property qudt:Coordinates-3D-DoublePrecision-double_X ;
   sh:property qudt:Coordinates-3D-DoublePrecision-double_Y ;
-  sh:property qudt:Coordinates-3D-DoublePrecision-double_Z ;
-.
-qudt:Coordinates-3D-DoublePrecision-double_X
-  a sh:PropertyShape ;
-  sh:path qudt:double_X ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:double ;
-  sh:maxCount 1 ;
-  sh:minCount 1 ;
-.
-qudt:Coordinates-3D-DoublePrecision-double_Y
-  a sh:PropertyShape ;
-  sh:path qudt:double_Y ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:double ;
-  sh:maxCount 1 ;
-  sh:minCount 1 ;
-.
-qudt:Coordinates-3D-DoublePrecision-double_Z
-  a sh:PropertyShape ;
-  sh:path qudt:double_Z ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:double ;
-  sh:maxCount 1 ;
-  sh:minCount 1 ;
-.
+  sh:property qudt:Coordinates-3D-DoublePrecision-double_Z .
+
 qudt:Coordinates-3D-SinglePrecision
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   <p>A 3D coordinates in single floating point precision for locating a point in physical space.
   </p>
@@ -1003,35 +542,10 @@ qudt:Coordinates-3D-SinglePrecision
   rdfs:subClassOf qudt:Coordinates-3D ;
   sh:property qudt:Coordinates-3D-SinglePrecision-float_X ;
   sh:property qudt:Coordinates-3D-SinglePrecision-float_Y ;
-  sh:property qudt:Coordinates-3D-SinglePrecision-float_Z ;
-.
-qudt:Coordinates-3D-SinglePrecision-float_X
-  a sh:PropertyShape ;
-  sh:path qudt:float_X ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:float ;
-  sh:maxCount 1 ;
-  sh:minCount 1 ;
-.
-qudt:Coordinates-3D-SinglePrecision-float_Y
-  a sh:PropertyShape ;
-  sh:path qudt:float_Y ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:float ;
-  sh:maxCount 1 ;
-  sh:minCount 1 ;
-.
-qudt:Coordinates-3D-SinglePrecision-float_Z
-  a sh:PropertyShape ;
-  sh:path qudt:float_Z ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:float ;
-  sh:maxCount 1 ;
-  sh:minCount 1 ;
-.
+  sh:property qudt:Coordinates-3D-SinglePrecision-float_Z .
+
 qudt:Coordinates-3D-Type
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   <p>A 3D coordinate system is a system for assigning a three-tuple of numbers or scalars to each point in an 3-dimensional space. 
   A corresponding 3D Coordinate Type is a data type that defines the data type for each coordinate (tuple member) in a 3D coordinate system.
@@ -1039,17 +553,10 @@ qudt:Coordinates-3D-Type
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "3D Coordinate Type" ;
   rdfs:subClassOf qudt:CartesianCoordinatesType ;
-  rdfs:subClassOf qudt:ThreeTuple ;
-.
-qudt:Coordinates-elementType
-  a sh:PropertyShape ;
-  sh:path qudt:elementDatatype ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:CoordinateMember ;
-.
+  rdfs:subClassOf qudt:ThreeTuple .
+
 qudt:DataEncoding
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   <p><em>Data Encoding</em> expresses the properties that specify how data is represented at the bit and byte level. 
   These properties are applicable to describing raw data.
@@ -1059,32 +566,10 @@ qudt:DataEncoding
   rdfs:subClassOf qudt:Aspect ;
   sh:property qudt:DataEncoding-bitOrder ;
   sh:property qudt:DataEncoding-byteOrder ;
-  sh:property qudt:DataEncoding-encoding ;
-.
-qudt:DataEncoding-bitOrder
-  a sh:PropertyShape ;
-  sh:path qudt:bitOrder ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:EndianType ;
-  sh:maxCount 1 ;
-.
-qudt:DataEncoding-byteOrder
-  a sh:PropertyShape ;
-  sh:path qudt:byteOrder ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:EndianType ;
-  sh:maxCount 1 ;
-.
-qudt:DataEncoding-encoding
-  a sh:PropertyShape ;
-  sh:path qudt:encoding ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:Encoding ;
-  sh:maxCount 1 ;
-.
+  sh:property qudt:DataEncoding-encoding .
+
 qudt:DataSetElement
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   A field is a tuple that carries a name, a type and optionally other properties that characterize a member element of a composite data structure.
   """ ;
@@ -1094,241 +579,32 @@ qudt:DataSetElement
   rdfs:subClassOf qudt:Tuple ;
   sh:property qudt:DataSetElement-elementLabel ;
   sh:property qudt:DataSetElement-optional ;
-  sh:property qudt:DataSetElement-quantityKind ;
-.
-qudt:DataSetElement-elementLabel
-  a sh:PropertyShape ;
-  sh:path qudt:elementLabel ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:string ;
-  sh:maxCount 1 ;
-  sh:minCount 1 ;
-.
-qudt:DataSetElement-optional
-  a sh:PropertyShape ;
-  sh:path qudt:optional ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:boolean ;
-  sh:maxCount 1 ;
-  sh:minCount 0 ;
-.
-qudt:DataSetElement-quantityKind
-  a sh:PropertyShape ;
-  sh:path qudt:hasQuantityKind ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:QuantityKind ;
-  sh:maxCount 1 ;
-.
-qudt:Datatype
-  a sh:NodeShape ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:property qudt:Datatype-ansiSQLName ;
-  sh:property qudt:Datatype-basis ;
-  sh:property qudt:Datatype-bounded ;
-  sh:property qudt:Datatype-cName ;
-  sh:property qudt:Datatype-cardinality ;
-  sh:property qudt:Datatype-id ;
-  sh:property qudt:Datatype-javaName ;
-  sh:property qudt:Datatype-jsName ;
-  sh:property qudt:Datatype-matlabName ;
-  sh:property qudt:Datatype-microsoftSQLServerName ;
-  sh:property qudt:Datatype-mySQLName ;
-  sh:property qudt:Datatype-odbcName ;
-  sh:property qudt:Datatype-oleDBName ;
-  sh:property qudt:Datatype-oracleSQLName ;
-  sh:property qudt:Datatype-orderedType ;
-  sh:property qudt:Datatype-protocolBuffersName ;
-  sh:property qudt:Datatype-pythonName ;
-  sh:property qudt:Datatype-vbName ;
-.
-qudt:Datatype-ansiSQLName
-  a sh:PropertyShape ;
-  sh:path qudt:ansiSQLName ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:string ;
-  sh:maxCount 1 ;
-  sh:minCount 0 ;
-.
-qudt:Datatype-basis
-  a sh:PropertyShape ;
-  sh:path qudt:basis ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:Datatype ;
-  sh:maxCount 1 ;
-.
-qudt:Datatype-bounded
-  a sh:PropertyShape ;
-  sh:path qudt:bounded ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class xsd:boolean ;
-  sh:maxCount 1 ;
-.
-qudt:Datatype-cName
-  a sh:PropertyShape ;
-  sh:path qudt:cName ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:string ;
-  sh:maxCount 1 ;
-  sh:minCount 0 ;
-.
-qudt:Datatype-cardinality
-  a sh:PropertyShape ;
-  sh:path qudt:cardinality ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:CardinalityType ;
-  sh:maxCount 1 ;
-.
-qudt:Datatype-description
-  a sh:PropertyShape ;
-  sh:path vaem:description ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:deactivated true ;
-  sh:maxCount 1 ;
-.
-qudt:Datatype-id
-  a sh:PropertyShape ;
-  sh:path qudt:id ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:string ;
-  sh:deactivated true ;
-  sh:maxCount 1 ;
-.
-qudt:Datatype-javaName
-  a sh:PropertyShape ;
-  sh:path qudt:javaName ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:string ;
-  sh:maxCount 1 ;
-  sh:minCount 0 ;
-.
-qudt:Datatype-jsName
-  a sh:PropertyShape ;
-  sh:path qudt:jsName ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:string ;
-  sh:maxCount 1 ;
-  sh:minCount 0 ;
-.
-qudt:Datatype-matlabName
-  a sh:PropertyShape ;
-  sh:path qudt:matlabName ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:string ;
-  sh:maxCount 1 ;
-  sh:minCount 0 ;
-.
-qudt:Datatype-microsoftSQLServerName
-  a sh:PropertyShape ;
-  sh:path qudt:microsoftSQLServerName ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:string ;
-  sh:maxCount 1 ;
-  sh:minCount 0 ;
-.
-qudt:Datatype-mySQLName
-  a sh:PropertyShape ;
-  sh:path qudt:mySQLName ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:string ;
-  sh:minCount 0 ;
-.
-qudt:Datatype-odbcName
-  a sh:PropertyShape ;
-  sh:path qudt:odbcName ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:string ;
-  sh:maxCount 1 ;
-  sh:minCount 0 ;
-.
-qudt:Datatype-oleDBName
-  a sh:PropertyShape ;
-  sh:path qudt:oleDBName ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:string ;
-  sh:maxCount 1 ;
-  sh:minCount 0 ;
-.
-qudt:Datatype-oracleSQLName
-  a sh:PropertyShape ;
-  sh:path qudt:oracleSQLName ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:string ;
-  sh:maxCount 1 ;
-  sh:minCount 0 ;
-.
-qudt:Datatype-orderedType
-  a sh:PropertyShape ;
-  sh:path qudt:orderedType ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:OrderedType ;
-  sh:maxCount 1 ;
-.
-qudt:Datatype-protocolBuffersName
-  a sh:PropertyShape ;
-  sh:path qudt:protocolBuffersName ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:string ;
-  sh:maxCount 1 ;
-  sh:minCount 0 ;
-.
-qudt:Datatype-pythonName
-  a sh:PropertyShape ;
-  sh:path qudt:pythonName ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:string ;
-  sh:maxCount 1 ;
-  sh:minCount 0 ;
-.
-qudt:Datatype-vbName
-  a sh:PropertyShape ;
-  sh:path qudt:vbName ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:string ;
-  sh:maxCount 1 ;
-  sh:minCount 0 ;
-.
-qudt:DatatypePropertyShape
-  a sh:PropertyShape ;
-  sh:path qudt:datatype ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:Datatype ;
-  sh:maxCount 1 ;
-  sh:minCount 1 ;
-.
+  sh:property qudt:DataSetElement-quantityKind .
+
 qudt:DateStringType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description "Date String Types are scalar data types that define the properties of strings that represent calendar dates." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Date String Type" ;
-  rdfs:subClassOf qudt:DateTimeStringType ;
-.
+  rdfs:subClassOf qudt:DateTimeStringType .
+
 qudt:DateTimeStringEncodingType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description "Date Time encodings are logical encodings for expressing date/time quantities as strings by applying unambiguous formatting and parsing rules." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Date Time String Encoding Type" ;
   rdfs:subClassOf qudt:StringEncodingType ;
   sh:property qudt:DateTimeStringEncodingType-allowedPattern ;
   sh:property [
-      sh:path qudt:allowedPattern ;
-      sh:qualifiedMinCount 1 ;
-      sh:qualifiedValueShape [
-          sh:datatype xsd:string ;
-        ] ;
+    sh:path qudt:allowedPattern ;
+    sh:qualifiedMinCount 1 ;
+    sh:qualifiedValueShape [
+      sh:datatype xsd:string ;
     ] ;
-.
-qudt:DateTimeStringEncodingType-allowedPattern
-  a sh:PropertyShape ;
-  sh:path qudt:allowedPattern ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:string ;
-  sh:minCount 1 ;
-.
+  ] .
+
 qudt:DateTimeStringType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   <p>A class of data types for structures that represent temporal quantities.
   For example, calendar dates, times, duration of time since a given epoch, etc.
@@ -1336,49 +612,17 @@ qudt:DateTimeStringType
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Temporal Type" ;
   rdfs:subClassOf qudt:StringType ;
-  sh:property qudt:DateTimeStringType-encoding ;
-.
-qudt:DateTimeStringType-encoding
-  a sh:PropertyShape ;
-  sh:path qudt:encoding ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:DateTimeStringEncodingType ;
-  sh:maxCount 1 ;
-.
-qudt:DateTypeUnion
-  a rdf:List ;
-  dcterms:description """
-  An rdf:List that can be used in property constraints as the type in an sh:or to indicate
-   that all values of a property must be an xsd date type.
-  """ ;
-  rdf:first [
-      sh:datatype xsd:date ;
-    ] ;
-  rdf:rest (
-      [
-        sh:datatype xsd:dateTime ;
-      ]
-      [
-        sh:datatype xsd:gYear ;
-      ]
-      [
-        sh:datatype xsd:gMonth ;
-      ]
-    ) ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "Date Type Union" ;
-.
+  sh:property qudt:DateTimeStringType-encoding .
+
 qudt:Dictionary
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description "A \"Map\"." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Dictionary Type" ;
-  rdfs:subClassOf qudt:Map ;
-.
+  rdfs:subClassOf qudt:Map .
+
 qudt:DimensionalDatatype
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   <p>A <em>Dimensional Data Type</em> is a data type that specifies a physical quantity or unit of measure.
   Information about the physical dimensions of the quantities and units is embedded in their types.
@@ -1386,50 +630,10 @@ qudt:DimensionalDatatype
   """^^rdf:HTML ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Dimensional Data Type" ;
-  rdfs:subClassOf qudt:StructuredDatatype ;
-.
-qudt:DimensionalityPropertyShape
-  a sh:PropertyShape ;
-  sh:path qudt:dimensionality ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:integer ;
-  sh:maxCount 1 ;
-.
-qudt:DimensionalityShape
-  a sh:NodeShape ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "Dimensions Shape" ;
-  sh:severity sh:Warning ;
-  sh:sparql [
-      sh:message "\"{$this}\" has {$actualDimensions} dimensions extent and needs to have {$specifiedDimensions}" ;
-      sh:prefixes <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatypePrefixes> ;
-      sh:select """
-        SELECT $this $actualDimensions $specifiedDimensions
-        WHERE {
-            $this qudt:dimensionality $dimensionality .
-            $this qudt:dimensions ?dimensions .
-            ?dimensions rdf:rest*/rdf:first $specifiedDimensions .
-            { SELECT $this (COUNT(?listValue )AS $actualDimensions)
-              WHERE {
-              $this qudt:value/rdf:rest*/rdf:first ?listValue .
-              } GROUP BY $this
-            }
-            FILTER ($actualDimensions != $specifiedDimensions)
-          }
-        """ ;
-    ] ;
-  sh:targetClass qudt:Array ;
-  sh:targetClass qudt:List ;
-.
-qudt:DimensionsPropertyShape
-  a sh:PropertyShape ;
-  sh:path qudt:dimensions ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:node qudt:IntegerListShape ;
-.
+  rdfs:subClassOf qudt:StructuredDatatype .
+
 qudt:DiscreteState
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   <p>A <em>Discrete State</em> is the parent class for enumerated values that express a 'State' or 'Condition'.
   Examples are 'on' and 'off for a switch, 'open' and 'closed' for a valve, and 'wet' and 'dry'.
@@ -1438,18 +642,10 @@ qudt:DiscreteState
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Discrete State" ;
   rdfs:subClassOf qudt:EnumeratedValue ;
-  sh:property qudt:DiscreteState-inverted ;
-.
-qudt:DiscreteState-inverted
-  a sh:PropertyShape ;
-  sh:path qudt:inverted ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:boolean ;
-  sh:maxCount 1 ;
-.
+  sh:property qudt:DiscreteState-inverted .
+
 qudt:DoublePrecisionType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   <p>A double precision data type specifies how a numeric value, such as an integer or real number, is stored in memory.
   Typically this occupies two words in computer memory, where the byte length of a word depends on machine address size of the computer processor. 
@@ -1458,13 +654,12 @@ qudt:DoublePrecisionType
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Double Precision Type" ;
   rdfs:subClassOf qudt:NumericType ;
-  sh:disjoint qudt:SinglePrecisionType ;
-.
+  sh:disjoint qudt:SinglePrecisionType .
+
 qudt:EarthCoordinateSystem
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
-  <p>A \"Trajectory Coordinate System\" for all earth-centered coordinates, such as:
+  <p>A "Trajectory Coordinate System" for all earth-centered coordinates, such as:
   </p>
   <ul>
   <li>Earth mean equator and prime meridian coordinate system;;</li>
@@ -1477,18 +672,10 @@ qudt:EarthCoordinateSystem
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Earth Coordinate System Type" ;
   rdfs:subClassOf qudt:TrajectoryCoordinateSystem ;
-  sh:property qudt:EarthCoordinateSystem-coordinateCenter ;
-.
-qudt:EarthCoordinateSystem-coordinateCenter
-  a sh:PropertyShape ;
-  sh:path qudt:coordinateCenter ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:CoordinateCenterKind ;
-  sh:hasValue qudt:CCT_EarthCentered ;
-.
+  sh:property qudt:EarthCoordinateSystem-coordinateCenter .
+
 qudt:Encoding
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   <p>An encoding is a rule or algorithm that is used to convert data from a native, or unspecified form into a specific form that satisfies the encoding rules. 
   Examples of encodings include character encodings, such as UTF-8.
@@ -1497,45 +684,26 @@ qudt:Encoding
   rdfs:label "Encoding" ;
   rdfs:subClassOf skos:Concept ;
   sh:property qudt:Encoding-bits ;
-  sh:property qudt:Encoding-bytes ;
-.
-qudt:Encoding-bits
-  a sh:PropertyShape ;
-  sh:path qudt:bits ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:integer ;
-  sh:maxCount 1 ;
-.
-qudt:Encoding-bytes
-  a sh:PropertyShape ;
-  sh:path qudt:bytes ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:integer ;
-  sh:maxCount 1 ;
-.
+  sh:property qudt:Encoding-bytes .
+
 qudt:EndianType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Endianness"^^xsd:anyURI ;
   qudt:plainTextDescription "In computing, endianness is the ordering used to represent some kind of data as a sequence of smaller units. Typical cases are the order in which integer values are stored as bytes in computer memory (relative to a given memory addressing scheme) and the transmission order over a network or other medium. When specifically talking about bytes, endianness is also referred to simply as byte order.  Most computer processors simply store integers as sequences of bytes, so that, conceptually, the encoded value can be obtained by simple concatenation. For an 'n-byte' integer value this allows 'n!' (n factorial) possible representations (one for each byte permutation). The two most common of them are: increasing numeric significance with increasing memory addresses, known as little-endian, and its opposite, called big-endian." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Endian Type" ;
   rdfs:subClassOf qudt:EnumeratedValue ;
   sh:property [
-      a sh:PropertyShape ;
-      sh:path [
-          sh:inversePath rdf:type ;
-        ] ;
-      rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-      sh:in (
-          qudt:LittleEndian
-          qudt:BigEndian
-        ) ;
+    a sh:PropertyShape ;
+    rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+    sh:in ( qudt:LittleEndian qudt:BigEndian ) ;
+    sh:path [
+      sh:inversePath rdf:type ;
     ] ;
-.
+  ] .
+
 qudt:EngineeringValueTupleMember
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   <p>A sub-type of 'Tuple Member Type'. 
   </p>"""^^rdf:HTML ;
@@ -1544,67 +712,33 @@ qudt:EngineeringValueTupleMember
   rdfs:subClassOf qudt:TupleMember ;
   sh:disjoint qudt:RawValueTupleMember ;
   sh:disjoint qudt:RawValueTupleMemberType ;
-  sh:property qudt:EngineeringValueTupleMember-elementType ;
-.
-qudt:EngineeringValueTupleMember-elementType
-  a sh:PropertyShape ;
-  sh:path qudt:elementDatatype ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:RealSinglePrecisionType ;
-.
+  sh:property qudt:EngineeringValueTupleMember-elementType .
+
 qudt:Enumeration
-  a rdfs:Class ;
-  a sh:NodeShape ;
-  vaem:isElaboratedIn <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  a rdfs:Class, sh:NodeShape ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "QUDT Enumeration" ;
-  rdfs:subClassOf qudt:StructuredDatatype ;
   rdfs:subClassOf dtype:Enumeration ;
+  rdfs:subClassOf qudt:StructuredDatatype ;
   sh:property qudt:Enumeration-bits ;
   sh:property qudt:Enumeration-defaultValue ;
   sh:property qudt:Enumeration-encoding ;
   sh:property qudt:Enumeration-value ;
-.
-qudt:Enumeration-bits
-  a sh:PropertyShape ;
-  sh:path qudt:bits ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:integer ;
-  sh:maxCount 1 ;
-.
-qudt:Enumeration-defaultValue
-  a sh:PropertyShape ;
-  sh:path qudt:defaultValue ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:EnumeratedValue ;
-.
-qudt:Enumeration-encoding
-  a sh:PropertyShape ;
-  sh:path qudt:encoding ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:maxCount 1 ;
-.
-qudt:Enumeration-value
-  a sh:PropertyShape ;
-  sh:path dtype:value ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:EnumeratedValue ;
-.
+  vaem:isElaboratedIn <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> .
+
 qudt:EnumerationScale
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   A sub-type of 'DTYPE Enumeration'.
   """ ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Enumeration scale" ;
-  rdfs:subClassOf qudt:Scale ;
   rdfs:subClassOf dtype:Enumeration ;
-  sh:class dtype:Enumeration ;
-.
+  rdfs:subClassOf qudt:Scale ;
+  sh:class dtype:Enumeration .
+
 qudt:FieldType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   A sub-type of 'Composite Data Type'.
   """ ;
@@ -1614,58 +748,19 @@ qudt:FieldType
   sh:property qudt:FieldType-elementName ;
   sh:property qudt:FieldType-elementType ;
   sh:property qudt:FieldType-fieldLabel ;
-  sh:property qudt:FieldType-fieldType ;
-.
-qudt:FieldType-elementName
-  a sh:PropertyShape ;
-  sh:path qudt:elementName ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:string ;
-  sh:maxCount 1 ;
-  sh:minCount 1 ;
-.
-qudt:FieldType-elementType
-  a sh:PropertyShape ;
-  sh:path qudt:elementDatatype ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:Datatype ;
-.
-qudt:FieldType-fieldLabel
-  a sh:PropertyShape ;
-  sh:path qudt:fieldLabel ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:string ;
-  sh:maxCount 1 ;
-  sh:minCount 1 ;
-.
-qudt:FieldType-fieldType
-  a sh:PropertyShape ;
-  sh:path qudt:fieldType ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:Datatype ;
-  sh:minCount 1 ;
-.
-qudt:FieldType-optional
-  a sh:PropertyShape ;
-  sh:path qudt:optional ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:boolean ;
-  sh:maxCount 1 ;
-  sh:minCount 0 ;
-.
+  sh:property qudt:FieldType-fieldType .
+
 qudt:FileFormat
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   A sub-type of 'Enumerated Value'.
   """ ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "File format" ;
-  rdfs:subClassOf qudt:EnumeratedValue ;
-.
+  rdfs:subClassOf qudt:EnumeratedValue .
+
 qudt:FixedIntervalTimeSeriesArray
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   <p>A <em>Fixed Interval Time Series Array Type</em> is a data type that specifies the properties of arrays that hold time series data.
   For example, data that has been sampled over uniformly spaced time intervals.
@@ -1673,36 +768,33 @@ qudt:FixedIntervalTimeSeriesArray
   </p>"""^^rdf:HTML ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Fixed Interval Time Series Array Type" ;
-  rdfs:subClassOf qudt:TimeSeriesArray ;
-.
+  rdfs:subClassOf qudt:TimeSeriesArray .
+
 qudt:FixedIntervalTimeSeriesArrayType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """A <em>Fixed Interval Time Series Array Type</em> is a data type that specifies the properties of arrays that hold time series data.
  For example, data that has been sampled over uniformly spaced time intervals. 
  A time series is a sequence of data points, measured typically at successive times, spaced at uniform or non-uniform time intervals.
  </p>"""^^rdf:HTML ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Fixed Interval Time Series Array Type" ;
-  rdfs:subClassOf qudt:TimeSeriesArrayType ;
-.
+  rdfs:subClassOf qudt:TimeSeriesArrayType .
+
 qudt:FloatingPointEncodingType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
-  <p>A type for specifying an \"Encoding\" with the following instance(s): 
-  \"Double Precision Encoding\", and \"Single Precision Real Encoding\".
+  <p>A type for specifying an "Encoding" with the following instance(s): 
+  "Double Precision Encoding", and "Single Precision Real Encoding".
   </p>"""^^rdf:HTML ;
   dcterms:description """
-  A \"Encoding\" with the following instance(s): \"Double Precision Encoding\", \"Single Precision Real Encoding\".
+  A "Encoding" with the following instance(s): "Double Precision Encoding", "Single Precision Real Encoding".
   """ ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Floating Point Encoding" ;
-  rdfs:subClassOf qudt:Encoding ;
-.
+  rdfs:subClassOf qudt:Encoding .
+
 qudt:FrameType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   <p>A <em>Frame Type</em> specifies the intertial type of a coordinate frame as either inertial, rotating, or non-rotating.
   </p>
@@ -1710,22 +802,16 @@ qudt:FrameType
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Frame Type" ;
   rdfs:subClassOf qudt:EnumeratedValue ;
-  sh:in (
-      qudt:FT_ROTATING
-      qudt:FT_NON-ROTATING
-      qudt:FT_INERTIAL
-    ) ;
-.
+  sh:in ( qudt:FT_ROTATING qudt:FT_NON-ROTATING qudt:FT_INERTIAL ) .
+
 qudt:Function
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Function" ;
-  rdfs:subClassOf qudt:Concept ;
-.
+  rdfs:subClassOf qudt:Concept .
+
 qudt:FunctionDatatype
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   <p>A function data type defines the input and output data type for a function or method. 
   The data type includes at least the function name and the number of its parameters. 
@@ -1736,66 +822,40 @@ qudt:FunctionDatatype
   rdfs:subClassOf qudt:StructuredDatatype ;
   sh:property qudt:FunctionDatatype-argType ;
   sh:property qudt:FunctionDatatype-functionArity ;
-  sh:property qudt:FunctionDatatype-returnType ;
-.
-qudt:FunctionDatatype-argType
-  a sh:PropertyShape ;
-  sh:path qudt:argType ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:Datatype ;
-.
-qudt:FunctionDatatype-functionArity
-  a sh:PropertyShape ;
-  sh:path qudt:functionArity ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:integer ;
-  sh:maxCount 1 ;
-  sh:minCount 1 ;
-.
-qudt:FunctionDatatype-returnType
-  a sh:PropertyShape ;
-  sh:path qudt:returnType ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:Datatype ;
-  sh:maxCount 1 ;
-  sh:minCount 0 ;
-.
+  sh:property qudt:FunctionDatatype-returnType .
+
 qudt:Graph
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   <p>A <em>Graph</em> is an instance of a kind of abstract data type, that consists of a set of nodes (also called vertices) and a set of edges that establish relationships (connections) between the nodes. 
   A Graph Type is a data type that defines the properties of data structures that represent graphs and their members (nodes and edges).
   </p>"""^^rdf:HTML ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Graph Type" ;
-  rdfs:subClassOf qudt:DataItem ;
-.
+  rdfs:subClassOf qudt:DataItem .
+
 qudt:GroundCoordinateSystem
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description "A sub-type of 'Aerospace coordinate system'." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Ground coordinate system" ;
-  rdfs:subClassOf qudt:AerospaceCoordinateSystem ;
-.
+  rdfs:subClassOf qudt:AerospaceCoordinateSystem .
+
 qudt:Heap
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   <p>A heap is a specialized tree-based data structure that satisfies the condition: if B is a child node of A, then $key(A) \\ge key(B)$. 
   This implies that an element with the greatest key is always in the root node, and so such a heap is sometimes called a max heap. 
   Alternatively, if the comparison is reversed, the smallest element is always in the root node, which results in a min heap. 
   The function or method that implements the key() operator is specified by the heap type.
   </p>"""^^rdf:HTML ;
+  prov:wasInfluencedBy <http://en.wikipedia.org/wiki/Heap_(data_structure)> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Heap" ;
-  rdfs:subClassOf qudt:OrderedTree ;
-  prov:wasInfluencedBy <http://en.wikipedia.org/wiki/Heap_(data_structure)> ;
-.
+  rdfs:subClassOf qudt:OrderedTree .
+
 qudt:HeterogenousArray
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   <p>An <em>Array></em> is a data structure that stores a collection of elements, typically of the same type, in a contiguous block of memory. 
   Each element in an array is identified by an index or key, which is typically a numerical identifier, either starting at '0' or '1'.
@@ -1825,19 +885,10 @@ qudt:HeterogenousArray
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Heterogenous Array" ;
   rdfs:subClassOf qudt:Array ;
-  sh:property qudt:HeterogenousArray-datatype ;
-.
-qudt:HeterogenousArray-datatype
-  a sh:PropertyShape ;
-  sh:path qudt:datatype ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:Datatype ;
-  sh:maxCount 1 ;
-  sh:minCount 1 ;
-.
+  sh:property qudt:HeterogenousArray-datatype .
+
 qudt:HexBinaryType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description "A string composed of hex characters." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Hexidecimal Binary Type" ;
@@ -1845,39 +896,10 @@ qudt:HexBinaryType
   sh:property qudt:HexBinaryType-length ;
   sh:property qudt:HexBinaryType-maxLength ;
   sh:property qudt:HexBinaryType-minLength ;
-  sh:property qudt:HexBinaryType-pattern ;
-.
-qudt:HexBinaryType-length
-  a sh:PropertyShape ;
-  sh:path qudt:length ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:integer ;
-  sh:maxCount 1 ;
-.
-qudt:HexBinaryType-maxLength
-  a sh:PropertyShape ;
-  sh:path qudt:maxLength ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:integer ;
-  sh:maxCount 1 ;
-.
-qudt:HexBinaryType-minLength
-  a sh:PropertyShape ;
-  sh:path qudt:minLength ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:integer ;
-  sh:maxCount 1 ;
-.
-qudt:HexBinaryType-pattern
-  a sh:PropertyShape ;
-  sh:path qudt:pattern ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:string ;
-  sh:maxCount 1 ;
-.
+  sh:property qudt:HexBinaryType-pattern .
+
 qudt:HomogeneousArray
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   <p>An <em>Array></em> is a data structure that stores a collection of elements, typically of the same type, in a contiguous block of memory. 
   Each element in an array is identified by an index or key, which is typically a numerical identifier, either starting at '0' or '1'.
@@ -1905,253 +927,153 @@ qudt:HomogeneousArray
   </p>"""^^rdf:HTML ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Homogeneous Array" ;
-  rdfs:subClassOf qudt:Array ;
-.
-qudt:IEEE754_1985RealEncoding
-  a qudt:FloatingPointEncodingType ;
-  qudt:bytes 32 ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "IEEE 754 1985 Real Encoding" ;
-.
-qudt:ISO8601-UTCDateTime-BasicFormat
-  a qudt:DateTimeStringEncodingType ;
-  qudt:allowedPattern "[0-9]{4}[0-9]{2}[0-9]{2}T[0-9]{2}[0-9]{2}[0-9]{2}.[0-9]+Z" ;
-  qudt:allowedPattern "[0-9]{4}[0-9]{2}[0-9]{2}T[0-9]{2}[0-9]{2}[0-9]{2}Z" ;
-  rdfs:isDefinedBy <file:///Users/ralphtq/git-qudt/qudt-public-repo/qudt> ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "ISO 8601 UTC Date Time - Basic Format" ;
-.
+  rdfs:subClassOf qudt:Array .
+
 qudt:IconicCue
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Iconic enumeration literal" ;
   rdfs:subClassOf qudt:ModalCue ;
   sh:disjoint qudt:AuralCue ;
   sh:disjoint qudt:KinestheticCue ;
   sh:disjoint qudt:VisualCue ;
-  sh:property qudt:IconicCue-image ;
-.
-qudt:IconicCue-image
-  a sh:PropertyShape ;
-  sh:path qudt:image ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:maxCount 1 ;
-  sh:minCount 1 ;
-.
-qudt:IconicCueEnumeration-defaultValue
-  a sh:PropertyShape ;
-  sh:path qudt:defaultValue ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:IconicCue ;
-.
+  sh:property qudt:IconicCue-image .
+
 qudt:InertialCoordinateFrame
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description "A \"Coordinate Frame\"." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Inertial Coordinate Frame" ;
   rdfs:seeAlso qudt:NonRotatingInertialFrame ;
   rdfs:subClassOf qudt:InertialReferenceFrame ;
-  sh:property qudt:InertialCoordinateFrame-frameType ;
-.
-qudt:InertialCoordinateFrame-frameType
-  a sh:PropertyShape ;
-  sh:path qudt:frameType ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:hasValue qudt:FT_NON-ROTATING ;
-.
+  sh:property qudt:InertialCoordinateFrame-frameType .
+
 qudt:InertialReferenceFrame
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   A sub-type of 'Reference Frame'.
   """ ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Inertial reference frame" ;
-  rdfs:subClassOf qudt:ReferenceFrame ;
-.
+  rdfs:subClassOf qudt:ReferenceFrame .
+
 qudt:IntegerDatatype
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description "An Integer Type is a data type that specifies how integer numbers are represented and stored in machine memory." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Integer Datatype" ;
   rdfs:subClassOf qudt:NumericType ;
-  rdfs:subClassOf qudt:OrdinalType ;
-.
+  rdfs:subClassOf qudt:OrdinalType .
+
 qudt:IntegerEncodingType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description "The encoding scheme for integer types" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Integer Encoding" ;
   rdfs:subClassOf qudt:Encoding ;
   sh:property [
-      a sh:PropertyShape ;
-      sh:path [
-          sh:inversePath rdf:type ;
-        ] ;
-      rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-      sh:in (
-          qudt:LongUnsignedIntegerEncoding
-          qudt:ShortUnsignedIntegerEncoding
-          qudt:ShortUnsignedIntegerEncoding
-          qudt:SignedIntegerEncoding
-          qudt:UnsignedIntegerEncoding
-        ) ;
+    a sh:PropertyShape ;
+    rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+    sh:in ( qudt:LongUnsignedIntegerEncoding qudt:ShortUnsignedIntegerEncoding
+      qudt:ShortUnsignedIntegerEncoding qudt:SignedIntegerEncoding qudt:UnsignedIntegerEncoding ) ;
+    sh:path [
+      sh:inversePath rdf:type ;
     ] ;
-.
+  ] .
+
 qudt:IntegerListShape
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:subClassOf rdf:List ;
   sh:property [
-      sh:path rdf:first ;
-      sh:datatype xsd:integer ;
-    ] ;
+    sh:datatype xsd:integer ;
+    sh:path rdf:first ;
+  ] ;
   sh:property [
-      sh:path rdf:rest ;
-      sh:or (
-          [
-            sh:node () ;
-          ]
-          [
-            sh:node qudt:IntegerListShape ;
-          ]
-        ) ;
-    ] ;
-.
-qudt:IntegerUnionList
-  a rdf:List ;
-  rdf:first [
-      sh:datatype xsd:int ;
-    ] ;
-  rdf:rest (
-      [
-        sh:datatype xsd:nonNegativeInteger ;
-      ]
-      [
-        sh:datatype xsd:positiveInteger ;
-      ]
-      [
-        sh:datatype xsd:integer ;
-      ]
-    ) ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "Integer Union List" ;
-.
+    sh:or ( [
+      sh:node ( ) ;
+    ] [
+      sh:node qudt:IntegerListShape ;
+    ] ) ;
+    sh:path rdf:rest ;
+  ] .
+
 qudt:InterpolatedTable
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description "A sub-type of 'Table Type'." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Interpolated Table Type" ;
   rdfs:subClassOf qudt:Table ;
-  rdfs:subClassOf qudt:TableType ;
-.
+  rdfs:subClassOf qudt:TableType .
+
 qudt:KinestheticCue
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Kinesthetic Cue" ;
   rdfs:subClassOf qudt:ModalCue ;
-  sh:property qudt:KinestheticCue-code ;
-.
-qudt:KinestheticCue-code
-  a sh:PropertyShape ;
-  sh:path dtype:code ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:maxCount 1 ;
-  sh:minCount 1 ;
-.
-qudt:KinestheticCueEnumeration-defaultValue
-  a sh:PropertyShape ;
-  sh:path qudt:defaultValue ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:KinestheticCue ;
-.
+  sh:property qudt:KinestheticCue-code .
+
 qudt:LargeObject
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   A 'LargeObject' datatype is used to store blocks of unstructured data (such as text, graphic images, video clips, and sound waveforms). 
   They often are used to allow efficient, random, piece-wise access to the data.
   """ ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Large object" ;
-  rdfs:subClassOf qudt:CompositeDatatype ;
-.
+  rdfs:subClassOf qudt:CompositeDatatype .
+
 qudt:LargeObjectType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description "A 'LargeObject' datatype is used to store blocks of unstructured data (such as text, graphic images, video clips, and sound waveforms). They often are used to allow efficient, random, piece-wise access to the data." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Large object" ;
-  rdfs:subClassOf qudt:CompositeDatatype ;
-.
+  rdfs:subClassOf qudt:CompositeDatatype .
+
 qudt:LimitType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Limit type" ;
-  rdfs:subClassOf qudt:EnumeratedValue ;
-.
+  rdfs:subClassOf qudt:EnumeratedValue .
+
 qudt:List
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description "A sub-type of 'AbstractDataItem'." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "List" ;
   rdfs:subClassOf qudt:DataItem ;
   sh:property qudt:DatatypePropertyShape ;
   sh:property qudt:MaybeQuantityPropertyShape ;
-  sh:property qudt:MaybeUnitPropertyShape ;
-.
-qudt:LittleEndian
-  a qudt:EndianType ;
-  dtype:literal "little" ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "Little Endian" ;
-.
+  sh:property qudt:MaybeUnitPropertyShape .
+
 qudt:LocalCoordinateSystem
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
-  A \"Trajectory Coordinate System\" with the following instance(s):
-   \"Local vertical curvilinear coordinate system\",
-   \"Local vertical local horizontal coordinate system\",
-   \"Vehicle centered local vertical curvilinear coordinate system\".
+  A "Trajectory Coordinate System" with the following instance(s):
+   "Local vertical curvilinear coordinate system",
+   "Local vertical local horizontal coordinate system",
+   "Vehicle centered local vertical curvilinear coordinate system".
   """ ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Local Coordinate System" ;
-  rdfs:subClassOf qudt:TrajectoryCoordinateSystem ;
-.
+  rdfs:subClassOf qudt:TrajectoryCoordinateSystem .
+
 qudt:LongIntegerType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
-  A \"Long Integer\" is an integer that can be represented in four octets (32 bits) of machine memory. 
+  A "Long Integer" is an integer that can be represented in four octets (32 bits) of machine memory. 
   Long integers may be signed or unsigned.
   """ ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Long Integer Type" ;
-  rdfs:subClassOf qudt:IntegerDatatype ;
-.
-qudt:LongUnsignedIntegerEncoding
-  a qudt:IntegerEncodingType ;
-  qudt:bytes 8 ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "Long Unsigned Integer Encoding" ;
-.
+  rdfs:subClassOf qudt:IntegerDatatype .
+
 qudt:LunarCoordinateSystem
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   Two slightly different coordinate frames are commonly used to define the orientation of the axes of a lunar body-fixed coordinate system:
    a mean Earth/rotation frame and a principal axis coordinate frame. 
-  The mean Earth/rotation frame (sometimes called the \"Mean Earth/polar axis\" frame) is a lunar body-fixed coordinate frame.
+  The mean Earth/rotation frame (sometimes called the "Mean Earth/polar axis" frame) is a lunar body-fixed coordinate frame.
   This has the X-axis aligned with the mean direction from the Moon to the Earth and the Z-axis aligned with the mean axis of rotation of the Moon. 
   The principal axis frame is a lunar body-fixed coordinate frame aligned with the principal axes of the Moon. 
   Due to the fact that the Moon is synchronously rotating but is not exactly symmetric, the principal axes and the mean Earth/rotation axes of the Moon do not coincide.
@@ -2163,197 +1085,75 @@ qudt:LunarCoordinateSystem
   sh:property qudt:LunarCoordinateSystem-realization ;
   sh:property qudt:LunarCoordinateSystem-xAxisDefinition ;
   sh:property qudt:LunarCoordinateSystem-yAxisDefinition ;
-  sh:property qudt:LunarCoordinateSystem-zAxisDefinition ;
-.
-qudt:LunarCoordinateSystem-coordinateCenter
-  a sh:PropertyShape ;
-  sh:path qudt:coordinateCenter ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:CoordinateCenterKind ;
-  sh:hasValue qudt:CCT_MoonCentered ;
-.
-qudt:LunarCoordinateSystem-realization
-  a sh:PropertyShape ;
-  sh:path qudt:realization ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:string ;
-  sh:maxCount 1 ;
-.
-qudt:LunarCoordinateSystem-xAxisDefinition
-  a sh:PropertyShape ;
-  sh:path qudt:xAxisDefinition ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:string ;
-  sh:maxCount 1 ;
-.
-qudt:LunarCoordinateSystem-yAxisDefinition
-  a sh:PropertyShape ;
-  sh:path qudt:yAxisDefinition ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:string ;
-  sh:maxCount 1 ;
-.
-qudt:LunarCoordinateSystem-zAxisDefinition
-  a sh:PropertyShape ;
-  sh:path qudt:zAxisDefinition ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:string ;
-  sh:maxCount 1 ;
-.
-qudt:Major
-  a qudt:MajorMinorType ;
-  dtype:code 2 ;
-  dtype:literal "major" ;
-  dtype:order "2"^^xsd:int ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/shacl/datatype> ;
-  rdfs:label "Major" ;
-.
+  sh:property qudt:LunarCoordinateSystem-zAxisDefinition .
+
 qudt:MajorMinorType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description "A sub-type of 'Enumerated Value'." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Major minor type" ;
   rdfs:subClassOf qudt:EnumeratedValue ;
-  sh:in (
-      qudt:Minor
-      qudt:Major
-    ) ;
-.
+  sh:in ( qudt:Minor qudt:Major ) .
+
 qudt:Map
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description "A Map Type is an abstract data type that defines the properties of map data structures. A Map (or Associative Array) is an abstract data structure composed of a collection of keys and a collection of values, where each key is associated with one value. The operation of finding the value associated with a key is called a lookup or indexing, and this is the most important operation supported by an associative array. The relationship between a key and its value is sometimes called a mapping or binding." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Map Type" ;
   rdfs:seeAlso qudt:AssociativeArray ;
-  rdfs:subClassOf qudt:Collection ;
-.
+  rdfs:subClassOf qudt:Collection .
+
 qudt:MarsCoordinateSystem
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
-  A \"Trajectory Coordinate System\" with the following instance(s): \"Mars mean equator and IAU-Node of epoch\", \"Mars mean equator and prime meridian body-fixed\".
+  A "Trajectory Coordinate System" with the following instance(s): "Mars mean equator and IAU-Node of epoch", "Mars mean equator and prime meridian body-fixed".
   """ ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Mars Coordinate System Type" ;
   rdfs:subClassOf qudt:TrajectoryCoordinateSystem ;
-  sh:property qudt:MarsCoordinateSystem-coordinateCenter ;
-.
-qudt:MarsCoordinateSystem-coordinateCenter
-  a sh:PropertyShape ;
-  sh:path qudt:coordinateCenter ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:CoordinateCenterKind ;
-  sh:hasValue qudt:CCT_MarsCentered ;
-.
-qudt:MassPropertiesArray
-  a rdf:Class ;
-  a sh:NodeShape ;
-  dcterms:description """
-  <p>A <em>Mass Properties Array</em> holds, for an object, four values for the properties:
-   Center of Gravity, Mass, Moment of Inertia, and Product of Inertia. 
-  """ ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "Mass Properties Array" ;
-  rdfs:subClassOf qudt:HeterogenousArray ;
-  sh:property qudt:QuantityKindsPropertyShape ;
-.
+  sh:property qudt:MarsCoordinateSystem-coordinateCenter .
+
 qudt:MathsFunctionType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description "A sub-type of 'QUDT Concept'." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Maths Function Type" ;
-  rdfs:subClassOf qudt:Concept ;
-.
+  rdfs:subClassOf qudt:Concept .
+
 qudt:Matrix
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   <p>A <em>Matrix</em> is a data type that specifies the properties of an N-dimensional data structure.
   </p>
   """^^rdf:HTML ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Matrix" ;
-  rdfs:subClassOf qudt:Array ;
-.
-qudt:MatrixElementOrder-byRow
-  a sh:PropertyShape ;
-  sh:path qudt:byRow ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:boolean ;
-  sh:maxCount 1 ;
-.
-qudt:MatrixElementOrder-dataOrder
-  a sh:PropertyShape ;
-  sh:path qudt:dataOrder ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:MatrixElementOrder ;
-  sh:maxCount 1 ;
-.
-qudt:MaybeQuantityPropertyShape
-  a sh:PropertyShape ;
-  sh:path qudt:quantity ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:Quantity ;
-  sh:maxCount 1 ;
-.
-qudt:MaybeUnitPropertyShape
-  a sh:PropertyShape ;
-  sh:path qudt:hasUnit ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:Unit ;
-  sh:maxCount 1 ;
-.
+  rdfs:subClassOf qudt:Array .
+
 qudt:MemoryOrderType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description "A sub-type of 'Enumerated Value'." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Memory order type" ;
-  rdfs:subClassOf qudt:EnumeratedValue ;
-.
-qudt:Minor
-  a qudt:MajorMinorType ;
-  dtype:code 1 ;
-  dtype:literal "minor" ;
-  dtype:order "1"^^xsd:int ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/shacl/datatype> ;
-  rdfs:label "Minor" ;
-.
+  rdfs:subClassOf qudt:EnumeratedValue .
+
 qudt:ModalCue
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Modal Cue" ;
   rdfs:subClassOf qudt:EnumeratedValue ;
-  sh:property qudt:ModalCue-duration ;
-.
-qudt:ModalCue-duration
-  a sh:PropertyShape ;
-  sh:path qudt:duration ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:maxCount 1 ;
-.
+  sh:property qudt:ModalCue-duration .
+
 qudt:ModalEnumeration
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description "A sub-type of 'QUDT Enumeration'." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Modal Enumeration" ;
   rdfs:subClassOf qudt:Enumeration ;
-  sh:property qudt:ModalEnumeration-defaultValue ;
-.
-qudt:ModalEnumeration-defaultValue
-  a sh:PropertyShape ;
-  sh:path qudt:defaultValue ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:ModalCue ;
-.
+  sh:property qudt:ModalEnumeration-defaultValue .
+
 qudt:MultiDimensionalArray
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   <p>A <em>Multi-Dimensional Array</em> is an extension of a standard one-dimensional array,
    where elements are organized in a grid-like structure across two or more dimensions. 
@@ -2372,11 +1172,10 @@ qudt:MultiDimensionalArray
   """^^rdf:HTML ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Multi-Dimensional Array Type" ;
-  rdfs:subClassOf qudt:Array ;
-.
+  rdfs:subClassOf qudt:Array .
+
 qudt:MultiDimensionalDataFormat
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   Data formats for storing and manipulating scalar and multidimensional data in a platform and discipline independent manner,
    for example HDF, CDF and netCDF.
@@ -2384,17 +1183,10 @@ qudt:MultiDimensionalDataFormat
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Multi dimensional data format" ;
   rdfs:subClassOf qudt:CompositeDatatype ;
-  sh:property qudt:MultiDimensionalDataFormat-descriptor ;
-.
-qudt:MultiDimensionalDataFormat-descriptor
-  a sh:PropertyShape ;
-  sh:path qudt:descriptor ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:maxCount 1 ;
-.
+  sh:property qudt:MultiDimensionalDataFormat-descriptor .
+
 qudt:MultiModalEnumeration
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description "A sub-type of 'QUDT Enumeration'." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Multi modal enumeration" ;
@@ -2403,41 +1195,10 @@ qudt:MultiModalEnumeration
   sh:property qudt:MultiModalEnumeration-iconicCueEnumeration ;
   sh:property qudt:MultiModalEnumeration-kinestheticCueEnumeration ;
   sh:property qudt:MultiModalEnumeration-modalCueEnumeration ;
-  sh:property qudt:MultiModalEnumeration-visualCueEnumeration ;
-.
-qudt:MultiModalEnumeration-auralCueEnumeration
-  a sh:PropertyShape ;
-  sh:path qudt:auralCueEnumeration ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:maxCount 1 ;
-.
-qudt:MultiModalEnumeration-iconicCueEnumeration
-  a sh:PropertyShape ;
-  sh:path qudt:iconicCueEnumeration ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:maxCount 1 ;
-.
-qudt:MultiModalEnumeration-kinestheticCueEnumeration
-  a sh:PropertyShape ;
-  sh:path qudt:kinestheticCueEnumeration ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:maxCount 1 ;
-.
-qudt:MultiModalEnumeration-modalCueEnumeration
-  a sh:PropertyShape ;
-  sh:path qudt:modalCueEnumeration ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:ModalEnumeration ;
-.
-qudt:MultiModalEnumeration-visualCueEnumeration
-  a sh:PropertyShape ;
-  sh:path qudt:visualCueEnumeration ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:maxCount 1 ;
-.
+  sh:property qudt:MultiModalEnumeration-visualCueEnumeration .
+
 qudt:MultiModalType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description "A sub-type of 'Enumerated Value'." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Multi Modal Type" ;
@@ -2446,197 +1207,95 @@ qudt:MultiModalType
   sh:property qudt:MultiModalType-iconicCue ;
   sh:property qudt:MultiModalType-kinestheticCue ;
   sh:property qudt:MultiModalType-modalCue ;
-  sh:property qudt:MultiModalType-visualCue ;
-.
-qudt:MultiModalType-auralCue
-  a sh:PropertyShape ;
-  sh:path qudt:auralCue ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:maxCount 1 ;
-.
-qudt:MultiModalType-iconicCue
-  a sh:PropertyShape ;
-  sh:path qudt:iconicCue ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:maxCount 1 ;
-.
-qudt:MultiModalType-kinestheticCue
-  a sh:PropertyShape ;
-  sh:path qudt:kinestheticCue ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:maxCount 1 ;
-.
-qudt:MultiModalType-modalCue
-  a sh:PropertyShape ;
-  sh:path qudt:modalCue ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:ModalCue ;
-.
-qudt:MultiModalType-visualCue
-  a sh:PropertyShape ;
-  sh:path qudt:visualCue ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:maxCount 1 ;
-.
+  sh:property qudt:MultiModalType-visualCue .
+
 qudt:MultiSet
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description "A bag is a set in which elements may be repeated." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Bag" ;
-  rdfs:subClassOf qudt:Collection ;
-.
+  rdfs:subClassOf qudt:Collection .
+
 qudt:N-Tuple
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
-  A tuple containing n objects is known as an \"n-tuple\". 
-  For example the 4-tuple (or \"quadruple\"), with components of respective types PERSON, DAY, MONTH and YEAR.
+  A tuple containing n objects is known as an "n-tuple". 
+  For example the 4-tuple (or "quadruple"), with components of respective types PERSON, DAY, MONTH and YEAR.
   This could be used to record that a certain person was born on a certain day of a certain month of a certain year.
   """ ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "N-Tuple Type" ;
   rdfs:subClassOf qudt:Tuple ;
-  sh:property qudt:N-Tuple-elementType ;
-.
-qudt:N-Tuple-elementType
-  a sh:PropertyShape ;
-  sh:path qudt:elementDatatype ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:Datatype ;
-  sh:minCount 0 ;
-.
+  sh:property qudt:N-Tuple-elementType .
+
 qudt:N-TupleType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
-  A tuple containing n objects is known as an \"n-tuple\". 
-  For example the 4-tuple (or \"quadruple\"), with components of respective types PERSON, DAY, MONTH and YEAR.
+  A tuple containing n objects is known as an "n-tuple". 
+  For example the 4-tuple (or "quadruple"), with components of respective types PERSON, DAY, MONTH and YEAR.
   This could be used to record that a certain person was born on a certain day of a certain month of a certain year.
   """ ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "N-Tuple Type" ;
   rdfs:subClassOf qudt:Tuple ;
-  sh:property qudt:N-Tuple-elementType ;
-.
-qudt:NonModifiableParameter
-  a qudt:ParameterModifiabilityType ;
-  dtype:code "0" ;
-  dtype:literal "fixed" ;
-  rdfs:comment "Parameter is fixed, not modifiable." ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "Non modifiable parameter" ;
-.
-qudt:NonNegativeIntegerUnionList
-  a rdf:List ;
-  rdf:first [
-      sh:datatype xsd:nonNegativeInteger ;
-    ] ;
-  rdf:rest (
-      [
-        sh:datatype xsd:positiveInteger ;
-      ]
-    ) ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "Non-negative union list" ;
-.
+  sh:property qudt:N-Tuple-elementType .
+
 qudt:NonRotatingInertialFrame
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
-  <p>The non-rotating (or \"inertial\") coordinate frames are defined by taking a \"snapshot\" of the orientation of a particular set of right-handed, orthogonal axes at a specific epoch or time. 
+  <p>The non-rotating (or "inertial") coordinate frames are defined by taking a "snapshot" of the orientation of a particular set of right-handed, orthogonal axes at a specific epoch or time. 
   In other words, the non-rotating coordinate frame, however it is defined, is frozen or fixed at a specific time - for all time. 
-  These non-rotating coordinate frames are referred to as \"of Epoch\" coordinate frames.
+  These non-rotating coordinate frames are referred to as "of Epoch" coordinate frames.
   </p>"""^^rdf:HTML ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Non Rotating Coordinate Frame" ;
   rdfs:seeAlso qudt:InertialCoordinateFrame ;
   rdfs:subClassOf qudt:InertialReferenceFrame ;
-  sh:property qudt:NonRotatingInertialFrame-frameType ;
-.
-qudt:NonRotatingInertialFrame-frameType
-  a sh:PropertyShape ;
-  sh:path qudt:frameType ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:hasValue qudt:FT_NON-ROTATING ;
-.
+  sh:property qudt:NonRotatingInertialFrame-frameType .
+
 qudt:NumericType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description "Numeric data types are data types whose values denote quantities as defined by a mathematical number system." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Numeric Type" ;
   rdfs:subClassOf qudt:ScalarDatatype ;
   sh:property qudt:NumericType-accuracy ;
-  sh:property qudt:NumericType-signedness ;
-.
-qudt:NumericType-accuracy
-  a sh:PropertyShape ;
-  sh:path qudt:accuracy ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:integer ;
-  sh:maxCount 1 ;
-.
-qudt:NumericType-signedness
-  a sh:PropertyShape ;
-  sh:path qudt:signedness ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:SignednessType ;
-  sh:maxCount 1 ;
-.
-qudt:OctetEncoding
-  a qudt:BooleanEncodingType ;
-  a qudt:ByteEncodingType ;
-  qudt:bytes 1 ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "OCTET Encoding" ;
-.
+  sh:property qudt:NumericType-signedness .
+
 qudt:OctetType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description "An 8 bit unsigned integer" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Octet Type" ;
-  rdfs:subClassOf qudt:UnsignedIntegerType ;
-.
+  rdfs:subClassOf qudt:UnsignedIntegerType .
+
 qudt:OffOnStateTypeEnumeration
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   A discrete state enumeration whose values are 'off' and 'on'. 
   The 'off' value is encoded as a zero (0) and the 'on' value as a one (1).
   """ ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:subClassOf qudt:Enumeration ;
-.
+  rdfs:subClassOf qudt:Enumeration .
+
 qudt:OnOffStateType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "On off state type" ;
-  rdfs:subClassOf qudt:DiscreteState ;
-.
+  rdfs:subClassOf qudt:DiscreteState .
+
 qudt:OnOffStateTypeEnumeration
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   qudt:inverted true ;
   rdfs:comment """
   A discrete state enumeration whose values are 'off' and 'on'. 
   The 'on' value is encoded as a zero (0) and the 'off' value as a one (1).
   """ ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:subClassOf qudt:Enumeration ;
-.
-qudt:OneMeansOff
-  a qudt:OnOffStateType ;
-  qudt:inverted true ;
-  dtype:literal "off" ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "One means off" ;
-.
+  rdfs:subClassOf qudt:Enumeration .
+
 qudt:OrderedCollection
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   <p>An <em>Ordered Collection Kind</em> is an abstract data type that defines the properties of collection data structures whose members can be linearly ordered. 
   An ordered collection is a collection together with an ordering relation (such as greater than) that linearly orders the collection elements.
@@ -2644,157 +1303,116 @@ qudt:OrderedCollection
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Ordered Collection Kind" ;
   rdfs:subClassOf qudt:Collection ;
-  sh:property qudt:OrderedCollection-orderingRelation ;
-.
-qudt:OrderedCollection-orderingRelation
-  a sh:PropertyShape ;
-  sh:path qudt:orderingRelation ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class dtype:ComparisonOperator ;
-  sh:maxCount 1 ;
-.
+  sh:property qudt:OrderedCollection-orderingRelation .
+
 qudt:OrderedTree
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
-  <p>An \"Ordered Tree Type\" is a data type that defines the properties of data structures that represent ordered trees. 
+  <p>An "Ordered Tree Type" is a data type that defines the properties of data structures that represent ordered trees. 
   An ordered tree is a tree where the children of every node are ordered, that is, there is a first child, second child, third child, etc. 
   Typically a type specification for an ordered tree will include the comparison operator (such as <b>lt</b> or <b>gt</b>) that is used to order the nodes.
   </p>"""^^rdf:HTML ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Ordered Tree Type" ;
   rdfs:subClassOf qudt:OrderedCollection ;
-  rdfs:subClassOf qudt:Tree ;
-.
+  rdfs:subClassOf qudt:Tree .
+
 qudt:OrderedType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description "Describes how a data or information structure is ordered." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Ordered type" ;
   rdfs:subClassOf qudt:EnumeratedValue ;
   sh:property qudt:OrderedType-literal ;
   sh:property [
-      a sh:PropertyShape ;
-      sh:path [
-          sh:inversePath rdf:type ;
-        ] ;
-      rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-      sh:in (
-          qudt:Unordered
-          qudt:PartiallyOrdered
-          qudt:TotallyOrdered
-        ) ;
+    a sh:PropertyShape ;
+    rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+    sh:in ( qudt:Unordered qudt:PartiallyOrdered qudt:TotallyOrdered ) ;
+    sh:path [
+      sh:inversePath rdf:type ;
     ] ;
-.
+  ] .
+
 qudt:OrdinalType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   <p>An ordinal data type is a data type that specifies the properties of values that can easily be put in a one to one correspondence with a subset of the natural numbers. 
   Examples include boolean, character, and integer data types.
    </p>"""^^rdf:HTML ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Ordinal Data Type" ;
-  rdfs:subClassOf qudt:ScalarDatatype ;
-.
+  rdfs:subClassOf qudt:ScalarDatatype .
+
 qudt:PaddingType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   <p>This describes how unused bits of a field are filled. 
   Unused bits could be set to one or zero. 
-  A third option is \"don't care\".
+  A third option is "don't care".
   </p>"""^^rdf:HTML ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Padding type" ;
   rdfs:subClassOf qudt:EnumeratedValue ;
-  sh:in (
-      qudt:PadWithOnes
-      qudt:PadWithZeros
-      qudt:PadWithAny
-    ) ;
-.
+  sh:in ( qudt:PadWithOnes qudt:PadWithZeros qudt:PadWithAny ) .
+
 qudt:ParameterModifiabilityType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   rdfs:comment "An enumeration of literals that signify whether a parameter is modifiable and if so, by whom." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Parameter modifiability type" ;
-  rdfs:subClassOf qudt:EnumeratedValue ;
-.
+  rdfs:subClassOf qudt:EnumeratedValue .
+
 qudt:PartialArray
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   A partial array is an Array with two attributes that define the starting and ending indices of the elements that are provided.
   """^^rdf:HTML ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Partial Array" ;
-  rdfs:subClassOf qudt:Array ;
-.
-qudt:PartiallyOrdered
-  a qudt:OrderedType ;
-  qudt:plainTextDescription "Partial ordered structure." ;
-  dtype:literal "partial" ;
-  rdfs:isDefinedBy <file:///Users/ralphtq/git-qudt/qudt-public-repo/qudt> ;
-  rdfs:label "Partially Ordered" ;
-.
+  rdfs:subClassOf qudt:Array .
+
 qudt:PhysicalAddress
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description "A physical address is a pointer to a memory location." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Physical Address Type" ;
-  rdfs:subClassOf qudt:CompositeDatatype ;
-.
+  rdfs:subClassOf qudt:CompositeDatatype .
+
 qudt:Polarity
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
-  A \"Tagged Enumeration\" with the following instance(s): \"negative\", \"positive\".
+  A "Tagged Enumeration" with the following instance(s): "negative", "positive".
   """ ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Polarity" ;
-  rdfs:subClassOf qudt:EnumeratedValue ;
-.
+  rdfs:subClassOf qudt:EnumeratedValue .
+
 qudt:PositiveBigIntegerType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description "Positive Integers are integers that are either non-zero and non-negative." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Positive Big Integer Type" ;
   rdfs:subClassOf qudt:IntegerDatatype ;
   rdfs:subClassOf qudt:UnsignedType ;
-  sh:disjoint qudt:SignedIntegerType ;
-.
+  sh:disjoint qudt:SignedIntegerType .
+
 qudt:PositiveIntegerType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description "Positive Integers are integers that are either non-zero and non-negative." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Positive Integer Type" ;
   rdfs:subClassOf qudt:IntegerDatatype ;
   rdfs:subClassOf qudt:UnsignedType ;
-  sh:disjoint qudt:SignedIntegerType ;
-.
+  sh:disjoint qudt:SignedIntegerType .
+
 qudt:Quantifiable
-  a rdfs:Class ;
-  a sh:NodeShape ;
-  vaem:isElaboratedIn <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  a rdfs:Class, sh:NodeShape ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   sh:property qudt:Quantifiable-dataEncoding ;
-.
-qudt:Quantifiable-dataEncoding
-  a sh:PropertyShape ;
-  sh:path qudt:dataEncoding ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:DataEncoding ;
-  sh:maxCount 1 ;
-.
+  vaem:isElaboratedIn <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> .
+
 qudt:QuantityKindList
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   <p>A <em>Quantity Kind List</em> is a list of qudt:QuantityKind. 
   They are used, for instance, to specify the quantity kind in a Mass Properties Array. 
@@ -2804,84 +1422,45 @@ qudt:QuantityKindList
   rdfs:label "Quantity kind List" ;
   rdfs:subClassOf rdf:List ;
   sh:property [
-      sh:path rdf:first ;
-      sh:class qudt:QuantityKind ;
-    ] ;
+    sh:class qudt:QuantityKind ;
+    sh:path rdf:first ;
+  ] ;
   sh:property [
-      sh:path rdf:rest ;
-      sh:or (
-          [
-            sh:node () ;
-          ]
-          [
-            sh:node qudt:QuantityKindList ;
-          ]
-        ) ;
-    ] ;
-.
-qudt:QuantityKindsPropertyShape
-  a sh:PropertyShape ;
-  sh:path qudt:hasQuantityKindsList ;
-  rdfs:comment "Invalid quantity kinds list - TODO: SPARQL Query" ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:node qudt:QuantityKindList ;
-.
+    sh:or ( [
+      sh:node ( ) ;
+    ] [
+      sh:node qudt:QuantityKindList ;
+    ] ) ;
+    sh:path rdf:rest ;
+  ] .
+
 qudt:QuantityValueType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description "A sub-type of 'Dimensional Data Type'." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Quantity value type" ;
   rdfs:subClassOf qudt:DimensionalDatatype ;
   sh:property qudt:QuantityValueType-basis ;
   sh:property qudt:QuantityValueType-elementType ;
-  sh:property qudt:QuantityValueType-elementUnit ;
-.
-qudt:QuantityValueType-basis
-  a sh:PropertyShape ;
-  sh:path qudt:basis ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:QuantityType ;
-.
-qudt:QuantityValueType-elementType
-  a sh:PropertyShape ;
-  sh:path qudt:elementDatatype ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:NumericType ;
-.
-qudt:QuantityValueType-elementUnit
-  a sh:PropertyShape ;
-  sh:path qudt:elementUnit ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:Unit ;
-  sh:maxCount 1 ;
-.
+  sh:property qudt:QuantityValueType-elementUnit .
+
 qudt:RawValueTupleMember
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description "A sub-type of 'Tuple Member Type'." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Raw value tuple member" ;
   rdfs:subClassOf qudt:TupleMember ;
-  sh:property qudt:RawValueTupleMember-elementType ;
-.
-qudt:RawValueTupleMember-elementType
-  a sh:PropertyShape ;
-  sh:path qudt:elementDatatype ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:UnsignedIntegerType ;
-.
+  sh:property qudt:RawValueTupleMember-elementType .
+
 qudt:RawValueTupleMemberType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Raw value tuple member type" ;
   rdfs:subClassOf qudt:TupleMember ;
-  sh:property qudt:RawValueTupleMember-elementType ;
-.
+  sh:property qudt:RawValueTupleMember-elementType .
+
 qudt:RealDatatype
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   <p>A real number is represented as a factor, called the mantissa, multiplied by a power (the exponent) of a base. 
   Different bases yield different approximations to real numbers, and conversion between them is limited in accuracy.
@@ -2896,46 +1475,10 @@ qudt:RealDatatype
   sh:property qudt:RealDatatype-maxExponent ;
   sh:property qudt:RealDatatype-maxMantissa ;
   sh:property qudt:RealDatatype-minMantissa ;
-  sh:property qudt:RealDatatype-precision ;
-.
-qudt:RealDatatype-base
-  a sh:PropertyShape ;
-  sh:path qudt:base ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:integer ;
-  sh:maxCount 1 ;
-.
-qudt:RealDatatype-maxExponent
-  a sh:PropertyShape ;
-  sh:path qudt:maxExponent ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:integer ;
-  sh:maxCount 1 ;
-.
-qudt:RealDatatype-maxMantissa
-  a sh:PropertyShape ;
-  sh:path qudt:maxMantissa ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:maxCount 1 ;
-  sh:or qudt:NumericTypeUnion ;
-.
-qudt:RealDatatype-minMantissa
-  a sh:PropertyShape ;
-  sh:path qudt:minMantissa ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:maxCount 1 ;
-  sh:or qudt:NumericTypeUnion ;
-.
-qudt:RealDatatype-precision
-  a sh:PropertyShape ;
-  sh:path qudt:precision ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:integer ;
-  sh:maxCount 1 ;
-.
+  sh:property qudt:RealDatatype-precision .
+
 qudt:RealDoublePrecisionType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   <p>A real double precision data type specifies how a real number, or an approximation of a real number is stored in memory.
   Typically this occupies two words in computer memory, where the byte length of a word depends on machine address size of the computer processor. 
@@ -2945,25 +1488,23 @@ qudt:RealDoublePrecisionType
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Real Double Precision Type" ;
   rdfs:subClassOf qudt:DoublePrecisionType ;
-  rdfs:subClassOf qudt:RealDatatype ;
-.
+  rdfs:subClassOf qudt:RealDatatype .
+
 qudt:RealNumberType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   rdfs:comment """
   <p>A <em>Real Number Type</em> is the class of data values that approximate real numbers in finite precision. 
-  Often, such values are expressed in \"mantissa, base, exponent\" form. 
+  Often, such values are expressed in "mantissa, base, exponent" form. 
   Any rational number can be expressed in the form m*b^<sup>e</sup>, where m (the mantissa), b (the base), and e (the exponent) are integers. 
   Typically, b is chosen to be either 2 or 10, and then the values of m and e are determined given the choice of base.
   </p>
   """^^rdf:HTML ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Real number type" ;
-  rdfs:subClassOf qudt:RealDatatype ;
-.
+  rdfs:subClassOf qudt:RealDatatype .
+
 qudt:RealSinglePrecisionType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   <p>A real single precision data type specifies how a real number,
    or an approximation of a real number is stored in memory that occupies one word in computer memory, 
@@ -2978,22 +1519,20 @@ qudt:RealSinglePrecisionType
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Real Single Precision Type" ;
   rdfs:subClassOf qudt:RealDatatype ;
-  rdfs:subClassOf qudt:SinglePrecisionType ;
-.
+  rdfs:subClassOf qudt:SinglePrecisionType .
+
 qudt:Record
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   A Record Type is a type whose values are records, i.e. aggregates of several items of possibly different types. 
   The aggregated items are called fields or members and are usually identified or indexed by field labels.
   """ ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Record Type" ;
-  rdfs:subClassOf qudt:CompositeDatatype ;
-.
+  rdfs:subClassOf qudt:CompositeDatatype .
+
 qudt:ReferenceDatatype
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   <p>A reference is an object containing information which refers to data stored elsewhere, as opposed to containing the data itself. 
   A reference data type is a data type that specifies how a reference is represented and stored in memory,
@@ -3002,13 +1541,12 @@ qudt:ReferenceDatatype
   </p>"""^^rdf:HTML ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Reference Data Type" ;
-  rdfs:subClassOf qudt:StructuredDatatype ;
-.
+  rdfs:subClassOf qudt:StructuredDatatype .
+
 qudt:ReferenceFrame
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
-  <p> A <em>Reference Frame</em> (or \"frame of reference\") in physics, may refer to a coordinate system or set of axes.
+  <p> A <em>Reference Frame</em> (or "frame of reference") in physics, may refer to a coordinate system or set of axes.
 The frame serves as the datum to measure the position, orientation, and other properties of objects in it.
 Reference frame may refer to an observational reference frame tied to the state of motion of an observer. 
 Reference frame may also refer to both an observational reference frame and an attached coordinate system as a unit.
@@ -3027,99 +1565,17 @@ Reference frame may also refer to both an observational reference frame and an a
   sh:property qudt:ReferenceFrame-yAxisDefinition ;
   sh:property qudt:ReferenceFrame-yCoordinateDefinition ;
   sh:property qudt:ReferenceFrame-zAxisDefinition ;
-  sh:property qudt:ReferenceFrame-zCoordinateDefinition ;
-.
-qudt:ReferenceFrame-comment
-  a sh:PropertyShape ;
-  sh:path vaem:comment ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:maxCount 1 ;
-.
-qudt:ReferenceFrame-description
-  a sh:PropertyShape ;
-  sh:path dcterms:description ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:maxCount 1 ;
-.
-qudt:ReferenceFrame-frameType
-  a sh:PropertyShape ;
-  sh:path qudt:frameType ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:FrameType ;
-.
-qudt:ReferenceFrame-informativeReference
-  a sh:PropertyShape ;
-  sh:path qudt:informativeReference ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:maxCount 1 ;
-.
-qudt:ReferenceFrame-realization
-  a sh:PropertyShape ;
-  sh:path qudt:realization ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:string ;
-  sh:maxCount 1 ;
-.
-qudt:ReferenceFrame-xAxisDefinition
-  a sh:PropertyShape ;
-  sh:path qudt:xAxisDefinition ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:string ;
-  sh:maxCount 1 ;
-.
-qudt:ReferenceFrame-xCoordinateDefinition
-  a sh:PropertyShape ;
-  sh:path qudt:xCoordinateDefinition ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:string ;
-  sh:maxCount 1 ;
-.
-qudt:ReferenceFrame-yAxisDefinition
-  a sh:PropertyShape ;
-  sh:path qudt:yAxisDefinition ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:string ;
-  sh:maxCount 1 ;
-.
-qudt:ReferenceFrame-yCoordinateDefinition
-  a sh:PropertyShape ;
-  sh:path qudt:yCoordinateDefinition ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:string ;
-  sh:maxCount 1 ;
-.
-qudt:ReferenceFrame-zAxisDefinition
-  a sh:PropertyShape ;
-  sh:path qudt:zAxisDefinition ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:string ;
-  sh:maxCount 1 ;
-.
-qudt:ReferenceFrame-zCoordinateDefinition
-  a sh:PropertyShape ;
-  sh:path qudt:zCoordinateDefinition ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:string ;
-  sh:maxCount 1 ;
-.
+  sh:property qudt:ReferenceFrame-zCoordinateDefinition .
+
 qudt:RotatingReferenceFrame
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description "A sub-type of 'Reference Frame'." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Rotating reference frame" ;
-  rdfs:subClassOf qudt:ReferenceFrame ;
-.
-qudt:SIGNED
-  a qudt:SignednessType ;
-  dtype:literal "signed" ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "Signed" ;
-.
+  rdfs:subClassOf qudt:ReferenceFrame .
+
 qudt:ScalarDatatype
-  a rdfs:Class ;
-  a sh:NodeShape ;
-  vaem:isElaboratedIn <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  a rdfs:Class, sh:NodeShape ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Scalar Datatype" ;
   rdfs:subClassOf rdfs:Datatype ;
@@ -3134,111 +1590,27 @@ qudt:ScalarDatatype
   sh:property qudt:ScalarDatatype-minExclusive ;
   sh:property qudt:ScalarDatatype-minInclusive ;
   sh:property qudt:ScalarDatatype-rdfsDatatype ;
-.
-qudt:ScalarDatatype-bitOrder
-  a sh:PropertyShape ;
-  sh:path qudt:bitOrder ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:EndianType ;
-  sh:maxCount 1 ;
-.
-qudt:ScalarDatatype-bits
-  a sh:PropertyShape ;
-  sh:path qudt:bits ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:integer ;
-  sh:maxCount 1 ;
-  sh:or qudt:IntegerUnionList ;
-.
-qudt:ScalarDatatype-byteOrder
-  a sh:PropertyShape ;
-  sh:path qudt:byteOrder ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:EndianType ;
-  sh:maxCount 1 ;
-.
-qudt:ScalarDatatype-bytes
-  a sh:PropertyShape ;
-  sh:path qudt:bytes ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:integer ;
-  sh:maxCount 1 ;
-  sh:or qudt:IntegerUnionList ;
-.
-qudt:ScalarDatatype-encoding
-  a sh:PropertyShape ;
-  sh:path qudt:encoding ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:Encoding ;
-  sh:maxCount 1 ;
-.
-qudt:ScalarDatatype-length
-  a sh:PropertyShape ;
-  sh:path qudt:length ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:integer ;
-  sh:maxCount 1 ;
-.
-qudt:ScalarDatatype-maxExclusive
-  a sh:PropertyShape ;
-  sh:path qudt:maxExclusive ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:string ;
-  sh:maxCount 1 ;
-  sh:or qudt:NumericTypeUnion ;
-.
-qudt:ScalarDatatype-maxInclusive
-  a sh:PropertyShape ;
-  sh:path qudt:maxInclusive ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:maxCount 1 ;
-  sh:or qudt:NumericTypeUnion ;
-.
-qudt:ScalarDatatype-minExclusive
-  a sh:PropertyShape ;
-  sh:path qudt:minExclusive ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:maxCount 1 ;
-  sh:or qudt:NumericTypeUnion ;
-.
-qudt:ScalarDatatype-minInclusive
-  a sh:PropertyShape ;
-  sh:path qudt:minInclusive ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:maxCount 1 ;
-  sh:or qudt:NumericTypeUnion ;
-.
-qudt:ScalarDatatype-rdfsDatatype
-  a sh:PropertyShape ;
-  sh:path qudt:rdfsDatatype ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class rdfs:Datatype ;
-  sh:maxCount 1 ;
-.
+  vaem:isElaboratedIn <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> .
+
 qudt:ScalarListShape
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:subClassOf rdf:List ;
   sh:property [
-      sh:path rdf:first ;
-      sh:or qudt:NumericTypeUnion ;
-    ] ;
+    sh:or qudt:NumericTypeUnion ;
+    sh:path rdf:first ;
+  ] ;
   sh:property [
-      sh:path rdf:rest ;
-      sh:or (
-          [
-            sh:node () ;
-          ]
-          [
-            sh:node qudt:ScalarListShape ;
-          ]
-        ) ;
-    ] ;
-.
+    sh:or ( [
+      sh:node ( ) ;
+    ] [
+      sh:node qudt:ScalarListShape ;
+    ] ) ;
+    sh:path rdf:rest ;
+  ] .
+
 qudt:Sequence
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   <p>A <em>Sequence</em> is an enumerated collection of objects in which repetitions are allowed. 
   Like a set, it contains members (also called elements, or terms). 
@@ -3253,11 +1625,10 @@ qudt:Sequence
   """^^rdf:HTML ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Sequence" ;
-  rdfs:subClassOf qudt:Collection ;
-.
+  rdfs:subClassOf qudt:Collection .
+
 qudt:Set
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   <p>A <em>Set</em> is an abstract data type that defines the properties of sets. 
   A set is a collection (container) of certain values, without any particular order, and no repeated values. 
@@ -3266,35 +1637,20 @@ qudt:Set
   """^^rdf:HTML ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Set Type" ;
-  rdfs:subClassOf qudt:Collection ;
-.
+  rdfs:subClassOf qudt:Collection .
+
 qudt:ShortIntegerType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   A Short Integer is an integer that can be represented in two octets (16 bits) of machine memory. 
   Short integers may be signed or unsigned.
   """ ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Short Integer Type" ;
-  rdfs:subClassOf qudt:IntegerDatatype ;
-.
-qudt:ShortSignedIntegerEncoding
-  a qudt:IntegerEncodingType ;
-  qudt:bytes 2 ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "Short Signed Integer Encoding" ;
-.
-qudt:ShortUnsignedIntegerEncoding
-  a qudt:BooleanEncodingType ;
-  a qudt:IntegerEncodingType ;
-  qudt:bytes 2 ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "Short Unsigned Integer Encoding" ;
-.
+  rdfs:subClassOf qudt:IntegerDatatype .
+
 qudt:SignedBigIntegerType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description "A Signed Big Integer is a signed integer that can be represented in eight octets (64 bits) of machine memory." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Signed Big Integer Type" ;
@@ -3302,57 +1658,18 @@ qudt:SignedBigIntegerType
   rdfs:subClassOf qudt:SignedIntegerType ;
   sh:property qudt:SignedBigIntegerType-literal ;
   sh:property qudt:SignedBigIntegerType-maxInclusive ;
-  sh:property qudt:SignedBigIntegerType-minInclusive ;
-.
-qudt:SignedBigIntegerType-literal
-  a sh:PropertyShape ;
-  sh:path dtype:literal ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:string ;
-.
-qudt:SignedBigIntegerType-maxInclusive
-  a sh:PropertyShape ;
-  sh:path qudt:maxInclusive ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:or qudt:NumericTypeUnion ;
-.
-qudt:SignedBigIntegerType-minInclusive
-  a sh:PropertyShape ;
-  sh:path qudt:minInclusive ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:or (
-      [
-        sh:datatype xsd:string ;
-      ]
-      [
-        sh:datatype xsd:integer ;
-      ]
-      [
-        sh:datatype xsd:float ;
-      ]
-      [
-        sh:datatype xsd:decimal ;
-      ]
-    ) ;
-.
-qudt:SignedIntegerEncoding
-  a qudt:IntegerEncodingType ;
-  qudt:bytes 4 ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "Signed Integer Encoding" ;
-.
+  sh:property qudt:SignedBigIntegerType-minInclusive .
+
 qudt:SignedIntegerType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description "Signed Integers are integers can take on both positive and negative values." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Signed Integer Type" ;
   rdfs:subClassOf qudt:IntegerDatatype ;
-  rdfs:subClassOf qudt:SignedType ;
-.
+  rdfs:subClassOf qudt:SignedType .
+
 qudt:SignedLongIntegerType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description "A Signed Long Integer is a signed integer that can be represented in four octets (32 bits) of machine memory." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Signed Long Integer Type" ;
@@ -3360,118 +1677,61 @@ qudt:SignedLongIntegerType
   rdfs:subClassOf qudt:SignedIntegerType ;
   sh:property qudt:SignedLongIntegerType-abbreviation ;
   sh:property qudt:SignedLongIntegerType-maxInclusive ;
-  sh:property qudt:SignedLongIntegerType-minInclusive ;
-.
-qudt:SignedLongIntegerType-abbreviation
-  a sh:PropertyShape ;
-  sh:path qudt:abbreviation ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:string ;
-  sh:hasValue "SI32" ;
-.
-qudt:SignedLongIntegerType-maxInclusive
-  a sh:PropertyShape ;
-  sh:path qudt:maxInclusive ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:or qudt:NumericTypeUnion ;
-.
-qudt:SignedLongIntegerType-minInclusive
-  a sh:PropertyShape ;
-  sh:path qudt:minInclusive ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:or (
-      [
-        sh:datatype xsd:string ;
-      ]
-      [
-        sh:datatype xsd:integer ;
-      ]
-      [
-        sh:datatype xsd:float ;
-      ]
-      [
-        sh:datatype xsd:decimal ;
-      ]
-    ) ;
-.
+  sh:property qudt:SignedLongIntegerType-minInclusive .
+
 qudt:SignedMediumIntegerType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
-  A \"Signed Medium Integers\" is an integer of 24 bits that can take on both positive and negative values.
+  A "Signed Medium Integers" is an integer of 24 bits that can take on both positive and negative values.
   """ ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Signed Integer Type" ;
-  rdfs:subClassOf qudt:SignedIntegerType ;
-.
+  rdfs:subClassOf qudt:SignedIntegerType .
+
 qudt:SignedShortIntegerType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description "A Signed Short Integer is a signed integer that can be represented in four octets (32 bits) of machine memory." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Signed Short Integer Type" ;
   rdfs:subClassOf qudt:ShortIntegerType ;
   rdfs:subClassOf qudt:SignedIntegerType ;
-  sh:property qudt:SignedShortIntegerType-abbreviation ;
-.
-qudt:SignedShortIntegerType-abbreviation
-  a sh:PropertyShape ;
-  sh:path qudt:abbreviation ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-.
+  sh:property qudt:SignedShortIntegerType-abbreviation .
+
 qudt:SignedType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description "A signed type is a numeric type that distinguishes between positive and negative numbers using an encoding scheme, such as sign and magnitude, one's compliment, and two's compliment to represent negative numbers." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Signed Type" ;
   rdfs:subClassOf qudt:NumericType ;
   sh:disjoint qudt:UnsignedType ;
-  sh:property qudt:SignedType-signedness ;
-.
-qudt:SignedType-signedness
-  a sh:PropertyShape ;
-  sh:path qudt:signedness ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-.
+  sh:property qudt:SignedType-signedness .
+
 qudt:SignedVariableLengthIntegerType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description "A Signed Variable Length Integer data type defines a data structure for representing signed integers that uses a variable number of bits depending on the magnitude of the integer. Typically, variable length integer data types are between one and 64 bits in length." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Signed Variable Length Integer Type" ;
   rdfs:subClassOf qudt:SignedIntegerType ;
-  rdfs:subClassOf qudt:VariableLengthIntegerType ;
-.
+  rdfs:subClassOf qudt:VariableLengthIntegerType .
+
 qudt:SignednessType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description "Specifics whether a value should be signed or unsigned." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/datatype> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Signedness type" ;
   rdfs:subClassOf qudt:EnumeratedValue ;
   sh:property [
-      a sh:PropertyShape ;
-      sh:path [
-          sh:inversePath rdf:type ;
-        ] ;
-      rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-      sh:in (
-          qudt:SIGNED
-          qudt:UNSIGNED
-        ) ;
+    a sh:PropertyShape ;
+    rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+    sh:in ( qudt:SIGNED qudt:UNSIGNED ) ;
+    sh:path [
+      sh:inversePath rdf:type ;
     ] ;
-.
-qudt:SinglePrecisionRealEncoding
-  a qudt:FloatingPointEncodingType ;
-  qudt:bytes 32 ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "Single Precision Real Encoding" ;
-.
+  ] .
+
 qudt:SinglePrecisionType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   A single precision data type specifies how a numeric value, such as an integer or real number,
    is stored in memory that occupies one word in computer memory,
@@ -3481,27 +1741,24 @@ qudt:SinglePrecisionType
   """ ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Single Precision Type" ;
-  rdfs:subClassOf qudt:NumericType ;
-.
+  rdfs:subClassOf qudt:NumericType .
+
 qudt:SplineCalibrator
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description "A sub-type of 'Map Type'." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Spline calibrator" ;
-  rdfs:subClassOf qudt:Map ;
-.
+  rdfs:subClassOf qudt:Map .
+
 qudt:SplinePoint
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description "A sub-type of 'Tuple Type'." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Spline point" ;
-  rdfs:subClassOf qudt:Tuple ;
-.
+  rdfs:subClassOf qudt:Tuple .
+
 qudt:StateSpaceMatrix
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   <p>In control engineering, a state space representation is a mathematical model of a physical system
    as a set of input, output and state variables related by first-order differential equations. 
@@ -3510,11 +1767,10 @@ qudt:StateSpaceMatrix
   </p>"""^^rdf:HTML ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "State Space Matrix Type" ;
-  rdfs:subClassOf qudt:Matrix ;
-.
+  rdfs:subClassOf qudt:Matrix .
+
 qudt:StateSpaceVector
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   A state vector in general control systems describes the observed states of an object in state space.
   For example in variables of the degrees of freedom for motion. 
@@ -3523,33 +1779,24 @@ qudt:StateSpaceVector
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "State Space Vector Type" ;
   rdfs:subClassOf qudt:Vector ;
-  sh:property qudt:StateSpaceVector-coordinateSystem ;
-.
-qudt:StateSpaceVector-coordinateSystem
-  a sh:PropertyShape ;
-  sh:path qudt:coordinateSystem ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:CoordinateSystem ;
-  sh:maxCount 1 ;
-.
+  sh:property qudt:StateSpaceVector-coordinateSystem .
+
 qudt:StringEncodingType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
-  <p><em>String Encoding Type</em> is an \"Encoding\" with the following instance(s):
-   \"UTF-16 String\", \"UTF-8 Encoding\".
+  <p><em>String Encoding Type</em> is an "Encoding" with the following instance(s):
+   "UTF-16 String", "UTF-8 Encoding".
    </p>
   """^^rdf:HTML ;
   dcterms:description """
-  An \"Encoding\" with the following instance(s): \"qudt:UTF8-StringEncoding\", \"qudt:UTF16-StringEncoding\".
+  An "Encoding" with the following instance(s): "qudt:UTF8-StringEncoding", "qudt:UTF16-StringEncoding".
   """ ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "String Encoding Type" ;
-  rdfs:subClassOf qudt:Encoding ;
-.
+  rdfs:subClassOf qudt:Encoding .
+
 qudt:StringType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   <p>A <em>String Type</em> is a data type that specifies the properties of a list structure that holds characters.
   </p>
@@ -3561,57 +1808,10 @@ qudt:StringType
   sh:property qudt:StringType-isByteString ;
   sh:property qudt:StringType-maxLength ;
   sh:property qudt:StringType-memberDatatype ;
-  sh:property qudt:StringType-typeMatrix ;
-.
-qudt:StringType-dimensionality
-  a sh:PropertyShape ;
-  sh:path qudt:dimensionality ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:or (
-      [
-        sh:datatype xsd:integer ;
-      ]
-      [
-        sh:datatype xsd:int ;
-      ]
-    ) ;
-.
-qudt:StringType-elementType
-  a sh:PropertyShape ;
-  sh:path qudt:elementDatatype ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:CharacterType ;
-.
-qudt:StringType-isByteString
-  a sh:PropertyShape ;
-  sh:path qudt:isByteString ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class xsd:boolean ;
-  sh:maxCount 1 ;
-.
-qudt:StringType-maxLength
-  a sh:PropertyShape ;
-  sh:path qudt:maxLength ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:integer ;
-  sh:maxCount 1 ;
-.
-qudt:StringType-memberDatatype
-  a sh:PropertyShape ;
-  sh:path qudt:memberDatatype ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:CharacterType ;
-.
-qudt:StringType-typeMatrix
-  a sh:PropertyShape ;
-  sh:path qudt:typeMatrix ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:maxCount 0 ;
-  sh:minCount 0 ;
-.
+  sh:property qudt:StringType-typeMatrix .
+
 qudt:StringUTF16
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   <p><em>String UTF-16</em> is a string data type that specifies the properties of string data structures which encode strings using the UTF-16 encoding. 
   UTF-16 is the native internal representation of text in many software systems, for example:
@@ -3628,48 +1828,25 @@ qudt:StringUTF16
   rdfs:label "String UTF16" ;
   rdfs:subClassOf qudt:StringType ;
   rdfs:subClassOf qudt:TextStringType ;
-  sh:property qudt:StringUTF16-memberDatatype ;
-.
-qudt:StringUTF16-memberDatatype
-  a sh:PropertyShape ;
-  sh:path qudt:memberDatatype ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:CharacterType ;
-  sh:hasValue qudt:UTF16-CHAR ;
-.
+  sh:property qudt:StringUTF16-memberDatatype .
+
 qudt:StringUTF8
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   String UTF-8 Type is a string data type that specifies the properties of string data structures which encode strings using the UTF-8 encoding. 
   UTF-8 includes ASCII, otherwise referred to as IA-5 (International Alphabet 5, as standardized by International Organization for Standardization [ISO]) as the first 128 values. 
   The Internet Engineering Task Force (IETF) requires all Internet protocols to identify the encoding used for character data with UTF-8 as at least one supported encoding. 
   The Internet Mail Consortium (IMC) recommends that all e-mail programs must be able to display and create mail using UTF-8.
   """ ;
-  vaem:isElaboratedIn <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "String UTF8 Type" ;
   rdfs:subClassOf qudt:StringType ;
   rdfs:subClassOf qudt:TextStringType ;
   sh:property qudt:StringUTF8-memberDatatype ;
-.
-qudt:StringUTF8-memberDatatype
-  a sh:PropertyShape ;
-  sh:path qudt:memberDatatype ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:CharacterType ;
-  sh:hasValue qudt:UTF8-CHAR ;
-.
-qudt:StructuredData-dimensionality
-  a sh:PropertyShape ;
-  sh:path qudt:dimensionality ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:integer ;
-  sh:maxCount 1 ;
-.
+  vaem:isElaboratedIn <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> .
+
 qudt:StructuredDatatype
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   <p>A <em>Structured Datatype</em>, in contrast to a scalar data type, is used to characterize classes of complex data structures.
   Examples are collections, linked and indexed lists, trees, ordered trees, and multi-dimensional file formats.
@@ -3677,26 +1854,10 @@ qudt:StructuredDatatype
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Structured Data Type" ;
   rdfs:subClassOf qudt:Datatype ;
-  sh:property qudt:StructuredDatatype-elementType ;
-.
-qudt:StructuredDatatype-elementType
-  a sh:PropertyShape ;
-  sh:path qudt:elementDatatype ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:Datatype ;
-  sh:maxCount 1 ;
-.
-qudt:SystemModifiableParameter
-  a qudt:ParameterModifiabilityType ;
-  dtype:code "1" ;
-  dtype:literal "system" ;
-  rdfs:comment "Parameter is modifiable by a (computer) system." ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "System modifiable parameter" ;
-.
+  sh:property qudt:StructuredDatatype-elementType .
+
 qudt:Table
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   A Table Type is a data type that specifies the properties of table data structures. 
   A table is both a mode of visual communication and a means of arranging data. 
@@ -3710,85 +1871,27 @@ qudt:Table
   sh:property qudt:Table-byRow ;
   sh:property qudt:Table-columns ;
   sh:property qudt:Table-dimensionality ;
-  sh:property qudt:Table-rows ;
-.
-qudt:Table-byRow
-  a sh:PropertyShape ;
-  sh:path qudt:byRow ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:boolean ;
-  sh:maxCount 1 ;
-.
-qudt:Table-columns
-  a sh:PropertyShape ;
-  sh:path qudt:columns ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:integer ;
-  sh:maxCount 1 ;
-.
-qudt:Table-dimensionality
-  a sh:PropertyShape ;
-  sh:path qudt:dimensionality ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:integer ;
-  sh:maxCount 1 ;
-.
-qudt:Table-rows
-  a sh:PropertyShape ;
-  sh:path qudt:rows ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:integer ;
-  sh:maxCount 1 ;
-.
+  sh:property qudt:Table-rows .
+
 qudt:TaggedEnumeration
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description "An enumeration where each literal  has a tag that is a non-negative integer. These enumerations are likely to have their literals encoded - hence the need for the tag." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Tagged Enumeration" ;
   rdfs:subClassOf qudt:Enumeration ;
-  sh:property qudt:TaggedEnumeration-code ;
-.
-qudt:TaggedEnumeration-code
-  a sh:PropertyShape ;
-  sh:path dtype:code ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:maxCount 1 ;
-  sh:minCount 1 ;
-.
+  sh:property qudt:TaggedEnumeration-code .
+
 qudt:TextStringType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   A <em>Text String Type</em> has encodings that are specified in subclasses or in connection to character arrays in <em>Structured Datatypes</em>.
   """ ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Text String Type" ;
-  rdfs:subClassOf qudt:StringType ;
-.
-qudt:TextTypeUnion
-  a rdf:List ;
-  dcterms:description """
-  An rdf:List that can be used in property constraints as value for sh:or to indicate that all values of a property
-   must be a plain string, a string with HTML markup, or a string with LaTeX markup.
-  """ ;
-  rdf:first [
-      sh:datatype xsd:string ;
-    ] ;
-  rdf:rest (
-      [
-        sh:datatype rdf:HTML ;
-      ]
-      [
-        sh:datatype qudt:LatexString ;
-      ]
-    ) ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "Text Type Union" ;
-.
+  rdfs:subClassOf qudt:StringType .
+
 qudt:ThreeBodyRotatingCoordinateSystem
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   <p>A <em>Three Body Rotating Coordinate System</em> is one that is associated with two different three-body systems.
   For example, the Sun-Earth-spacecraft system and the Earth-Moon-spacecraft system.
@@ -3804,11 +1907,10 @@ qudt:ThreeBodyRotatingCoordinateSystem
   """^^rdf:HTML ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Three Body Rotating Coordinate System Type" ;
-  rdfs:subClassOf qudt:AerospaceCoordinateSystem ;
-.
+  rdfs:subClassOf qudt:AerospaceCoordinateSystem .
+
 qudt:ThreeTuple
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   A three-tuple is a tuple with exactly three members. 
   A Three-Tuple Type is a data type that defines the type properties of a class of three-tuples and their members.
@@ -3817,67 +1919,37 @@ qudt:ThreeTuple
   rdfs:label "Three-Tuple" ;
   rdfs:subClassOf qudt:N-Tuple ;
   sh:property qudt:ThreeTuple-elementType ;
-  sh:property qudt:ThreeTuple-elementTypeCount ;
-.
-qudt:ThreeTuple-elementType
-  a sh:PropertyShape ;
-  sh:path qudt:elementDatatype ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:TupleMember ;
-  sh:minCount 0 ;
-.
-qudt:ThreeTuple-elementTypeCount
-  a sh:PropertyShape ;
-  sh:path qudt:elementTypeCount ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:integer ;
-  sh:hasValue 3 ;
-.
+  sh:property qudt:ThreeTuple-elementTypeCount .
+
 qudt:Time
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   rdfs:comment "The class of data values that denote a point in time. Time values may be encoded in a 12-hour clock or a 24-hour clock, such as 1:35 AM, or 13:35." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Time" ;
   rdfs:subClassOf qudt:ScalarDatatype ;
-  sh:property qudt:Time-type ;
-.
-qudt:Time-type
-  a sh:PropertyShape ;
-  sh:path qudt:type ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:TimeStringType ;
-.
+  sh:property qudt:Time-type .
+
 qudt:TimeDataType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description "A sub-type of 'QUDT Enumeration'." ;
   dtype:value qudt:TIME ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Time data type" ;
   rdfs:subClassOf qudt:Enumeration ;
-  rdfs:subClassOf qudt:ScalarDatatype ;
-.
+  rdfs:subClassOf qudt:ScalarDatatype .
+
 qudt:TimeInterval
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   rdfs:comment """A relative interval that is an increment in time. 
   For example, this is used in time series arrays to express the time point of a vector of values.
   """ ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Time interval" ;
   rdfs:subClassOf qudt:Concept ;
-  sh:property qudt:TimeInterval-type ;
-.
-qudt:TimeInterval-type
-  a sh:PropertyShape ;
-  sh:path qudt:type ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:TimeStringType ;
-.
+  sh:property qudt:TimeInterval-type .
+
 qudt:TimeSeriesArray
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   rdfs:comment """
   A Time Series Array is a data type that specifies the properties of arrays that hold time series data. 
   A time series is a sequence of data points, measured at successive time intervals. 
@@ -3887,35 +1959,10 @@ qudt:TimeSeriesArray
   rdfs:label "Time Series Array" ;
   rdfs:subClassOf qudt:Array ;
   sh:property qudt:TimeSeriesArray-incrementDatatype ;
-  sh:property qudt:TimeSeriesArray-vector ;
-.
-qudt:TimeSeriesArray-dimensions
-  a sh:PropertyShape ;
-  sh:path qudt:dimensions ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:int ;
-  sh:maxCount 1 ;
-  sh:minCount 1 ;
-.
-qudt:TimeSeriesArray-incrementDatatype
-  a sh:PropertyShape ;
-  sh:path qudt:incrementDatatype ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:TimeStringType ;
-  sh:maxCount 1 ;
-  sh:minCount 1 ;
-.
-qudt:TimeSeriesArray-vector
-  a sh:PropertyShape ;
-  sh:path qudt:vector ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:Vector ;
-  sh:maxCount 1 ;
-  sh:minCount 1 ;
-.
+  sh:property qudt:TimeSeriesArray-vector .
+
 qudt:TimeSeriesArrayType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   <p>A <em>Time Series Array Type</em> is a data type that specifies the properties of arrays that hold time series data. 
   A time series is a sequence of data points, measured at successive time intervals. 
@@ -3924,66 +1971,47 @@ qudt:TimeSeriesArrayType
   """^^rdf:HTML ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Time Series Array Type" ;
-  rdfs:subClassOf qudt:ArrayType ;
-.
+  rdfs:subClassOf qudt:ArrayType .
+
 qudt:TimeStringType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description "Time takes a number of forms, depending on the units used (e.g., year, day, minute, millisecond, or combinations thereof) and the origin (i.e., time zero) to which the time value is related." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Time Type" ;
   rdfs:subClassOf qudt:DateTimeStringType ;
-  rdfs:subClassOf qudt:TextStringType ;
-.
-qudt:TotallyOrdered
-  a qudt:OrderedType ;
-  qudt:plainTextDescription "Totally ordered structure." ;
-  dtype:literal "total" ;
-  rdfs:isDefinedBy <file:///Users/ralphtq/git-qudt/qudt-public-repo/qudt> ;
-  rdfs:label "Totally Ordered" ;
-.
+  rdfs:subClassOf qudt:TextStringType .
+
 qudt:TrajectoryCoordinateSystem
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description "A \"Coordinate System\"." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Trajectory Coordinate System" ;
-  rdfs:subClassOf qudt:AerospaceCoordinateSystem ;
-.
+  rdfs:subClassOf qudt:AerospaceCoordinateSystem .
+
 qudt:Tree
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
-  A \"Tree\" is a data type that defines the properties of data structures that represent trees. 
+  A "Tree" is a data type that defines the properties of data structures that represent trees. 
   Each node is either a leaf or an internal node. 
   An internal node has one or more child nodes and is called the parent of its child nodes. 
   Leaf nodes have no chidren. Nodes that share the same parent are siblings. 
   In graph theoretic terminology, a tree is a connected, undirected, acyclic graph.
   """ ;
+  prov:wasInfluencedBy <http://en.wikipedia.org/wiki/Tree_(data_structure)> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Tree Type" ;
-  rdfs:subClassOf qudt:Graph ;
-  prov:wasInfluencedBy <http://en.wikipedia.org/wiki/Tree_(data_structure)> ;
-.
+  rdfs:subClassOf qudt:Graph .
+
 qudt:Triplet
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description "A \"Tuple\"." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Triplet" ;
   rdfs:seeAlso qudt:ThreeTuple ;
-  rdfs:subClassOf qudt:ThreeTuple ;
-.
-qudt:True
-  a qudt:BooleanStateType ;
-  dtype:code "1" ;
-  dtype:literal "true" ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "true" ;
-.
+  rdfs:subClassOf qudt:ThreeTuple .
+
 qudt:Tuple
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   <p>The term <em>Tuple</em> originated as an abstraction of the sequence: single, double, triple, quadruple, quintuple, n-tuple. 
   In mathematics, a tuple is a finite sequence (also known as an <em>Ordered List</em> of objects, each of a specified type. 
@@ -3994,32 +2022,10 @@ qudt:Tuple
   rdfs:subClassOf qudt:CompositeDatatype ;
   sh:property qudt:Tuple-elementType ;
   sh:property qudt:Tuple-elementTypeCount ;
-  sh:property qudt:Tuple-length ;
-.
-qudt:Tuple-elementType
-  a sh:PropertyShape ;
-  sh:path qudt:elementDatatype ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:TupleMember ;
-.
-qudt:Tuple-elementTypeCount
-  a sh:PropertyShape ;
-  sh:path qudt:elementTypeCount ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:integer ;
-  sh:minCount 0 ;
-.
-qudt:Tuple-length
-  a sh:PropertyShape ;
-  sh:path qudt:length ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:integer ;
-  sh:maxCount 1 ;
-  sh:minCount 0 ;
-.
+  sh:property qudt:Tuple-length .
+
 qudt:TupleMember
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   <p><em>Tuple Member</em> defines the properties of a member of a tuple. 
   It is used to provide fine grained type specification to the elements of tuples.
@@ -4029,24 +2035,10 @@ qudt:TupleMember
   rdfs:label "Tuple Member Type" ;
   rdfs:subClassOf qudt:CompositeDatatype ;
   sh:property qudt:TupleMember-elementType ;
-  sh:property qudt:TupleMember-orderInStructure ;
-.
-qudt:TupleMember-elementType
-  a sh:PropertyShape ;
-  sh:path qudt:elementDatatype ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:ScalarDatatype ;
-.
-qudt:TupleMember-orderInStructure
-  a sh:PropertyShape ;
-  sh:path qudt:orderInStructure ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:maxCount 1 ;
-  sh:minCount 1 ;
-.
+  sh:property qudt:TupleMember-orderInStructure .
+
 qudt:TupleType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   <p><em>Tuple</em> originated as an abstraction of the sequence: single, double, triple, quadruple, quintuple, n-tuple.  
   In mathematics, a tuple is a finite sequence (also known as an <em>Ordered List</em> of objects, each of a specified type. 
@@ -4058,24 +2050,10 @@ qudt:TupleType
   rdfs:subClassOf qudt:CompositeDatatype ;
   sh:property qudt:Tuple-elementType ;
   sh:property qudt:Tuple-elementTypeCount ;
-  sh:property qudt:Tuple-length ;
-.
-qudt:Two-Tuple-elementType
-  a sh:PropertyShape ;
-  sh:path qudt:elementDatatype ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:minCount 0 ;
-.
-qudt:Two-Tuple-elementTypeCount
-  a sh:PropertyShape ;
-  sh:path qudt:elementTypeCount ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:integer ;
-  sh:hasValue 2 ;
-.
+  sh:property qudt:Tuple-length .
+
 qudt:TwoTuple
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   A 2-tuple is called a pair. 
   For example, a complex number can be represented as a 2-tuple.
@@ -4085,53 +2063,36 @@ qudt:TwoTuple
   rdfs:label "Two-Tuple" ;
   rdfs:subClassOf qudt:N-Tuple ;
   sh:property qudt:TwoTuple-elementType ;
-  sh:property qudt:TwoTuple-elementTypeCount ;
-.
-qudt:TwoTuple-elementType
-  a sh:PropertyShape ;
-  sh:path qudt:elementDatatype ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:minCount 0 ;
-.
-qudt:TwoTuple-elementTypeCount
-  a sh:PropertyShape ;
-  sh:path qudt:elementTypeCount ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:integer ;
-  sh:hasValue 2 ;
-.
+  sh:property qudt:TwoTuple-elementTypeCount .
+
 qudt:TwoTupleType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description "A 2-tuple is called a pair. For example, a complex number can be represented as a 2-tuple, and 2D coordinates are sometimes represented as 2-tuples." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Two-Tuple Type" ;
   rdfs:subClassOf qudt:N-TupleType ;
   sh:property qudt:Two-Tuple-elementType ;
-  sh:property qudt:Two-Tuple-elementTypeCount ;
-.
+  sh:property qudt:Two-Tuple-elementTypeCount .
+
 qudt:TypeList
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description "A sub-type of 'QUDT Datatype'." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Type list" ;
-  rdfs:subClassOf qudt:Datatype ;
-.
+  rdfs:subClassOf qudt:Datatype .
+
 qudt:TypeMatrix
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   rdfs:comment """
   Members of this class are matrix data structures that describe the datatypes of a class of matrices. 
   That is, the members of this class are matrices with cells that contain datatypes (c.f. type:Datatype) and are used to describe the datatype structure of other matrices.
   """ ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Type matrix" ;
-  rdfs:subClassOf qudt:Matrix ;
-.
+  rdfs:subClassOf qudt:Matrix .
+
 qudt:TypeVector
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   <p>A <em>Type Vector</em> is a vector whose elements are data types. 
   They are used to specify the type of each component of a vector or class of vectors. 
@@ -4139,37 +2100,10 @@ qudt:TypeVector
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Type vector" ;
   rdfs:subClassOf qudt:Vector ;
-  sh:property qudt:TypeVector-datatype ;
-.
-qudt:TypeVector-datatype
-  a sh:PropertyShape ;
-  sh:path qudt:datatype ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:DataType ;
-.
-qudt:UNARY-FUNCTION
-  a qudt:FunctionDatatype ;
-  dcterms:description "This type identifies functions that have exactly one argument."^^rdf:HTML ;
-  qudt:functionArity 1 ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "UNARY-FUNCTION" ;
-.
-qudt:UNSIGNED
-  a qudt:SignednessType ;
-  dtype:literal "unsigned" ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "Unsigned" ;
-.
-qudt:Unordered
-  a qudt:OrderedType ;
-  qudt:plainTextDescription "Unordered structure." ;
-  dtype:literal "unordered" ;
-  rdfs:isDefinedBy <file:///Users/ralphtq/git-qudt/qudt-public-repo/qudt> ;
-  rdfs:label "Unordered" ;
-.
+  sh:property qudt:TypeVector-datatype .
+
 qudt:UnsignedBigIntegerType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description "An Unsgned Big Integer is an unsigned integer that can be represented in eight octets (64 bits) of machine memory." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Unsigned Big Integer Type" ;
@@ -4177,47 +2111,19 @@ qudt:UnsignedBigIntegerType
   rdfs:subClassOf qudt:UnsignedIntegerType ;
   sh:property qudt:UnsignedBigIntegerType-abbreviation ;
   sh:property qudt:UnsignedBigIntegerType-maxInclusive ;
-  sh:property qudt:UnsignedBigIntegerType-minInclusive ;
-.
-qudt:UnsignedBigIntegerType-abbreviation
-  a sh:PropertyShape ;
-  sh:path qudt:abbreviation ;
-  rdfs:isDefinedBy <file:///Users/ralphtq/git-qudt/qudt-public-repo/qudt> ;
-  sh:hasValue "UI64" ;
-.
-qudt:UnsignedBigIntegerType-maxInclusive
-  a sh:PropertyShape ;
-  sh:path qudt:maxInclusive ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:hasValue "2^{64}-1" ;
-  sh:or qudt:NumericTypeUnion ;
-.
-qudt:UnsignedBigIntegerType-minInclusive
-  a sh:PropertyShape ;
-  sh:path qudt:minInclusive ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:hasValue "0" ;
-  sh:or qudt:NumericTypeUnion ;
-.
-qudt:UnsignedIntegerEncoding
-  a qudt:IntegerEncodingType ;
-  qudt:bytes 4 ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "Unsigned Integer Encoding" ;
-.
+  sh:property qudt:UnsignedBigIntegerType-minInclusive .
+
 qudt:UnsignedIntegerType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description "Unsgned Integers are integers that are either strictly non-negative or non-positive." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Unsigned Integer Type" ;
   rdfs:subClassOf qudt:IntegerDatatype ;
   rdfs:subClassOf qudt:UnsignedType ;
-  sh:disjoint qudt:SignedIntegerType ;
-.
+  sh:disjoint qudt:SignedIntegerType .
+
 qudt:UnsignedLongIntegerType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description "An Unsigned Long Integer is an unsigned integer that can be represented in four octets (32 bits) of machine memory." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Unsigned Long Integer Type" ;
@@ -4225,41 +2131,19 @@ qudt:UnsignedLongIntegerType
   rdfs:subClassOf qudt:UnsignedIntegerType ;
   sh:property qudt:UnsignedLongIntegerType-literal ;
   sh:property qudt:UnsignedLongIntegerType-maxInclusive ;
-  sh:property qudt:UnsignedLongIntegerType-minInclusive ;
-.
-qudt:UnsignedLongIntegerType-literal
-  a sh:PropertyShape ;
-  sh:path dtype:literal ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:string ;
-.
-qudt:UnsignedLongIntegerType-maxInclusive
-  a sh:PropertyShape ;
-  sh:path qudt:maxInclusive ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:hasValue "2^{32}-1" ;
-  sh:or qudt:NumericTypeUnion ;
-.
-qudt:UnsignedLongIntegerType-minInclusive
-  a sh:PropertyShape ;
-  sh:path qudt:minInclusive ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:hasValue "0" ;
-  sh:or qudt:NumericTypeUnion ;
-.
+  sh:property qudt:UnsignedLongIntegerType-minInclusive .
+
 qudt:UnsignedMediumIntegerType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
-  An \"Unsigned Medium Integer\" is an integer of 24 bits that only takes on both positive values.
+  An "Unsigned Medium Integer" is an integer of 24 bits that only takes on both positive values.
   """ ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Unsigned Medium Integer Type" ;
-  rdfs:subClassOf qudt:UnsignedIntegerType ;
-.
+  rdfs:subClassOf qudt:UnsignedIntegerType .
+
 qudt:UnsignedShortIntegerType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description "An Unsigned Short Integer is an unsigned integer that can be represented in four octets (32 bits) of machine memory." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Unsigned Short Integer Type" ;
@@ -4267,135 +2151,56 @@ qudt:UnsignedShortIntegerType
   rdfs:subClassOf qudt:UnsignedIntegerType ;
   sh:property qudt:UnsignedShortIntegerType-abbreviation ;
   sh:property qudt:UnsignedShortIntegerType-maxInclusive ;
-  sh:property qudt:UnsignedShortIntegerType-minInclusive ;
-.
-qudt:UnsignedShortIntegerType-abbreviation
-  a sh:PropertyShape ;
-  sh:path qudt:abbreviation ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:hasValue "UI16" ;
-.
-qudt:UnsignedShortIntegerType-maxInclusive
-  a sh:PropertyShape ;
-  sh:path qudt:maxInclusive ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:hasValue "2^{16}-1" ;
-.
-qudt:UnsignedShortIntegerType-minInclusive
-  a sh:PropertyShape ;
-  sh:path qudt:minInclusive ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:hasValue "0" ;
-.
+  sh:property qudt:UnsignedShortIntegerType-minInclusive .
+
 qudt:UnsignedType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description "An unsigned data type is a numeric type that does not distinguish between positive and negative values." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Unsigned Type" ;
   rdfs:subClassOf qudt:NumericType ;
   sh:disjoint qudt:SignedType ;
-  sh:property qudt:UnsignedType-signedness ;
-.
-qudt:UnsignedType-signedness
-  a sh:PropertyShape ;
-  sh:path qudt:signedness ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:SignednessType ;
-  sh:hasValue qudt:UNSIGNED ;
-.
+  sh:property qudt:UnsignedType-signedness .
+
 qudt:UnsignedVariableLengthIntegerType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
-  An \"Unsigned Variable Length Integer\" data type defines a data structure for representing unsigned integers that uses a variable number of bits depending on the magnitude of the integer. 
+  An "Unsigned Variable Length Integer" data type defines a data structure for representing unsigned integers that uses a variable number of bits depending on the magnitude of the integer. 
   Typically, variable length integer data types are between one and 64 bits in length.
   """ ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Unsigned Variable Length Integer Type" ;
   rdfs:subClassOf qudt:UnsignedIntegerType ;
-  rdfs:subClassOf qudt:VariableLengthIntegerType ;
-.
-qudt:UserModifiableParameter
-  a qudt:ParameterModifiabilityType ;
-  dtype:code "2" ;
-  dtype:literal "user" ;
-  rdfs:comment "Parameter is modifiable by a user." ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "User modifiable parameter" ;
-.
-qudt:ValidateQuantityHasUnitShape
-  a sh:NodeShape ;
-  dcterms:description """
-  <p>Specifies and checks an optional property for a quantified value.
-  </p>"""^^rdf:HTML ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/qudt> ;
-  rdfs:label "Validate Quantity has Unit Shape" ;
-  sh:property qudt:MaybeQuantityPropertyShape ;
-  sh:property qudt:MaybeUnitPropertyShape ;
-  sh:severity sh:Warning ;
-  sh:sparql [
-      sh:message "Quantity \"{$this}\" must have a unit." ;
-      sh:prefixes <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatypePrefixes> ;
-      sh:select """
-        SELECT $this
-        WHERE {
-             $this qudt:quantity ?quantity .
-             FILTER NOT EXISTS {?quantity qudt:hasUnit ?unit} 
-             }
-        """ ;
-    ] ;
-  sh:targetClass qudt:Array ;
-  sh:targetClass qudt:List ;
-  sh:targetClass qudt:Quantity ;
-  sh:targetClass qudt:Vector ;
-.
+  rdfs:subClassOf qudt:VariableLengthIntegerType .
+
 qudt:VariableIntervalTimeSeriesArray
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description "A Variable Interval Time Series Array Type is a data type that specifies the properties of arrays that hold time series data that has been sampled over non-uniformly spaced time intervals. A time series is a sequence of data points, measured typically at successive times, spaced at uniform or non-uniform time intervals. For variable interval time series, the successive time intervals may follow a repeating pattern, or may be completely random." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Variable Interval Time Series Array Type" ;
-  rdfs:subClassOf qudt:TimeSeriesArray ;
-.
+  rdfs:subClassOf qudt:TimeSeriesArray .
+
 qudt:VariableIntervalTimeSeriesArrayType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   rdfs:comment "A Variable Interval Time Series Array Type is a data type that specifies the properties of arrays that hold time series data that has been sampled over non-uniformly spaced time intervals. A time series is a sequence of data points, measured typically at successive times, spaced at uniform or non-uniform time intervals. For variable interval time series, the successive time intervals may follow a repeating pattern, or may be completely random." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Variable Interval Time Series Array Type" ;
-  rdfs:subClassOf qudt:TimeSeriesArrayType ;
-.
+  rdfs:subClassOf qudt:TimeSeriesArrayType .
+
 qudt:VariableLengthIntegerType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
-  A \"Variable Length Integer\" data type defines a data structure for representing integers that uses a variable number of bits depending on the magnitude of the integer. 
+  A "Variable Length Integer" data type defines a data structure for representing integers that uses a variable number of bits depending on the magnitude of the integer. 
   Typically, variable length integer data types are between one and 64 bits in length.
   """ ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Variable Length Integer Type" ;
   rdfs:subClassOf qudt:IntegerDatatype ;
   sh:property qudt:VariableLengthIntegerType-maxBits ;
-  sh:property qudt:VariableLengthIntegerType-minBits ;
-.
-qudt:VariableLengthIntegerType-maxBits
-  a sh:PropertyShape ;
-  sh:path qudt:maxBits ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:integer ;
-  sh:hasValue 64 ;
-.
-qudt:VariableLengthIntegerType-minBits
-  a sh:PropertyShape ;
-  sh:path qudt:minBits ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:datatype xsd:integer ;
-  sh:hasValue 1 ;
-.
+  sh:property qudt:VariableLengthIntegerType-minBits .
+
 qudt:Vector
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description """
   <p>A <em>Vector</em> is an array data type that can have a dimensionality of one, or more elements.
   Vectors can represent physical quantities, such as velocity, force, displacement;
@@ -4426,118 +2231,61 @@ qudt:Vector
   rdfs:label "Vector" ;
   rdfs:subClassOf qudt:Array ;
   sh:property qudt:MaybeQuantityPropertyShape ;
-  sh:property qudt:QuantityKindsPropertyShape ;
-.
+  sh:property qudt:QuantityKindsPropertyShape .
+
 qudt:VehicleCoordinateSystem
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   dcterms:description "A sub-type of 'Aerospace coordinate system'." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Vehicle coordinate system" ;
   rdfs:subClassOf qudt:AerospaceCoordinateSystem ;
   sh:property qudt:VehicleCoordinateSystem-pitchRotationDefinition ;
   sh:property qudt:VehicleCoordinateSystem-rollRotationDefinition ;
-  sh:property qudt:VehicleCoordinateSystem-yawRotationDefinition ;
-.
-qudt:VehicleCoordinateSystem-pitchRotationDefinition
-  a sh:PropertyShape ;
-  sh:path qudt:pitchRotationDefinition ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:AxialOrientationType ;
-  sh:maxCount 1 ;
-.
-qudt:VehicleCoordinateSystem-rollRotationDefinition
-  a sh:PropertyShape ;
-  sh:path qudt:rollRotationDefinition ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:AxialOrientationType ;
-  sh:maxCount 1 ;
-  sh:minCount 0 ;
-.
-qudt:VehicleCoordinateSystem-yawRotationDefinition
-  a sh:PropertyShape ;
-  sh:path qudt:yawRotationDefinition ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:AxialOrientationType ;
-  sh:maxCount 1 ;
-  sh:minCount 0 ;
-.
+  sh:property qudt:VehicleCoordinateSystem-yawRotationDefinition .
+
 qudt:VisualCue
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Visual Cue" ;
-  rdfs:subClassOf qudt:ModalCue ;
-.
-qudt:VisualCueEnumeration-defaultValue
-  a sh:PropertyShape ;
-  sh:path qudt:defaultValue ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  sh:class qudt:VisualCue ;
-.
-qudt:WDST_DRY
-  a qudt:WetDryStateType ;
-  dtype:code "2" ;
-  dtype:literal "dry" ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "Dry" ;
-.
-qudt:WDST_WET
-  a qudt:WetDryStateType ;
-  dtype:code "1" ;
-  dtype:literal "wet" ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "Wet" ;
-.
+  rdfs:subClassOf qudt:ModalCue .
+
 qudt:WetDryStateType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Wet dry state type" ;
   rdfs:subClassOf qudt:DiscreteState ;
-  rdfs:subClassOf qudt:EnumeratedValue ;
-.
-qudt:WordAligned
-  a qudt:AlignmentType ;
-  dtype:literal "word" ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "Word Aligned" ;
-.
-qudt:XSDatomicTypeUnion
-  a rdf:List ;
-  dcterms:description """
-  <p>In XML Schema Definition (XSD) xsd:anySimpleType is the base type for all simple types.
-  Simple types in XSD represent atomic values without any child elements or complex structures.
-  All simple types are compliant with xsd:anySimpleType.
-  </p>
-  <p>In XSD, the atomic types are: xsd:string, xsd:boolean, xsd:decimal, xsd:float,
-   xsd:double, xsd:duration, xsd:dateTime, xsd:time, xsd:date, xsd:gYearMonth, xsd:gYear, xsd:gMonthDay,
-   xsd:gDay, xsd:gMonth, xsd:hexBinary, xsd:base64Binary, xsd:anyURI, xsd:QName, and xsd:NOTATION.
-  </p>"""^^rdf:HTML ;
-  rdf:first [
-      sh:datatype xsd:anySimpleType ;
-    ] ;
-  rdf:rest (
-      [
-        sh:datatype xsd:anySimpleType ;
-      ]
-    ) ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "XSD Atomic Type Union" ;
-.
-qudt:Yes
-  a qudt:YesNoType ;
-  dtype:literal "Y" ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "Yes" ;
-.
+  rdfs:subClassOf qudt:EnumeratedValue .
+
 qudt:YesNoType
-  a rdfs:Class ;
-  a sh:NodeShape ;
+  a rdfs:Class, sh:NodeShape ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Yes no type" ;
-  rdfs:subClassOf qudt:EnumeratedValue ;
-.
+  rdfs:subClassOf qudt:EnumeratedValue .
+
+dcterms:contributor
+  a rdf:Property ;
+  rdfs:label "contributor" .
+
+dcterms:creator
+  a rdf:Property ;
+  rdfs:label "creator" .
+
+dcterms:description
+  a rdf:Property ;
+  rdfs:label "description" .
+
+dcterms:rights
+  a rdf:Property ;
+  rdfs:label "rights" .
+
+dcterms:subject
+  a rdf:Property ;
+  rdfs:label "subject" .
+
+dcterms:title
+  a rdf:Property ;
+  rdfs:label "title" .
+
 qudt:accuracy
   a rdf:Property ;
   dcterms:description """
@@ -4551,156 +2299,156 @@ qudt:accuracy
   </p>
   """^^rdf:HTML ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "accuracy" ;
-.
+  rdfs:label "accuracy" .
+
 qudt:alignment
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "alignment" ;
-.
+  rdfs:label "alignment" .
+
 qudt:allowedPattern
   a rdf:Property ;
   dcterms:description "This property relates a date string encoding (c.f. type:DateStringEncodingType) to one or more XML Schema compliant regular expressions that together determine the allowed lexical expressions that can be unambiguously parsed to determine a temporal quantity." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "allowed pattern" ;
-.
+  rdfs:label "allowed pattern" .
+
 qudt:ansiSQLName
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "ANSI SQL name" ;
-  rdfs:subPropertyOf qudt:id ;
-.
+  rdfs:subPropertyOf qudt:id .
+
 qudt:arg1Type
   a rdf:Property ;
   dcterms:description "This property relates a funciton data type with the type of its arg1." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "arg1Type" ;
-  rdfs:subPropertyOf qudt:argType ;
-.
+  rdfs:subPropertyOf qudt:argType .
+
 qudt:arg2Type
   a rdf:Property ;
   dcterms:description "This property relates a funciton data type with the type of its arg2." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "arg2Type" ;
-  rdfs:subPropertyOf qudt:argType ;
-.
+  rdfs:subPropertyOf qudt:argType .
+
 qudt:arg3Type
   a rdf:Property ;
   dcterms:description "This property relates a funciton data type with the type of its arg3." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "arg3Type" ;
-  rdfs:subPropertyOf qudt:argType ;
-.
+  rdfs:subPropertyOf qudt:argType .
+
 qudt:argType
   a rdf:Property ;
   dcterms:description "This property relates a function data type with the type of one of its arguments." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "argType" ;
-  rdfs:subPropertyOf qudt:elementDatatype ;
-.
+  rdfs:subPropertyOf qudt:elementDatatype .
+
 qudt:auralCue
   a rdf:Property ;
   rdfs:label "aural cue" ;
-  rdfs:subPropertyOf qudt:modalCue ;
-.
+  rdfs:subPropertyOf qudt:modalCue .
+
 qudt:auralCueEnumeration
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "aural cue enumeration" ;
-  rdfs:subPropertyOf qudt:modalCueEnumeration ;
-.
+  rdfs:subPropertyOf qudt:modalCueEnumeration .
+
 qudt:base
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "base" ;
-.
+  rdfs:label "base" .
+
 qudt:basis
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "basis" ;
-.
+  rdfs:label "basis" .
+
 qudt:bitOrder
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "bit order" ;
-.
+  rdfs:label "bit order" .
+
 qudt:bits
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "bits" ;
-.
+  rdfs:label "bits" .
+
 qudt:bounded
   a rdf:Property ;
   dcterms:description "A datatype is bounded if its value space has either a finite upper and lower bound. Either bound may be inclusive or exclusive. " ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "bounded" ;
-.
+  rdfs:label "bounded" .
+
 qudt:byteOrder
   a rdf:Property ;
   dcterms:description "Byte order is an enumeration of two values: 'Big Endian' and 'Little Endian' and is used to denote whether the most signiticant byte is either first or last, respectively." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "byte order" ;
-.
+  rdfs:label "byte order" .
+
 qudt:bytes
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "bytes" ;
-.
+  rdfs:label "bytes" .
+
 qudt:cName
   a rdf:Property ;
   rdfs:comment "Datatype name in the C programming language" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "C Language name" ;
   rdfs:label "C name" ;
-  rdfs:subPropertyOf qudt:id ;
-.
+  rdfs:subPropertyOf qudt:id .
+
 qudt:cardinality
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "cardinality" ;
-.
+  rdfs:label "cardinality" .
+
 qudt:columns
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "columns" ;
-.
+  rdfs:label "columns" .
+
 qudt:coordinateCenter
   a rdf:Property ;
   rdfs:domain qudt:CoordinateSystem ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "coordinate center" ;
-  skos:prefLabel "coordinate center" ;
-.
+  skos:prefLabel "coordinate center" .
+
 qudt:coordinateSystem
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "coordinate system" ;
-.
+  rdfs:label "coordinate system" .
+
 qudt:coordinateSystemFrame
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "coordinate system frame" ;
-.
+  rdfs:label "coordinate system frame" .
+
 qudt:dataEncoding
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "data encoding" ;
-.
+  rdfs:label "data encoding" .
+
 qudt:dataOrder
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "data order" ;
-.
+  rdfs:label "data order" .
+
 qudt:datatype
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "datatype" ;
-.
+  rdfs:label "datatype" .
+
 qudt:defaultValue
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "Default Value" ;
-.
+  rdfs:label "Default Value" .
+
 qudt:dimensionality
   a rdf:Property ;
   dcterms:description """
@@ -4709,8 +2457,8 @@ qudt:dimensionality
   Whereas a vector or a string has a dimensionality of 1.
   """ ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "dimensionality" ;
-.
+  rdfs:label "dimensionality" .
+
 qudt:dimensions
   a rdf:Property ;
   dcterms:description """
@@ -4724,8 +2472,8 @@ qudt:dimensions
   For example a 4 by 4 array has dimensions (4 4), whereas a vector or a string has dimensions (1).
   """ ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "dimensions" ;
-.
+  rdfs:label "dimensions" .
+
 qudt:elementDatatype
   a rdf:Property ;
   dcterms:description """
@@ -4733,32 +2481,32 @@ qudt:elementDatatype
   It is used for structured data types with elements that are all of the same type.
   """ ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "element datatype" ;
-.
+  rdfs:label "element datatype" .
+
 qudt:elementKind
   a rdf:Property ;
   dcterms:description "This property is used to describe the quantity kind for a dimensional data type." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "element kind" ;
-  rdfs:subPropertyOf qudt:elementKind ;
-.
+  rdfs:subPropertyOf qudt:elementKind .
+
 qudt:elementLabel
   a rdf:Property ;
   dcterms:description "This property is used to label the field of a composite data structure." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "element label" ;
-.
+  rdfs:label "element label" .
+
 qudt:elementName
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "element name" ;
-.
+  rdfs:label "element name" .
+
 qudt:elementTypeCount
   a rdf:Property ;
   dcterms:description "This property determines the allowed number of element types that a structured data type may have." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "element type count" ;
-.
+  rdfs:label "element type count" .
+
 qudt:elementTypeList
   a rdf:Property ;
   dcterms:description """
@@ -4766,190 +2514,181 @@ qudt:elementTypeList
   It is used for structured data types with elements that are of different types.
   """ ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "element type list" ;
-.
+  rdfs:label "element type list" .
+
 qudt:elementUnit
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "element unit" ;
-.
+  rdfs:label "element unit" .
+
 qudt:encoding
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "encoding" ;
-.
+  rdfs:label "encoding" .
+
 qudt:enumeration
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "enumeration" ;
-.
+  rdfs:label "enumeration" .
+
 qudt:exponent
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "exponent" ;
-.
+  rdfs:label "exponent" .
+
 qudt:field
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "field" ;
-.
+  rdfs:label "field" .
+
 qudt:fieldLabels
   a rdf:Property ;
   dcterms:description "This property is used to list the field labels for a record type." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "field labels" ;
-.
+  rdfs:label "field labels" .
+
 qudt:fieldName
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "field name" ;
-.
+  rdfs:label "field name" .
+
 qudt:float_X
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "float X" ;
-.
+  rdfs:label "float X" .
+
 qudt:float_Y
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "float Y" ;
-.
+  rdfs:label "float Y" .
+
 qudt:float_Z
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "float Z" ;
-.
+  rdfs:label "float Z" .
+
 qudt:frameType
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "frame type" ;
-.
+  rdfs:label "frame type" .
+
 qudt:functionArity
   a rdf:Property ;
   dcterms:description "This property is used to state the number of arguments for a function type." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "function arity" ;
-.
+  rdfs:label "function arity" .
+
 qudt:hasQuantityKindsList
   a rdf:Property ;
   dcterms:description "This property is used to specify a list of quantity kinds." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "quantity kinds" ;
-.
-qudt:hexbinary
-  a rdfs:Datatype ;
-  a sh:NodeShape ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "hexbinary" ;
-  rdfs:subClassOf xsd:string ;
-  sh:datatype xsd:string ;
-  sh:pattern "[0-9A-F]*" ;
-.
+  rdfs:label "quantity kinds" .
+
 qudt:iconicCue
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "iconic cue" ;
-  rdfs:subPropertyOf qudt:modalCue ;
-.
+  rdfs:subPropertyOf qudt:modalCue .
+
 qudt:iconicCueEnumeration
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "iconic cue enumeration" ;
-  rdfs:subPropertyOf qudt:modalCueEnumeration ;
-.
+  rdfs:subPropertyOf qudt:modalCueEnumeration .
+
 qudt:inverted
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "inverted" ;
-.
+  rdfs:label "inverted" .
+
 qudt:isByteString
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "is byte string" ;
-.
+  rdfs:label "is byte string" .
+
 qudt:isHeterogeneous
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "is heterogeneous" ;
-.
+  rdfs:label "is heterogeneous" .
+
 qudt:javaName
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "java name" ;
-  rdfs:subPropertyOf qudt:id ;
-.
+  rdfs:subPropertyOf qudt:id .
+
 qudt:jsName
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Javascript name" ;
-  rdfs:subPropertyOf qudt:id ;
-.
+  rdfs:subPropertyOf qudt:id .
+
 qudt:kinestheticCue
   a rdf:Property ;
   rdfs:label "kinesthetic cue" ;
-  rdfs:subPropertyOf qudt:modalCue ;
-.
+  rdfs:subPropertyOf qudt:modalCue .
+
 qudt:kinestheticCueEnumeration
   a rdf:Property ;
   rdfs:label "kinesthetic cue enumeration" ;
-  rdfs:subPropertyOf qudt:modalCueEnumeration ;
-.
+  rdfs:subPropertyOf qudt:modalCueEnumeration .
+
 qudt:length
   a rdf:Property ;
   dcterms:description "The length of a structure, for example the size of a vector" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "length" ;
-.
+  rdfs:label "length" .
+
 qudt:lowerBound
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "lower bound" ;
-.
+  rdfs:label "lower bound" .
+
 qudt:mantissa
   a rdf:Property ;
   rdfs:comment "In scientific notation, the mantissa of a real number is the integer coefficient preceding the base raised to the exponent." ;
-  rdfs:label "mantissa" ;
-.
+  rdfs:label "mantissa" .
+
 qudt:matlabName
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "matlab name" ;
-  rdfs:subPropertyOf qudt:id ;
-.
+  rdfs:subPropertyOf qudt:id .
+
 qudt:maxBits
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "maximum bits" ;
-.
+  rdfs:label "maximum bits" .
+
 qudt:maxDepth
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "max depth" ;
-.
+  rdfs:label "max depth" .
+
 qudt:maxExclusive
   a rdf:Property ;
   dcterms:description "maxExclusive is the exclusive upper bound of the value space for a datatype with the ordered property. The value of maxExclusive must be in the value space of the base type or be equal to {value} in {base type definition}." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "max exclusive" ;
-  rdfs:subPropertyOf qudt:upperBound ;
-.
+  rdfs:subPropertyOf qudt:upperBound .
+
 qudt:maxExponent
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "max exponent" ;
-.
+  rdfs:label "max exponent" .
+
 qudt:maxInclusive
   a rdf:Property ;
   dcterms:description "maxInclusive is the inclusive upper bound of the value space for a datatype with the ordered property. The value of maxInclusive must be in the value space of the base type." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "max inclusive" ;
-  rdfs:subPropertyOf qudt:upperBound ;
-.
+  rdfs:subPropertyOf qudt:upperBound .
+
 qudt:maxLength
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "max length" ;
-.
+  rdfs:label "max length" .
+
 qudt:maxMantissa
   a rdf:Property ;
   dcterms:description """
@@ -4959,16 +2698,16 @@ qudt:maxMantissa
   <p><em>M = b<sup></sup> - 1</em> .</p>
   """^^rdf:HTML ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "max mantissa" ;
-.
+  rdfs:label "max mantissa" .
+
 qudt:member
   a rdf:Property ;
   dcterms:description """
   This property is used to define a collection's elements. 
   """ ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "member" ;
-.
+  rdfs:label "member" .
+
 qudt:memberDatatype
   a rdf:Property ;
   dcterms:description """
@@ -4976,38 +2715,38 @@ qudt:memberDatatype
   It is used for collections with elements that are all of the same type.
   """ ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "member datatype" ;
-.
+  rdfs:label "member datatype" .
+
 qudt:microsoftSQLServerName
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Microsoft SQL Server name" ;
-  rdfs:subPropertyOf qudt:id ;
-.
+  rdfs:subPropertyOf qudt:id .
+
 qudt:minBits
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "minimum bits" ;
-.
+  rdfs:label "minimum bits" .
+
 qudt:minExclusive
   a rdf:Property ;
   dcterms:description "minExclusive is the exclusive lower bound of the value space for a datatype with the ordered property. The value of minExclusive must be in the value space of the base type or be equal to {value} in {base type definition}." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "min exclusive" ;
-  rdfs:subPropertyOf qudt:lowerBound ;
-.
+  rdfs:subPropertyOf qudt:lowerBound .
+
 qudt:minInclusive
   a rdf:Property ;
   dcterms:description "minInclusive is the inclusive lower bound of the value space for a datatype with the ordered property. The value of minInclusive must be in the value space of the base type." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "min inclusive" ;
-  rdfs:subPropertyOf qudt:lowerBound ;
-.
+  rdfs:subPropertyOf qudt:lowerBound .
+
 qudt:minLength
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "min length" ;
-.
+  rdfs:label "min length" .
+
 qudt:minMantissa
   a rdf:Property ;
   dcterms:description """
@@ -5017,52 +2756,45 @@ qudt:minMantissa
   <p><em>M = -(b<sup>p</sup> - 1)</em>.
   </p>"""^^rdf:HTML ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "min mantissa" ;
-.
+  rdfs:label "min mantissa" .
+
 qudt:minValue
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "minimum value" ;
-.
+  rdfs:label "minimum value" .
+
 qudt:modalCue
   a rdf:Property ;
-  rdfs:label "modal cue" ;
-.
+  rdfs:label "modal cue" .
+
 qudt:modalCueEnumeration
   a rdf:Property ;
   rdfs:label "modal cue enumeration" ;
-  rdfs:subPropertyOf qudt:enumeration ;
-.
+  rdfs:subPropertyOf qudt:enumeration .
+
 qudt:modifiability
   a rdf:Property ;
   rdfs:comment "Reference to one in a list of enumerated elements that indicates whether data (e.g. variable or parameter) can be changed." ;
-  rdfs:label "modifiability" ;
-.
+  rdfs:label "modifiability" .
+
 qudt:mySQLName
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "MySQL name" ;
-  rdfs:subPropertyOf qudt:id ;
-.
-qudt:negative
-  a qudt:Polarity ;
-  dtype:code "1" ;
-  dtype:literal "negative" ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "negative" ;
-.
+  rdfs:subPropertyOf qudt:id .
+
 qudt:negativeDeltaLimit
   a rdf:Property ;
   dcterms:description "A negative change limit between consecutive sample values for a parameter. The Negative Delta may be the encoded value or engineering units value depending on whether or not a Calibrator is defined."^^rdf:HTML ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "negative delta limit" ;
-.
+  rdfs:label "negative delta limit" .
+
 qudt:odbcName
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "ODBC name" ;
-  rdfs:subPropertyOf qudt:id ;
-.
+  rdfs:subPropertyOf qudt:id .
+
 qudt:oleDBName
   a rdf:Property ;
   dcterms:description """
@@ -5070,77 +2802,70 @@ qudt:oleDBName
   The API provides a set of interfaces implemented using the Component Object Model (COM); it is otherwise unrelated to OLE.
   </p>"""^^rdf:HTML ;
   dcterms:description "OLE DB (Object Linking and Embedding, Database, sometimes written as OLEDB or OLE-DB), an API designed by Microsoft, allows accessing data from a variety of sources in a uniform manner. The API provides a set of interfaces implemented using the Component Object Model (COM); it is otherwise unrelated to OLE. " ;
+  prov:wasInfluencedBy <http://en.wikipedia.org/wiki/OLE_DB> ;
+  prov:wasInfluencedBy <http://msdn.microsoft.com/en-us/library/windows/desktop/ms714931(v=vs.85).aspx> ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/OLE_DB"^^xsd:anyURI ;
   qudt:informativeReference "http://msdn.microsoft.com/en-us/library/windows/desktop/ms714931(v=vs.85).aspx"^^xsd:anyURI ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "OLE DB name" ;
-  rdfs:subPropertyOf qudt:id ;
-  prov:wasInfluencedBy <http://en.wikipedia.org/wiki/OLE_DB> ;
-  prov:wasInfluencedBy <http://msdn.microsoft.com/en-us/library/windows/desktop/ms714931(v=vs.85).aspx> ;
-.
+  rdfs:subPropertyOf qudt:id .
+
 qudt:optional
   a rdf:Property ;
-  rdfs:label "optional" ;
-.
+  rdfs:label "optional" .
+
 qudt:oracleSQLName
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "ORACLE SQL name" ;
-  rdfs:subPropertyOf qudt:id ;
-.
+  rdfs:subPropertyOf qudt:id .
+
 qudt:orderInStructure
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "order in structure" ;
-.
+  rdfs:label "order in structure" .
+
 qudt:orderedType
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "ordered type" ;
-.
+  rdfs:label "ordered type" .
+
 qudt:orderingRelation
   a rdf:Property ;
   dcterms:description """
-  This property identifies the mathematical comparison operator (such as \"<\" or \">\") that is used to order the elements of a collection.
+  This property identifies the mathematical comparison operator (such as "<" or ">") that is used to order the elements of a collection.
   """ ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "Ordering Relation" ;
-.
+  rdfs:label "Ordering Relation" .
+
 qudt:originDefinition
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "origin definition" ;
-.
+  rdfs:label "origin definition" .
+
 qudt:padding
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "padding" ;
-.
+  rdfs:label "padding" .
+
 qudt:pattern
   a rdf:Property ;
   dcterms:description "A pattern is a constraint on the value space of a datatype which is achieved by constraining the lexical space to literals which match a specific pattern. The value of pattern must be a regular expression." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "pattern" ;
-.
+  rdfs:label "pattern" .
+
 qudt:pitchRotationDefinition
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "pitch rotation definition" ;
-  rdfs:subPropertyOf qudt:rotationDefinition ;
-.
-qudt:positive
-  a qudt:Polarity ;
-  dtype:code "2" ;
-  dtype:literal "positive" ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "positive" ;
-.
+  rdfs:subPropertyOf qudt:rotationDefinition .
+
 qudt:positiveDeltaLimit
   a rdf:Property ;
   dcterms:description "A positive change limit between consecutive sample values for a parameter. The Positive Delta may be the encoded value or engineering units value depending on whether or not a Calibrator is defined."^^rdf:HTML ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "Positive delta limit" ;
-.
+  rdfs:label "Positive delta limit" .
+
 qudt:precision
   a rdf:Property ;
   dcterms:description """
@@ -5157,155 +2882,155 @@ qudt:precision
   </p>
   """^^rdf:HTML ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "precision" ;
-.
+  rdfs:label "precision" .
+
 qudt:protocolBuffersName
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "protocol buffers name" ;
-  rdfs:subPropertyOf qudt:id ;
-.
+  rdfs:subPropertyOf qudt:id .
+
 qudt:pythonName
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "python name" ;
-  rdfs:subPropertyOf qudt:id ;
-.
+  rdfs:subPropertyOf qudt:id .
+
 qudt:rdfsDatatype
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "rdfs datatype" ;
-.
+  rdfs:label "rdfs datatype" .
+
 qudt:realization
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "realization" ;
-.
+  rdfs:label "realization" .
+
 qudt:referenceFrame
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "reference frame" ;
-  rdfs:subPropertyOf qudt:coordinateSystemFrame ;
-.
+  rdfs:subPropertyOf qudt:coordinateSystemFrame .
+
 qudt:referenceFrameType
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "reference frame type" ;
-.
+  rdfs:label "reference frame type" .
+
 qudt:returnType
   a rdf:Property ;
   dcterms:description "This property is used to state the return type of a function type." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "return type" ;
-  rdfs:subPropertyOf qudt:elementDatatype ;
-.
+  rdfs:subPropertyOf qudt:elementDatatype .
+
 qudt:rgbCode
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "rgb code" ;
-.
+  rdfs:label "rgb code" .
+
 qudt:rollRotationDefinition
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "roll rotation definition" ;
-  rdfs:subPropertyOf qudt:rotationDefinition ;
-.
+  rdfs:subPropertyOf qudt:rotationDefinition .
+
 qudt:rotationDefinition
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "rotation definition" ;
-.
+  rdfs:label "rotation definition" .
+
 qudt:rows
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "rows" ;
-.
+  rdfs:label "rows" .
+
 qudt:signedness
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "signedness" ;
-.
+  rdfs:label "signedness" .
+
 qudt:significantDigits
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "significant digits" ;
-.
+  rdfs:label "significant digits" .
+
 qudt:sound
   a rdf:Property ;
   rdfs:comment "The intended use of the sound property is to be associated with modal enumerations" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "sound" ;
-.
+  rdfs:label "sound" .
+
 qudt:stringValue
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "string value" ;
-  rdfs:subPropertyOf qudt:scalarValue ;
-.
+  rdfs:subPropertyOf qudt:scalarValue .
+
 qudt:timeDatatype
   a rdf:Property ;
   rdfs:label "time datatype" ;
-  rdfs:subPropertyOf qudt:type ;
-.
+  rdfs:subPropertyOf qudt:type .
+
 qudt:totalDigits
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "total digits" ;
-.
+  rdfs:label "total digits" .
+
 qudt:type
   a rdf:Property ;
   rdfs:comment "A reference to the specification of the data type of a variable or constant." ;
-  rdfs:label "type" ;
-.
+  rdfs:label "type" .
+
 qudt:typeMatrix
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "type matrix" ;
-.
+  rdfs:label "type matrix" .
+
 qudt:typeVector
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "type vector" ;
-.
+  rdfs:label "type vector" .
+
 qudt:upperBound
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "upper bound" ;
-.
+  rdfs:label "upper bound" .
+
 qudt:valueRange
   a rdf:Property ;
-  rdfs:label "value range" ;
-.
+  rdfs:label "value range" .
+
 qudt:valueType
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "value type" ;
-.
+  rdfs:label "value type" .
+
 qudt:valueVector
   a rdf:Property ;
   rdfs:comment "A list of the values of elements in a Partial Array." ;
-  rdfs:label "value vector" ;
-.
+  rdfs:label "value vector" .
+
 qudt:vbName
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Visual Basic name" ;
-  rdfs:subPropertyOf qudt:id ;
-.
+  rdfs:subPropertyOf qudt:id .
+
 qudt:vector
   a rdf:Property ;
-  rdfs:label "vector" ;
-.
+  rdfs:label "vector" .
+
 qudt:visualCue
   a rdf:Property ;
   rdfs:label "visual cue" ;
-  rdfs:subPropertyOf qudt:modalCue ;
-.
+  rdfs:subPropertyOf qudt:modalCue .
+
 qudt:visualCueEnumeration
   a rdf:Property ;
   rdfs:label "visual cue enumeration" ;
-  rdfs:subPropertyOf qudt:modalCueEnumeration ;
-.
+  rdfs:subPropertyOf qudt:modalCueEnumeration .
+
 qudt:xAxisDefinition
   a rdf:Property ;
   dcterms:description """
@@ -5314,13 +3039,13 @@ qudt:xAxisDefinition
   An epoch might also be given.
   """ ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "X-Axis Definition" ;
-.
+  rdfs:label "X-Axis Definition" .
+
 qudt:xCoordinateDefinition
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "X-Coordinate definition" ;
-.
+  rdfs:label "X-Coordinate definition" .
+
 qudt:yAxisDefinition
   a rdf:Property ;
   dcterms:description """
@@ -5329,19 +3054,19 @@ qudt:yAxisDefinition
   An epoch might also be given.
   """ ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "Y-Axis definition" ;
-.
+  rdfs:label "Y-Axis definition" .
+
 qudt:yCoordinateDefinition
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "Y-Coordinate definition" ;
-.
+  rdfs:label "Y-Coordinate definition" .
+
 qudt:yawRotationDefinition
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
   rdfs:label "Yaw rotation definition" ;
-  rdfs:subPropertyOf qudt:rotationDefinition ;
-.
+  rdfs:subPropertyOf qudt:rotationDefinition .
+
 qudt:zAxisDefinition
   a rdf:Property ;
   dcterms:description """
@@ -5350,13 +3075,31 @@ qudt:zAxisDefinition
   An epoch might also be given.
   """ ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "Z-Axis definition" ;
-.
+  rdfs:label "Z-Axis definition" .
+
 qudt:zCoordinateDefinition
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "Z-Coordinate definition" ;
-.
+  rdfs:label "Z-Coordinate definition" .
+
+<http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatypePrefixes>
+  sh:declare [
+    sh:namespace "http://qudt.org/schema/qudt/"^^xsd:anyURI ;
+    sh:prefix "qudt" ;
+  ] ;
+  sh:declare [
+    sh:namespace "http://qudt.org/vocab/quantitykind/"^^xsd:anyURI ;
+    sh:prefix "quantitykind" ;
+  ] ;
+  sh:declare [
+    sh:namespace "http://qudt.org/vocab/unit/"^^xsd:anyURI ;
+    sh:prefix "unit" ;
+  ] ;
+  sh:declare [
+    sh:namespace "http://www.w3.org/1999/02/22-rdf-syntax-ns#"^^xsd:anyURI ;
+    sh:prefix "rdf" ;
+  ] .
+
 <http://qudt.org/schema/shacl/datatype/GMD_datatype>
   a vaem:GraphMetaData ;
   dcterms:description """
@@ -5368,10 +3111,12 @@ qudt:zCoordinateDefinition
   """^^rdf:HTML ;
   dcterms:modified "2025-04-02T10:54:24-05:00"^^xsd:dateTime ;
   dcterms:rights """
-  <p>The QUDT Ontologies are issued under a Creative Commons Attribution 4.0 International License (CC BY 4.0), available  <a href=\"https://creativecommons.org/licenses/by/4.0/\">here</a>. 
-  Attribution should be made to <a href=\"https://www.qudt.org\">QUDT.org</a>.
+  <p>The QUDT Ontologies are issued under a Creative Commons Attribution 4.0 International License (CC BY 4.0), available  <a href="https://creativecommons.org/licenses/by/4.0/">here</a>. 
+  Attribution should be made to <a href="https://www.qudt.org">QUDT.org</a>.
   </p>"""^^rdf:HTML ;
   dcterms:subject "Datatypes" ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  rdfs:label "QUDT Schema for Datatypes - Version $$QUDT_VERSION$$" ;
   vaem:graphTitle "QUDT Schema for Datatypes - Version $$QUDT_VERSION$$" ;
   vaem:hasGraphRole vaem:SchemaGraph ;
   vaem:isMetadataFor <http://qudt.org/$$QUDT_VERSION$$/schema/datatype> ;
@@ -5393,47 +3138,2063 @@ qudt:zCoordinateDefinition
   vaem:usesNonImportedResource dcterms:rights ;
   vaem:usesNonImportedResource dcterms:title ;
   vaem:usesNonImportedResource <http://voag.linkedmodel.org/voag#QUDT-Attribution> ;
-  vaem:withAttributionTo <http://voag.linkedmodel.org/voag#QUDT-Attribution> ;
+  vaem:withAttributionTo <http://voag.linkedmodel.org/voag#QUDT-Attribution> .
+
+qudt:AllValuesMustHaveSameDataTypeShape
+  a sh:NodeShape ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-  rdfs:label "QUDT Schema for Datatypes - Version $$QUDT_VERSION$$" ;
-.
+  rdfs:label "All Values must have same DataType Shape" ;
+  sh:severity sh:Violation ;
+  sh:sparql [
+    sh:message "Data Item {$this} has type {?valueType}." ;
+    sh:prefixes <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatypePrefixes> ;
+    sh:select """
+        SELECT $this ?valueType
+        WHERE {
+              $this qudt:datatype/qudt:rdfsDatatype ?datatype .
+              $this qudt:value ?valueList.
+              ?valueList rdf:rest*/rdf:first ?value .
+              BIND(datatype(?value) as ?valueType) .
+              FILTER(?valueType != ?datatype)
+        }
+        """ ;
+  ] ;
+  sh:targetClass qudt:HomogeneousArray .
+
+qudt:Array-isHeterogeneous
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:boolean ;
+  sh:maxCount 1 ;
+  sh:path qudt:isHeterogeneous .
+
+qudt:Array-value
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:node qudt:NumericListShape ;
+  sh:path qudt:value .
+
+qudt:Array2DvalueList
+  a rdfs:Resource ;
+  dcterms:description """
+  An rdf:List for a 2D array.
+  For example "[[1,2], [3,4], [5,6]]"
+  """ ;
+  rdf:first [
+    sh:datatype qudt:List ;
+  ] ;
+  rdf:rest ( [
+    sh:datatype qudt:List ;
+  ] ) ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  rdfs:label "2D Array Value List" ;
+  rdfs:subClassOf rdf:List .
+
+qudt:AuralCue-sound
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:anyURI ;
+  sh:maxCount 1 ;
+  sh:minCount 1 ;
+  sh:path qudt:sound .
+
+qudt:AuralCueEnumeration-defaultValue
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:AuralCue ;
+  sh:path qudt:defaultValue .
+
+qudt:BalancedTree-maxDepth
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:integer ;
+  sh:maxCount 1 ;
+  sh:path qudt:maxDepth .
+
+qudt:BigEndian
+  a qudt:EndianType ;
+  dtype:literal "big" ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  rdfs:label "Big Endian" .
+
+qudt:BitAligned
+  a qudt:AlignmentType ;
+  dtype:literal "bit" ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  rdfs:label "Bit Aligned" .
+
+qudt:BitField
+  a rdfs:Datatype ;
+  dcterms:description """
+  <p>A bit field is a common idiom used in computer programming to store a set of Boolean datatype flags compactly, as a series of bits. 
+  The bit field is stored in an integral type of known, fixed bit-width. 
+  Each Boolean flag is stored in a separate bit. 
+  Usually the source code will define a set of constants, each a power of two, that semantically associate each individual bit with its respective Boolean flag. 
+  The bitwise operators and, or, and not are used in combination to set, reset and test the flags.
+  </p>"""^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  rdfs:subClassOf xsd:string .
+
+qudt:BooleanEncoding
+  a qudt:BooleanEncodingType ;
+  qudt:bits 1 ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  rdfs:label "Boolean Encoding" .
+
+qudt:BooleanType-encoding
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:BooleanEncodingType ;
+  sh:path qudt:encoding .
+
+qudt:ByColumn
+  a qudt:ArrayDataOrder ;
+  dtype:literal "byColumn" ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  rdfs:label "By Column" .
+
+qudt:ByLeftMostIndex
+  a qudt:ArrayDataOrder ;
+  dtype:literal "byLeftMostIndex" ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  rdfs:label "By Left Most Index" .
+
+qudt:ByRow
+  a qudt:ArrayDataOrder ;
+  dtype:literal "byRow" ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  rdfs:label "By row" .
+
+qudt:ByteAligned
+  a qudt:AlignmentType ;
+  dtype:literal "byte" ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  rdfs:label "Byte Aligned" .
+
+qudt:CRC32
+  a rdfs:Datatype ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  rdfs:label "CRC-32" ;
+  rdfs:subClassOf xsd:integer .
+
+qudt:CT_COUNTABLY-INFINITE
+  a qudt:CardinalityType ;
+  dcterms:description """
+  A set of numbers is called countably infinite if there is a way to enumerate them.
+  Formally this is done with a bijection function that associates each number in the set with exactly one of the positive integers.
+  The set of all fractions is also countably infinite.
+  In other words, any set $X$ that has the same cardinality as the set of the natural numbers,
+   or $| X | \\; =  \\; | \\mathbb N | \\; = \\; \\aleph0$, is said to be a countably infinite set.
+  """^^qudt:LatexString ;
+  dtype:literal "countable" ;
+  qudt:informativeReference "http://www.math.vanderbilt.edu/~schectex/courses/infinity.pdf"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  rdfs:label "Countably Infinite Cardinality Type" .
+
+qudt:CT_FINITE
+  a qudt:CardinalityType ;
+  dcterms:description """
+  Any set $X$ with cardinality less than that of the natural numbers, or
+  $$| X | \\; <  \\; | \\mathbb N | $$
+  is said to be a finite set.
+  """^^qudt:LatexString ;
+  dtype:literal "finite" ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  rdfs:label "Finite Cardinality Type" .
+
+qudt:CT_UNCOUNTABLE
+  a qudt:CardinalityType ;
+  dcterms:description """
+  Any set with cardinality greater than that of the natural numbers, or 
+  $$| X | \\; >  \\; | \\mathbb N | $$
+  
+  For example $| R| \\; =  \\;  c  \\; > |\\mathbb N |$, is said to be uncountable.
+  """^^qudt:LatexString ;
+  dtype:literal "uncountable" ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  rdfs:label "Uncountable Cardinality Type" .
+
+qudt:CardinalityType-literal
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:string ;
+  sh:maxCount 1 ;
+  sh:path dtype:literal .
+
+qudt:CharEncoding
+  a qudt:BooleanEncodingType, qudt:CharEncodingType ;
+  dcterms:description "7 bits of 1 octet" ;
+  qudt:bytes 1 ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  rdfs:label "Char Encoding" .
+
+qudt:Collection-memberQuantity
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:Quantity ;
+  sh:maxCount 1 ;
+  sh:path qudt:quantify .
+
+qudt:Collection-memberUnit
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:Unit ;
+  sh:maxCount 1 ;
+  sh:path qudt:hasUnit .
+
+qudt:ColorCue-rgbCode
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:string ;
+  sh:maxCount 1 ;
+  sh:minCount 1 ;
+  sh:path qudt:rgbCode .
+
+qudt:CompositeDataStructure-dataElement
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:DataSetElement ;
+  sh:path qudt:field .
+
+qudt:CompositeDatatype-alignment
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:AlignmentType ;
+  sh:path qudt:alignment .
+
+qudt:CompositeDatatype-elementType
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:QuantityKind ;
+  sh:maxCount 1 ;
+  sh:minCount 1 ;
+  sh:path qudt:hasQuantityKind .
+
+qudt:CompositeDatatype-padding
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:PaddingType ;
+  sh:maxCount 1 ;
+  sh:path qudt:padding .
+
+qudt:CompositionTree-compositionFunction
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:CompositionFunction ;
+  sh:maxCount 1 ;
+  sh:minCount 1 ;
+  sh:path qudt:function .
+
+qudt:CoordinateSystem-abbreviation
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:maxCount 1 ;
+  sh:path qudt:abbreviation .
+
+qudt:CoordinateSystem-acronym
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:maxCount 1 ;
+  sh:path vaem:acronym .
+
+qudt:CoordinateSystem-coordinateCenter
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:CoordinateCenterKind ;
+  sh:maxCount 1 ;
+  sh:path qudt:coordinateCenter .
+
+qudt:CoordinateSystem-originDefinition
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:string ;
+  sh:maxCount 1 ;
+  sh:path qudt:originDefinition .
+
+qudt:CoordinateSystem-referenceFrame
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:ReferenceFrame ;
+  sh:maxCount 1 ;
+  sh:path qudt:referenceFrame .
+
+qudt:Coordinates-2D-DoublePrecision-double_X
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:double ;
+  sh:maxCount 1 ;
+  sh:minCount 1 ;
+  sh:path qudt:double_X .
+
+qudt:Coordinates-2D-DoublePrecision-double_Y
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:double ;
+  sh:maxCount 1 ;
+  sh:minCount 1 ;
+  sh:path qudt:double_Y .
+
+qudt:Coordinates-2D-SinglePrecision-float_X
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:float ;
+  sh:maxCount 1 ;
+  sh:minCount 1 ;
+  sh:path qudt:float_X .
+
+qudt:Coordinates-2D-SinglePrecision-float_Y
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:float ;
+  sh:maxCount 1 ;
+  sh:minCount 1 ;
+  sh:path qudt:float_Y .
+
+qudt:Coordinates-3D-DoublePrecision-double_X
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:double ;
+  sh:maxCount 1 ;
+  sh:minCount 1 ;
+  sh:path qudt:double_X .
+
+qudt:Coordinates-3D-DoublePrecision-double_Y
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:double ;
+  sh:maxCount 1 ;
+  sh:minCount 1 ;
+  sh:path qudt:double_Y .
+
+qudt:Coordinates-3D-DoublePrecision-double_Z
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:double ;
+  sh:maxCount 1 ;
+  sh:minCount 1 ;
+  sh:path qudt:double_Z .
+
+qudt:Coordinates-3D-SinglePrecision-float_X
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:float ;
+  sh:maxCount 1 ;
+  sh:minCount 1 ;
+  sh:path qudt:float_X .
+
+qudt:Coordinates-3D-SinglePrecision-float_Y
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:float ;
+  sh:maxCount 1 ;
+  sh:minCount 1 ;
+  sh:path qudt:float_Y .
+
+qudt:Coordinates-3D-SinglePrecision-float_Z
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:float ;
+  sh:maxCount 1 ;
+  sh:minCount 1 ;
+  sh:path qudt:float_Z .
+
+qudt:Coordinates-elementType
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:CoordinateMember ;
+  sh:path qudt:elementDatatype .
+
+qudt:DataEncoding-bitOrder
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:EndianType ;
+  sh:maxCount 1 ;
+  sh:path qudt:bitOrder .
+
+qudt:DataEncoding-byteOrder
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:EndianType ;
+  sh:maxCount 1 ;
+  sh:path qudt:byteOrder .
+
+qudt:DataEncoding-encoding
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:Encoding ;
+  sh:maxCount 1 ;
+  sh:path qudt:encoding .
+
+qudt:DataSetElement-elementLabel
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:string ;
+  sh:maxCount 1 ;
+  sh:minCount 1 ;
+  sh:path qudt:elementLabel .
+
+qudt:DataSetElement-optional
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:boolean ;
+  sh:maxCount 1 ;
+  sh:minCount 0 ;
+  sh:path qudt:optional .
+
+qudt:DataSetElement-quantityKind
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:QuantityKind ;
+  sh:maxCount 1 ;
+  sh:path qudt:hasQuantityKind .
+
+qudt:Datatype
+  a sh:NodeShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:property qudt:Datatype-ansiSQLName ;
+  sh:property qudt:Datatype-basis ;
+  sh:property qudt:Datatype-bounded ;
+  sh:property qudt:Datatype-cName ;
+  sh:property qudt:Datatype-cardinality ;
+  sh:property qudt:Datatype-id ;
+  sh:property qudt:Datatype-javaName ;
+  sh:property qudt:Datatype-jsName ;
+  sh:property qudt:Datatype-matlabName ;
+  sh:property qudt:Datatype-microsoftSQLServerName ;
+  sh:property qudt:Datatype-mySQLName ;
+  sh:property qudt:Datatype-odbcName ;
+  sh:property qudt:Datatype-oleDBName ;
+  sh:property qudt:Datatype-oracleSQLName ;
+  sh:property qudt:Datatype-orderedType ;
+  sh:property qudt:Datatype-protocolBuffersName ;
+  sh:property qudt:Datatype-pythonName ;
+  sh:property qudt:Datatype-vbName .
+
+qudt:Datatype-ansiSQLName
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:string ;
+  sh:maxCount 1 ;
+  sh:minCount 0 ;
+  sh:path qudt:ansiSQLName .
+
+qudt:Datatype-basis
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:Datatype ;
+  sh:maxCount 1 ;
+  sh:path qudt:basis .
+
+qudt:Datatype-bounded
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class xsd:boolean ;
+  sh:maxCount 1 ;
+  sh:path qudt:bounded .
+
+qudt:Datatype-cName
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:string ;
+  sh:maxCount 1 ;
+  sh:minCount 0 ;
+  sh:path qudt:cName .
+
+qudt:Datatype-cardinality
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:CardinalityType ;
+  sh:maxCount 1 ;
+  sh:path qudt:cardinality .
+
+qudt:Datatype-description
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:deactivated true ;
+  sh:maxCount 1 ;
+  sh:path vaem:description .
+
+qudt:Datatype-id
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:string ;
+  sh:deactivated true ;
+  sh:maxCount 1 ;
+  sh:path qudt:id .
+
+qudt:Datatype-javaName
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:string ;
+  sh:maxCount 1 ;
+  sh:minCount 0 ;
+  sh:path qudt:javaName .
+
+qudt:Datatype-jsName
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:string ;
+  sh:maxCount 1 ;
+  sh:minCount 0 ;
+  sh:path qudt:jsName .
+
+qudt:Datatype-matlabName
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:string ;
+  sh:maxCount 1 ;
+  sh:minCount 0 ;
+  sh:path qudt:matlabName .
+
+qudt:Datatype-microsoftSQLServerName
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:string ;
+  sh:maxCount 1 ;
+  sh:minCount 0 ;
+  sh:path qudt:microsoftSQLServerName .
+
+qudt:Datatype-mySQLName
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:string ;
+  sh:minCount 0 ;
+  sh:path qudt:mySQLName .
+
+qudt:Datatype-odbcName
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:string ;
+  sh:maxCount 1 ;
+  sh:minCount 0 ;
+  sh:path qudt:odbcName .
+
+qudt:Datatype-oleDBName
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:string ;
+  sh:maxCount 1 ;
+  sh:minCount 0 ;
+  sh:path qudt:oleDBName .
+
+qudt:Datatype-oracleSQLName
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:string ;
+  sh:maxCount 1 ;
+  sh:minCount 0 ;
+  sh:path qudt:oracleSQLName .
+
+qudt:Datatype-orderedType
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:OrderedType ;
+  sh:maxCount 1 ;
+  sh:path qudt:orderedType .
+
+qudt:Datatype-protocolBuffersName
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:string ;
+  sh:maxCount 1 ;
+  sh:minCount 0 ;
+  sh:path qudt:protocolBuffersName .
+
+qudt:Datatype-pythonName
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:string ;
+  sh:maxCount 1 ;
+  sh:minCount 0 ;
+  sh:path qudt:pythonName .
+
+qudt:Datatype-vbName
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:string ;
+  sh:maxCount 1 ;
+  sh:minCount 0 ;
+  sh:path qudt:vbName .
+
+qudt:DatatypePropertyShape
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:Datatype ;
+  sh:maxCount 1 ;
+  sh:minCount 1 ;
+  sh:path qudt:datatype .
+
+qudt:DateTimeStringEncodingType-allowedPattern
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:string ;
+  sh:minCount 1 ;
+  sh:path qudt:allowedPattern .
+
+qudt:DateTimeStringType-encoding
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:DateTimeStringEncodingType ;
+  sh:maxCount 1 ;
+  sh:path qudt:encoding .
+
+qudt:DateTypeUnion
+  a rdf:List ;
+  dcterms:description """
+  An rdf:List that can be used in property constraints as the type in an sh:or to indicate
+   that all values of a property must be an xsd date type.
+  """ ;
+  rdf:first [
+    sh:datatype xsd:date ;
+  ] ;
+  rdf:rest ( [
+    sh:datatype xsd:dateTime ;
+  ] [
+    sh:datatype xsd:gYear ;
+  ] [
+    sh:datatype xsd:gMonth ;
+  ] ) ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  rdfs:label "Date Type Union" .
+
+qudt:DimensionalityPropertyShape
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:integer ;
+  sh:maxCount 1 ;
+  sh:path qudt:dimensionality .
+
+qudt:DimensionalityShape
+  a sh:NodeShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  rdfs:label "Dimensions Shape" ;
+  sh:severity sh:Warning ;
+  sh:sparql [
+    sh:message "\"{$this}\" has {$actualDimensions} dimensions extent and needs to have {$specifiedDimensions}" ;
+    sh:prefixes <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatypePrefixes> ;
+    sh:select """
+        SELECT $this $actualDimensions $specifiedDimensions
+        WHERE {
+            $this qudt:dimensionality $dimensionality .
+            $this qudt:dimensions ?dimensions .
+            ?dimensions rdf:rest*/rdf:first $specifiedDimensions .
+            { SELECT $this (COUNT(?listValue )AS $actualDimensions)
+              WHERE {
+              $this qudt:value/rdf:rest*/rdf:first ?listValue .
+              } GROUP BY $this
+            }
+            FILTER ($actualDimensions != $specifiedDimensions)
+          }
+        """ ;
+  ] ;
+  sh:targetClass qudt:Array ;
+  sh:targetClass qudt:List .
+
+qudt:DimensionsPropertyShape
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:node qudt:IntegerListShape ;
+  sh:path qudt:dimensions .
+
+qudt:DiscreteState-inverted
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:boolean ;
+  sh:maxCount 1 ;
+  sh:path qudt:inverted .
+
+qudt:EarthCoordinateSystem-coordinateCenter
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:CoordinateCenterKind ;
+  sh:hasValue qudt:CCT_EarthCentered ;
+  sh:path qudt:coordinateCenter .
+
+qudt:Encoding-bits
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:integer ;
+  sh:maxCount 1 ;
+  sh:path qudt:bits .
+
+qudt:Encoding-bytes
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:integer ;
+  sh:maxCount 1 ;
+  sh:path qudt:bytes .
+
+qudt:EngineeringValueTupleMember-elementType
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:RealSinglePrecisionType ;
+  sh:path qudt:elementDatatype .
+
+qudt:Enumeration-bits
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:integer ;
+  sh:maxCount 1 ;
+  sh:path qudt:bits .
+
+qudt:Enumeration-defaultValue
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:EnumeratedValue ;
+  sh:path qudt:defaultValue .
+
+qudt:Enumeration-encoding
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:maxCount 1 ;
+  sh:path qudt:encoding .
+
+qudt:Enumeration-value
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:EnumeratedValue ;
+  sh:path dtype:value .
+
+qudt:FieldType-elementName
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:string ;
+  sh:maxCount 1 ;
+  sh:minCount 1 ;
+  sh:path qudt:elementName .
+
+qudt:FieldType-elementType
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:Datatype ;
+  sh:path qudt:elementDatatype .
+
+qudt:FieldType-fieldLabel
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:string ;
+  sh:maxCount 1 ;
+  sh:minCount 1 ;
+  sh:path qudt:fieldLabel .
+
+qudt:FieldType-fieldType
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:Datatype ;
+  sh:minCount 1 ;
+  sh:path qudt:fieldType .
+
+qudt:FieldType-optional
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:boolean ;
+  sh:maxCount 1 ;
+  sh:minCount 0 ;
+  sh:path qudt:optional .
+
+qudt:FunctionDatatype-argType
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:Datatype ;
+  sh:path qudt:argType .
+
+qudt:FunctionDatatype-functionArity
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:integer ;
+  sh:maxCount 1 ;
+  sh:minCount 1 ;
+  sh:path qudt:functionArity .
+
+qudt:FunctionDatatype-returnType
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:Datatype ;
+  sh:maxCount 1 ;
+  sh:minCount 0 ;
+  sh:path qudt:returnType .
+
+qudt:HeterogenousArray-datatype
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:Datatype ;
+  sh:maxCount 1 ;
+  sh:minCount 1 ;
+  sh:path qudt:datatype .
+
+qudt:HexBinaryType-length
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:integer ;
+  sh:maxCount 1 ;
+  sh:path qudt:length .
+
+qudt:HexBinaryType-maxLength
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:integer ;
+  sh:maxCount 1 ;
+  sh:path qudt:maxLength .
+
+qudt:HexBinaryType-minLength
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:integer ;
+  sh:maxCount 1 ;
+  sh:path qudt:minLength .
+
+qudt:HexBinaryType-pattern
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:string ;
+  sh:maxCount 1 ;
+  sh:path qudt:pattern .
+
+qudt:IEEE754_1985RealEncoding
+  a qudt:FloatingPointEncodingType ;
+  qudt:bytes 32 ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  rdfs:label "IEEE 754 1985 Real Encoding" .
+
+qudt:ISO8601-UTCDateTime-BasicFormat
+  a qudt:DateTimeStringEncodingType ;
+  qudt:allowedPattern "[0-9]{4}[0-9]{2}[0-9]{2}T[0-9]{2}[0-9]{2}[0-9]{2}.[0-9]+Z" ;
+  qudt:allowedPattern "[0-9]{4}[0-9]{2}[0-9]{2}T[0-9]{2}[0-9]{2}[0-9]{2}Z" ;
+  rdfs:isDefinedBy <file:///Users/ralphtq/git-qudt/qudt-public-repo/qudt> ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  rdfs:label "ISO 8601 UTC Date Time - Basic Format" .
+
+qudt:IconicCue-image
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:maxCount 1 ;
+  sh:minCount 1 ;
+  sh:path qudt:image .
+
+qudt:IconicCueEnumeration-defaultValue
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:IconicCue ;
+  sh:path qudt:defaultValue .
+
+qudt:InertialCoordinateFrame-frameType
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:hasValue qudt:FT_NON-ROTATING ;
+  sh:path qudt:frameType .
+
+qudt:IntegerUnionList
+  a rdf:List ;
+  rdf:first [
+    sh:datatype xsd:int ;
+  ] ;
+  rdf:rest ( [
+    sh:datatype xsd:nonNegativeInteger ;
+  ] [
+    sh:datatype xsd:positiveInteger ;
+  ] [
+    sh:datatype xsd:integer ;
+  ] ) ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  rdfs:label "Integer Union List" .
+
+qudt:KinestheticCue-code
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:maxCount 1 ;
+  sh:minCount 1 ;
+  sh:path dtype:code .
+
+qudt:KinestheticCueEnumeration-defaultValue
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:KinestheticCue ;
+  sh:path qudt:defaultValue .
+
+qudt:LittleEndian
+  a qudt:EndianType ;
+  dtype:literal "little" ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  rdfs:label "Little Endian" .
+
+qudt:LongUnsignedIntegerEncoding
+  a qudt:IntegerEncodingType ;
+  qudt:bytes 8 ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  rdfs:label "Long Unsigned Integer Encoding" .
+
+qudt:LunarCoordinateSystem-coordinateCenter
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:CoordinateCenterKind ;
+  sh:hasValue qudt:CCT_MoonCentered ;
+  sh:path qudt:coordinateCenter .
+
+qudt:LunarCoordinateSystem-realization
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:string ;
+  sh:maxCount 1 ;
+  sh:path qudt:realization .
+
+qudt:LunarCoordinateSystem-xAxisDefinition
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:string ;
+  sh:maxCount 1 ;
+  sh:path qudt:xAxisDefinition .
+
+qudt:LunarCoordinateSystem-yAxisDefinition
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:string ;
+  sh:maxCount 1 ;
+  sh:path qudt:yAxisDefinition .
+
+qudt:LunarCoordinateSystem-zAxisDefinition
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:string ;
+  sh:maxCount 1 ;
+  sh:path qudt:zAxisDefinition .
+
+qudt:Major
+  a qudt:MajorMinorType ;
+  dtype:code 2 ;
+  dtype:literal "major" ;
+  dtype:order "2"^^xsd:int ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/shacl/datatype> ;
+  rdfs:label "Major" .
+
+qudt:MarsCoordinateSystem-coordinateCenter
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:CoordinateCenterKind ;
+  sh:hasValue qudt:CCT_MarsCentered ;
+  sh:path qudt:coordinateCenter .
+
+qudt:MassPropertiesArray
+  a rdf:Class, sh:NodeShape ;
+  dcterms:description """
+  <p>A <em>Mass Properties Array</em> holds, for an object, four values for the properties:
+   Center of Gravity, Mass, Moment of Inertia, and Product of Inertia. 
+  """ ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  rdfs:label "Mass Properties Array" ;
+  rdfs:subClassOf qudt:HeterogenousArray ;
+  sh:property qudt:QuantityKindsPropertyShape .
+
+qudt:MatrixElementOrder-byRow
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:boolean ;
+  sh:maxCount 1 ;
+  sh:path qudt:byRow .
+
+qudt:MatrixElementOrder-dataOrder
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:MatrixElementOrder ;
+  sh:maxCount 1 ;
+  sh:path qudt:dataOrder .
+
+qudt:MaybeQuantityPropertyShape
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:Quantity ;
+  sh:maxCount 1 ;
+  sh:path qudt:quantity .
+
+qudt:MaybeUnitPropertyShape
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:Unit ;
+  sh:maxCount 1 ;
+  sh:path qudt:hasUnit .
+
+qudt:Minor
+  a qudt:MajorMinorType ;
+  dtype:code 1 ;
+  dtype:literal "minor" ;
+  dtype:order "1"^^xsd:int ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/shacl/datatype> ;
+  rdfs:label "Minor" .
+
+qudt:ModalCue-duration
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:maxCount 1 ;
+  sh:path qudt:duration .
+
+qudt:ModalEnumeration-defaultValue
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:ModalCue ;
+  sh:path qudt:defaultValue .
+
+qudt:MultiDimensionalDataFormat-descriptor
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:maxCount 1 ;
+  sh:path qudt:descriptor .
+
+qudt:MultiModalEnumeration-auralCueEnumeration
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:maxCount 1 ;
+  sh:path qudt:auralCueEnumeration .
+
+qudt:MultiModalEnumeration-iconicCueEnumeration
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:maxCount 1 ;
+  sh:path qudt:iconicCueEnumeration .
+
+qudt:MultiModalEnumeration-kinestheticCueEnumeration
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:maxCount 1 ;
+  sh:path qudt:kinestheticCueEnumeration .
+
+qudt:MultiModalEnumeration-modalCueEnumeration
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:ModalEnumeration ;
+  sh:path qudt:modalCueEnumeration .
+
+qudt:MultiModalEnumeration-visualCueEnumeration
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:maxCount 1 ;
+  sh:path qudt:visualCueEnumeration .
+
+qudt:MultiModalType-auralCue
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:maxCount 1 ;
+  sh:path qudt:auralCue .
+
+qudt:MultiModalType-iconicCue
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:maxCount 1 ;
+  sh:path qudt:iconicCue .
+
+qudt:MultiModalType-kinestheticCue
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:maxCount 1 ;
+  sh:path qudt:kinestheticCue .
+
+qudt:MultiModalType-modalCue
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:ModalCue ;
+  sh:path qudt:modalCue .
+
+qudt:MultiModalType-visualCue
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:maxCount 1 ;
+  sh:path qudt:visualCue .
+
+qudt:N-Tuple-elementType
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:Datatype ;
+  sh:minCount 0 ;
+  sh:path qudt:elementDatatype .
+
+qudt:NonModifiableParameter
+  a qudt:ParameterModifiabilityType ;
+  dtype:code "0" ;
+  dtype:literal "fixed" ;
+  rdfs:comment "Parameter is fixed, not modifiable." ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  rdfs:label "Non modifiable parameter" .
+
+qudt:NonNegativeIntegerUnionList
+  a rdf:List ;
+  rdf:first [
+    sh:datatype xsd:nonNegativeInteger ;
+  ] ;
+  rdf:rest ( [
+    sh:datatype xsd:positiveInteger ;
+  ] ) ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  rdfs:label "Non-negative union list" .
+
+qudt:NonRotatingInertialFrame-frameType
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:hasValue qudt:FT_NON-ROTATING ;
+  sh:path qudt:frameType .
+
+qudt:NumericType-accuracy
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:integer ;
+  sh:maxCount 1 ;
+  sh:path qudt:accuracy .
+
+qudt:NumericType-signedness
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:SignednessType ;
+  sh:maxCount 1 ;
+  sh:path qudt:signedness .
+
+qudt:OctetEncoding
+  a qudt:BooleanEncodingType, qudt:ByteEncodingType ;
+  qudt:bytes 1 ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  rdfs:label "OCTET Encoding" .
+
+qudt:OneMeansOff
+  a qudt:OnOffStateType ;
+  dtype:literal "off" ;
+  qudt:inverted true ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  rdfs:label "One means off" .
+
+qudt:OrderedCollection-orderingRelation
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class dtype:ComparisonOperator ;
+  sh:maxCount 1 ;
+  sh:path qudt:orderingRelation .
+
+qudt:PartiallyOrdered
+  a qudt:OrderedType ;
+  dtype:literal "partial" ;
+  qudt:plainTextDescription "Partial ordered structure." ;
+  rdfs:isDefinedBy <file:///Users/ralphtq/git-qudt/qudt-public-repo/qudt> ;
+  rdfs:label "Partially Ordered" .
+
+qudt:Quantifiable-dataEncoding
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:DataEncoding ;
+  sh:maxCount 1 ;
+  sh:path qudt:dataEncoding .
+
+qudt:QuantityKindsPropertyShape
+  a sh:PropertyShape ;
+  rdfs:comment "Invalid quantity kinds list - TODO: SPARQL Query" ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:node qudt:QuantityKindList ;
+  sh:path qudt:hasQuantityKindsList .
+
+qudt:QuantityValueType-basis
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:QuantityType ;
+  sh:path qudt:basis .
+
+qudt:QuantityValueType-elementType
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:NumericType ;
+  sh:path qudt:elementDatatype .
+
+qudt:QuantityValueType-elementUnit
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:Unit ;
+  sh:maxCount 1 ;
+  sh:path qudt:elementUnit .
+
+qudt:RawValueTupleMember-elementType
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:UnsignedIntegerType ;
+  sh:path qudt:elementDatatype .
+
+qudt:RealDatatype-base
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:integer ;
+  sh:maxCount 1 ;
+  sh:path qudt:base .
+
+qudt:RealDatatype-maxExponent
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:integer ;
+  sh:maxCount 1 ;
+  sh:path qudt:maxExponent .
+
+qudt:RealDatatype-maxMantissa
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:maxCount 1 ;
+  sh:or qudt:NumericTypeUnion ;
+  sh:path qudt:maxMantissa .
+
+qudt:RealDatatype-minMantissa
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:maxCount 1 ;
+  sh:or qudt:NumericTypeUnion ;
+  sh:path qudt:minMantissa .
+
+qudt:RealDatatype-precision
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:integer ;
+  sh:maxCount 1 ;
+  sh:path qudt:precision .
+
+qudt:ReferenceFrame-comment
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:maxCount 1 ;
+  sh:path vaem:comment .
+
+qudt:ReferenceFrame-description
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:maxCount 1 ;
+  sh:path dcterms:description .
+
+qudt:ReferenceFrame-frameType
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:FrameType ;
+  sh:path qudt:frameType .
+
+qudt:ReferenceFrame-informativeReference
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:maxCount 1 ;
+  sh:path qudt:informativeReference .
+
+qudt:ReferenceFrame-realization
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:string ;
+  sh:maxCount 1 ;
+  sh:path qudt:realization .
+
+qudt:ReferenceFrame-xAxisDefinition
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:string ;
+  sh:maxCount 1 ;
+  sh:path qudt:xAxisDefinition .
+
+qudt:ReferenceFrame-xCoordinateDefinition
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:string ;
+  sh:maxCount 1 ;
+  sh:path qudt:xCoordinateDefinition .
+
+qudt:ReferenceFrame-yAxisDefinition
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:string ;
+  sh:maxCount 1 ;
+  sh:path qudt:yAxisDefinition .
+
+qudt:ReferenceFrame-yCoordinateDefinition
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:string ;
+  sh:maxCount 1 ;
+  sh:path qudt:yCoordinateDefinition .
+
+qudt:ReferenceFrame-zAxisDefinition
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:string ;
+  sh:maxCount 1 ;
+  sh:path qudt:zAxisDefinition .
+
+qudt:ReferenceFrame-zCoordinateDefinition
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:string ;
+  sh:maxCount 1 ;
+  sh:path qudt:zCoordinateDefinition .
+
+qudt:SIGNED
+  a qudt:SignednessType ;
+  dtype:literal "signed" ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  rdfs:label "Signed" .
+
+qudt:ScalarDatatype-bitOrder
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:EndianType ;
+  sh:maxCount 1 ;
+  sh:path qudt:bitOrder .
+
+qudt:ScalarDatatype-bits
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:integer ;
+  sh:maxCount 1 ;
+  sh:or qudt:IntegerUnionList ;
+  sh:path qudt:bits .
+
+qudt:ScalarDatatype-byteOrder
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:EndianType ;
+  sh:maxCount 1 ;
+  sh:path qudt:byteOrder .
+
+qudt:ScalarDatatype-bytes
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:integer ;
+  sh:maxCount 1 ;
+  sh:or qudt:IntegerUnionList ;
+  sh:path qudt:bytes .
+
+qudt:ScalarDatatype-encoding
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:Encoding ;
+  sh:maxCount 1 ;
+  sh:path qudt:encoding .
+
+qudt:ScalarDatatype-length
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:integer ;
+  sh:maxCount 1 ;
+  sh:path qudt:length .
+
+qudt:ScalarDatatype-maxExclusive
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:string ;
+  sh:maxCount 1 ;
+  sh:or qudt:NumericTypeUnion ;
+  sh:path qudt:maxExclusive .
+
+qudt:ScalarDatatype-maxInclusive
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:maxCount 1 ;
+  sh:or qudt:NumericTypeUnion ;
+  sh:path qudt:maxInclusive .
+
+qudt:ScalarDatatype-minExclusive
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:maxCount 1 ;
+  sh:or qudt:NumericTypeUnion ;
+  sh:path qudt:minExclusive .
+
+qudt:ScalarDatatype-minInclusive
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:maxCount 1 ;
+  sh:or qudt:NumericTypeUnion ;
+  sh:path qudt:minInclusive .
+
+qudt:ScalarDatatype-rdfsDatatype
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class rdfs:Datatype ;
+  sh:maxCount 1 ;
+  sh:path qudt:rdfsDatatype .
+
+qudt:ShortSignedIntegerEncoding
+  a qudt:IntegerEncodingType ;
+  qudt:bytes 2 ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  rdfs:label "Short Signed Integer Encoding" .
+
+qudt:ShortUnsignedIntegerEncoding
+  a qudt:BooleanEncodingType, qudt:IntegerEncodingType ;
+  qudt:bytes 2 ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  rdfs:label "Short Unsigned Integer Encoding" .
+
+qudt:SignedBigIntegerType-literal
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:string ;
+  sh:path dtype:literal .
+
+qudt:SignedBigIntegerType-maxInclusive
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:or qudt:NumericTypeUnion ;
+  sh:path qudt:maxInclusive .
+
+qudt:SignedBigIntegerType-minInclusive
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:or ( [
+    sh:datatype xsd:string ;
+  ] [
+    sh:datatype xsd:integer ;
+  ] [
+    sh:datatype xsd:float ;
+  ] [
+    sh:datatype xsd:decimal ;
+  ] ) ;
+  sh:path qudt:minInclusive .
+
+qudt:SignedIntegerEncoding
+  a qudt:IntegerEncodingType ;
+  qudt:bytes 4 ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  rdfs:label "Signed Integer Encoding" .
+
+qudt:SignedLongIntegerType-abbreviation
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:string ;
+  sh:hasValue "SI32" ;
+  sh:path qudt:abbreviation .
+
+qudt:SignedLongIntegerType-maxInclusive
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:or qudt:NumericTypeUnion ;
+  sh:path qudt:maxInclusive .
+
+qudt:SignedLongIntegerType-minInclusive
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:or ( [
+    sh:datatype xsd:string ;
+  ] [
+    sh:datatype xsd:integer ;
+  ] [
+    sh:datatype xsd:float ;
+  ] [
+    sh:datatype xsd:decimal ;
+  ] ) ;
+  sh:path qudt:minInclusive .
+
+qudt:SignedShortIntegerType-abbreviation
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:path qudt:abbreviation .
+
+qudt:SignedType-signedness
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:path qudt:signedness .
+
+qudt:SinglePrecisionRealEncoding
+  a qudt:FloatingPointEncodingType ;
+  qudt:bytes 32 ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  rdfs:label "Single Precision Real Encoding" .
+
+qudt:StateSpaceVector-coordinateSystem
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:CoordinateSystem ;
+  sh:maxCount 1 ;
+  sh:path qudt:coordinateSystem .
+
+qudt:StringType-dimensionality
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:or ( [
+    sh:datatype xsd:integer ;
+  ] [
+    sh:datatype xsd:int ;
+  ] ) ;
+  sh:path qudt:dimensionality .
+
+qudt:StringType-elementType
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:CharacterType ;
+  sh:path qudt:elementDatatype .
+
+qudt:StringType-isByteString
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class xsd:boolean ;
+  sh:maxCount 1 ;
+  sh:path qudt:isByteString .
+
+qudt:StringType-maxLength
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:integer ;
+  sh:maxCount 1 ;
+  sh:path qudt:maxLength .
+
+qudt:StringType-memberDatatype
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:CharacterType ;
+  sh:path qudt:memberDatatype .
+
+qudt:StringType-typeMatrix
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:maxCount 0 ;
+  sh:minCount 0 ;
+  sh:path qudt:typeMatrix .
+
+qudt:StringUTF16-memberDatatype
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:CharacterType ;
+  sh:hasValue qudt:UTF16-CHAR ;
+  sh:path qudt:memberDatatype .
+
+qudt:StringUTF8-memberDatatype
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:CharacterType ;
+  sh:hasValue qudt:UTF8-CHAR ;
+  sh:path qudt:memberDatatype .
+
+qudt:StructuredData-dimensionality
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:integer ;
+  sh:maxCount 1 ;
+  sh:path qudt:dimensionality .
+
+qudt:StructuredDatatype-elementType
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:Datatype ;
+  sh:maxCount 1 ;
+  sh:path qudt:elementDatatype .
+
+qudt:SystemModifiableParameter
+  a qudt:ParameterModifiabilityType ;
+  dtype:code "1" ;
+  dtype:literal "system" ;
+  rdfs:comment "Parameter is modifiable by a (computer) system." ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  rdfs:label "System modifiable parameter" .
+
+qudt:Table-byRow
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:boolean ;
+  sh:maxCount 1 ;
+  sh:path qudt:byRow .
+
+qudt:Table-columns
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:integer ;
+  sh:maxCount 1 ;
+  sh:path qudt:columns .
+
+qudt:Table-dimensionality
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:integer ;
+  sh:maxCount 1 ;
+  sh:path qudt:dimensionality .
+
+qudt:Table-rows
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:integer ;
+  sh:maxCount 1 ;
+  sh:path qudt:rows .
+
+qudt:TaggedEnumeration-code
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:maxCount 1 ;
+  sh:minCount 1 ;
+  sh:path dtype:code .
+
+qudt:TextTypeUnion
+  a rdf:List ;
+  dcterms:description """
+  An rdf:List that can be used in property constraints as value for sh:or to indicate that all values of a property
+   must be a plain string, a string with HTML markup, or a string with LaTeX markup.
+  """ ;
+  rdf:first [
+    sh:datatype xsd:string ;
+  ] ;
+  rdf:rest ( [
+    sh:datatype rdf:HTML ;
+  ] [
+    sh:datatype qudt:LatexString ;
+  ] ) ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  rdfs:label "Text Type Union" .
+
+qudt:ThreeTuple-elementType
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:TupleMember ;
+  sh:minCount 0 ;
+  sh:path qudt:elementDatatype .
+
+qudt:ThreeTuple-elementTypeCount
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:integer ;
+  sh:hasValue 3 ;
+  sh:path qudt:elementTypeCount .
+
+qudt:Time-type
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:TimeStringType ;
+  sh:path qudt:type .
+
+qudt:TimeInterval-type
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:TimeStringType ;
+  sh:path qudt:type .
+
+qudt:TimeSeriesArray-dimensions
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:int ;
+  sh:maxCount 1 ;
+  sh:minCount 1 ;
+  sh:path qudt:dimensions .
+
+qudt:TimeSeriesArray-incrementDatatype
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:TimeStringType ;
+  sh:maxCount 1 ;
+  sh:minCount 1 ;
+  sh:path qudt:incrementDatatype .
+
+qudt:TimeSeriesArray-vector
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:Vector ;
+  sh:maxCount 1 ;
+  sh:minCount 1 ;
+  sh:path qudt:vector .
+
+qudt:TotallyOrdered
+  a qudt:OrderedType ;
+  dtype:literal "total" ;
+  qudt:plainTextDescription "Totally ordered structure." ;
+  rdfs:isDefinedBy <file:///Users/ralphtq/git-qudt/qudt-public-repo/qudt> ;
+  rdfs:label "Totally Ordered" .
+
+qudt:True
+  a qudt:BooleanStateType ;
+  dtype:code "1" ;
+  dtype:literal "true" ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  rdfs:label "true" .
+
+qudt:Tuple-elementType
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:TupleMember ;
+  sh:path qudt:elementDatatype .
+
+qudt:Tuple-elementTypeCount
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:integer ;
+  sh:minCount 0 ;
+  sh:path qudt:elementTypeCount .
+
+qudt:Tuple-length
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:integer ;
+  sh:maxCount 1 ;
+  sh:minCount 0 ;
+  sh:path qudt:length .
+
+qudt:TupleMember-elementType
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:ScalarDatatype ;
+  sh:path qudt:elementDatatype .
+
+qudt:TupleMember-orderInStructure
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:maxCount 1 ;
+  sh:minCount 1 ;
+  sh:path qudt:orderInStructure .
+
+qudt:Two-Tuple-elementType
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:minCount 0 ;
+  sh:path qudt:elementDatatype .
+
+qudt:Two-Tuple-elementTypeCount
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:integer ;
+  sh:hasValue 2 ;
+  sh:path qudt:elementTypeCount .
+
+qudt:TwoTuple-elementType
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:minCount 0 ;
+  sh:path qudt:elementDatatype .
+
+qudt:TwoTuple-elementTypeCount
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:integer ;
+  sh:hasValue 2 ;
+  sh:path qudt:elementTypeCount .
+
+qudt:TypeVector-datatype
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:DataType ;
+  sh:path qudt:datatype .
+
+qudt:UNARY-FUNCTION
+  a qudt:FunctionDatatype ;
+  dcterms:description "This type identifies functions that have exactly one argument."^^rdf:HTML ;
+  qudt:functionArity 1 ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  rdfs:label "UNARY-FUNCTION" .
+
+qudt:UNSIGNED
+  a qudt:SignednessType ;
+  dtype:literal "unsigned" ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  rdfs:label "Unsigned" .
+
+qudt:Unordered
+  a qudt:OrderedType ;
+  dtype:literal "unordered" ;
+  qudt:plainTextDescription "Unordered structure." ;
+  rdfs:isDefinedBy <file:///Users/ralphtq/git-qudt/qudt-public-repo/qudt> ;
+  rdfs:label "Unordered" .
+
+qudt:UnsignedBigIntegerType-abbreviation
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <file:///Users/ralphtq/git-qudt/qudt-public-repo/qudt> ;
+  sh:hasValue "UI64" ;
+  sh:path qudt:abbreviation .
+
+qudt:UnsignedBigIntegerType-maxInclusive
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:hasValue "2^{64}-1" ;
+  sh:or qudt:NumericTypeUnion ;
+  sh:path qudt:maxInclusive .
+
+qudt:UnsignedBigIntegerType-minInclusive
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:hasValue "0" ;
+  sh:or qudt:NumericTypeUnion ;
+  sh:path qudt:minInclusive .
+
+qudt:UnsignedIntegerEncoding
+  a qudt:IntegerEncodingType ;
+  qudt:bytes 4 ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  rdfs:label "Unsigned Integer Encoding" .
+
+qudt:UnsignedLongIntegerType-literal
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:string ;
+  sh:path dtype:literal .
+
+qudt:UnsignedLongIntegerType-maxInclusive
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:hasValue "2^{32}-1" ;
+  sh:or qudt:NumericTypeUnion ;
+  sh:path qudt:maxInclusive .
+
+qudt:UnsignedLongIntegerType-minInclusive
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:hasValue "0" ;
+  sh:or qudt:NumericTypeUnion ;
+  sh:path qudt:minInclusive .
+
+qudt:UnsignedShortIntegerType-abbreviation
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:hasValue "UI16" ;
+  sh:path qudt:abbreviation .
+
+qudt:UnsignedShortIntegerType-maxInclusive
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:hasValue "2^{16}-1" ;
+  sh:path qudt:maxInclusive .
+
+qudt:UnsignedShortIntegerType-minInclusive
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:hasValue "0" ;
+  sh:path qudt:minInclusive .
+
+qudt:UnsignedType-signedness
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:SignednessType ;
+  sh:hasValue qudt:UNSIGNED ;
+  sh:path qudt:signedness .
+
+qudt:UserModifiableParameter
+  a qudt:ParameterModifiabilityType ;
+  dtype:code "2" ;
+  dtype:literal "user" ;
+  rdfs:comment "Parameter is modifiable by a user." ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  rdfs:label "User modifiable parameter" .
+
+qudt:ValidateQuantityHasUnitShape
+  a sh:NodeShape ;
+  dcterms:description """
+  <p>Specifies and checks an optional property for a quantified value.
+  </p>"""^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/qudt> ;
+  rdfs:label "Validate Quantity has Unit Shape" ;
+  sh:property qudt:MaybeQuantityPropertyShape ;
+  sh:property qudt:MaybeUnitPropertyShape ;
+  sh:severity sh:Warning ;
+  sh:sparql [
+    sh:message "Quantity \"{$this}\" must have a unit." ;
+    sh:prefixes <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatypePrefixes> ;
+    sh:select """
+        SELECT $this
+        WHERE {
+             $this qudt:quantity ?quantity .
+             FILTER NOT EXISTS {?quantity qudt:hasUnit ?unit} 
+             }
+        """ ;
+  ] ;
+  sh:targetClass qudt:Array ;
+  sh:targetClass qudt:List ;
+  sh:targetClass qudt:Quantity ;
+  sh:targetClass qudt:Vector .
+
+qudt:VariableLengthIntegerType-maxBits
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:integer ;
+  sh:hasValue 64 ;
+  sh:path qudt:maxBits .
+
+qudt:VariableLengthIntegerType-minBits
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:datatype xsd:integer ;
+  sh:hasValue 1 ;
+  sh:path qudt:minBits .
+
+qudt:VehicleCoordinateSystem-pitchRotationDefinition
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:AxialOrientationType ;
+  sh:maxCount 1 ;
+  sh:path qudt:pitchRotationDefinition .
+
+qudt:VehicleCoordinateSystem-rollRotationDefinition
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:AxialOrientationType ;
+  sh:maxCount 1 ;
+  sh:minCount 0 ;
+  sh:path qudt:rollRotationDefinition .
+
+qudt:VehicleCoordinateSystem-yawRotationDefinition
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:AxialOrientationType ;
+  sh:maxCount 1 ;
+  sh:minCount 0 ;
+  sh:path qudt:yawRotationDefinition .
+
+qudt:VisualCueEnumeration-defaultValue
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  sh:class qudt:VisualCue ;
+  sh:path qudt:defaultValue .
+
+qudt:WDST_DRY
+  a qudt:WetDryStateType ;
+  dtype:code "2" ;
+  dtype:literal "dry" ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  rdfs:label "Dry" .
+
+qudt:WDST_WET
+  a qudt:WetDryStateType ;
+  dtype:code "1" ;
+  dtype:literal "wet" ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  rdfs:label "Wet" .
+
+qudt:WordAligned
+  a qudt:AlignmentType ;
+  dtype:literal "word" ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  rdfs:label "Word Aligned" .
+
+qudt:XSDatomicTypeUnion
+  a rdf:List ;
+  dcterms:description """
+  <p>In XML Schema Definition (XSD) xsd:anySimpleType is the base type for all simple types.
+  Simple types in XSD represent atomic values without any child elements or complex structures.
+  All simple types are compliant with xsd:anySimpleType.
+  </p>
+  <p>In XSD, the atomic types are: xsd:string, xsd:boolean, xsd:decimal, xsd:float,
+   xsd:double, xsd:duration, xsd:dateTime, xsd:time, xsd:date, xsd:gYearMonth, xsd:gYear, xsd:gMonthDay,
+   xsd:gDay, xsd:gMonth, xsd:hexBinary, xsd:base64Binary, xsd:anyURI, xsd:QName, and xsd:NOTATION.
+  </p>"""^^rdf:HTML ;
+  rdf:first [
+    sh:datatype xsd:anySimpleType ;
+  ] ;
+  rdf:rest ( [
+    sh:datatype xsd:anySimpleType ;
+  ] ) ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  rdfs:label "XSD Atomic Type Union" .
+
+qudt:Yes
+  a qudt:YesNoType ;
+  dtype:literal "Y" ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  rdfs:label "Yes" .
+
+qudt:hexbinary
+  a rdfs:Datatype, sh:NodeShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  rdfs:label "hexbinary" ;
+  rdfs:subClassOf xsd:string ;
+  sh:datatype xsd:string ;
+  sh:pattern "[0-9A-F]*" .
+
+qudt:negative
+  a qudt:Polarity ;
+  dtype:code "1" ;
+  dtype:literal "negative" ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  rdfs:label "negative" .
+
+qudt:positive
+  a qudt:Polarity ;
+  dtype:code "2" ;
+  dtype:literal "positive" ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  rdfs:label "positive" .
+
+xsd:NOTATION
+  a rdfs:Datatype .
+
+xsd:QName
+  a rdfs:Datatype .
+
+xsd:anyURI
+  a rdfs:Datatype .
+
+xsd:base64Binary
+  a rdfs:Datatype .
+
+xsd:boolean
+  a rdfs:Datatype .
+
+xsd:byte
+  a rdfs:Datatype .
+
+xsd:date
+  a rdfs:Datatype .
+
 xsd:dateTime
+  a rdfs:Datatype ;
   dcterms:description """
   <p>YYYY-MM-DDThh:mm:ss[.dd] or YYYY-DDDThh:mm:ss[.dd], where 'YYYY' is the year, 'MM' is the two-digit month, 'DD' is the two-digit day, 'DDD' is the three digit day of year, 'T' is constant, 'hh:mm:ss[.dd]' is the UTC time in hours, minutes, seconds, and optional fractional seconds. 
   As many 'd' characters to the right of the period as required may be used to obtain the required precision. 
   All fields require leading zeros.
   </p>"""^^rdf:HTML ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
-.
-xsd:string       a rdfs:Datatype .
-xsd:boolean      a rdfs:Datatype .
-xsd:decimal      a rdfs:Datatype .
-xsd:float        a rdfs:Datatype .
-xsd:double       a rdfs:Datatype .
-xsd:duration     a rdfs:Datatype .
-xsd:dateTime     a rdfs:Datatype .
-xsd:time         a rdfs:Datatype .
-xsd:date         a rdfs:Datatype .
-xsd:gYear        a rdfs:Datatype .
-xsd:gYearMonth   a rdfs:Datatype .
-xsd:gMonth       a rdfs:Datatype .
-xsd:gMonthDay    a rdfs:Datatype .
-xsd:gDay         a rdfs:Datatype .
-xsd:hexBinary    a rdfs:Datatype .
-xsd:base64Binary a rdfs:Datatype .
-xsd:anyURI       a rdfs:Datatype .
-xsd:QName        a rdfs:Datatype .
-xsd:NOTATION     a rdfs:Datatype .
-xsd:integer      a rdfs:Datatype .
-xsd:nonPositiveInteger a rdfs:Datatype .
-xsd:negativeInteger    a rdfs:Datatype .
-xsd:long         a rdfs:Datatype .
-xsd:int          a rdfs:Datatype .
-xsd:short        a rdfs:Datatype .
-xsd:byte         a rdfs:Datatype .
-xsd:nonNegativeInteger a rdfs:Datatype .
-xsd:unsignedLong a rdfs:Datatype .
-xsd:unsignedInt  a rdfs:Datatype .
-xsd:unsignedShort a rdfs:Datatype .
-xsd:unsignedByte a rdfs:Datatype .
-xsd:positiveInteger a rdfs:Datatype .
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> .
+
+xsd:decimal
+  a rdfs:Datatype .
+
+xsd:double
+  a rdfs:Datatype .
+
+xsd:duration
+  a rdfs:Datatype .
+
+xsd:float
+  a rdfs:Datatype .
+
+xsd:gDay
+  a rdfs:Datatype .
+
+xsd:gMonth
+  a rdfs:Datatype .
+
+xsd:gMonthDay
+  a rdfs:Datatype .
+
+xsd:gYear
+  a rdfs:Datatype .
+
+xsd:gYearMonth
+  a rdfs:Datatype .
+
+xsd:hexBinary
+  a rdfs:Datatype .
+
+xsd:int
+  a rdfs:Datatype .
+
+xsd:integer
+  a rdfs:Datatype .
+
+xsd:long
+  a rdfs:Datatype .
+
+xsd:negativeInteger
+  a rdfs:Datatype .
+
+xsd:nonNegativeInteger
+  a rdfs:Datatype .
+
+xsd:nonPositiveInteger
+  a rdfs:Datatype .
+
+xsd:positiveInteger
+  a rdfs:Datatype .
+
+xsd:short
+  a rdfs:Datatype .
+
+xsd:string
+  a rdfs:Datatype .
+
+xsd:time
+  a rdfs:Datatype .
+
+xsd:unsignedByte
+  a rdfs:Datatype .
+
+xsd:unsignedInt
+  a rdfs:Datatype .
+
+xsd:unsignedLong
+  a rdfs:Datatype .
+
+xsd:unsignedShort
+  a rdfs:Datatype .
+
+

--- a/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
+++ b/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
@@ -35255,42 +35255,6 @@ unit:N
   rdfs:label "न्यूटन"@hi ;
   rdfs:label "ニュートン"@ja ;
   rdfs:label "牛顿"@zh .
-  
-unit:NCM
-  a qudt:Unit ;
-  dcterms:description """
-The $\\textit{normal cubic metre}$ is a unit representing the amount of a product contained in a volume of one cubic metre at reference 'normal' temperature and pressure conditions. As such, it is a measure of the actual amount of product, most commonly referring to oil, not the volume of the product. The reference conditions for normal cubic metre vary depending on purpose and application.
-  """^^qudt:LatexString ;
-  qudt:conversionMultiplier 0.0 ;
-  qudt:conversionMultiplierSN 0.0E0 ;
-  qudt:hasDimensionVector qkdv:A1E0L0I0M0H0T0D0 ;
-  qudt:hasQuantityKind quantitykind:AmountOfSubstance ;
-  qudt:informativeReference "https://www.wikidata.org/entity/Q350023"^^xsd:anyURI ;
-  qudt:scalingOf unit:MOL ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
-  rdfs:label "Normal Cubic Meter"@en-US ;
-  rdfs:label "Normal Cubic Metre"@en ;
-  rdfs:label "Normkubikmeter"@de ;
-  rdfs:seeAlso unit:SCM .
-
-unit:NCM_1ATM_0DEG_C_NL
-  a qudt:ContextualUnit, qudt:Unit ;
-  dcterms:description """
-The $\\textit{normal cubic metre}$ is a unit for liquid products conforming to the Dutch Mining Regulations (Mijnbouwregeling) for reporting in the Dutch oil and gas industry, and used predominantly for crude oil. As such, it is a measure of the actual amount of oil, not the volume of the oil. The reference conditions for a Dutch normal cubic metre are 0 degrees Celsius at 1 standard atmosphere (atm), equivalent to 101.325 kilopascals (kPa) of pressure.
-  """^^qudt:LatexString ;
-  qudt:conversionMultiplier 0.0 ;
-  qudt:conversionMultiplierSN 0.0E0 ;
-  qudt:hasDimensionVector qkdv:A1E0L0I0M0H0T0D0 ;
-  qudt:hasQuantityKind quantitykind:AmountOfSubstance ;
-  qudt:informativeReference "http://wetten.overheid.nl/jci1.3:c:BWBR0014468&hoofdstuk=11&paragraaf=11.3&artikel=11.3.1"^^xsd:anyURI ;
-  qudt:informativeReference "https://nl.wikipedia.org/wiki/Normaal_kubieke_meter"^^xsd:anyURI ;
-  qudt:informativeReference "https://open.overheid.nl/Details/fefb9108-c56d-453a-badb-c2ad144da3a1/2"^^xsd:anyURI ;
-  qudt:scalingOf unit:MOL ;
-  qudt:symbol "Nm³" ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
-  rdfs:label "Normaal Kubieke Meter"@nl ;
-  rdfs:label "Normal Cubic Metre"@en ;
-  rdfs:seeAlso unit:SCM .
 
 unit:N-CentiM
   a qudt:Unit ;
@@ -36109,6 +36073,42 @@ unit:NAT-PER-SEC
   qudt:uneceCommonCode "Q19" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Nat per Second"@en .
+
+unit:NCM
+  a qudt:Unit ;
+  dcterms:description """
+The $\\textit{normal cubic metre}$ is a unit representing the amount of a product contained in a volume of one cubic metre at reference 'normal' temperature and pressure conditions. As such, it is a measure of the actual amount of product, most commonly referring to oil, not the volume of the product. The reference conditions for normal cubic metre vary depending on purpose and application.
+  """^^qudt:LatexString ;
+  qudt:conversionMultiplier 0.0 ;
+  qudt:conversionMultiplierSN 0.0E0 ;
+  qudt:hasDimensionVector qkdv:A1E0L0I0M0H0T0D0 ;
+  qudt:hasQuantityKind quantitykind:AmountOfSubstance ;
+  qudt:informativeReference "https://www.wikidata.org/entity/Q350023"^^xsd:anyURI ;
+  qudt:scalingOf unit:MOL ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
+  rdfs:label "Normal Cubic Meter"@en-US ;
+  rdfs:label "Normal Cubic Metre"@en ;
+  rdfs:label "Normkubikmeter"@de ;
+  rdfs:seeAlso unit:SCM .
+
+unit:NCM_1ATM_0DEG_C_NL
+  a qudt:ContextualUnit, qudt:Unit ;
+  dcterms:description """
+The $\\textit{normal cubic metre}$ is a unit for liquid products conforming to the Dutch Mining Regulations (Mijnbouwregeling) for reporting in the Dutch oil and gas industry, and used predominantly for crude oil. As such, it is a measure of the actual amount of oil, not the volume of the oil. The reference conditions for a Dutch normal cubic metre are 0 degrees Celsius at 1 standard atmosphere (atm), equivalent to 101.325 kilopascals (kPa) of pressure.
+  """^^qudt:LatexString ;
+  qudt:conversionMultiplier 0.0 ;
+  qudt:conversionMultiplierSN 0.0E0 ;
+  qudt:hasDimensionVector qkdv:A1E0L0I0M0H0T0D0 ;
+  qudt:hasQuantityKind quantitykind:AmountOfSubstance ;
+  qudt:informativeReference "http://wetten.overheid.nl/jci1.3:c:BWBR0014468&hoofdstuk=11&paragraaf=11.3&artikel=11.3.1"^^xsd:anyURI ;
+  qudt:informativeReference "https://nl.wikipedia.org/wiki/Normaal_kubieke_meter"^^xsd:anyURI ;
+  qudt:informativeReference "https://open.overheid.nl/Details/fefb9108-c56d-453a-badb-c2ad144da3a1/2"^^xsd:anyURI ;
+  qudt:scalingOf unit:MOL ;
+  qudt:symbol "Nm³" ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
+  rdfs:label "Normaal Kubieke Meter"@nl ;
+  rdfs:label "Normal Cubic Metre"@en ;
+  rdfs:seeAlso unit:SCM .
 
 unit:NP
   a qudt:DimensionlessUnit, qudt:LogarithmicUnit, qudt:Unit ;
@@ -45255,8 +45255,8 @@ A $\\textit{standard cubic metre}$ as defined by ISO 91:2017, generally applicab
   qudt:conversionMultiplierSN 0.0E0 ;
   qudt:hasDimensionVector qkdv:A1E0L0I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:AmountOfSubstance ;
-  qudt:informativeReference "urn:iso:std:iso:91:ed-1:v1"^^xsd:anyURI ;
   qudt:informativeReference "urn:iso:std:iso:2533:ed-1:v1"^^xsd:anyURI ;
+  qudt:informativeReference "urn:iso:std:iso:91:ed-1:v1"^^xsd:anyURI ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Standard Cubic Metre"@en .
 


### PR DESCRIPTION
## Spotless Config Changes: 

- It is important that no file is configured to be formatted by multiple formatters - otherwise the results are undefined, and possibly unexpected.

- Now, the default configuration for RDF only covers src files and has only the turtle-formatter fix (removing `\r`) characters.

- The execution `format-dist` modifies this to apply only to ttl files in dist and replace all the placeholders.

## Other changes:

- As a consequence of reinstating source formatting checks, two src files needed to be reformatted

- The format check was moved up to run before anything that takes noticable time, so the build fails fast if there are problems

- in the `fix` workflow, removed the format check that leads to early exit if no formatting problems are present

Fixes #1249 