### PR TITLE
Autogenerate and unify UCUM codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,14 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
 
 ### Fixed
 
-- Fixed typo in `qudt:ucumCode` of `unit:MegaN-PER-M2`
+- Fixed `qudt:ucumCode` of many units, such that they all follow the same pattern (see 'Changed' below).
+
+### Changed
+
+- Build process
+  - 'qudt:ucumCode' is now calculated based on factor units or base units, the same way `qudt:symbol` is. The 'canonical'
+    form is used throughout no (`/`), just multiplication of factors with positive or negative exponents, in the order
+    they appear in the unit's localname
 
 ## [3.1.5] - 2025-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
 
 ### Fixed
 
-- Fixed `qudt:ucumCode` of many units, such that they all follow the same pattern (see 'Changed' below).
+- Fixed `qudt:ucumCode` of many units, such that they all follow the same pattern (see 'Changed' below), and such that
+  no unit has more than one.
 
 ### Changed
 
@@ -21,6 +22,7 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
   - 'qudt:ucumCode' is now calculated based on factor units or base units, the same way `qudt:symbol` is. The 'canonical'
     form is used throughout no (`/`), just multiplication of factors with positive or negative exponents, in the order
     they appear in the unit's localname
+- SHACL shapes: enforce at most one `qudt:ucumCode` per unit.
 
 ## [3.1.5] - 2025-08-28
 

--- a/pom.xml
+++ b/pom.xml
@@ -416,6 +416,10 @@
                                         <toGraphsPattern>dist:schema:${name}</toGraphsPattern>
                                     </add>
                                     <sparqlQuery>
+                                        <file>src/build/sparql2shacl/ucumCode/query.rq</file>
+                                        <toFile>target/inspection/ucumCode/query.txt</toFile>
+                                    </sparqlQuery>
+                                    <sparqlQuery>
                                         <file>src/build/inspection/label/generate-default-labels.rq</file>
                                         <toFile>target/inspection/label/default-labels.txt</toFile>
                                     </sparqlQuery>
@@ -1053,6 +1057,7 @@
                                                 qudt:conversionMultiplier
                                                 qudt:conversionMultiplierSN
                                                 qudt:symbol
+                                                qudt:ucumCode
                                                 qudt:hasDimensionVector
                                                 qudt:hasReciprocalUnit
                                                 qudt:hasQuantityKind
@@ -1101,6 +1106,7 @@
                                                 qudt:conversionMultiplier
                                                 qudt:conversionMultiplierSN
                                                 qudt:symbol
+                                                qudt:ucumCode
                                                 qudt:hasDimensionVector
                                                 qudt:hasReciprocalUnit
                                                 qudt:hasQuantityKind
@@ -1594,6 +1600,113 @@
                                         </sparqlAsk>
                                     </until>
                                     <savepoint><id>08-infer-symbol</id></savepoint>
+                                    <until>
+                                        <message>Checking for missing/wrong ucumCodes that can be corrected/inferred</message>
+                                        <indexVar>iteration</indexVar>
+                                        <body>
+                                            <clear>
+                                                <graph>inferred:ucumCode</graph>
+                                                <graph>delete:ucumCode</graph>
+                                            </clear>
+                                            <shaclValidate>
+                                                <failOnSeverity>None</failOnSeverity>
+                                                <message>Preventing qudt:ucumCode that does not match the ucumCode calculated from base unit(s)</message>
+                                                <shapes>
+                                                    <file>target/sparql2shacl/ucumCode/validate.ttl</file>
+                                                </shapes>
+                                                <data>
+                                                    <file>target/dist/schema/SCHEMA_QUDT.ttl</file>
+                                                    <graph>dist:vocab:VOCAB_QUDT-UNITS-ALL.ttl</graph>
+                                                    <graph>dist:vocab:VOCAB_QUDT-PREFIXES.ttl</graph>
+                                                    <file>src/build/sparql2shacl/ucumCode/units-overriding-inferred-ucum-code.ttl</file>
+                                                </data>
+                                                <validationReport>
+                                                    <graph>delete:ucumCode</graph>
+                                                    <file>target/fix/ucumCode/delete-${iteration}.ttl</file>
+                                                </validationReport>
+                                            </shaclValidate>
+                                            <when>
+                                                <sparqlAsk>
+                                                    <![CDATA[
+                                                        ASK WHERE {
+                                                            GRAPH <delete:ucumCode> {
+                                                                [] a sh:ValidationReport ;
+                                                                   sh:conforms false .
+                                                            }
+                                                        }
+                                                    ]]>
+                                                </sparqlAsk>
+                                                <body>
+                                                    <sparqlUpdate>
+                                                        <message>Deleting invalid ucumCodes</message>
+                                                        <sparql>
+                                                            <![CDATA[
+                                                        DELETE {
+                                                            GRAPH <dist:vocab:VOCAB_QUDT-UNITS-ALL.ttl> {
+                                                                ?unit qudt:ucumCode ?incorrectUcumCode .
+                                                            }
+                                                            GRAPH <dist:vocab:VOCAB_QUDT-UNITS-ALL.ttl> {
+                                                                ?unit qudt:ucumCode ?incorrectUcumCode .
+                                                            }
+                                                        }
+                                                        WHERE {
+                                                            GRAPH <dist:vocab:VOCAB_QUDT-UNITS-ALL.ttl> {
+                                                                {
+                                                                    ?unit qudt:ucumCode ?incorrectUcumCode .
+                                                                }
+                                                            }
+                                                            GRAPH <delete:ucumCode> {
+                                                                ?res
+                                                                    rdf:type                      sh:ValidationResult;
+                                                                    sh:resultPath                 qudt:ucumCode;
+                                                                    sh:resultSeverity             sh:Violation;
+                                                                    sh:value                      ?unit
+                                                            }
+                                                        }
+                                                        ]]>
+                                                        </sparql>
+                                                    </sparqlUpdate>
+                                                    <shaclInfer>
+                                                        <message>Inferring missing qudt:ucumCode</message>
+                                                        <!-- it would be nice to iterate, but if we do that, we end up adding triples without
+                                                            deleting the incorrect versions. we have to go through main-fixSrc-main-fixSrc...
+                                                            as often as it takes.
+                                                        -->
+                                                        <iterateUntilStable>false</iterateUntilStable>
+                                                        <shapes>
+                                                            <file>target/sparql2shacl/ucumCode/infer.ttl</file>
+                                                        </shapes>
+                                                        <data>
+                                                            <file>target/dist/schema/SCHEMA_QUDT.ttl</file>
+                                                            <graph>dist:vocab:VOCAB_QUDT-UNITS-ALL.ttl</graph>
+                                                            <graph>dist:vocab:VOCAB_QUDT-PREFIXES.ttl</graph>
+                                                            <file>src/build/sparql2shacl/ucumCode/units-overriding-inferred-ucum-code.ttl</file>
+                                                        </data>
+                                                        <inferred>
+                                                            <graph>inferred:ucumCode</graph>
+                                                            <file>target/fix/ucumCode/inferred-${iteration}.ttl</file>
+                                                        </inferred>
+                                                    </shaclInfer>
+                                                    <add>
+                                                        <graph>inferred:ucumCode</graph>
+                                                        <toGraph>dist:vocab:VOCAB_QUDT-UNITS-ALL.ttl</toGraph>
+                                                    </add>
+                                                </body>
+                                            </when>
+                                        </body>
+                                        <sparqlAsk>
+                                            <![CDATA[
+                                            ASK WHERE {
+                                              FILTER NOT EXISTS {
+                                                    GRAPH <inferred:ucumCode> {
+                                                        ?s ?p ?o
+                                                    }
+                                                }
+                                            }
+                                        ]]>
+                                        </sparqlAsk>
+                                    </until>
+                                    <savepoint><id>08.5-infer-ucumCode</id></savepoint>
 
                                     <sparqlQuery>
                                         <message>Calculating default labels units that don't have them from 'en' labels</message>
@@ -2237,6 +2350,7 @@
                                                         qudt:conversionMultiplier
                                                         qudt:conversionMultiplierSN
                                                         qudt:symbol
+                                                        qudt:ucumCode
                                                         qudt:hasDimensionVector
                                                         qudt:hasReciprocalUnit
                                                         qudt:hasQuantityKind
@@ -2274,6 +2388,7 @@
                                                         qudt:conversionMultiplier
                                                         qudt:conversionMultiplierSN
                                                         qudt:symbol
+                                                        qudt:ucumCode
                                                         qudt:hasDimensionVector
                                                         qudt:hasReciprocalUnit
                                                         qudt:hasQuantityKind
@@ -2323,6 +2438,7 @@
                                                                 qudt:conversionMultiplier
                                                                 qudt:conversionMultiplierSN
                                                                 qudt:symbol
+                                                                qudt:ucumCode
                                                                 qudt:hasDimensionVector
                                                                 qudt:hasReciprocalUnit
                                                                 qudt:hasQuantityKind
@@ -2361,6 +2477,7 @@
                                                                 qudt:conversionMultiplier
                                                                 qudt:conversionMultiplierSN
                                                                 qudt:symbol
+                                                                qudt:ucumCode
                                                                 qudt:hasDimensionVector
                                                                 qudt:hasReciprocalUnit
                                                                 qudt:hasQuantityKind

--- a/src/build/sparql2shacl/ucumCode/infer-template.ttl
+++ b/src/build/sparql2shacl/ucumCode/infer-template.ttl
@@ -1,0 +1,40 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix qfn: <http://qudt.org/shacl/functions#> .
+@prefix qudt: <http://qudt.org/schema/qudt/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+
+qfn:inferUcumCodes
+  a owl:Ontology ;
+  owl:imports qfn: .
+
+qfn:inferUcumCodesRule
+  a sh:NodeShape ;
+  sh:rule [
+    a sh:SPARQLRule ;
+    sh:construct """
+        CONSTRUCT {
+                 $this qudt:ucumCode ?calculatedUcumCode ;
+                }
+        WHERE
+        {
+            {
+
+
+{{QUERY_WITHOUT_PREFIXES}}
+
+
+            }
+
+            FILTER NOT EXISTS {
+                qudt:UnitsOverridingInferredUcumCode qudt:includes ?this .
+            }
+        }
+
+        """ ;
+    sh:prefixes qfn: ;
+  ] ;
+  sh:targetClass qudt:Unit .
+
+

--- a/src/build/sparql2shacl/ucumCode/query.rq
+++ b/src/build/sparql2shacl/ucumCode/query.rq
@@ -1,0 +1,154 @@
+SELECT
+    ?this
+    ?actualUcumCode
+    (STRDT(?calculatedUcumCodeString, qudt:UCUMcs) AS ?calculatedUcumCode)
+    ?sourceRelation
+    (qudt:ucumCode as ?path)
+
+WHERE {
+    # union of 2 very different subqueries
+    # first: calculate ucumCodes via factor units
+    # second: calculate ucumCodes via scalingof (see below)
+    {
+        BIND(qudt:hasFactorUnit as ?sourceRelation)
+        ?this
+            a qudt:Unit ;
+            optional {
+                ?this qudt:ucumCode ?actualUcumCode
+            }
+        {
+            SELECT
+                ?this
+                (SAMPLE(?denominatorLocalname) as ?denomName)
+                (SAMPLE(?numeratorLocalname) as ?numerName)
+                (IF(BOUND(?denomName),
+                    IF(BOUND(?numerName),
+                        CONCAT(?numerName,"-PER-",?denomName),
+                        CONCAT("PER-",?denomName)
+                    ),
+                    ?numerName)
+                AS ?unitLocalnameReconstructed)
+                (SAMPLE(?denominatorUcumCode) as ?denomSymb)
+                (SAMPLE(?numeratorUcumCode) as ?numerSymb)
+                (IF(BOUND(?denomSymb),
+                    IF(BOUND(?numerSymb),
+                        CONCAT(?numerSymb,".",?denomSymb),
+                        ?denomSymb
+                    ),
+                    ?numerSymb)
+                AS ?calculatedUcumCodeString)
+            WHERE
+            {
+
+                {
+                    SELECT ?this
+                        (GROUP_CONCAT(?baseUcumCode; separator=".") as ?numeratorUcumCode)
+                        (GROUP_CONCAT(?baseLocalname; separator="-") as ?numeratorLocalname)
+                    {
+                        SELECT DISTINCT ?this ?base ?baseLocalname ?posInNumerator ?baseUcumCode
+                        {
+
+                            ?this
+                            a qudt:Unit ;
+                            BIND(qfn:localname(?this) as ?unitLocalname )
+                            BIND(
+                                IF(
+                                    CONTAINS(?unitLocalname, "PER"),
+                                    STRBEFORE(?unitLocalname, "-PER-"),
+                                    ?unitLocalname)
+                                AS ?unitLocalnameNumerator)
+
+                            ?this qudt:hasFactorUnit ?fu .
+                            ?fu   qudt:exponent ?exp .
+                            ?fu qudt:hasUnit ?base .
+                            ?base qudt:ucumCode ?ucumCode .
+                            BIND(qfn:localname(?base) AS ?baseLocalnameTmp)
+                            BIND(
+                                IF(
+                                    ABS(?exp) = 1,
+                                    ?baseLocalnameTmp,
+                                    CONCAT(?baseLocalnameTmp, STR(abs(?exp))))
+                                AS ?baseLocalname)
+                            BIND(CONCAT("(?<=(-|^))",?baseLocalname,"(?=(-|$)).*$") as ?regexBaseLocalname)
+                            BIND(STRLEN(REPLACE(?unitLocalnameNumerator, ?regexBaseLocalname, "")) AS ?posInNumeratorTmp)
+                            BIND(IF(?posInNumeratorTmp = STRLEN(?unitLocalnameNumerator), -1, ?posInNumeratorTmp) AS ?posInNumerator)
+                            BIND(CONCAT(STR(?ucumCode), IF(?exp != 1, STR(?exp), "")) AS ?baseUcumCode)
+                            FILTER(?posInNumerator > -1)
+                        } ORDER BY ?this ?posInNumerator
+                    } GROUP BY ?this
+                }
+                UNION
+                {
+                    SELECT ?this
+                        (GROUP_CONCAT(?baseUcumCode; separator=".") as ?denominatorUcumCode)
+                        (GROUP_CONCAT(?baseLocalname; separator="-") as ?denominatorLocalname)
+                    {
+                        SELECT DISTINCT ?this ?base ?baseLocalname ?posInDenominator ?baseUcumCode
+                        {
+
+                            ?this
+                            a qudt:Unit ;
+                            BIND(qfn:localname(?this) as ?unitLocalname )
+                            BIND(STRAFTER(?unitLocalname, "PER-") AS ?unitLocalnameDenominator)
+
+                            ?this qudt:hasFactorUnit ?fu .
+                            ?fu   qudt:exponent ?exp .
+                            ?fu qudt:hasUnit ?base .
+                            ?base qudt:ucumCode ?ucumCode .
+                            BIND(qfn:localname(?base) AS ?baseLocalnameTmp)
+                            BIND(
+                                IF(
+                                    ABS(?exp) = 1,
+                                    ?baseLocalnameTmp,
+                                    CONCAT(?baseLocalnameTmp, STR(abs(?exp))))
+                                AS ?baseLocalname)
+                            BIND(CONCAT("(?<=(-|^))",?baseLocalname,"(?=(-|$)).*$") as ?regexBaseLocalname)
+                            BIND(STRLEN(REPLACE(?unitLocalnameDenominator, ?regexBaseLocalname, "")) AS ?posInDenominatorTmp)
+                            BIND(IF(?posInDenominatorTmp = STRLEN(?unitLocalnameDenominator), -1, ?posInDenominatorTmp) AS ?posInDenominator)
+                            BIND(CONCAT(STR(?ucumCode), IF(?exp != 1, STR(?exp), "")) AS ?baseUcumCode)
+                            FILTER(?posInDenominator > -1)
+                        } ORDER BY ?this ?posInDenominator
+                    } GROUP BY ?this
+                }
+            } GROUP BY ?this
+            HAVING(qfn:localname(?this) = ?unitLocalnameReconstructed)
+        }
+    }
+
+
+    UNION
+
+    # second subquery: calculate ucumCodes via scalingOf
+    {
+        {
+            BIND(qudt:scalingOf as ?sourceRelation)
+            ?this
+                a qudt:Unit ;
+                qudt:scalingOf ?base .
+            OPTIONAL {
+                ?this qudt:ucumCode ?actualUcumCode
+            }
+            ?base qudt:ucumCode ?baseUnitUcumCode .
+            BIND(qfn:localname(?this) as ?unitLocalname )
+            BIND(qfn:localname(?base) AS ?baseLocalname)
+            OPTIONAL {
+                ?this qudt:prefix ?prefix .
+                ?prefix qudt:ucumCode ?prefixUcumCode .
+                BIND(qfn:localname(?prefix) AS ?prefixLocalname)
+            }
+            BIND(
+                IF(BOUND(?prefixUcumCode),
+                    CONCAT(STR(?prefixUcumCode), STR(?baseUnitUcumCode)),
+                    STR(?baseUnitUcumCode))
+                AS ?calculatedUcumCodeString)
+            BIND(
+                IF(BOUND(?prefixLocalname),
+                    CONCAT(?prefixLocalname, ?baseLocalname),
+                    ?baseLocalname)
+                AS ?scaledUnitLocalnameReconstructed)
+            FILTER( ?unitLocalname = ?scaledUnitLocalnameReconstructed )
+        }
+    }
+    FILTER(!BOUND(?actualUcumCode) || ?calculatedUcumCodeString != STR(?actualUcumCode))
+}
+

--- a/src/build/sparql2shacl/ucumCode/units-overriding-inferred-ucum-code.ttl
+++ b/src/build/sparql2shacl/ucumCode/units-overriding-inferred-ucum-code.ttl
@@ -1,0 +1,7 @@
+@prefix qudt: <http://qudt.org/schema/qudt/> .
+@prefix unit: <http://qudt.org/vocab/unit/> .
+
+qudt:UnitsOverridingInferreducumCode
+  qudt:includes unit:DontFindThis .
+
+

--- a/src/build/sparql2shacl/ucumCode/validate-template.ttl
+++ b/src/build/sparql2shacl/ucumCode/validate-template.ttl
@@ -1,0 +1,42 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix qfn: <http://qudt.org/shacl/functions#> .
+@prefix qudt: <http://qudt.org/schema/qudt/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+
+qfn:validateSymbols
+  a owl:Ontology ;
+  owl:imports qfn: .
+
+qfn:ucumCodeRule
+  a sh:NodeShape ;
+  sh:severity sh:Violation ;
+  sh:sparql [
+    a sh:SPARQLConstraint ;
+    sh:message """
+    Unit {$this} has ucumCode '{?actualUcumCode}', but '{?calculatedUcumCode}' is inferred via {?sourceRelation}.
+    If the current ucumCode is correct, add the unit to `src/build/sparql2shacl/ucumCode/units-overriding-inferred-ucum-code.ttl`
+    """ ;
+    sh:prefixes qfn: ;
+    sh:select """
+    SELECT * WHERE
+    {
+        {
+
+
+{{QUERY_WITHOUT_PREFIXES}}
+
+
+        }
+
+        FILTER NOT EXISTS {
+            qudt:UnitsOverridingInferredUcumCode qudt:includes ?this .
+        }
+    }
+
+    """ ;
+  ] ;
+  sh:targetClass qudt:Unit .
+
+

--- a/src/main/rdf/schema/shacl/SCHEMA_QUDT_NoOWL.ttl
+++ b/src/main/rdf/schema/shacl/SCHEMA_QUDT_NoOWL.ttl
@@ -2986,6 +2986,7 @@ qudt:Unit-ucumCode
   a sh:PropertyShape ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/qudt> ;
   sh:datatype qudt:UCUMcs ;
+  sh:maxCount 1 ;
   sh:path qudt:ucumCode ;
   sh:pattern "[\\x21-\\x7e]+" .
 

--- a/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
+++ b/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
@@ -28967,7 +28967,6 @@ unit:L
   qudt:siExactMatch si-unit:litre ;
   qudt:symbol "L" ;
   qudt:ucumCode "L"^^qudt:UCUMcs ;
-  qudt:ucumCode "l"^^qudt:UCUMcs ;
   qudt:udunitsCode "L" ;
   qudt:uneceCommonCode "LTR" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q11582> ;

--- a/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
+++ b/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
@@ -179,7 +179,6 @@ unit:A-HR-PER-KiloGM
   qudt:iec61360Code "0112/2///62720#UAD884" ;
   qudt:symbol "A·h/kg" ;
   qudt:ucumCode "A.h.kg-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "A.h/kg"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Ampere Hour per Kilogram" ;
   rdfs:label "Ampere Hour per Kilogram"@en .
@@ -271,7 +270,6 @@ unit:A-M2-PER-J-SEC
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
   qudt:symbol "A·m²/(J·s)" ;
   qudt:ucumCode "A.m2.J-1.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "A.m2/(J.s)"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A10" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q97540991> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -338,7 +336,6 @@ unit:A-PER-CentiM
   qudt:plainTextDescription "SI base unit ampere divided by the 0.01-fold of the SI base unit metre" ;
   qudt:symbol "A/cm" ;
   qudt:ucumCode "A.cm-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "A/cm"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A2" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Amper na Centimeter"@sl ;
@@ -369,7 +366,6 @@ unit:A-PER-CentiM2
   qudt:plainTextDescription "SI base unit ampere divided by the 0.0001-fold  of the power of the SI base unit metre by exponent 2" ;
   qudt:symbol "A/cm²" ;
   qudt:ucumCode "A.cm-2"^^qudt:UCUMcs ;
-  qudt:ucumCode "A/cm2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A4" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Amper na Centimetr Kwadratowy"@pl ;
@@ -400,7 +396,6 @@ unit:A-PER-DEG_C
   qudt:informativeReference "http://web.mit.edu/course/21/21.guide/use-tab.htm"^^xsd:anyURI ;
   qudt:symbol "A/°C" ;
   qudt:ucumCode "A.Cel-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "A/Cel"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Amper na Stopień Celsjusza"@pl ;
   rdfs:label "Amper na Stopinja Celzija"@sl ;
@@ -433,7 +428,6 @@ unit:A-PER-GM
   qudt:hasQuantityKind quantitykind:SpecificElectricCurrent ;
   qudt:symbol "A/g" ;
   qudt:ucumCode "A.g-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "A/g"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Amper na Gram"@pl ;
   rdfs:label "Amper na Gram"@sl ;
@@ -467,7 +461,6 @@ unit:A-PER-J
   qudt:hasReciprocalUnit unit:WB ;
   qudt:symbol "A/J" ;
   qudt:ucumCode "A.J-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "A/J"^^qudt:UCUMcs ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q30064159> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Amper na Dżul"@pl ;
@@ -498,7 +491,6 @@ unit:A-PER-K
   qudt:iec61360Code "0112/2///62720#UAD896" ;
   qudt:symbol "A/K" ;
   qudt:ucumCode "A.K-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "A/K"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Amper na Kelvin"@sl ;
   rdfs:label "Amper na Kelwin"@pl ;
@@ -528,7 +520,6 @@ unit:A-PER-KiloGM
   qudt:iec61360Code "0112/2///62720#UAB485" ;
   qudt:symbol "A/kg" ;
   qudt:ucumCode "A.kg-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "A/kg"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H31" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Amper na Kilogram"@pl ;
@@ -567,7 +558,6 @@ unit:A-PER-M
   qudt:iec61360Code "0112/2///62720#UAA104" ;
   qudt:symbol "A/m" ;
   qudt:ucumCode "A.m-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "A/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "AE" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q2844478> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -616,7 +606,6 @@ This unit is commonly used in the SI unit system.
   qudt:informativeReference "https://en.wikipedia.org/wiki/Current_density"^^xsd:anyURI ;
   qudt:symbol "A/m²" ;
   qudt:ucumCode "A.m-2"^^qudt:UCUMcs ;
-  qudt:ucumCode "A/m2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A41" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q2844477> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -656,7 +645,6 @@ unit:A-PER-M2-K2
   qudt:informativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
   qudt:symbol "A/(m²·K²)" ;
   qudt:ucumCode "A.m-2.K-2"^^qudt:UCUMcs ;
-  qudt:ucumCode "A/(m2.K2)"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A6" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q105883158> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -694,7 +682,6 @@ unit:A-PER-MilliM
   qudt:plainTextDescription "SI base unit ampere divided by the 0.001-fold of the SI base unit metre" ;
   qudt:symbol "A/mm" ;
   qudt:ucumCode "A.mm-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "A/mm"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A3" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Amper na Millimeter"@sl ;
@@ -725,7 +712,6 @@ unit:A-PER-MilliM2
   qudt:plainTextDescription "SI base unit ampere divided by the 0.000 001-fold of the power of the SI base unit metre by exponent 2" ;
   qudt:symbol "A/mm²" ;
   qudt:ucumCode "A.mm-2"^^qudt:UCUMcs ;
-  qudt:ucumCode "A/mm2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A7" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Amper na Kvadratni Millimeter"@sl ;
@@ -752,7 +738,6 @@ unit:A-PER-PA
   qudt:iec61360Code "0112/2///62720#UAB320" ;
   qudt:symbol "A/Pa" ;
   qudt:ucumCode "A.Pa-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "A/Pa"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "N93" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Amper na Pascal"@sl ;
@@ -788,7 +773,6 @@ unit:A-PER-RAD
   qudt:hasQuantityKind quantitykind:ElectricCurrentPerAngle ;
   qudt:symbol "A/rad" ;
   qudt:ucumCode "A.rad-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "A/rad"^^qudt:UCUMcs ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q30064202> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Amper na Radian"@pl ;
@@ -1187,7 +1171,6 @@ unit:ATM-M3-PER-MOL
   qudt:hasQuantityKind quantitykind:HenrysLawVolatilityConstant ;
   qudt:symbol "atm·m³/mol" ;
   qudt:ucumCode "atm.m3.mol-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "atm.m3/mol"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Standard Atmosphere Cubic Meter per Mole"@en-US ;
   rdfs:label "Standard Atmosphere Cubic Metre per Mole" ;
@@ -1205,7 +1188,6 @@ unit:ATM-PER-M
   qudt:iec61360Code "0112/2///62720#UAB423" ;
   qudt:symbol "atm/m" ;
   qudt:ucumCode "atm.m-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "atm/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P83" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Standard Atmosphere per Meter"@en-US ;
@@ -1254,7 +1236,6 @@ unit:ATM_T-PER-M
   qudt:iec61360Code "0112/2///62720#UAB424" ;
   qudt:symbol "at/m" ;
   qudt:ucumCode "att.m-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "att/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P84" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Technical Atmosphere per Meter"@en-US ;
@@ -1383,7 +1364,6 @@ unit:A_Ab-PER-CentiM2
   qudt:informativeReference "http://www.efunda.com/glossary/units/units--electric_current_density--abampere_per_square_centimeter.cfm"^^xsd:anyURI ;
   qudt:symbol "abA/cm²" ;
   qudt:ucumCode "Bi.cm-2"^^qudt:UCUMcs ;
-  qudt:ucumCode "Bi/cm2"^^qudt:UCUMcs ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q30063541> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Abampere per Square Centimeter"@en-US ;
@@ -1451,6 +1431,7 @@ unit:AttoA
   qudt:hasQuantityKind quantitykind:TotalCurrent ;
   qudt:iec61360Code "0112/2///62720#UAB637" ;
   qudt:symbol "aA" ;
+  qudt:ucumCode "aA"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Attoamper"@hu ;
   rdfs:label "Attoamper"@pl ;
@@ -1699,7 +1680,6 @@ unit:B-PER-M
   qudt:iec61360Code "0112/2///62720#UAB480" ;
   qudt:symbol "B/m" ;
   qudt:ucumCode "B.m-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "B/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P43" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Bel na Meter"@sl ;
@@ -1797,7 +1777,6 @@ unit:BAR-L-PER-SEC
   qudt:plainTextDescription "The unit 'Bar Litre Per Second' is the product of the unit bar and the unit litre divided by the SI base unit second" ;
   qudt:symbol "bar·L/s" ;
   qudt:ucumCode "bar.L.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "bar.L/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F91" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Bar Liter per Second"@en-US ;
@@ -1816,7 +1795,6 @@ unit:BAR-M3-PER-SEC
   qudt:plainTextDescription "product out of the 0.001-fold of the unit bar and the power of the SI base unit metre with the exponent 3 divided by the SI base unit second" ;
   qudt:symbol "bar·m³/s" ;
   qudt:ucumCode "bar.m3.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "bar.m3/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F92" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Bar Cubic Meter per Second"@en-US ;
@@ -1835,7 +1813,6 @@ unit:BAR-PER-BAR
   qudt:plainTextDescription "pressure relation consisting of the unit bar divided by the unit bar" ;
   qudt:symbol "bar/bar" ;
   qudt:ucumCode "bar.bar-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "bar/bar"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J56" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Bar per Bar" ;
@@ -1852,7 +1829,6 @@ unit:BAR-PER-DEG_C
   qudt:iec61360Code "0112/2///62720#UAD921" ;
   qudt:symbol "bar/°C" ;
   qudt:ucumCode "bar.Cel-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "bar/Cel"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Bar per Degree Celsius" ;
   rdfs:label "Bar per Degree Celsius"@en .
@@ -1869,7 +1845,6 @@ unit:BAR-PER-K
   qudt:plainTextDescription "unit with the name bar divided by the SI base unit kelvin" ;
   qudt:symbol "bar/K" ;
   qudt:ucumCode "bar.K-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "bar/K"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F81" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Bar per Kelvin" ;
@@ -1946,7 +1921,6 @@ unit:BARN-PER-SR
   qudt:iec61360Code "0112/2///62720#UAB128" ;
   qudt:symbol "b/sr" ;
   qudt:ucumCode "b.sr-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "b/sr"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A17" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Barn per Steradian" ;
@@ -2177,7 +2151,6 @@ unit:BBL_US-PER-DAY
   qudt:plainTextDescription "unit of the volume barrel (US petroleum) for crude oil according to the Anglo-American system of units divided by the unit day" ;
   qudt:symbol "bbl{US petroleum}/d" ;
   qudt:ucumCode "[bbl_us].d-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[bbl_us]/d"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B1" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q21178489> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -2197,7 +2170,6 @@ unit:BBL_US-PER-MIN
   qudt:plainTextDescription "unit of the volume barrel (US petroleum) for crude oil according to the Anglo-American system of units divided by the unit minute" ;
   qudt:symbol "bbl{US petroleum}/min" ;
   qudt:ucumCode "[bbl_us].min-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[bbl_us]/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "5A" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Barrel (US) per Minute" ;
@@ -2251,7 +2223,6 @@ unit:BBL_US_PET-PER-HR
   qudt:plainTextDescription "unit of the volume barrel (US petroleum) for crude oil according to the Anglo-American system of units divided by the unit hour" ;
   qudt:symbol "bbl{US petroleum}/h" ;
   qudt:ucumCode "[bbl_us].h-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[bbl_us]/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J62" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Barrel (us Petroleum) per Hour" ;
@@ -2270,7 +2241,6 @@ unit:BBL_US_PET-PER-SEC
   qudt:plainTextDescription "unit of the volume barrel (US petroleum) for crude oil according to the Anglo-American system of units divided by the SI base unit second" ;
   qudt:symbol "bbl{US petroleum}/s" ;
   qudt:ucumCode "[bbl_us].s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[bbl_us]/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J62" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Barrel (us Petroleum) per Second" ;
@@ -2284,7 +2254,6 @@ unit:BEAT-PER-MIN
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:HeartRate ;
   qudt:symbol "BPM" ;
-  qudt:ucumCode "/min{H.B.}"^^qudt:UCUMcs ;
   qudt:ucumCode "min-1{H.B.}"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Heart Beats per Minute" ;
@@ -2412,7 +2381,6 @@ unit:BIT-PER-M
   qudt:iec61360Code "0112/2///62720#UAA340" ;
   qudt:symbol "b/m" ;
   qudt:ucumCode "bit.m-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "bit/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E88" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Bit per Meter"@en-US ;
@@ -2460,9 +2428,7 @@ unit:BIT-PER-SEC
   qudt:iec61360Code "0112/2///62720#UAA343" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Data_rate_units#Kilobyte_per_second"^^xsd:anyURI ;
   qudt:symbol "b/s" ;
-  qudt:ucumCode "Bd"^^qudt:UCUMcs ;
   qudt:ucumCode "bit.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "bit/s"^^qudt:UCUMcs ;
   qudt:udunitsCode "Bd" ;
   qudt:udunitsCode "bps" ;
   qudt:uneceCommonCode "B10" ;
@@ -2557,7 +2523,6 @@ unit:BQ-PER-KiloGM
   qudt:plainTextDescription "\"Becquerel per Kilogram\" is used to describe radioactivity, which is often expressed in becquerels per unit of volume or weight, to express how much radioactive material is contained in a sample." ;
   qudt:symbol "Bq/kg" ;
   qudt:ucumCode "Bq.kg-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "Bq/kg"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A18" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q88768297> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -2592,7 +2557,6 @@ unit:BQ-PER-L
   qudt:hasQuantityKind quantitykind:ActivityConcentration ;
   qudt:symbol "Bq/L" ;
   qudt:ucumCode "Bq.L-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "Bq/L"^^qudt:UCUMcs ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q106651237> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Becquerel per Liter"@en-US ;
@@ -2613,7 +2577,6 @@ unit:BQ-PER-M2
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
   qudt:symbol "Bq/m²" ;
   qudt:ucumCode "Bq.m-2"^^qudt:UCUMcs ;
-  qudt:ucumCode "Bq/m2"^^qudt:UCUMcs ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q98103135> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Becquerel na Kvadratni Meter"@sl ;
@@ -2653,7 +2616,6 @@ unit:BQ-PER-M3
   qudt:plainTextDescription "The SI derived unit of unit in the category of Radioactivity concentration." ;
   qudt:symbol "Bq/m³" ;
   qudt:ucumCode "Bq.m-3"^^qudt:UCUMcs ;
-  qudt:ucumCode "Bq/m3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A19" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q98102832> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -2718,7 +2680,6 @@ unit:BREATH-PER-MIN
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:RespiratoryRate ;
   qudt:symbol "breath/min" ;
-  qudt:ucumCode "/min{breath}"^^qudt:UCUMcs ;
   qudt:ucumCode "min-1{breath}"^^qudt:UCUMcs ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q30064611> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -2853,7 +2814,6 @@ unit:BTU_IT-FT-PER-FT2-HR-DEG_F
   qudt:plainTextDescription "British thermal unit (international table) foot per hour Square foot degree Fahrenheit is the unit of the thermal conductivity according to the Imperial system of units." ;
   qudt:symbol "Btu{IT}·ft/(ft²·h·°F)" ;
   qudt:ucumCode "[Btu_IT].[ft_i].[ft_i]-2.h-1.[degF]-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[Btu_IT].[ft_i]/([ft_i]2.h.[degF])"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J40" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "British Thermal Unit (international Definition) Foot per Square Foot Hour Degree Fahrenheit" ;
@@ -2902,7 +2862,6 @@ unit:BTU_IT-IN-PER-FT2-HR-DEG_F
   qudt:plainTextDescription "BTU (th) Inch per Square Foot Hour Degree Fahrenheit is an Imperial unit for 'Thermal Conductivity', an International British thermal unit inch per second per square foot per degree Fahrenheit is a unit of thermal conductivity in the US Customary Units and British Imperial Units." ;
   qudt:symbol "Btu{IT}·in/(ft²·h·°F)" ;
   qudt:ucumCode "[Btu_IT].[in_i].[ft_i]-2.h-1.[degF]-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[Btu_IT].[in_i]/([ft_i]2.h.[degF])"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J41" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "British Thermal Unit (international Definition) Inch per Square Foot Hour Degree Fahrenheit" ;
@@ -2925,7 +2884,6 @@ unit:BTU_IT-IN-PER-FT2-SEC-DEG_F
   qudt:plainTextDescription "British thermal unit (international table) inch per second Square foot degree Fahrenheit is the unit of the thermal conductivity according to the Imperial system of units." ;
   qudt:symbol "Btu{IT}·in/(ft²·s·°F)" ;
   qudt:ucumCode "[Btu_IT].[in_i].[ft_i]-2.s-1.[degF]-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[Btu_IT].[in_i]/([ft_i]2.s.[degF])"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J42" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "British Thermal Unit (international Definition) Inch per Square Foot Second Degree Fahrenheit" ;
@@ -2946,7 +2904,6 @@ unit:BTU_IT-IN-PER-HR-FT2-DEG_F
   qudt:plainTextDescription "unit of the thermal conductivity according to the Imperial system of units" ;
   qudt:symbol "Btu{IT}·in/(h·ft²·°F)" ;
   qudt:ucumCode "[Btu_IT].[in_i].h-1.[ft_i]-2.[degF]-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[Btu_IT].[in_i]/(h.[ft_i]2.[degF])"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J41" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "British Thermal Unit (international Definition) Inch per Hour Square Foot Degree Fahrenheit" ;
@@ -2966,7 +2923,6 @@ unit:BTU_IT-IN-PER-SEC-FT2-DEG_F
   qudt:plainTextDescription "unit of the thermal conductivity according to the Imperial system of units" ;
   qudt:symbol "Btu{IT}·in/(s·ft²·°F)" ;
   qudt:ucumCode "[Btu_IT].[in_i].s-1.[ft_i]-2.[degF]-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[Btu_IT].[in_i]/(s.[ft_i]2.[degF])"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J42" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "British Thermal Unit (international Definition) Inch per Second Square Foot Degree Fahrenheit" ;
@@ -2990,7 +2946,6 @@ unit:BTU_IT-PER-DEG_F
   qudt:iec61360Code "0112/2///62720#UAB271" ;
   qudt:symbol "Btu{IT}/°F" ;
   qudt:ucumCode "[Btu_IT].[degF]-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[Btu_IT]/[degF]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "N60" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "British Thermal Unit (international Definition) per Degree Fahrenheit" ;
@@ -3010,7 +2965,6 @@ unit:BTU_IT-PER-DEG_R
   qudt:iec61360Code "0112/2///62720#UAB273" ;
   qudt:symbol "Btu{IT}/°R" ;
   qudt:ucumCode "[Btu_IT].[degR]-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[Btu_IT]/[degR]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "N62" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "British Thermal Unit (international Definition) per Degree Rankine" ;
@@ -3032,7 +2986,6 @@ unit:BTU_IT-PER-FT2
   qudt:iec61360Code "0112/2///62720#UAB283" ;
   qudt:symbol "Btu{IT}/ft²" ;
   qudt:ucumCode "[Btu_IT].[ft_i]-2"^^qudt:UCUMcs ;
-  qudt:ucumCode "[Btu_IT]/[ft_i]2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P37" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "British Thermal Unit (international Definition) per Square Foot" ;
@@ -3071,7 +3024,6 @@ unit:BTU_IT-PER-FT2-HR-DEG_F
   qudt:hasReciprocalUnit unit:FT2-HR-DEG_F-PER-BTU_IT ;
   qudt:symbol "Btu{IT}/(ft²·h·°F)" ;
   qudt:ucumCode "[Btu_IT].[ft_i]-2.h-1.[degF]-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[Btu_IT]/([ft_i]2.h.[degF])"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "British Thermal Unit (international Definition) per Square Foot Hour Degree Fahrenheit" ;
   rdfs:label "British Thermal Unit (international Definition) per Square Foot Hour Degree Fahrenheit"@en .
@@ -3107,7 +3059,6 @@ unit:BTU_IT-PER-FT2-SEC-DEG_F
   qudt:hasQuantityKind quantitykind:CoefficientOfHeatTransfer ;
   qudt:symbol "Btu{IT}/(ft²·s·°F)" ;
   qudt:ucumCode "[Btu_IT].[ft_i]-2.s-1.[degF]-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[Btu_IT]/([ft_i]2.s.[degF])"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "N76" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "British Thermal Unit (international Definition) per Square Foot Second Degree Fahrenheit" ;
@@ -3134,7 +3085,6 @@ unit:BTU_IT-PER-FT3
   qudt:informativeReference "http://www.translatorscafe.com/cafe/EN/units-converter/fuel-efficiency--volume/c/"^^xsd:anyURI ;
   qudt:symbol "Btu{IT}/ft³" ;
   qudt:ucumCode "[Btu_IT].[ft_i]-3"^^qudt:UCUMcs ;
-  qudt:ucumCode "[Btu_IT]/[ft_i]3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "N58" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "British Thermal Unit (international Definition) per Cubic Foot" ;
@@ -3159,7 +3109,6 @@ unit:BTU_IT-PER-HR
   qudt:informativeReference "http://www.simetric.co.uk/sibtu.htm"^^xsd:anyURI ;
   qudt:symbol "Btu{IT}/h" ;
   qudt:ucumCode "[Btu_IT].h-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[Btu_IT]/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "2I" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "British Thermal Unit (international Definition) per Hour" ;
@@ -3180,7 +3129,6 @@ unit:BTU_IT-PER-HR-FT2
   qudt:hasQuantityKind quantitykind:PowerPerArea ;
   qudt:symbol "Btu{IT}/(h·ft²)" ;
   qudt:ucumCode "[Btu_IT].h-1.[ft_i]-2"^^qudt:UCUMcs ;
-  qudt:ucumCode "[Btu_IT]/(h.[ft_i]2)"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "British Thermal Unit (international Definition) per Hour Square Foot" ;
   rdfs:label "British Thermal Unit (international Definition) per Hour Square Foot"@en .
@@ -3215,7 +3163,6 @@ unit:BTU_IT-PER-HR-FT2-DEG_R
   qudt:plainTextDescription "unit of the heat transfer coefficient according to the Imperial system of units" ;
   qudt:symbol "Btu{IT}/(h·ft²·°R)" ;
   qudt:ucumCode "[Btu_IT].h-1.[ft_i]-2.[degR]-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[Btu_IT]/(h.[ft_i]2.[degR])"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A23" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "British Thermal Unit (international Definition) per Hour Square Foot Degree Rankine" ;
@@ -3251,7 +3198,6 @@ unit:BTU_IT-PER-LB
   qudt:informativeReference "http://www.efunda.com/glossary/units/units--energy_density--british_thermal_unit_it_per_cubic_foot.cfm"^^xsd:anyURI ;
   qudt:symbol "Btu{IT}/lbm" ;
   qudt:ucumCode "[Btu_IT].[lb_av]-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[Btu_IT]/[lb_av]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "AZ" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "British Thermal Unit (international Definition) per Pound Mass" ;
@@ -3275,7 +3221,6 @@ unit:BTU_IT-PER-LB-DEG_F
   qudt:hasQuantityKind quantitykind:SpecificHeatCapacityAtSaturation ;
   qudt:symbol "Btu{IT}/(lbm·°F)" ;
   qudt:ucumCode "[Btu_IT].[lb_av]-1.[degF]-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[Btu_IT]/([lb_av].[degF])"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "British Thermal Unit (international Definition) per Pound Mass Degree Fahrenheit" ;
   rdfs:label "British Thermal Unit (international Definition) per Pound Mass Degree Fahrenheit"@en .
@@ -3293,7 +3238,6 @@ unit:BTU_IT-PER-LB-DEG_R
   qudt:hasQuantityKind quantitykind:SpecificHeatCapacity ;
   qudt:symbol "Btu{IT}/(lbm·°R)" ;
   qudt:ucumCode "[Btu_IT].[lb_av]-1.[degR]-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[Btu_IT]/([lb_av].[degR])"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "British Thermal Unit (international Definition) per Pound Mass Degree Rankine" ;
   rdfs:label "British Thermal Unit (international Definition) per Pound Mass Degree Rankine"@en .
@@ -3311,7 +3255,6 @@ unit:BTU_IT-PER-LB_F
   qudt:plainTextDescription "Unit of heat energy according to the Imperial system of units divided by the unit avoirdupois pound of force according to the avoirdupois system of units" ;
   qudt:symbol "Btu{IT}/lbf" ;
   qudt:ucumCode "[Btu_IT].[lbf_av]-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[Btu_IT]/[lbf_av]"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "British Thermal Unit (international Definition) per Pound Force" ;
   rdfs:label "British Thermal Unit (international Definition) per Pound Force"@en .
@@ -3329,7 +3272,6 @@ unit:BTU_IT-PER-LB_F-DEG_F
   qudt:plainTextDescription "Unit of heat energy according to the Imperial system of units divided by the product of a pound of force and a degree Fahrenheit" ;
   qudt:symbol "Btu{IT}/(lbf·°F)" ;
   qudt:ucumCode "[Btu_IT].[lbf_av]-1.[degF]-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[Btu_IT]/([lbf_av].[degF])"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J43" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "British Thermal Unit (international Definition) per Pound Force Degree Fahrenheit" ;
@@ -3348,7 +3290,6 @@ unit:BTU_IT-PER-LB_F-DEG_R
   qudt:plainTextDescription "Unit of heat energy according to the Imperial system of units divided by the product of a pound of force and a degree Rankine" ;
   qudt:symbol "Btu{IT}/(lbf·°R)" ;
   qudt:ucumCode "[Btu_IT].[lbf_av]-1.[degR]-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[Btu_IT]/([lbf_av].[degR])"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A21" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "British Thermal Unit (international Definition) per Pound Force Degree Rankine" ;
@@ -3367,7 +3308,6 @@ unit:BTU_IT-PER-MIN
   qudt:plainTextDescription "unit of the heat energy according to the Imperial system of units divided by the unit minute" ;
   qudt:symbol "Btu{IT}/min" ;
   qudt:ucumCode "[Btu_IT].min-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[Btu_IT]/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J44" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "British Thermal Unit (international Definition) per Minute" ;
@@ -3385,7 +3325,6 @@ unit:BTU_IT-PER-MOL_LB
   qudt:hasQuantityKind quantitykind:EnergyPerMassAmountOfSubstance ;
   qudt:symbol "Btu{IT}/lb-mol" ;
   qudt:ucumCode "[Btu_IT].[mol_lb]-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[Btu_IT]/[mol_lb]"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "British Thermal Unit (international Definition) per Pound Mole" ;
   rdfs:label "British Thermal Unit (international Definition) per Pound Mole"@en .
@@ -3403,7 +3342,6 @@ unit:BTU_IT-PER-MOL_LB-DEG_F
   qudt:hasQuantityKind quantitykind:MolarHeatCapacity ;
   qudt:symbol "Btu{IT}/(lb-mol·°F)" ;
   qudt:ucumCode "[Btu_IT].[mol_lb]-1.[degF]-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[Btu_IT]/([mol_lb].[degF])"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "British Thermal Unit (international Definition) per Pound Mole Degree Fahrenheit" ;
   rdfs:label "British Thermal Unit (international Definition) per Pound Mole Degree Fahrenheit"@en .
@@ -3425,7 +3363,6 @@ unit:BTU_IT-PER-SEC
   qudt:informativeReference "http://www.simetric.co.uk/sibtu.htm"^^xsd:anyURI ;
   qudt:symbol "Btu{IT}/s" ;
   qudt:ucumCode "[Btu_IT].s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[Btu_IT]/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J45" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "British Thermal Unit (international Definition) per Second" ;
@@ -3444,7 +3381,6 @@ unit:BTU_IT-PER-SEC-FT-DEG_R
   qudt:plainTextDescription "unit of the thermal conductivity according to the Imperial system of units" ;
   qudt:symbol "Btu{IT}/(s·ft·°R)" ;
   qudt:ucumCode "[Btu_IT].s-1.[ft_i]-1.[degR]-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[Btu_IT]/(s.[ft_i].[degR])"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A22" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "British Thermal Unit (international Definition) per Second Foot Degree Rankine" ;
@@ -3465,7 +3401,6 @@ unit:BTU_IT-PER-SEC-FT2
   qudt:hasQuantityKind quantitykind:PowerPerArea ;
   qudt:symbol "Btu{IT}/(s·ft²)" ;
   qudt:ucumCode "[Btu_IT].s-1.[ft_i]-2"^^qudt:UCUMcs ;
-  qudt:ucumCode "[Btu_IT]/(s.[ft_i]2)"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "N53" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "British Thermal Unit (international Definition) per Second Square Foot" ;
@@ -3499,7 +3434,6 @@ unit:BTU_IT-PER-SEC-FT2-DEG_R
   qudt:plainTextDescription "unit of the heat transfer coefficient according to the Imperial system of units" ;
   qudt:symbol "Btu{IT}/(s·ft²·°R)" ;
   qudt:ucumCode "[Btu_IT].s-1.[ft_i]-2.[degR]-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[Btu_IT]/(s.[ft_i]2.[degR])"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A20" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "British Thermal Unit (international Definition) per Second Square Foot Degree Rankine" ;
@@ -3571,8 +3505,7 @@ unit:BTU_TH-FT-PER-FT2-HR-DEG_F
   qudt:informativeReference "http://en.wikipedia.org/wiki/Thermal_conductivity"^^xsd:anyURI ;
   qudt:informativeReference "http://www.translatorscafe.com/cafe/EN/units-converter/thermal-conductivity/c/"^^xsd:anyURI ;
   qudt:symbol "Btu{th}·ft/(ft²·h·°F)" ;
-  qudt:ucumCode "[Btu_th].[ft_i]-2.h-1.[degF]-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[Btu_th]/([ft_i]2.h.[degF])"^^qudt:UCUMcs ;
+  qudt:ucumCode "[Btu_th].[ft_i].[ft_i]-2.h-1.[degF]-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "British Thermal Unit (thermochemical Definition) Foot per Square Foot Hour Degree Fahrenheit" ;
   rdfs:label "British Thermal Unit (thermochemical Definition) Foot per Square Foot Hour Degree Fahrenheit"@en .
@@ -3592,7 +3525,6 @@ unit:BTU_TH-FT-PER-HR-FT2-DEG_F
   qudt:plainTextDescription "unit of the thermal conductivity according to the Imperial system of units" ;
   qudt:symbol "Btu{th}·ft/(h·ft²·°F)" ;
   qudt:ucumCode "[Btu_th].[ft_i].h-1.[ft_i]-2.[degF]-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[Btu_th].[ft_i]/(h.[ft_i]2.[degF])"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J46" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "British Thermal Unit (thermochemical Definition) Foot per Hour Square Foot Degree Fahrenheit" ;
@@ -3617,7 +3549,6 @@ unit:BTU_TH-IN-PER-FT2-HR-DEG_F
   qudt:plainTextDescription "Unit of thermal conductivity according to the Imperial system of units" ;
   qudt:symbol "Btu{th}·in/(ft²·h·°F)" ;
   qudt:ucumCode "[Btu_th].[in_i].[ft_i]-2.h-1.[degF]-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[Btu_th].[in_i]/([ft_i]2.h.[degF])"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J48" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "British Thermal Unit (thermochemical Definition) Inch per Square Foot Hour Degree Fahrenheit" ;
@@ -3643,7 +3574,6 @@ unit:BTU_TH-IN-PER-FT2-SEC-DEG_F
   qudt:plainTextDescription "Unit of thermal conductivity according to the Imperial system of units" ;
   qudt:symbol "Btu{th}·in/(ft²·s·°F)" ;
   qudt:ucumCode "[Btu_th].[in_i].[ft_i]-2.s-1.[degF]-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[Btu_th].[in_i]/([ft_i]2.s.[degF])"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "British Thermal Unit (thermochemical Definition) Inch per Square Foot Second Degree Fahrenheit" ;
   rdfs:label "British Thermal Unit (thermochemical Definition) Inch per Square Foot Second Degree Fahrenheit"@en .
@@ -3753,7 +3683,6 @@ unit:BTU_TH-PER-FT3
   qudt:informativeReference "http://www.translatorscafe.com/cafe/EN/units-converter/fuel-efficiency--volume/c/"^^xsd:anyURI ;
   qudt:symbol "Btu{th}/ft³" ;
   qudt:ucumCode "[Btu_th].[ft_i]-3"^^qudt:UCUMcs ;
-  qudt:ucumCode "[Btu_th]/[ft_i]3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "N59" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "British Thermal Unit (thermochemical Definition) per Cubic Foot" ;
@@ -3772,7 +3701,6 @@ unit:BTU_TH-PER-HR
   qudt:plainTextDescription "unit of the heat energy according to the Imperial system of units divided by the unit hour" ;
   qudt:symbol "Btu{th}/h" ;
   qudt:ucumCode "[Btu_th].h-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[Btu_th]/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J47" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "British Thermal Unit (thermochemical Definition) per Hour" ;
@@ -3808,7 +3736,6 @@ unit:BTU_TH-PER-LB
   qudt:informativeReference "http://www.efunda.com/glossary/units/units--thermal_heat_capacity--british_thermal_unit_therm_per_pound_mass.cfm"^^xsd:anyURI ;
   qudt:symbol "Btu{th}/lbm" ;
   qudt:ucumCode "[Btu_th].[lb_av]-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[Btu_th]/[lb_av]"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "British Thermal Unit (thermochemical Definition) per Pound Mass" ;
   rdfs:label "British Thermal Unit (thermochemical Definition) per Pound Mass"@en .
@@ -3830,7 +3757,6 @@ unit:BTU_TH-PER-LB-DEG_F
   qudt:plainTextDescription "unit of the thermal conductivity according to the Imperial system of units divided by the units pound and degree Fahrenheit" ;
   qudt:symbol "Btu{th}/(lbm·°F)" ;
   qudt:ucumCode "[Btu_th].[lb_av]-1.[degF]-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[Btu_th]/([lb_av].[degF])"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J50" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "British Thermal Unit (thermochemical Definition) per Pound Mass Degree Fahrenheit" ;
@@ -3863,7 +3789,6 @@ unit:BTU_TH-PER-MIN
   qudt:plainTextDescription "unit of the heat energy according to the Imperial system of units divided by the unit minute" ;
   qudt:symbol "Btu{th}/min" ;
   qudt:ucumCode "[Btu_th].min-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[Btu_th]/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J51" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "British Thermal Unit (thermochemical Definition) per Minute" ;
@@ -3882,7 +3807,6 @@ unit:BTU_TH-PER-SEC
   qudt:plainTextDescription "unit of the heat energy according to the Imperial system of units divided by the SI base unit second" ;
   qudt:symbol "Btu{th}/s" ;
   qudt:ucumCode "[Btu_th].s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[Btu_th]/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J52" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "British Thermal Unit (thermochemical Definition) per Second" ;
@@ -3937,7 +3861,6 @@ unit:BU_UK-PER-DAY
   qudt:plainTextDescription "unit of the volume bushel (UK) (for fluids and for dry measures) according to the Imperial system of units divided by the unit for time day" ;
   qudt:symbol "bsh{UK}/d" ;
   qudt:ucumCode "[bu_br].d-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[bu_br]/d"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J64" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Bushel (UK) per Day" ;
@@ -3976,7 +3899,6 @@ unit:BU_UK-PER-MIN
   qudt:plainTextDescription "unit of the volume bushel (UK) (for fluids and for dry measures) according to the Imperial system of units divided by the unit for time minute" ;
   qudt:symbol "bsh{UK}/min" ;
   qudt:ucumCode "[bu_br].min-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[bu_br]/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J66" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Bushel (UK) per Minute" ;
@@ -3996,7 +3918,6 @@ unit:BU_UK-PER-SEC
   qudt:plainTextDescription "unit of the volume bushel (UK) (for fluids and for dry measures) according to the Imperial system of units divided by the SI base unit second" ;
   qudt:symbol "bsh{UK}/s" ;
   qudt:ucumCode "[bu_br].s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[bu_br]/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J67" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Bushel (UK) per Second" ;
@@ -4059,7 +3980,6 @@ unit:BU_US_DRY-PER-DAY
   qudt:plainTextDescription "unit of the volume bushel (US dry) for dry measure according to the Anglo-American system of units divided by the unit for time day" ;
   qudt:symbol "bsh{US}/d" ;
   qudt:ucumCode "[bu_us].d-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[bu_us]/d"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J68" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Bushel (US Dry) per Day" ;
@@ -4078,7 +3998,6 @@ unit:BU_US_DRY-PER-HR
   qudt:plainTextDescription "unit of the volume bushel (US dry) for dry measure according to the Anglo-American system of units divided by the unit for time hour" ;
   qudt:symbol "bsh{US}/h" ;
   qudt:ucumCode "[bu_us].h-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[bu_us]/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J69" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Bushel (US Dry) per Hour" ;
@@ -4097,7 +4016,6 @@ unit:BU_US_DRY-PER-MIN
   qudt:plainTextDescription "unit of the volume bushel (US dry) for dry measure according to the Anglo-American system of units divided by the unit for time minute" ;
   qudt:symbol "bsh{US}/min" ;
   qudt:ucumCode "[bu_us].min-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[bu_us]/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J70" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Bushel (US Dry) per Minute" ;
@@ -4116,7 +4034,6 @@ unit:BU_US_DRY-PER-SEC
   qudt:plainTextDescription "unit of the volume bushel (US dry) for dry measure according to the Anglo-American system of units divided by the SI base unit second" ;
   qudt:symbol "bsh{US}/s" ;
   qudt:ucumCode "[bu_us].s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[bu_us]/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J71" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Bushel (US Dry) per Second" ;
@@ -4165,7 +4082,6 @@ unit:BYTE-PER-SEC
   qudt:iec61360Code "0112/2///62720#UAB305" ;
   qudt:symbol "B/s" ;
   qudt:ucumCode "By.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "By/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P93" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Byte per Second" ;
@@ -4209,11 +4125,11 @@ unit:C
   qudt:hasDimensionVector qkdv:A0E1L0I0M0H0T1D0 ;
   qudt:hasFactorUnit [
     qudt:exponent 1 ;
-    qudt:hasUnit unit:SEC ;
+    qudt:hasUnit unit:A ;
   ] ;
   qudt:hasFactorUnit [
     qudt:exponent 1 ;
-    qudt:hasUnit unit:A ;
+    qudt:hasUnit unit:SEC ;
   ] ;
   qudt:hasQuantityKind quantitykind:ElectricCharge ;
   qudt:iec61360Code "0112/2///62720#UAA130" ;
@@ -4347,7 +4263,6 @@ unit:C-M2-PER-KiloGM
   qudt:iec61360Code "0112/2///62720#UAD912" ;
   qudt:symbol "C·m²/kg" ;
   qudt:ucumCode "C.m2.kg-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "C.m2/kg"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J53" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Coulomb Kvadratni Meter na Kilogram"@sl ;
@@ -4383,7 +4298,6 @@ unit:C-M2-PER-V
   qudt:iec61360Code "0112/2///62720#UAB486" ;
   qudt:symbol "C·m²/V" ;
   qudt:ucumCode "C.m2.V-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "C.m2/V"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A27" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Coulomb Kvadratni Meter na Volt"@sl ;
@@ -4422,7 +4336,6 @@ unit:C-PER-CentiM2
   qudt:plainTextDescription "derived SI unit coulomb divided by the 0.0001-fold of the power of the SI base unit metre by exponent 2" ;
   qudt:symbol "C/cm²" ;
   qudt:ucumCode "C.cm-2"^^qudt:UCUMcs ;
-  qudt:ucumCode "C/cm2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A33" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q106808180> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -4455,7 +4368,6 @@ unit:C-PER-CentiM3
   qudt:plainTextDescription "derived SI unit coulomb divided by the 0.000 001-fold of the power of the SI base unit metre by exponent 3" ;
   qudt:symbol "C/cm³" ;
   qudt:ucumCode "C.cm-3"^^qudt:UCUMcs ;
-  qudt:ucumCode "C/cm3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A28" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q106808138> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -4490,7 +4402,6 @@ unit:C-PER-KiloGM
   qudt:iec61360Code "0112/2///62720#UAA131" ;
   qudt:symbol "C/kg" ;
   qudt:ucumCode "C.kg-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "C/kg"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "CKG" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q28683485> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -4529,7 +4440,6 @@ unit:C-PER-KiloGM-SEC
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
   qudt:symbol "C/(kg·s)" ;
   qudt:ucumCode "C.kg-1.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "C/(kg.s)"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A31" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q99721917> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -4569,7 +4479,6 @@ unit:C-PER-M
   qudt:iec61360Code "0112/2///62720#UAB337" ;
   qudt:symbol "C/m" ;
   qudt:ucumCode "C.m-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "C/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P10" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q80117150> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -4610,7 +4519,6 @@ unit:C-PER-M2
   qudt:iec61360Code "0112/2///62720#UAA134" ;
   qudt:symbol "C/m²" ;
   qudt:ucumCode "C.m-2"^^qudt:UCUMcs ;
-  qudt:ucumCode "C/m2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A34" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q68343206> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -4657,7 +4565,6 @@ unit:C-PER-M3
   qudt:iec61360Code "0112/2///62720#UAA135" ;
   qudt:symbol "C/m³" ;
   qudt:ucumCode "C.m-3"^^qudt:UCUMcs ;
-  qudt:ucumCode "C/m3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A29" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q69425409> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -4694,7 +4601,6 @@ unit:C-PER-MOL
   qudt:iec61360Code "0112/2///62720#UAB142" ;
   qudt:symbol "C/mol" ;
   qudt:ucumCode "C.mol-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "C/mol"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A32" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q21396202> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -4731,7 +4637,6 @@ unit:C-PER-MilliM2
   qudt:plainTextDescription "derived SI unit coulomb divided by the 0.000 001-fold of the power of the SI base unit metre by exponent 2" ;
   qudt:symbol "C/mm²" ;
   qudt:ucumCode "C.mm-2"^^qudt:UCUMcs ;
-  qudt:ucumCode "C/mm2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A35" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q106808174> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -4764,7 +4669,6 @@ unit:C-PER-MilliM3
   qudt:plainTextDescription "derived SI unit coulomb divided by the 0.000 000 001-fold of the power of the SI base unit metre by exponent 3" ;
   qudt:symbol "C/mm³" ;
   qudt:ucumCode "C.mm-3"^^qudt:UCUMcs ;
-  qudt:ucumCode "C/mm3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A30" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q106808120> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -4797,7 +4701,6 @@ unit:C2-M2-PER-J
   qudt:hasQuantityKind quantitykind:Polarizability ;
   qudt:symbol "C²·m²/J" ;
   qudt:ucumCode "C2.m2.J-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "C2.m2/J"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Coulomb Carré Mètre Carré par Joule"@fr ;
   rdfs:label "Coulomb Persegi Meter Persegi per Joule"@ms ;
@@ -4833,7 +4736,6 @@ unit:C3-M-PER-J2
   qudt:hasQuantityKind quantitykind:CubicElectricDipoleMomentPerSquareEnergy ;
   qudt:symbol "C³·m/J²" ;
   qudt:ucumCode "C3.m.J-2"^^qudt:UCUMcs ;
-  qudt:ucumCode "C3.m/J2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Coulomb Cub Metru pe Joule Pătrat"@ro ;
   rdfs:label "Coulomb Cube Mètre par Joule Carré"@fr ;
@@ -4869,7 +4771,6 @@ unit:C4-M4-PER-J3
   qudt:hasQuantityKind quantitykind:QuarticElectricDipoleMomentPerCubicEnergy ;
   qudt:symbol "C⁴·m⁴/J³" ;
   qudt:ucumCode "C4.m4.J-3"^^qudt:UCUMcs ;
-  qudt:ucumCode "C4.m4/J3"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Coulomb hoch vier Meter hoch vier pro Kubikjoule"@de ;
   rdfs:label "Quartic Coulomb Quartic Meter per Cubic Joule"@en-US ;
@@ -4977,7 +4878,6 @@ unit:CAL_IT-PER-GM
   qudt:plainTextDescription "unit calorie according to the international steam table divided by the 0.001-fold of the SI base unit kilogram" ;
   qudt:symbol "cal{IT}/g" ;
   qudt:ucumCode "cal_IT.g-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "cal_IT/g"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D75" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "International Table Calorie per Gram" ;
@@ -5001,7 +4901,6 @@ unit:CAL_IT-PER-GM-DEG_C
   qudt:plainTextDescription "unit calorieIT divided by the products of the units gram and degree Celsius" ;
   qudt:symbol "cal{IT}/(g·°C)" ;
   qudt:ucumCode "cal_IT.g-1.Cel-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "cal_IT/(g.Cel)"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J76" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "International Table Calorie per Gram Degree Celsius" ;
@@ -5025,7 +4924,6 @@ unit:CAL_IT-PER-GM-K
   qudt:plainTextDescription "unit calorieIT divided by the product of the SI base unit gram and Kelvin" ;
   qudt:symbol "cal{IT}/(g·K)" ;
   qudt:ucumCode "cal_IT.g-1.K-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "cal_IT/(g.K)"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D76" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "International Table Calorie per Gram Kelvin" ;
@@ -5045,7 +4943,6 @@ unit:CAL_IT-PER-SEC-CentiM-K
   qudt:plainTextDescription "unit of the thermal conductivity according to the Imperial system of units" ;
   qudt:symbol "cal{IT}/(s·cm·K)" ;
   qudt:ucumCode "cal_IT.s-1.cm-1.K-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "cal_IT/(s.cm.K)"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D71" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "International Table Calorie per Second Centimeter Kelvin"@en-US ;
@@ -5066,7 +4963,6 @@ unit:CAL_IT-PER-SEC-CentiM2-K
   qudt:plainTextDescription "unit of the heat transfer coefficient according to the Imperial system of units" ;
   qudt:symbol "cal{IT}/(s·cm²·K)" ;
   qudt:ucumCode "cal_IT.s-1.cm-2.K-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "cal_IT/(s.cm2.K)"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D72" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "International Table Calorie per Second Square Centimeter Kelvin"@en-US ;
@@ -5137,7 +5033,6 @@ unit:CAL_TH-PER-CentiM-SEC-DEG_C
   qudt:plainTextDescription "unit of the thermal conductivity according to the Imperial system of units" ;
   qudt:symbol "cal/(cm·s·°C)" ;
   qudt:ucumCode "cal_th.cm-1.s-1.Cel-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "cal_th/(cm.s.Cel)"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J78" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Thermochemical Calorie per Centimeter Second Degree Celsius"@en-US ;
@@ -5205,7 +5100,6 @@ unit:CAL_TH-PER-CentiM3-K
   qudt:plainTextDescription "Thermochemical Calorie per Cubic Centimeter Kelvin is a unit for Volumetric Heat Capacity expressed as cal{th}/(cm³·K)." ;
   qudt:symbol "cal/(cm³·K)" ;
   qudt:ucumCode "cal_th.cm-3.K-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "cal_th/(cm3.K)"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Thermochemical Calorie per Cubic Centimeter Kelvin"@en-US ;
   rdfs:label "Thermochemical Calorie per Cubic Centimetre Kelvin" ;
@@ -5228,7 +5122,6 @@ unit:CAL_TH-PER-GM
   qudt:plainTextDescription "unit thermochemical calorie divided by the 0.001-fold of the SI base unit kilogram" ;
   qudt:symbol "cal/g" ;
   qudt:ucumCode "cal_th.g-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "cal_th/g"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B36" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Thermochemical Calorie per Gram" ;
@@ -5252,7 +5145,6 @@ unit:CAL_TH-PER-GM-DEG_C
   qudt:plainTextDescription "unit calorie (thermochemical) divided by the product of the unit gram and degree Celsius" ;
   qudt:symbol "cal/(g·°C)" ;
   qudt:ucumCode "cal_th.g-1.Cel-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "cal_th/(g.Cel)"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J79" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Thermochemical Calorie per Gram Degree Celsius" ;
@@ -5276,7 +5168,6 @@ unit:CAL_TH-PER-GM-K
   qudt:plainTextDescription "unit calorie (thermochemical) divided by the product of the SI derived unit gram and the SI base unit Kelvin" ;
   qudt:symbol "cal/(g·K)" ;
   qudt:ucumCode "cal_th.g-1.K-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "cal_th/(g.K)"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D37" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Thermochemical Calorie per Gram Kelvin" ;
@@ -5296,7 +5187,6 @@ unit:CAL_TH-PER-MIN
   qudt:plainTextDescription "unit calorie divided by the unit minute" ;
   qudt:symbol "cal/min" ;
   qudt:ucumCode "cal_th.min-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "cal_th/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J81" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Thermochemical Calorie per Minute" ;
@@ -5316,7 +5206,6 @@ unit:CAL_TH-PER-SEC
   qudt:plainTextDescription "unit calorie divided by the SI base unit second" ;
   qudt:symbol "cal/s" ;
   qudt:ucumCode "cal_th.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "cal_th/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J82" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Thermochemical Calorie per Second" ;
@@ -5336,7 +5225,6 @@ unit:CAL_TH-PER-SEC-CentiM-K
   qudt:plainTextDescription "unit of the thermal conductivity according to the Imperial system of units" ;
   qudt:symbol "cal/(s·cm·K)" ;
   qudt:ucumCode "cal_th.s-1.cm-1.K-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "cal_th/(s.cm.K)"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D38" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Thermochemical Calorie per Second Centimeter Kelvin"@en-US ;
@@ -5357,7 +5245,6 @@ unit:CAL_TH-PER-SEC-CentiM2-K
   qudt:plainTextDescription "unit of the heat transfer coefficient according to the Imperial system of units" ;
   qudt:symbol "cal/(s·cm²·K)" ;
   qudt:ucumCode "cal_th.s-1.cm-2.K-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "cal_th/(s.cm2.K)"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D39" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Thermochemical Calorie per Second Square Centimeter Kelvin"@en-US ;
@@ -8697,7 +8584,6 @@ unit:CD-PER-IN2
   qudt:iec61360Code "0112/2///62720#UAB257" ;
   qudt:symbol "cd/in²" ;
   qudt:ucumCode "cd.[in_i]-2"^^qudt:UCUMcs ;
-  qudt:ucumCode "cd/[in_i]2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P28" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q30066654> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -8713,7 +8599,6 @@ unit:CD-PER-KiloLM
   qudt:hasQuantityKind quantitykind:LuminousIntensityDistribution ;
   qudt:symbol "cd/klm" ;
   qudt:ucumCode "cd.klm-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "cd/klm"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Candela par Kilolumen"@fr ;
   rdfs:label "Candela per Chilolumen"@it ;
@@ -8737,7 +8622,6 @@ unit:CD-PER-LM
   qudt:hasQuantityKind quantitykind:LuminousIntensityDistribution ;
   qudt:symbol "cd/lm" ;
   qudt:ucumCode "cd.lm-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "cd/lm"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Candela par Lumen"@fr ;
   rdfs:label "Candela per Lumen" ;
@@ -8771,7 +8655,6 @@ unit:CD-PER-M2
   qudt:iec61360Code "0112/2///62720#UAA371" ;
   qudt:symbol "cd/m²" ;
   qudt:ucumCode "cd.m-2"^^qudt:UCUMcs ;
-  qudt:ucumCode "cd/m2"^^qudt:UCUMcs ;
   qudt:udunitsCode "nt" ;
   qudt:uneceCommonCode "A24" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q281096> ;
@@ -8897,6 +8780,7 @@ unit:CI-PER-KiloGM
   qudt:hasQuantityKind quantitykind:SpecificActivity ;
   qudt:iec61360Code "0112/2///62720#UAB091" ;
   qudt:symbol "Ci/kg" ;
+  qudt:ucumCode "Ci.kg-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A42" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Curie per Kilogram" ;
@@ -9271,6 +9155,7 @@ unit:CentiGRAY
   qudt:hasQuantityKind quantitykind:Kerma ;
   qudt:iec61360Code "0112/2///62720#UAB503" ;
   qudt:symbol "cGy" ;
+  qudt:ucumCode "cGy"^^qudt:UCUMcs ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q94733760> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Centigray" ;
@@ -9353,7 +9238,6 @@ unit:CentiM-PER-BAR
   qudt:iec61360Code "0112/2///62720#UAA377" ;
   qudt:symbol "cm/bar" ;
   qudt:ucumCode "cm.bar-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "cm/bar"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G04" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Centimeter per Bar"@en-US ;
@@ -9376,7 +9260,6 @@ unit:CentiM-PER-HR
   qudt:plainTextDescription "0.01-fold of the SI base unit metre divided by the unit hour" ;
   qudt:symbol "cm/h" ;
   qudt:ucumCode "cm.h-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "cm/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H49" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q106611483> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -9396,7 +9279,6 @@ unit:CentiM-PER-K
   qudt:plainTextDescription "0.01-fold of the SI base unit metre divided by the SI base unit kelvin" ;
   qudt:symbol "cm/K" ;
   qudt:ucumCode "cm.K-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "cm/K"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F51" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Centimeter na Kelvin"@sl ;
@@ -9426,7 +9308,6 @@ unit:CentiM-PER-KiloYR
   qudt:hasQuantityKind quantitykind:Velocity ;
   qudt:symbol "cm/ka" ;
   qudt:ucumCode "cm.ka-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "cm/ka"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Centimeter per Kiloyear"@en-US ;
   rdfs:label "Centimetre per Kiloyear" ;
@@ -9451,7 +9332,6 @@ unit:CentiM-PER-SEC
   qudt:latexDefinition "$cm/s$"^^qudt:LatexString ;
   qudt:symbol "cm/s" ;
   qudt:ucumCode "cm.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "cm/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "2M" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q18413919> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -9529,7 +9409,6 @@ unit:CentiM-PER-SEC2
   qudt:iec61360Code "0112/2///62720#UAB398" ;
   qudt:symbol "cm/s²" ;
   qudt:ucumCode "cm.s-2"^^qudt:UCUMcs ;
-  qudt:ucumCode "cm/s2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M39" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q39699418> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -9560,7 +9439,6 @@ unit:CentiM-PER-YR
   qudt:hasQuantityKind quantitykind:Velocity ;
   qudt:symbol "cm/a" ;
   qudt:ucumCode "cm.a-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "cm/a"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Centimeter per Year"@en-US ;
   rdfs:label "Centimetre per Year" ;
@@ -9578,8 +9456,7 @@ unit:CentiM-SEC-DEG_C
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H1T1D0 ;
   qudt:hasQuantityKind quantitykind:LengthTemperatureTime ;
   qudt:symbol "cm·s·°C" ;
-  qudt:ucumCode "cm.s.Cel-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "cm.s/Cel"^^qudt:UCUMcs ;
+  qudt:ucumCode "cm.s.Cel"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Centimeter Saat Darjah Celsius"@ms ;
   rdfs:label "Centimeter Second Degree Celsius"@en-US ;
@@ -9687,7 +9564,6 @@ unit:CentiM2-PER-ERG
   qudt:iec61360Code "0112/2///62720#UAB168" ;
   qudt:symbol "cm²/erg" ;
   qudt:ucumCode "cm2.erg-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "cm2/erg"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D16" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Square Centimeter per Erg"@en-US ;
@@ -9706,7 +9582,6 @@ unit:CentiM2-PER-GM
   qudt:iec61360Code "0112/2///62720#UAB193" ;
   qudt:symbol "cm²/g" ;
   qudt:ucumCode "cm2.g-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "cm2/g"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H15" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Centimeter Persegi per Gram"@ms ;
@@ -9737,7 +9612,6 @@ unit:CentiM2-PER-SEC
   qudt:iec61360Code "0112/2///62720#UAB408" ;
   qudt:symbol "cm²/s" ;
   qudt:ucumCode "cm2.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "cm2/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M81" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q26162545> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -9783,7 +9657,6 @@ unit:CentiM2-PER-V-SEC
   qudt:hasQuantityKind quantitykind:Mobility ;
   qudt:symbol "cm²/(V·s)" ;
   qudt:ucumCode "cm2.V-1.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "cm2/(V.s)"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Centimeter Persegi per Volt Saat"@ms ;
   rdfs:label "Centimetr Kwadratowy na Wolt Sekunda"@pl ;
@@ -9874,7 +9747,6 @@ unit:CentiM3-PER-BAR
   qudt:iec61360Code "0112/2///62720#UAA387" ;
   qudt:symbol "cm³/bar" ;
   qudt:ucumCode "cm3.bar-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "cm3/bar"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G94" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Cubic Centimeter per Bar"@en-US ;
@@ -9895,7 +9767,6 @@ unit:CentiM3-PER-CentiM3
   qudt:plainTextDescription "volume ratio consisting of the 0.000 001-fold of the power of the SI base unit metre with the exponent 3 divided by the power of the SI base unit metre with the exponent 3" ;
   qudt:symbol "cm³/cm³" ;
   qudt:ucumCode "cm3.cm-3"^^qudt:UCUMcs ;
-  qudt:ucumCode "cm3/cm3"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Centimeter Kubik per Centimeter Kubik"@ms ;
   rdfs:label "Centimetr Krychlový na Centimetr Krychlový"@cs ;
@@ -9927,7 +9798,6 @@ unit:CentiM3-PER-DAY
   qudt:plainTextDescription "0.000001-fold of the power of the SI base unit metre with the exponent 3 divided by the unit day" ;
   qudt:symbol "cm³/d" ;
   qudt:ucumCode "cm3.d-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "cm3/d"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G47" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q107313819> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -9985,7 +9855,6 @@ unit:CentiM3-PER-GM
   qudt:iec61360Code "0112/2///62720#UAD918" ;
   qudt:symbol "cm³/g" ;
   qudt:ucumCode "cm3.g-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "cm3/g"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Centimeter Kubik per Gram"@ms ;
   rdfs:label "Centimetr Krychlový na Gram"@cs ;
@@ -10017,7 +9886,6 @@ unit:CentiM3-PER-HR
   qudt:plainTextDescription "0.000001-fold of the power of the SI base unit metre with the exponent 3 divided by the unit hour" ;
   qudt:symbol "cm³/h" ;
   qudt:ucumCode "cm3.h-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "cm3/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G48" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q107028457> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -10069,7 +9937,6 @@ unit:CentiM3-PER-K
   qudt:plainTextDescription "0.000001-fold of the power of the SI base unit metre with the exponent 3 divided by the SI base unit kelvin" ;
   qudt:symbol "cm³/K" ;
   qudt:ucumCode "cm3.K-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "cm3/K"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G27" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Centimeter Kubik per Kelvin"@ms ;
@@ -10101,7 +9968,6 @@ unit:CentiM3-PER-M3
   qudt:plainTextDescription "volume ratio consisting of the 0.000001-fold of the power of the SI base unit metre with the exponent 3 divided by the power of the SI base unit metre with the exponent 3" ;
   qudt:symbol "cm³/m³" ;
   qudt:ucumCode "cm3.m-3"^^qudt:UCUMcs ;
-  qudt:ucumCode "cm3/m3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J87" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q106998070> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -10135,7 +10001,6 @@ unit:CentiM3-PER-MIN
   qudt:plainTextDescription "0,000 001-fold of the power of the SI base unit metre with the exponent 3 divided by the unit minute" ;
   qudt:symbol "cm³/min" ;
   qudt:ucumCode "cm3.min-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "cm3/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G49" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q107028485> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -10188,7 +10053,6 @@ unit:CentiM3-PER-MOL
   qudt:plainTextDescription "0.000 001-fold of the power of the SI base unit metre with the exponent 3 divided by the SI base unit mol" ;
   qudt:symbol "cm³/mol" ;
   qudt:ucumCode "cm3.mol-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "cm3/mol"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A36" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q24008537> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -10248,7 +10112,6 @@ unit:CentiM3-PER-SEC
   qudt:plainTextDescription "0,000 001-fold of the power of the SI base unit metre with the exponent 3 divided by the SI base unit second" ;
   qudt:symbol "cm³/s" ;
   qudt:ucumCode "cm3.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "cm3/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "2J" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q107313800> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -10353,6 +10216,7 @@ unit:CentiMOL
   qudt:hasQuantityKind quantitykind:AmountOfSubstance ;
   qudt:hasQuantityKind quantitykind:ExtentOfReaction ;
   qudt:symbol "cmol" ;
+  qudt:ucumCode "cmol"^^qudt:UCUMcs ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q70397725> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Centimol"@cs ;
@@ -10382,7 +10246,6 @@ unit:CentiMOL-PER-KiloGM
   qudt:plainTextDescription "1/100 of SI unit of amount of substance per kilogram" ;
   qudt:symbol "cmol/kg" ;
   qudt:ucumCode "cmol.kg-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "cmol/kg"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Centimol na Kilogram"@cs ;
   rdfs:label "Centimol na Kilogram"@pl ;
@@ -10407,7 +10270,6 @@ unit:CentiMOL-PER-L
   qudt:hasQuantityKind quantitykind:Concentration ;
   qudt:symbol "cmol/L" ;
   qudt:ucumCode "cmol.L-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "cmol/L"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Centimole per Liter"@en-US ;
   rdfs:label "Centimole per Litre" ;
@@ -10508,6 +10370,7 @@ unit:CentiN
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Force ;
   qudt:symbol "cN" ;
+  qudt:ucumCode "cN"^^qudt:UCUMcs ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q94416535> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Centinewton" ;
@@ -10616,7 +10479,6 @@ unit:CentiPOISE-PER-BAR
   qudt:plainTextDescription "0.01-fold of the CGS unit of the dynamic viscosity poise divided by the unit of the pressure bar" ;
   qudt:symbol "cP/bar" ;
   qudt:ucumCode "cP.bar-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "cP/bar"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J74" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Centipoise per Bar" ;
@@ -10632,7 +10494,6 @@ unit:CentiPOISE-PER-K
   qudt:iec61360Code "0112/2///62720#UAA357" ;
   qudt:symbol "cP/K" ;
   qudt:ucumCode "cP.K-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "cP/K"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J73" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Centipoise per Kelvin" ;
@@ -10900,7 +10761,6 @@ unit:DEG-PER-HR
   qudt:hasQuantityKind quantitykind:AngularVelocity ;
   qudt:symbol "°/h" ;
   qudt:ucumCode "deg.h-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "deg/h"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Degree per Hour" ;
   rdfs:label "Degree per Hour"@en .
@@ -10917,7 +10777,6 @@ unit:DEG-PER-M
   qudt:iec61360Code "0112/2///62720#UAA025" ;
   qudt:symbol "°/m" ;
   qudt:ucumCode "deg.m-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "deg/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H27" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q106610962> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -10936,7 +10795,6 @@ unit:DEG-PER-MIN
   qudt:hasQuantityKind quantitykind:AngularVelocity ;
   qudt:symbol "°/min" ;
   qudt:ucumCode "deg.min-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "deg/min"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Degree per Minute" ;
   rdfs:label "Degree per Minute"@en .
@@ -10954,7 +10812,6 @@ unit:DEG-PER-SEC
   qudt:iec61360Code "0112/2///62720#UAA026" ;
   qudt:symbol "°/s" ;
   qudt:ucumCode "deg.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "deg/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E96" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q39998555> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -10973,7 +10830,6 @@ unit:DEG-PER-SEC2
   qudt:iec61360Code "0112/2///62720#UAB407" ;
   qudt:symbol "°/s²" ;
   qudt:ucumCode "deg.s-2"^^qudt:UCUMcs ;
-  qudt:ucumCode "deg/s2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M45" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q106611437> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -11329,7 +11185,6 @@ unit:DEG_C-PER-BAR
   qudt:iec61360Code "0112/2///62720#UAA035" ;
   qudt:symbol "°C/bar" ;
   qudt:ucumCode "Cel.bar-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "Cel/bar"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F60" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Degree Celsius per Bar" ;
@@ -11348,7 +11203,6 @@ unit:DEG_C-PER-HR
   qudt:iec61360Code "0112/2///62720#UAA036" ;
   qudt:symbol "°C/h" ;
   qudt:ucumCode "Cel.h-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "Cel/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H12" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Degree Celsius per Hour" ;
@@ -11368,7 +11222,6 @@ unit:DEG_C-PER-K
   qudt:plainTextDescription "unit with the name Degree Celsius divided by the SI base unit kelvin" ;
   qudt:symbol "°C/K" ;
   qudt:ucumCode "Cel.K-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "Cel/K"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E98" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Celsius per Kelvin"@tr ;
@@ -11399,7 +11252,6 @@ unit:DEG_C-PER-M
   qudt:hasQuantityKind quantitykind:TemperatureGradient ;
   qudt:symbol "°C/m" ;
   qudt:ucumCode "Cel.m-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "Cel/m"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Celsius per Metre"@tr ;
   rdfs:label "Darjah Celsius per Meter"@ms ;
@@ -11433,7 +11285,6 @@ unit:DEG_C-PER-MIN
   qudt:iec61360Code "0112/2///62720#UAA037" ;
   qudt:symbol "°C/min" ;
   qudt:ucumCode "Cel.min-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "Cel/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H13" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Degree Celsius per Minute" ;
@@ -11452,7 +11303,6 @@ unit:DEG_C-PER-SEC
   qudt:iec61360Code "0112/2///62720#UAA038" ;
   qudt:symbol "°C/s" ;
   qudt:ucumCode "Cel.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "Cel/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H14" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Celsius per Saniye"@tr ;
@@ -11484,7 +11334,6 @@ unit:DEG_C-PER-YR
   qudt:hasQuantityKind quantitykind:TemperaturePerTime ;
   qudt:symbol "°C/a" ;
   qudt:ucumCode "Cel.a-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "Cel/a"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Degree Celsius per Year" ;
   rdfs:label "Degree Celsius per Year"@en .
@@ -11514,7 +11363,7 @@ unit:DEG_C2
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H2T0D0 ;
   qudt:hasQuantityKind quantitykind:TemperatureVariance ;
   qudt:symbol "°C²" ;
-  qudt:ucumCode "K2"^^qudt:UCUMcs ;
+  qudt:ucumCode "Cel2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Celsiuskare"@tr ;
   rdfs:label "Darjah Celsius Persegi"@ms ;
@@ -11543,8 +11392,7 @@ unit:DEG_C2-PER-SEC
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H2T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:symbol "°C²/s" ;
-  qudt:ucumCode "K2.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "K2/s"^^qudt:UCUMcs ;
+  qudt:ucumCode "Cel2.s-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Celsiuskare per Saniye"@tr ;
   rdfs:label "Darjah Celsius Persegi per Saat"@ms ;
@@ -11657,8 +11505,7 @@ unit:DEG_F-HR-FT2-PER-BTU_IT
   qudt:iec61360Code "0112/2///62720#UAA043" ;
   qudt:plainTextDescription "unit of the thermal resistor according to the Imperial system of units" ;
   qudt:symbol "°F·h·ft²/Btu{IT}" ;
-  qudt:ucumCode "[degF].h-1.[ft_i]-2.[Btu_IT]-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[degF]/(h.[ft_i]2.[Btu_IT])"^^qudt:UCUMcs ;
+  qudt:ucumCode "[degF].h.[ft_i]2.[Btu_IT]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J22" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Degree Fahrenheit Hour Square Foot per British Thermal Unit (international Definition)" ;
@@ -11694,8 +11541,7 @@ unit:DEG_F-HR-FT2-PER-BTU_TH
   qudt:iec61360Code "0112/2///62720#UAA040" ;
   qudt:plainTextDescription "unit of the thermal resistor according to the according to the Imperial system of units" ;
   qudt:symbol "°F·h·ft²/Btu{th}" ;
-  qudt:ucumCode "[degF].h-1.[ft_i]-2.[Btu_th]-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[degF]/(h.[ft_i]2.[Btu_th])"^^qudt:UCUMcs ;
+  qudt:ucumCode "[degF].h.[ft_i]2.[Btu_th]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J19" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Degree Fahrenheit Hour Square Foot per British Thermal Unit (thermochemical Definition)" ;
@@ -11731,7 +11577,6 @@ unit:DEG_F-HR-PER-BTU_IT
   qudt:hasQuantityKind quantitykind:ThermalResistance ;
   qudt:symbol "°F·h/Btu{IT}" ;
   qudt:ucumCode "[degF].h.[Btu_IT]-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[degF].h/[Btu_IT]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "N84" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Degree Fahrenheit Hour per British Thermal Unit (international Definition)" ;
@@ -11764,7 +11609,6 @@ unit:DEG_F-PER-BAR
   qudt:iec61360Code "0112/2///62720#UAA042" ;
   qudt:symbol "°F/bar" ;
   qudt:ucumCode "[degF].bar-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[degF]/bar"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J21" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Degree Fahrenheit per Bar" ;
@@ -11785,7 +11629,6 @@ unit:DEG_F-PER-HR
   qudt:iec61360Code "0112/2///62720#UAA044" ;
   qudt:symbol "°F/h" ;
   qudt:ucumCode "[degF].h-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[degF]/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J23" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Degree Fahrenheit per Hour" ;
@@ -11810,7 +11653,6 @@ unit:DEG_F-PER-K
   qudt:plainTextDescription "traditional unit degree Fahrenheit for temperature according to the Anglo-American system of units divided by the SI base unit Kelvin" ;
   qudt:symbol "°F/K" ;
   qudt:ucumCode "[degF].K-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[degF]/K"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J20" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Degree Fahrenheit per Kelvin" ;
@@ -11831,7 +11673,6 @@ unit:DEG_F-PER-MIN
   qudt:iec61360Code "0112/2///62720#UAA045" ;
   qudt:symbol "°F/min" ;
   qudt:ucumCode "[degF].min-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[degF]/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J24" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Degree Fahrenheit per Minute" ;
@@ -11852,7 +11693,6 @@ unit:DEG_F-PER-SEC
   qudt:iec61360Code "0112/2///62720#UAA046" ;
   qudt:symbol "°F/s" ;
   qudt:ucumCode "[degF].s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[degF]/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J25" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Degree Fahrenheit per Second" ;
@@ -11876,7 +11716,6 @@ unit:DEG_F-PER-SEC2
   qudt:plainTextDescription "'Degree Fahrenheit per Square Second' is a unit for expressing the acceleration of a temperature expressed as 'degF /s2'." ;
   qudt:symbol "°F/s²" ;
   qudt:ucumCode "[degF].s-2"^^qudt:UCUMcs ;
-  qudt:ucumCode "[degF]/s2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Degree Fahrenheit per Square Second" ;
   rdfs:label "Degree Fahrenheit per Square Second"@en .
@@ -11962,7 +11801,6 @@ unit:DEG_R-PER-HR
   qudt:iec61360Code "0112/2///62720#UAA051" ;
   qudt:symbol "°R/h" ;
   qudt:ucumCode "[degR].h-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[degR]/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J28" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Degree Rankine per Hour" ;
@@ -11982,7 +11820,6 @@ unit:DEG_R-PER-MIN
   qudt:iec61360Code "0112/2///62720#UAA052" ;
   qudt:symbol "°R/min" ;
   qudt:ucumCode "[degR].min-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[degR]/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J29" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Degree Rankine per Minute" ;
@@ -12002,7 +11839,6 @@ unit:DEG_R-PER-SEC
   qudt:iec61360Code "0112/2///62720#UAA053" ;
   qudt:symbol "°R/s" ;
   qudt:ucumCode "[degR].s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[degR]/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J30" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Degree Rankine per Second" ;
@@ -12064,12 +11900,12 @@ unit:DPI
   qudt:conversionMultiplierSN 3.937007874015748031496062992125984E1 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T0D0 ;
   qudt:hasFactorUnit [
-    qudt:exponent -1 ;
-    qudt:hasUnit unit:IN ;
-  ] ;
-  qudt:hasFactorUnit [
     qudt:exponent 1 ;
     qudt:hasUnit unit:ONE ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent -1 ;
+    qudt:hasUnit unit:IN ;
   ] ;
   qudt:hasQuantityKind quantitykind:DotsPerInch ;
   qudt:hasQuantityKind quantitykind:LineicResolution ;
@@ -12227,7 +12063,6 @@ unit:DYN-PER-CentiM
   qudt:plainTextDescription "CGS unit of the surface tension" ;
   qudt:symbol "dyn/cm" ;
   qudt:ucumCode "dyn.cm-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "dyn/cm"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "DX" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q106455582> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -12251,7 +12086,6 @@ unit:DYN-PER-CentiM2
   qudt:iec61360Code "0112/2///62720#UAA424" ;
   qudt:symbol "dyn/cm²" ;
   qudt:ucumCode "dyn.cm-2"^^qudt:UCUMcs ;
-  qudt:ucumCode "dyn/cm2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D9" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q107361141> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -12272,7 +12106,6 @@ unit:DYN-SEC-PER-CentiM
   qudt:plainTextDescription "CGS unit of the mechanical impedance" ;
   qudt:symbol "dyn·s/cm" ;
   qudt:ucumCode "dyn.s.cm-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "dyn.s/cm"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A51" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Dyne Second per Centimeter"@en-US ;
@@ -12292,7 +12125,6 @@ unit:DYN-SEC-PER-CentiM3
   qudt:plainTextDescription "CGS unit of the acoustic image impedance of the medium" ;
   qudt:symbol "dyn·s/cm³" ;
   qudt:ucumCode "dyn.s.cm-3"^^qudt:UCUMcs ;
-  qudt:ucumCode "dyn.s/cm3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A50" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Dyne Second per Cubic Centimeter"@en-US ;
@@ -12458,6 +12290,7 @@ unit:DecaK
   qudt:hasQuantityKind quantitykind:Temperature ;
   qudt:hasQuantityKind quantitykind:ThermodynamicTemperature ;
   qudt:symbol "daK" ;
+  qudt:ucumCode "daK"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Decakelvin" ;
   rdfs:label "Decakelvin"@cs ;
@@ -12666,7 +12499,6 @@ unit:DeciB-MilliW-PER-MegaHZ
   qudt:iec61360Code "0112/2///62720#UAD892" ;
   qudt:symbol "dB·mW/MHz" ;
   qudt:ucumCode "dB.mW.MHz-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "dB.mW/MHz"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "DBM" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Decibel Milliwatt per Megahertz" ;
@@ -12682,7 +12514,6 @@ unit:DeciB-PER-KiloM
   qudt:iec61360Code "0112/2///62720#UAA410" ;
   qudt:symbol "dB/km" ;
   qudt:ucumCode "dB.km-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "dB/km"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H51" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Decibel per Kilometer"@en-US ;
@@ -12699,7 +12530,6 @@ unit:DeciB-PER-M
   qudt:iec61360Code "0112/2///62720#UAA411" ;
   qudt:symbol "dB/m" ;
   qudt:ucumCode "dB.m-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "dB/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H52" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Decibel per Meter"@en-US ;
@@ -12749,7 +12579,6 @@ unit:DeciBAR-PER-YR
   qudt:hasQuantityKind quantitykind:ForcePerAreaTime ;
   qudt:symbol "dbar/a" ;
   qudt:ucumCode "dbar.a-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "dbar/a"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Decibar per Year" ;
   rdfs:label "Decibar per Year"@en .
@@ -12951,7 +12780,6 @@ unit:DeciL-PER-GM
   qudt:plainTextDescription "0.1-fold of the unit of the volume litre divided by the 0.001-fold of the SI base unit kilogram" ;
   qudt:symbol "dL/g" ;
   qudt:ucumCode "dL.g-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "dL/g"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "22" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q106630077> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -13072,7 +12900,6 @@ unit:DeciM3-PER-DAY
   qudt:plainTextDescription "0,001-fold of the power of the SI base unit metre with the exponent 3 divided by the unit for time day" ;
   qudt:symbol "dm³/d" ;
   qudt:ucumCode "dm3.d-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "dm3/d"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J90" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Cubic Decimeter per Day"@en-US ;
@@ -13095,7 +12922,6 @@ unit:DeciM3-PER-HR
   qudt:plainTextDescription "0,001-fold of the power of the SI base unit metre with the exponent 3 divided by the unit hour" ;
   qudt:symbol "dm³/h" ;
   qudt:ucumCode "dm3.h-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "dm3/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E92" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q102178883> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -13115,7 +12941,6 @@ unit:DeciM3-PER-KiloGM
   qudt:iec61360Code "0112/2///62720#UAB409" ;
   qudt:symbol "dm³/kg" ;
   qudt:ucumCode "dm3.kg-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "dm3/kg"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "N28" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Cubic Decimeter per Kilogram"@en-US ;
@@ -13147,7 +12972,6 @@ unit:DeciM3-PER-M3
   qudt:plainTextDescription "volume ratio consisting of the 0.001-fold of the power of the SI base unit metre with the exponent 3 divided by the power of the SI base unit metre with the exponent 3" ;
   qudt:symbol "dm³/m³" ;
   qudt:ucumCode "dm3.m-3"^^qudt:UCUMcs ;
-  qudt:ucumCode "dm3/m3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J91" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q106998079> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -13180,8 +13004,7 @@ unit:DeciM3-PER-MIN
   qudt:iec61360Code "0112/2///62720#UAA418" ;
   qudt:plainTextDescription "0,001-fold of the power of the SI base unit metre with the exponent 3 divided by the unit for time minute" ;
   qudt:symbol "dm³/min" ;
-  qudt:ucumCode "dm3.min-3"^^qudt:UCUMcs ;
-  qudt:ucumCode "dm3/min3"^^qudt:UCUMcs ;
+  qudt:ucumCode "dm3.min-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J92" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Cubic Decimeter per Minute"@en-US ;
@@ -13202,7 +13025,6 @@ unit:DeciM3-PER-MOL
   qudt:plainTextDescription "0,001-fold of the power of the SI base unit metre with the exponent 3 divided by the SI base unit mol" ;
   qudt:symbol "dm³/mol" ;
   qudt:ucumCode "dm3.mol-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "dm3/mol"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A37" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q24008536> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -13236,7 +13058,6 @@ unit:DeciM3-PER-SEC
   qudt:plainTextDescription "0,001-fold of the power of the SI base unit metre with the exponent 3 divided by the unit for time second" ;
   qudt:symbol "dm³/s" ;
   qudt:ucumCode "dm3.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "dm3/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J93" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Cubic Decimeter per Second"@en-US ;
@@ -13264,6 +13085,7 @@ unit:DeciN
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Force ;
   qudt:symbol "dN" ;
+  qudt:ucumCode "dN"^^qudt:UCUMcs ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q95948747> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Decinewton" ;
@@ -13325,6 +13147,7 @@ unit:DeciS
   qudt:hasQuantityKind quantitykind:Admittance ;
   qudt:hasQuantityKind quantitykind:Conductance ;
   qudt:symbol "dS" ;
+  qudt:ucumCode "dS"^^qudt:UCUMcs ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q95676297> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Decisiemens" ;
@@ -13354,7 +13177,6 @@ unit:DeciS-PER-M
   qudt:plainTextDescription "Decisiemens per metre." ;
   qudt:symbol "dS/m" ;
   qudt:ucumCode "dS.m-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "dS/m"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Decisiemens na Meter"@sl ;
   rdfs:label "Decisiemens na Metr"@cs ;
@@ -13409,6 +13231,7 @@ unit:DeciTONNE
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Mass ;
   qudt:symbol "dt" ;
+  qudt:ucumCode "dt"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "DTN" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q106611734> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -13521,16 +13344,16 @@ unit:ERG
   qudt:derivedUnitOfSystem sou:CGS-GAUSS ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:hasFactorUnit [
-    qudt:exponent -2 ;
-    qudt:hasUnit unit:SEC ;
+    qudt:exponent 1 ;
+    qudt:hasUnit unit:GM ;
   ] ;
   qudt:hasFactorUnit [
     qudt:exponent 2 ;
     qudt:hasUnit unit:CentiM ;
   ] ;
   qudt:hasFactorUnit [
-    qudt:exponent 1 ;
-    qudt:hasUnit unit:GM ;
+    qudt:exponent -2 ;
+    qudt:hasUnit unit:SEC ;
   ] ;
   qudt:hasQuantityKind quantitykind:Energy ;
   qudt:iec61360Code "0112/2///62720#UAA429" ;
@@ -13571,7 +13394,6 @@ unit:ERG-CentiM2-PER-GM
   qudt:iec61360Code "0112/2///62720#UAB149" ;
   qudt:symbol "erg·cm²/g" ;
   qudt:ucumCode "erg.cm2.g-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "erg.cm2/g"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A67" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Erg Square Centimeter per Gram"@en-US ;
@@ -13591,7 +13413,6 @@ unit:ERG-PER-CentiM
   qudt:plainTextDescription "CGS unit of the length-related energy" ;
   qudt:symbol "erg/cm" ;
   qudt:ucumCode "erg.cm-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "erg/cm"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A58" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Erg per Centimeter"@en-US ;
@@ -13634,7 +13455,6 @@ unit:ERG-PER-CentiM2-SEC
   qudt:iec61360Code "0112/2///62720#UAB055" ;
   qudt:symbol "erg/(cm²·s)" ;
   qudt:ucumCode "erg.cm-2.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "erg/(cm2.s)"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A65" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q28657331> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -13656,7 +13476,6 @@ unit:ERG-PER-CentiM3
   qudt:iec61360Code "0112/2///62720#UAB146" ;
   qudt:symbol "erg/cm³" ;
   qudt:ucumCode "erg.cm-3"^^qudt:UCUMcs ;
-  qudt:ucumCode "erg/cm3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A60" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q107361161> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -13677,7 +13496,6 @@ unit:ERG-PER-GM
   qudt:plainTextDescription "CGS unit of the mass-related energy" ;
   qudt:symbol "erg/g" ;
   qudt:ucumCode "erg.g-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "erg/g"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A61" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q107378414> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -13698,7 +13516,6 @@ unit:ERG-PER-GM-SEC
   qudt:plainTextDescription "CGS unit of the mass-related power" ;
   qudt:symbol "erg/(g·s)" ;
   qudt:ucumCode "erg.g-1.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "erg/(g.s)"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A62" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Erg per Gram Second" ;
@@ -13720,7 +13537,6 @@ unit:ERG-PER-SEC
   qudt:latexDefinition "$g\\cdot cm^{2}/s^{3}$"^^qudt:LatexString ;
   qudt:symbol "erg/s" ;
   qudt:ucumCode "erg.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "erg/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A63" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q106997401> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -13822,7 +13638,6 @@ unit:EV-M2-PER-KiloGM
   qudt:iec61360Code "0112/2///62720#UAA428" ;
   qudt:symbol "eV·m²/kg" ;
   qudt:ucumCode "eV.m2.kg-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "eV.m2/kg"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A56" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Electron Volt Square Meter per Kilogram"@en-US ;
@@ -13840,7 +13655,6 @@ unit:EV-PER-ANGSTROM
   qudt:plainTextDescription "unit electronvolt divided by the unit angstrom" ;
   qudt:symbol "eV/Å" ;
   qudt:ucumCode "eV.Ao-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "eV/Ao"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Electron Volt per Angstrom" ;
   rdfs:label "Electron Volt per Angstrom"@en .
@@ -13856,7 +13670,6 @@ unit:EV-PER-K
   qudt:hasQuantityKind quantitykind:HeatCapacity ;
   qudt:symbol "eV/K" ;
   qudt:ucumCode "eV.K-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "eV/K"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Electron Volt per Kelvin" ;
   rdfs:label "Electron Volt per Kelvin"@en .
@@ -13876,7 +13689,6 @@ unit:EV-PER-M
   qudt:plainTextDescription "unit electronvolt divided by the SI base unit metre" ;
   qudt:symbol "eV/m" ;
   qudt:ucumCode "eV.m-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "eV/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A54" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q98635536> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -13900,7 +13712,6 @@ unit:EV-PER-T
   qudt:hasQuantityKind quantitykind:MagneticMoment ;
   qudt:symbol "eV/T" ;
   qudt:ucumCode "eV.T-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "eV/T"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Electron Volt per Tesla" ;
   rdfs:label "Electron Volt per Tesla"@en .
@@ -13998,6 +13809,7 @@ unit:ExaBIT
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:InformationEntropy ;
   qudt:symbol "Eb" ;
+  qudt:ucumCode "Ebit"^^qudt:UCUMcs ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q1195111> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Exabit" ;
@@ -14012,6 +13824,7 @@ unit:ExaBIT-PER-SEC
   qudt:hasQuantityKind quantitykind:DataRate ;
   qudt:iec61360Code "0112/2///62720#UAA139" ;
   qudt:symbol "Eb/s" ;
+  qudt:ucumCode "Ebit.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E58" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Exabit per Second" ;
@@ -14115,7 +13928,6 @@ unit:ExaJ-PER-SEC
   qudt:iec61360Code "0112/2///62720#UAB515" ;
   qudt:symbol "EJ/s" ;
   qudt:ucumCode "EJ.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "EJ/s"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Exadżul na Sekunda"@pl ;
   rdfs:label "Exajoule na Sekunda"@cs ;
@@ -14140,6 +13952,7 @@ unit:ExaV
   qudt:hasQuantityKind quantitykind:EnergyPerElectricCharge ;
   qudt:hasQuantityKind quantitykind:Voltage ;
   qudt:symbol "EV" ;
+  qudt:ucumCode "EV"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Exavolt" ;
   rdfs:label "Exavolt"@cs ;
@@ -14166,6 +13979,7 @@ unit:ExaV-A
   qudt:hasQuantityKind quantitykind:ApparentPower ;
   qudt:iec61360Code "0112/2///62720#UAB537" ;
   qudt:symbol "EV·A" ;
+  qudt:ucumCode "EV.A"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Exavolt Amper"@ro ;
   rdfs:label "Exavolt Amper"@sl ;
@@ -14189,6 +14003,7 @@ unit:ExaVA
   qudt:hasQuantityKind quantitykind:ApparentPower ;
   qudt:iec61360Code "0112/2///62720#UAB537" ;
   qudt:symbol "EVA" ;
+  qudt:ucumCode "EVA"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Exa Volt Ampere" ;
   rdfs:label "Exa Volt Ampere"@en ;
@@ -14207,6 +14022,7 @@ unit:ExaW
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAB507" ;
   qudt:symbol "EW" ;
+  qudt:ucumCode "EW"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Exavatio"@es ;
   rdfs:label "Exawat"@pl ;
@@ -14355,12 +14171,12 @@ unit:FARAD
   qudt:derivedCoherentUnitOfSystem sou:SI ;
   qudt:hasDimensionVector qkdv:A0E2L-2I0M-1H0T4D0 ;
   qudt:hasFactorUnit [
-    qudt:exponent -1 ;
-    qudt:hasUnit unit:V ;
-  ] ;
-  qudt:hasFactorUnit [
     qudt:exponent 1 ;
     qudt:hasUnit unit:C ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent -1 ;
+    qudt:hasUnit unit:V ;
   ] ;
   qudt:hasQuantityKind quantitykind:Capacitance ;
   qudt:iec61360Code "0112/2///62720#UAA144" ;
@@ -14414,7 +14230,6 @@ unit:FARAD-PER-KiloM
   qudt:plainTextDescription "SI derived unit farad divided by the 1 000-fold of the SI base unit metre" ;
   qudt:symbol "F/km" ;
   qudt:ucumCode "F.km-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "F/km"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H33" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Farad na Kilometer"@sl ;
@@ -14449,7 +14264,6 @@ unit:FARAD-PER-M
   qudt:iec61360Code "0112/2///62720#UAA146" ;
   qudt:symbol "F/m" ;
   qudt:ucumCode "F.m-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "F/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A69" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q21294882> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -14512,7 +14326,6 @@ unit:FARAD_Ab-PER-CentiM
   qudt:hasQuantityKind quantitykind:Permittivity ;
   qudt:symbol "abF/cm" ;
   qudt:ucumCode "GF.cm-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "GF/cm"^^qudt:UCUMcs ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q30063650> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Abfarad per Centimeter"@en-US ;
@@ -14713,7 +14526,6 @@ unit:FRAME-PER-SEC
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:VideoFrameRate ;
   qudt:symbol "fps" ;
-  qudt:ucumCode "/s{frame}"^^qudt:UCUMcs ;
   qudt:ucumCode "s-1{frame}"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Frame per Second" ;
@@ -14827,7 +14639,7 @@ unit:FT-LB_F-PER-FT2
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:EnergyPerArea ;
   qudt:symbol "ft·lbf/ft²" ;
-  qudt:ucumCode "[ft_i].[lbf_av].[sft_i]-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[ft_i].[lbf_av].[ft_i]-2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Foot Pound Force per Square Foot" ;
   rdfs:label "Foot Pound Force per Square Foot"@en .
@@ -14846,7 +14658,7 @@ unit:FT-LB_F-PER-FT2-SEC
   qudt:hasQuantityKind quantitykind:PowerPerArea ;
   qudt:latexSymbol "$ft \\cdot lbf/(ft^2 \\cdot s)$"^^qudt:LatexString ;
   qudt:symbol "ft·lbf/(ft²·s)" ;
-  qudt:ucumCode "[ft_i].[lbf_av].[sft_i]-1.s-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[ft_i].[lbf_av].[ft_i]-2.s-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Foot Pound Force per Square Foot Second" ;
   rdfs:label "Foot Pound Force per Square Foot Second"@en .
@@ -14979,7 +14791,6 @@ unit:FT-PER-DAY
   qudt:hasQuantityKind quantitykind:Velocity ;
   qudt:symbol "ft/d" ;
   qudt:ucumCode "[ft_i].d-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[ft_i]/d"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Foot per Day" ;
   rdfs:label "Foot per Day"@en .
@@ -14996,7 +14807,7 @@ unit:FT-PER-DEG_F
   qudt:iec61360Code "0112/2///62720#UAA441" ;
   qudt:plainTextDescription "unit foot as a linear measure according to the Anglo-American and the Imperial system of units divided by the unit for temperature degree Fahrenheit" ;
   qudt:symbol "ft/°F" ;
-  qudt:ucumCode "[ft_i].[lbf_av].[degF]"^^qudt:UCUMcs ;
+  qudt:ucumCode "[ft_i].[degF]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K13" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Foot per Degree Fahrenheit" ;
@@ -15018,7 +14829,6 @@ unit:FT-PER-HR
   qudt:iec61360Code "0112/2///62720#UAA442" ;
   qudt:symbol "ft/h" ;
   qudt:ucumCode "[ft_i].h-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[ft_i]/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K14" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q106611504> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -15041,7 +14851,6 @@ unit:FT-PER-MIN
   qudt:iec61360Code "0112/2///62720#UAA448" ;
   qudt:symbol "ft/min" ;
   qudt:ucumCode "[ft_i].min-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[ft_i]/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "FR" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q22673229> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -15058,7 +14867,6 @@ unit:FT-PER-PSI
   qudt:iec61360Code "0112/2///62720#UAA447" ;
   qudt:symbol "ft/psi" ;
   qudt:ucumCode "[ft_i].[psi]-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[ft_i]/[psi]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K17" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Foot per Psi" ;
@@ -15082,7 +14890,6 @@ unit:FT-PER-SEC
   qudt:informativeReference "http://en.wikipedia.org/wiki/Foot_per_second?oldid=491316573"^^xsd:anyURI ;
   qudt:symbol "ft/s" ;
   qudt:ucumCode "[ft_i].s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[ft_i]/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "FS" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q748716> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -15135,7 +14942,6 @@ unit:FT-PER-SEC2
   qudt:iec61360Code "0112/2///62720#UAA452" ;
   qudt:symbol "ft/s²" ;
   qudt:ucumCode "[ft_i].s-2"^^qudt:UCUMcs ;
-  qudt:ucumCode "[ft_i]/s2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A73" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q3867152> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -15200,7 +15006,6 @@ unit:FT2
   qudt:iec61360Code "0112/2///62720#UAA454" ;
   qudt:symbol "ft²" ;
   qudt:ucumCode "[ft_i]2"^^qudt:UCUMcs ;
-  qudt:ucumCode "[sft_i]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "FTK" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q857027> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -15220,7 +15025,7 @@ unit:FT2-DEG_F
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H1T0D0 ;
   qudt:hasQuantityKind quantitykind:AreaTemperature ;
   qudt:symbol "ft²·°F" ;
-  qudt:ucumCode "[sft_i].[degF]"^^qudt:UCUMcs ;
+  qudt:ucumCode "[ft_i]2.[degF]"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Square Foot Degree Fahrenheit" ;
   rdfs:label "Square Foot Degree Fahrenheit"@en .
@@ -15238,7 +15043,7 @@ unit:FT2-HR-DEG_F
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H1T1D0 ;
   qudt:hasQuantityKind quantitykind:AreaTimeTemperature ;
   qudt:symbol "ft²·h·°F" ;
-  qudt:ucumCode "[sft_i].h.[degF]"^^qudt:UCUMcs ;
+  qudt:ucumCode "[ft_i]2.h.[degF]"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Square Foot Hour Degree Fahrenheit" ;
   rdfs:label "Square Foot Hour Degree Fahrenheit"@en .
@@ -15258,7 +15063,7 @@ unit:FT2-HR-DEG_F-PER-BTU_IT
   qudt:hasReciprocalUnit unit:BTU_IT-PER-FT2-HR-DEG_F ;
   qudt:hasReciprocalUnit unit:BTU_IT-PER-HR-FT2-DEG_F ;
   qudt:symbol "ft²·h·°F/Btu{IT}" ;
-  qudt:ucumCode "[sft_i].h.[degF].[Btu_IT]-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[ft_i]2.h.[degF].[Btu_IT]-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Square Foot Hour Degree Fahrenheit per British Thermal Unit (international Definition)" ;
   rdfs:label "Square Foot Hour Degree Fahrenheit per British Thermal Unit (international Definition)"@en .
@@ -15275,7 +15080,7 @@ unit:FT2-PER-BTU_IT-IN
   qudt:hasDimensionVector qkdv:A0E0L-1I0M-1H0T2D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:symbol "ft²/(Btu{IT}·in)" ;
-  qudt:ucumCode "[sft_i].[Btu_IT]-1.[in_i]-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[ft_i]2.[Btu_IT]-1.[in_i]-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Square Foot per British Thermal Unit (international Definition) Inch" ;
   rdfs:label "Square Foot per British Thermal Unit (international Definition) Inch"@en .
@@ -15295,7 +15100,7 @@ unit:FT2-PER-HR
   qudt:hasReciprocalUnit unit:HR-PER-FT2 ;
   qudt:iec61360Code "0112/2///62720#UAB247" ;
   qudt:symbol "ft²/h" ;
-  qudt:ucumCode "[sft_i].h-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[ft_i]2.h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M79" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q107410870> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -15317,7 +15122,7 @@ unit:FT2-PER-SEC
   qudt:hasReciprocalUnit unit:SEC-PER-FT2 ;
   qudt:iec61360Code "0112/2///62720#UAA455" ;
   qudt:symbol "ft²/s" ;
-  qudt:ucumCode "[sft_i].s-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[ft_i]2.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "S3" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q107410810> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -15337,7 +15142,7 @@ unit:FT2-SEC-DEG_F
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H1T1D0 ;
   qudt:hasQuantityKind quantitykind:AreaTimeTemperature ;
   qudt:symbol "ft²·s·°F" ;
-  qudt:ucumCode "[sft_i].s.[degF]"^^qudt:UCUMcs ;
+  qudt:ucumCode "[ft_i]2.s.[degF]"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Square Foot Second Degree Fahrenheit" ;
   rdfs:label "Square Foot Second Degree Fahrenheit"@en .
@@ -15361,7 +15166,6 @@ unit:FT3
   qudt:hasReciprocalUnit unit:PER-FT3 ;
   qudt:iec61360Code "0112/2///62720#UAA456" ;
   qudt:symbol "ft³" ;
-  qudt:ucumCode "[cft_i]"^^qudt:UCUMcs ;
   qudt:ucumCode "[ft_i]3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "FTQ" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q1545979> ;
@@ -15382,7 +15186,7 @@ unit:FT3-PER-DAY
   qudt:iec61360Code "0112/2///62720#UAA458" ;
   qudt:plainTextDescription "power of the unit foot according to the Anglo-American and the Imperial system of units with the exponent 3 divided by the unit for time day" ;
   qudt:symbol "ft³/d" ;
-  qudt:ucumCode "[cft_i].d-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[ft_i]3.d-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K22" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Cubic Foot per Day" ;
@@ -15400,7 +15204,7 @@ unit:FT3-PER-DEG_F
   qudt:iec61360Code "0112/2///62720#UAA457" ;
   qudt:plainTextDescription "power of the unit foot as a linear measure according to the Anglo-American and the Imperial system of units with the exponent 3 divided by the unit for temperature degree Fahrenheit" ;
   qudt:symbol "ft³/°F" ;
-  qudt:ucumCode "[cft_i].[degF]-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[ft_i]3.[degF]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K21" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Cubic Foot per Degree Fahrenheit" ;
@@ -15419,7 +15223,7 @@ unit:FT3-PER-HR
   qudt:iec61360Code "0112/2///62720#UAA459" ;
   qudt:plainTextDescription "power of the unit foot according to the Anglo-American and the Imperial system of units with the exponent 3 divided by the unit hour" ;
   qudt:symbol "ft³/h" ;
-  qudt:ucumCode "[cft_i].h-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[ft_i]3.h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "2K" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Cubic Foot per Hour" ;
@@ -15457,10 +15261,7 @@ unit:FT3-PER-MIN
   qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA461" ;
   qudt:symbol "ft³/min" ;
-  qudt:ucumCode "[cft_i].min-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[cft_i]/min"^^qudt:UCUMcs ;
   qudt:ucumCode "[ft_i]3.min-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[ft_i]3/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "2L" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q856240> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -15479,7 +15280,7 @@ unit:FT3-PER-MIN-FT2
   qudt:iec61360Code "0112/2///62720#UAB086" ;
   qudt:plainTextDescription "unit of the volume flow rate according to the Anglio-American and imperial system of units cubic foot per minute related to the transfer area according to the Anglian American and Imperial system of units square foot" ;
   qudt:symbol "ft³/(min·ft²)" ;
-  qudt:ucumCode "[cft_i].min-1.[sft_i]-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[ft_i]3.min-1.[ft_i]-2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "36" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Cubic Foot per Minute Square Foot" ;
@@ -15515,10 +15316,7 @@ unit:FT3-PER-SEC
   qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA462" ;
   qudt:symbol "ft³/s" ;
-  qudt:ucumCode "[cft_i].s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[cft_i]/s"^^qudt:UCUMcs ;
   qudt:ucumCode "[ft_i]3.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[ft_i]3/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E17" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q5196162> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -15536,6 +15334,7 @@ unit:FT4
   qudt:hasQuantityKind quantitykind:SecondPolarMomentOfArea ;
   qudt:iec61360Code "0112/2///62720#UAB209" ;
   qudt:symbol "ft⁴" ;
+  qudt:ucumCode "[ft_i]4"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "N27" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Quartic Foot" ;
@@ -15670,6 +15469,7 @@ unit:FemtoA
   qudt:hasQuantityKind quantitykind:TotalCurrent ;
   qudt:iec61360Code "0112/2///62720#UAB638" ;
   qudt:symbol "fA" ;
+  qudt:ucumCode "fA"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Femtoamper"@hu ;
   rdfs:label "Femtoamper"@pl ;
@@ -15726,6 +15526,7 @@ unit:FemtoFARAD
   qudt:hasQuantityKind quantitykind:Capacitance ;
   qudt:iec61360Code "0112/2///62720#UAB588" ;
   qudt:symbol "fF" ;
+  qudt:ucumCode "fF"^^qudt:UCUMcs ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q95447253> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Femtofarad" ;
@@ -15755,6 +15556,7 @@ unit:FemtoGM
   qudt:hasQuantityKind quantitykind:Mass ;
   qudt:iec61360Code "0112/2///62720#UAB834" ;
   qudt:symbol "fg" ;
+  qudt:ucumCode "fg"^^qudt:UCUMcs ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q1913097> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Femtogram" ;
@@ -15814,7 +15616,6 @@ unit:FemtoGM-PER-L
   qudt:hasQuantityKind quantitykind:MassDensity ;
   qudt:symbol "fg/L" ;
   qudt:ucumCode "fg.L-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "fg/L"^^qudt:UCUMcs ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q104907185> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Femtogram per Liter"@en-US ;
@@ -15943,7 +15744,6 @@ unit:FemtoMOL-PER-KiloGM
   qudt:hasQuantityKind quantitykind:AmountOfSubstancePerMass ;
   qudt:symbol "fmol/kg" ;
   qudt:ucumCode "fmol.kg-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "fmol/kg"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Femtomol na Kilogram"@cs ;
   rdfs:label "Femtomol na Kilogram"@pl ;
@@ -15969,7 +15769,6 @@ unit:FemtoMOL-PER-L
   qudt:hasQuantityKind quantitykind:WaterSolubility ;
   qudt:symbol "fmol/L" ;
   qudt:ucumCode "fmol.L-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "fmol/L"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Femtomole per Liter"@en-US ;
   rdfs:label "Femtomole per Litre" ;
@@ -16019,6 +15818,7 @@ unit:FemtoV
   qudt:hasQuantityKind quantitykind:Voltage ;
   qudt:iec61360Code "0112/2///62720#UAC770" ;
   qudt:symbol "fV" ;
+  qudt:ucumCode "fV"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Femtovolt" ;
   rdfs:label "Femtovolt"@cs ;
@@ -16042,12 +15842,12 @@ unit:G
   qudt:factorUnitScalar 9.80665 ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T-2D0 ;
   qudt:hasFactorUnit [
-    qudt:exponent -2 ;
-    qudt:hasUnit unit:SEC ;
-  ] ;
-  qudt:hasFactorUnit [
     qudt:exponent 1 ;
     qudt:hasUnit unit:M ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent -2 ;
+    qudt:hasUnit unit:SEC ;
   ] ;
   qudt:hasQuantityKind quantitykind:Acceleration ;
   qudt:hasQuantityKind quantitykind:LinearAcceleration ;
@@ -16184,7 +15984,7 @@ unit:GAL_UK-PER-MIN
   qudt:iec61360Code "0112/2///62720#UAA503" ;
   qudt:plainTextDescription "unit gallon (UK dry or liq.) according to the Imperial system of units divided by the SI unit minute" ;
   qudt:symbol "gal{UK}/min" ;
-  qudt:ucumCode "[gal_br].m-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[gal_br].min-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G3" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Gallon (UK) per Minute" ;
@@ -16246,7 +16046,6 @@ unit:GAL_US-PER-DAY
   qudt:iec61360Code "0112/2///62720#UAA506" ;
   qudt:symbol "gal{US}/d" ;
   qudt:ucumCode "[gal_us].d-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[gal_us]/d"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "GB" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Us Gallon per Day" ;
@@ -16265,7 +16064,6 @@ unit:GAL_US-PER-HR
   qudt:plainTextDescription "unit gallon (US, liq.) according to the Anglo-American system of units divided by the SI unit hour" ;
   qudt:symbol "gal{US}/h" ;
   qudt:ucumCode "[gal_us].h-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[gal_us]/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G50" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Us Gallon per Hour" ;
@@ -16285,7 +16083,6 @@ unit:GAL_US-PER-MIN
   qudt:iec61360Code "0112/2///62720#UAA508" ;
   qudt:symbol "gal{US}/min" ;
   qudt:ucumCode "[gal_us].min-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[gal_us]/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G2" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q64996135> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -16305,7 +16102,6 @@ unit:GAL_US-PER-SEC
   qudt:plainTextDescription "unit gallon (US, liq.) according to the Anglo-American system of units divided by the SI base unit second" ;
   qudt:symbol "gal{US}/s" ;
   qudt:ucumCode "[gal_us].s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[gal_us]/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K30" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Us Gallon per Second" ;
@@ -16958,7 +16754,6 @@ unit:GM-PER-CentiM2
   qudt:plainTextDescription "0,001-fold of the SI base unit kilogram divided by the 0.0001-fold of the power of the SI base unit metre and exponent 2" ;
   qudt:symbol "g/cm²" ;
   qudt:ucumCode "g.cm-2"^^qudt:UCUMcs ;
-  qudt:ucumCode "g/cm2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "25" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q107133637> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -17011,7 +16806,6 @@ unit:GM-PER-CentiM3
   qudt:plainTextDescription "0.001-fold of the SI base unit kilogram divided by the 0.000001-fold of the power of the SI base unit metre with the exponent 3" ;
   qudt:symbol "g/cm³" ;
   qudt:ucumCode "g.cm-3"^^qudt:UCUMcs ;
-  qudt:ucumCode "g/cm3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "23" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q13147228> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -17133,8 +16927,7 @@ unit:GM-PER-DEG_C
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H-1T0D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:symbol "g/°C" ;
-  qudt:ucumCode "d.Cel-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "d/Cel"^^qudt:UCUMcs ;
+  qudt:ucumCode "g.Cel-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Gram na Stopień Celsjusza"@pl ;
   rdfs:label "Gram na Stopinja Celzija"@sl ;
@@ -17167,7 +16960,6 @@ unit:GM-PER-DeciL
   qudt:hasReciprocalUnit unit:DeciL-PER-GM ;
   qudt:symbol "g/dL" ;
   qudt:ucumCode "g.dL-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "g/dL"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Gram per Deciliter"@en-US ;
   rdfs:label "Gram per Decilitre" ;
@@ -17263,7 +17055,6 @@ unit:GM-PER-GM
   qudt:qkdvNumerator qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:symbol "g/g" ;
   qudt:ucumCode "g.g-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "g/g"^^qudt:UCUMcs ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q107440839> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Gram na Gram"@cs ;
@@ -17295,7 +17086,6 @@ unit:GM-PER-HA
   qudt:hasQuantityKind quantitykind:MassPerArea ;
   qudt:symbol "g/ha" ;
   qudt:ucumCode "g.har-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "g/har"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Gram per Hectare" ;
   rdfs:label "Gram per Hectare"@en .
@@ -17395,7 +17185,6 @@ unit:GM-PER-HectoGM
   qudt:qkdvNumerator qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:symbol "g/hg" ;
   qudt:ucumCode "g.hg-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "g/hg"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Gram na Hectogram"@cs ;
   rdfs:label "Gram na Hectogram"@pl ;
@@ -17454,7 +17243,6 @@ unit:GM-PER-KiloGM
   qudt:qkdvNumerator qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:symbol "g/kg" ;
   qudt:ucumCode "g.kg-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "g/kg"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "GK" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q21061369> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -17518,7 +17306,6 @@ unit:GM-PER-L
   qudt:plainTextDescription "0,001-fold of the SI base unit kilogram divided by the unit litre" ;
   qudt:symbol "g/L" ;
   qudt:ucumCode "g.L-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "g/L"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "GL" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q834105> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -17668,7 +17455,6 @@ unit:GM-PER-M2
   qudt:plainTextDescription "0,001-fold of the SI base unit kilogram divided by the power of the SI base unit metre with the exponent 2" ;
   qudt:symbol "g/m²" ;
   qudt:ucumCode "g.m-2"^^qudt:UCUMcs ;
-  qudt:ucumCode "g/m2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "GM" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q107133676> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -17718,7 +17504,7 @@ unit:GM-PER-M2-HR
   qudt:hasQuantityKind quantitykind:MassPerAreaTime ;
   qudt:plainTextDescription "0.0001-fold of the SI base unit kilogram divided by the SI base unit meter with the exponent 2 over a period of 1 hour " ;
   qudt:symbol "g/(m²·h)" ;
-  qudt:ucumCode "g.m-2.hr-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "g.m-2.h-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Gram per Square Meter Hour"@en-US ;
   rdfs:label "Gram per Square Metre Hour" ;
@@ -17760,7 +17546,6 @@ unit:GM-PER-M3
   qudt:plainTextDescription "0,001-fold of the SI base unit kilogram divided by the power of the SI base unit metre with the exponent 3" ;
   qudt:symbol "g/m³" ;
   qudt:ucumCode "g.m-3"^^qudt:UCUMcs ;
-  qudt:ucumCode "g/m3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A93" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q21604951> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -17969,7 +17754,6 @@ unit:GM-PER-MOL
   qudt:plainTextDescription "0.01-fold of the SI base unit kilogram divided by the SI base unit mol" ;
   qudt:symbol "g/mol" ;
   qudt:ucumCode "g.mol-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "g/mol"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A94" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q28924752> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -18005,7 +17789,6 @@ unit:GM-PER-MilliL
   qudt:plainTextDescription "0,001-fold of the SI base unit kilogram divided by the 0.001-fold of the unit litre" ;
   qudt:symbol "g/mL" ;
   qudt:ucumCode "g.mL-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "g/mL"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "GJ" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q101877596> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -18521,7 +18304,7 @@ unit:GRAIN-PER-M3
   qudt:hasQuantityKind quantitykind:MassDensity ;
   qudt:plainTextDescription "Grains per cubic metre of volume" ;
   qudt:symbol "gr{UK}/m³" ;
-  qudt:ucumCode "[gr]/m3"^^qudt:UCUMcs ;
+  qudt:ucumCode "[gr].m-3"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Grain per Cubic Meter"@en-US ;
   rdfs:label "Grain per Cubic Metre" ;
@@ -18714,6 +18497,7 @@ unit:GibiBIT
   qudt:hasQuantityKind quantitykind:DatasetOfBits ;
   qudt:iec61360Code "0112/2///62720#UAB152" ;
   qudt:symbol "Gib" ;
+  qudt:ucumCode "Gibit"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B30" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q1204894> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -18787,6 +18571,7 @@ unit:GibiBYTE
   qudt:iec61360Code "0112/2///62720#UAA162" ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Byte#Multiple-byte_units"^^xsd:anyURI ;
   qudt:symbol "GiB" ;
+  qudt:ucumCode "GiBy"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E62" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q79765> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -18808,6 +18593,7 @@ unit:GigaA
   qudt:hasQuantityKind quantitykind:TotalCurrent ;
   qudt:iec61360Code "0112/2///62720#UAB639" ;
   qudt:symbol "GA" ;
+  qudt:ucumCode "GA"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Gigaamper"@hu ;
   rdfs:label "Gigaamper"@pl ;
@@ -18832,6 +18618,7 @@ unit:GigaBIT
   qudt:hasQuantityKind quantitykind:DatasetOfBits ;
   qudt:iec61360Code "0112/2///62720#UAB156" ;
   qudt:symbol "Gb" ;
+  qudt:ucumCode "Gbit"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B68" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q3105497> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -19205,7 +18992,6 @@ unit:GigaJ-PER-M2
   qudt:hasQuantityKind quantitykind:StrainEnergyReleaseRate ;
   qudt:symbol "GJ/m²" ;
   qudt:ucumCode "GJ.m-2"^^qudt:UCUMcs ;
-  qudt:ucumCode "GJ/m2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Gigadżul na Metr Kwadratowy"@pl ;
   rdfs:label "Gigajoule na Kvadratni Meter"@sl ;
@@ -19252,6 +19038,7 @@ unit:GigaN
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Force ;
   qudt:symbol "GN" ;
+  qudt:ucumCode "GN"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Giganewton" ;
   rdfs:label "Giganewton"@cs ;
@@ -19277,6 +19064,7 @@ unit:GigaN-M-PER-M2
   qudt:hasQuantityKind quantitykind:ForcePerLength ;
   qudt:iec61360Code "0112/2///62720#UAB554" ;
   qudt:symbol "GN·m/m²" ;
+  qudt:ucumCode "GN.m.m-2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Giganewton Meter na Kvadratni Meter"@sl ;
   rdfs:label "Giganewton Meter per Meter Persegi"@ms ;
@@ -19424,7 +19212,6 @@ unit:GigaPA-CentiM3-PER-GM
   qudt:hasQuantityKind quantitykind:SpecificModulus ;
   qudt:symbol "GPa·cm³/g" ;
   qudt:ucumCode "GPa.cm3.g-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "GPa.cm3/g"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Gigapascal Centimeter Kubik per Gram"@ms ;
   rdfs:label "Gigapascal Centimetr Krychlový na Gram"@cs ;
@@ -19452,6 +19239,7 @@ unit:GigaV
   qudt:hasQuantityKind quantitykind:Voltage ;
   qudt:iec61360Code "0112/2///62720#UAC772" ;
   qudt:symbol "GV" ;
+  qudt:ucumCode "GV"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Gigavolt" ;
   rdfs:label "Gigavolt"@cs ;
@@ -19535,6 +19323,7 @@ unit:GigaVAR
   qudt:hasQuantityKind quantitykind:ReactivePower ;
   qudt:iec61360Code "0112/2///62720#UAC508" ;
   qudt:symbol "GVA{Reactive}" ;
+  qudt:ucumCode "GVA{reactive}"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Giga Volt Ampere Reactive" ;
   rdfs:label "Giga Volt Ampere Reactive"@en .
@@ -19656,12 +19445,12 @@ unit:H
   qudt:derivedCoherentUnitOfSystem sou:SI ;
   qudt:hasDimensionVector qkdv:A0E-2L2I0M1H0T-2D0 ;
   qudt:hasFactorUnit [
-    qudt:exponent -1 ;
-    qudt:hasUnit unit:A ;
-  ] ;
-  qudt:hasFactorUnit [
     qudt:exponent 1 ;
     qudt:hasUnit unit:WB ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent -1 ;
+    qudt:hasUnit unit:A ;
   ] ;
   qudt:hasQuantityKind quantitykind:Inductance ;
   qudt:iec61360Code "0112/2///62720#UAA165" ;
@@ -20035,7 +19824,6 @@ unit:HR-FT2
   qudt:hasQuantityKind quantitykind:AreaTime ;
   qudt:symbol "h·ft²" ;
   qudt:ucumCode "h.[ft_i]2"^^qudt:UCUMcs ;
-  qudt:ucumCode "h.[sft_i]"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Hour Square Foot" ;
   rdfs:label "Hour Square Foot"@en .
@@ -20086,7 +19874,6 @@ unit:HR-PER-YR
   qudt:qkdvNumerator qkdv:A0E0L0I0M0H0T1D0 ;
   qudt:symbol "h/a" ;
   qudt:ucumCode "h.a-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "h/a"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Hour per Year" ;
   rdfs:label "Hour per Year"@en ;
@@ -20870,7 +20657,6 @@ unit:IN-PER-MIN
   qudt:iec61360Code "0112/2///62720#UAB393" ;
   qudt:symbol "in/min" ;
   qudt:ucumCode "[in_i].min-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[in_i]/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M63" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Inch per Minute" ;
@@ -20923,7 +20709,6 @@ unit:IN-PER-SEC
   qudt:iec61360Code "0112/2///62720#UAA542" ;
   qudt:symbol "in/s" ;
   qudt:ucumCode "[in_i].s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[in_i]/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "IU" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q6014364> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -20977,7 +20762,6 @@ unit:IN-PER-SEC2
   qudt:iec61360Code "0112/2///62720#UAB044" ;
   qudt:symbol "in/s²" ;
   qudt:ucumCode "[in_i].s-2"^^qudt:UCUMcs ;
-  qudt:ucumCode "[in_i]/s2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "IV" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q106630045> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -21019,7 +20803,6 @@ unit:IN2
   qudt:iec61360Code "0112/2///62720#UAA547" ;
   qudt:symbol "in²" ;
   qudt:ucumCode "[in_i]2"^^qudt:UCUMcs ;
-  qudt:ucumCode "[sin_i]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "INK" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q1063786> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -21038,7 +20821,7 @@ unit:IN2-PER-SEC
   qudt:iec61360Code "0112/2///62720#UAA548" ;
   qudt:plainTextDescription "power of the unit inch according to the Anglo-American and the Imperial system of units with the exponent 2 divided by the SI base unit second" ;
   qudt:symbol "in²/s" ;
-  qudt:ucumCode "[sin_i].s-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[in_i]2.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G08" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q107410833> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -21060,7 +20843,6 @@ unit:IN3
   qudt:hasReciprocalUnit unit:PER-IN3 ;
   qudt:iec61360Code "0112/2///62720#UAA549" ;
   qudt:symbol "in³" ;
-  qudt:ucumCode "[cin_i]"^^qudt:UCUMcs ;
   qudt:ucumCode "[in_i]3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "INQ" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q2140397> ;
@@ -21081,7 +20863,7 @@ unit:IN3-PER-HR
   qudt:iec61360Code "0112/2///62720#UAA550" ;
   qudt:plainTextDescription "power of the unit inch according to the Anglo-American and the Imperial system of units with the exponent 3 divided by the unit hour" ;
   qudt:symbol "in³/h" ;
-  qudt:ucumCode "[cin_i].h-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[in_i]3.h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G56" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Cubic Inch per Hour" ;
@@ -21119,10 +20901,7 @@ unit:IN3-PER-MIN
   qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAA551" ;
   qudt:symbol "in³/min" ;
-  qudt:ucumCode "[cin_i].min-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[cin_i]/min"^^qudt:UCUMcs ;
   qudt:ucumCode "[in_i]3.min-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[in_i]3/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G57" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Cubic Inch per Minute" ;
@@ -21141,7 +20920,7 @@ unit:IN3-PER-SEC
   qudt:iec61360Code "0112/2///62720#UAA552" ;
   qudt:plainTextDescription "power of the unit inch according to the Anglo-American and the Imperial system of units with the exponent 3 divided by the SI base unit second" ;
   qudt:symbol "in³/s" ;
-  qudt:ucumCode "[cin_i].s-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[in_i]3.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G58" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Cubic Inch per Second" ;
@@ -21294,7 +21073,6 @@ unit:IU
   qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/InternationalUnit> ;
   qudt:symbol "IU" ;
   qudt:ucumCode "[IU]"^^qudt:UCUMcs ;
-  qudt:ucumCode "[iU]"^^qudt:UCUMcs ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q835916> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "International Unit" ;
@@ -21314,9 +21092,6 @@ The magnitude of one $IU/L$ depends on the material, so there is no single conve
   qudt:hasQuantityKind quantitykind:SerumLevel ;
   qudt:symbol "IU/L" ;
   qudt:ucumCode "[IU].L-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[IU]/L"^^qudt:UCUMcs ;
-  qudt:ucumCode "[iU].L-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[iU]/L"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "International Unit per Liter"@en-US ;
   rdfs:label "International Unit per Litre" ;
@@ -21356,9 +21131,6 @@ The magnitude of one $IU/L$ depends on the material, so there is no single conve
   qudt:hasQuantityKind quantitykind:SerumLevel ;
   qudt:symbol "IU/mL" ;
   qudt:ucumCode "[IU].mL-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[IU]/mL"^^qudt:UCUMcs ;
-  qudt:ucumCode "[iU].mL-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[iU]/mL"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "International Unit per Milliliter"@en-US ;
   rdfs:label "International Unit per Millilitre" ;
@@ -21441,7 +21213,6 @@ unit:J-M-PER-MOL
   qudt:hasQuantityKind quantitykind:LengthMolarEnergy ;
   qudt:symbol "J·m/mol" ;
   qudt:ucumCode "J.m.mol-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "J.m/mol"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Dżul Metr na Mol"@pl ;
   rdfs:label "Joule Meter na Mol"@sl ;
@@ -21600,7 +21371,6 @@ unit:J-PER-CentiM3-K
   qudt:plainTextDescription "Joule per Cubic Centimeter Kelvin is a unit for Volumetric Heat Capacity expressed as J/(cm³·K)" ;
   qudt:symbol "J/(cm³·K)" ;
   qudt:ucumCode "J.cm-3.K-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "J/(cm3.K)"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Dżul na Centimetr Sześcienny Kelwin"@pl ;
   rdfs:label "Joule na Centimetr Krychlový Kelvin"@cs ;
@@ -21812,7 +21582,6 @@ unit:J-PER-KiloGM
   qudt:iec61360Code "0112/2///62720#UAA175" ;
   qudt:symbol "J/kg" ;
   qudt:ucumCode "J.kg-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "J/kg"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J2" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q57175225> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -21923,7 +21692,7 @@ unit:J-PER-KiloGM-K-M3
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H-1T-2D0 ;
   qudt:hasQuantityKind quantitykind:SpecificHeatVolume ;
   qudt:symbol "J/(kg·K·m³)" ;
-  qudt:ucumCode "J.kg-1.K.m-3"^^qudt:UCUMcs ;
+  qudt:ucumCode "J.kg-1.K-1.m-3"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Dżul na Kilogram Kelwin Metr Sześcienny"@pl ;
   rdfs:label "Joule na Kilogram Kelvin Kubični Meter"@sl ;
@@ -21992,7 +21761,6 @@ unit:J-PER-M
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
   qudt:symbol "J/m" ;
   qudt:ucumCode "J.m-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "J/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B12" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q56023789> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -22036,7 +21804,6 @@ unit:J-PER-M2
   qudt:iec61360Code "0112/2///62720#UAA179" ;
   qudt:symbol "J/m²" ;
   qudt:ucumCode "J.m-2"^^qudt:UCUMcs ;
-  qudt:ucumCode "J/m2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B13" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q80374519> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -22089,7 +21856,6 @@ unit:J-PER-M3
   qudt:iec61360Code "0112/2///62720#UAA180" ;
   qudt:symbol "J/m³" ;
   qudt:ucumCode "J.m-3"^^qudt:UCUMcs ;
-  qudt:ucumCode "J/m3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B8" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q69424806> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -22203,7 +21969,6 @@ unit:J-PER-MOL
   qudt:iec61360Code "0112/2///62720#UAA183" ;
   qudt:symbol "J/mol" ;
   qudt:ucumCode "J.mol-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "J/mol"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B15" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q13035094> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -22438,7 +22203,6 @@ unit:J-SEC-PER-MOL
   qudt:hasQuantityKind quantitykind:MolarAngularMomentum ;
   qudt:symbol "J·s/mol" ;
   qudt:ucumCode "J.s.mol-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "J.s/mol"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Dżul Sekunda na Mol"@pl ;
   rdfs:label "Joule Saat per Mole"@ms ;
@@ -22838,7 +22602,6 @@ unit:K-PER-SEC
   qudt:iec61360Code "0112/2///62720#UAA192" ;
   qudt:symbol "K/s" ;
   qudt:ucumCode "K.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "K/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F12" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Kelvin na Sekunda"@cs ;
@@ -22871,7 +22634,6 @@ unit:K-PER-SEC2
   qudt:hasQuantityKind quantitykind:TemperaturePerSquareTime ;
   qudt:symbol "K/s²" ;
   qudt:ucumCode "K.s-2"^^qudt:UCUMcs ;
-  qudt:ucumCode "K/s^2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Kelvin na Kvadratni Sekunda"@sl ;
   rdfs:label "Kelvin na Čtvereční Sekunda"@cs ;
@@ -22937,7 +22699,6 @@ unit:K-PER-W
   qudt:iec61360Code "0112/2///62720#UAA187" ;
   qudt:symbol "K/W" ;
   qudt:ucumCode "K.W-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "K/W"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B21" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q3194958> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -23026,12 +22787,12 @@ unit:KAT
   qudt:derivedCoherentUnitOfSystem sou:SI ;
   qudt:hasDimensionVector qkdv:A1E0L0I0M0H0T-1D0 ;
   qudt:hasFactorUnit [
-    qudt:exponent -1 ;
-    qudt:hasUnit unit:SEC ;
-  ] ;
-  qudt:hasFactorUnit [
     qudt:exponent 1 ;
     qudt:hasUnit unit:MOL ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent -1 ;
+    qudt:hasUnit unit:SEC ;
   ] ;
   qudt:hasQuantityKind quantitykind:CatalyticActivity ;
   qudt:iec61360Code "0112/2///62720#UAB196" ;
@@ -23080,7 +22841,7 @@ unit:KAT-PER-L
   qudt:hasQuantityKind quantitykind:CatalyticActivityConcentration ;
   qudt:plainTextDescription "A unit of catalytic activity used especially in the chemistry of enzymes. A catalyst is a substance that starts or speeds a chemical reaction. Enzymes are proteins that act as catalysts within the bodies of living plants and animals. A catalyst has an activity of one katal if it enables a reaction to proceed at the rate of one mole per second. " ;
   qudt:symbol "kat/L" ;
-  qudt:ucumCode "kat/L"^^qudt:UCUMcs ;
+  qudt:ucumCode "kat.L-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Katal per Liter"@en-US ;
   rdfs:label "Katal per Litre" ;
@@ -23127,7 +22888,7 @@ unit:KAT-PER-MicroL
   qudt:hasQuantityKind quantitykind:CatalyticActivityConcentration ;
   qudt:plainTextDescription "A unit of catalytic activity used especially in the chemistry of enzymes. A catalyst is a substance that starts or speeds a chemical reaction. Enzymes are proteins that act as catalysts within the bodies of living plants and animals. A catalyst has an activity of one katal if it enables a reaction to proceed at the rate of one mole per second. " ;
   qudt:symbol "kat/μL" ;
-  qudt:ucumCode "kat/uL"^^qudt:UCUMcs ;
+  qudt:ucumCode "kat.uL-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Katal per Microliter"@en-US ;
   rdfs:label "Katal per Microlitre" ;
@@ -23224,7 +22985,6 @@ unit:KN-PER-SEC
   qudt:hasQuantityKind quantitykind:LinearAcceleration ;
   qudt:symbol "kn/s" ;
   qudt:ucumCode "[kn_i].s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[kn_i]/s"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Knot per Second" ;
   rdfs:label "Knot per Second"@en .
@@ -23263,6 +23023,7 @@ unit:KibiBIT
   qudt:hasQuantityKind quantitykind:DatasetOfBits ;
   qudt:iec61360Code "0112/2///62720#UAB158" ;
   qudt:symbol "Kib" ;
+  qudt:ucumCode "Kibit"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C21" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q3815076> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -23335,6 +23096,7 @@ unit:KibiBYTE
   qudt:iec61360Code "0112/2///62720#UAA197" ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Byte#Multiple-byte_units"^^xsd:anyURI ;
   qudt:symbol "KiB" ;
+  qudt:ucumCode "KiBy"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E64" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q79756> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -23521,6 +23283,7 @@ unit:KiloBIT
   qudt:hasQuantityKind quantitykind:DatasetOfBits ;
   qudt:iec61360Code "0112/2///62720#UAB159" ;
   qudt:symbol "kb" ;
+  qudt:ucumCode "kbit"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C37" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q3194304> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -23636,7 +23399,6 @@ unit:KiloBTU_IT-PER-FT2
   qudt:plainTextDescription "kBTU per Square Foot is an Imperial unit for 'Energy Per Area." ;
   qudt:symbol "kBtu{IT}/ft²" ;
   qudt:ucumCode "k[Btu_IT].[ft_i]-2"^^qudt:UCUMcs ;
-  qudt:ucumCode "k[Btu_IT]/[ft_i]2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Kilo British Thermal Unit (international Definition) per Square Foot" ;
   rdfs:label "Kilo British Thermal Unit (international Definition) per Square Foot"@en .
@@ -23655,7 +23417,6 @@ unit:KiloBTU_IT-PER-HR
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:symbol "kBtu{IT}/h" ;
   qudt:ucumCode "k[Btu_IT].h-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "k[Btu_IT]/h"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Kilo British Thermal Unit (international Definition) per Hour" ;
   rdfs:label "Kilo British Thermal Unit (international Definition) per Hour"@en .
@@ -23687,7 +23448,6 @@ unit:KiloBTU_TH-PER-HR
   qudt:plainTextDescription "unit of the heat energy according to the Imperial system of units divided by the unit hour" ;
   qudt:symbol "kBtu{th}/h" ;
   qudt:ucumCode "k[Btu_th].h-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "k[Btu_th]/h"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Kilo British Thermal Unit (thermochemical Definition) per Hour" ;
   rdfs:label "Kilo British Thermal Unit (thermochemical Definition) per Hour"@en .
@@ -23943,7 +23703,6 @@ unit:KiloCAL-PER-GM
   qudt:hasQuantityKind quantitykind:SpecificEnergy ;
   qudt:symbol "kcal/g" ;
   qudt:ucumCode "kcal.g-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "kcal/g"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Kilocalorie per Gram" ;
   rdfs:label "Kilocalorie per Gram"@en .
@@ -23964,7 +23723,7 @@ unit:KiloCAL-PER-GM-DEG_C
   qudt:hasQuantityKind quantitykind:SpecificHeatCapacityAtConstantVolume ;
   qudt:hasQuantityKind quantitykind:SpecificHeatCapacityAtSaturation ;
   qudt:symbol "kcal/(g·°C)" ;
-  qudt:ucumCode "cal.g-1.Cel-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "kcal.g-1.Cel-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Kilocalorie per Gram Degree Celsius" ;
   rdfs:label "Kilocalorie per Gram Degree Celsius"@en .
@@ -23987,7 +23746,6 @@ unit:KiloCAL-PER-MIN
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:symbol "kcal/min" ;
   qudt:ucumCode "kcal.min-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "kcal/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K54" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Kilocalorie per Minute" ;
@@ -24006,7 +23764,6 @@ unit:KiloCAL-PER-MOL
   qudt:hasQuantityKind quantitykind:MolarEnergy ;
   qudt:symbol "kcal/mol" ;
   qudt:ucumCode "kcal.mol-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "kcal/mol"^^qudt:UCUMcs ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q6408112> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Kilocalorie per Mole" ;
@@ -24050,7 +23807,6 @@ unit:KiloCAL-PER-SEC
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:symbol "kcal/s" ;
   qudt:ucumCode "kcal.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "kcal/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K55" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Kilocalorie per Second" ;
@@ -24145,7 +23901,6 @@ unit:KiloCAL_TH
   qudt:iec61360Code "0112/2///62720#UAA590" ;
   qudt:plainTextDescription "1000-fold of the unit calorie, which is used particularly for calorific values of food" ;
   qudt:symbol "kcal" ;
-  qudt:ucumCode "[Cal]"^^qudt:UCUMcs ;
   qudt:ucumCode "kcal_th"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K53" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -24218,6 +23973,7 @@ unit:KiloCD
   qudt:hasQuantityKind quantitykind:LuminousIntensity ;
   qudt:iec61360Code "0112/2///62720#UAB365" ;
   qudt:symbol "kcd" ;
+  qudt:ucumCode "kcd"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P33" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Chilocandela"@it ;
@@ -24289,7 +24045,6 @@ unit:KiloCubicFT
   qudt:prefix prefix:Kilo ;
   qudt:scalingOf unit:FT3 ;
   qudt:symbol "k(ft³)" ;
-  qudt:ucumCode "[k.cft_i]"^^qudt:UCUMcs ;
   qudt:ucumCode "k[ft_i]3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "FC" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -24344,6 +24099,7 @@ unit:KiloFARAD
   qudt:hasQuantityKind quantitykind:Capacitance ;
   qudt:iec61360Code "0112/2///62720#UAB384" ;
   qudt:symbol "kF" ;
+  qudt:ucumCode "kF"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "N90" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q95378017> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -24563,7 +24319,6 @@ unit:KiloGM-M-PER-SEC
   qudt:iec61360Code "0112/2///62720#UAA615" ;
   qudt:symbol "kg·m/s" ;
   qudt:ucumCode "kg.m.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "kg.m/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B31" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q78775089> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -24873,7 +24628,6 @@ unit:KiloGM-PER-DAY
   qudt:plainTextDescription "SI base unit kilogram divided by the unit day" ;
   qudt:symbol "kg/d" ;
   qudt:ucumCode "kg.d-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "kg/d"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F30" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q107210127> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -24998,7 +24752,7 @@ unit:KiloGM-PER-FT2
   qudt:hasQuantityKind quantitykind:MassPerArea ;
   qudt:plainTextDescription "SI base unit kilogram divided by the square of the imperial foot" ;
   qudt:symbol "kg/ft²" ;
-  qudt:ucumCode "kg.ft-2"^^qudt:UCUMcs ;
+  qudt:ucumCode "kg.[ft_i]-2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Kilogram per Square Foot" ;
   rdfs:label "Kilogram per Square Foot"@en .
@@ -25047,7 +24801,6 @@ unit:KiloGM-PER-HA
   qudt:hasQuantityKind quantitykind:MassPerArea ;
   qudt:symbol "kg/ha" ;
   qudt:ucumCode "kg.har-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "kg/har"^^qudt:UCUMcs ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q107460919> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Kilogram per Hectare" ;
@@ -25063,7 +24816,7 @@ unit:KiloGM-PER-HA-YR
   qudt:hasQuantityKind quantitykind:MassPerAreaTime ;
   qudt:plainTextDescription "A measure of areal density over time equivalent to 1 kg per hectare per year." ;
   qudt:symbol "kg/(ha·a)" ;
-  qudt:ucumCode "kg.har-1.year-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "kg.har-1.a-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Kilogram per Hectare Year" ;
   rdfs:label "Kilogram per Hectare Year"@en .
@@ -25084,7 +24837,6 @@ unit:KiloGM-PER-HR
   qudt:iec61360Code "0112/2///62720#UAA607" ;
   qudt:symbol "kg/h" ;
   qudt:ucumCode "kg.h-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "kg/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E93" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q107210138> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -25295,7 +25047,6 @@ unit:KiloGM-PER-KiloMOL
   qudt:plainTextDescription "SI base unit kilogram divided by the 1 000-fold of the SI base unit mol" ;
   qudt:symbol "kg/kmol" ;
   qudt:ucumCode "kg.kmol-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "kg/kmol"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F24" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q106623580> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -25329,7 +25080,6 @@ unit:KiloGM-PER-L
   qudt:plainTextDescription "SI base unit kilogram divided by the unit litre" ;
   qudt:symbol "kg/L" ;
   qudt:ucumCode "kg.L-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "kg/L"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B35" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q104907192> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -25387,7 +25137,6 @@ unit:KiloGM-PER-M
   qudt:iec61360Code "0112/2///62720#UAA616" ;
   qudt:symbol "kg/m" ;
   qudt:ucumCode "kg.m-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "kg/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "KL" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q25999243> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -25562,7 +25311,6 @@ unit:KiloGM-PER-M2
   qudt:iec61360Code "0112/2///62720#UAD513" ;
   qudt:symbol "kg/m²" ;
   qudt:ucumCode "kg.m-2"^^qudt:UCUMcs ;
-  qudt:ucumCode "kg/m2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "28" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q25377184> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -25726,7 +25474,6 @@ unit:KiloGM-PER-M3
   qudt:plainTextDescription "Kilogram per cubic metre is an SI derived unit of density, defined by mass in kilograms divided by volume in cubic metres. The official SI symbolic abbreviation is kg . m^-3, or equivalently either kg/m^3." ;
   qudt:symbol "kg/m³" ;
   qudt:ucumCode "kg.m-3"^^qudt:UCUMcs ;
-  qudt:ucumCode "kg/m3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "KMQ" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q844211> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -25879,7 +25626,6 @@ unit:KiloGM-PER-MIN
   qudt:plainTextDescription "SI base unit kilogram divided by the unit minute" ;
   qudt:symbol "kg/min" ;
   qudt:ucumCode "kg.min-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "kg/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F31" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q107210172> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -25936,7 +25682,6 @@ unit:KiloGM-PER-MOL
   qudt:iec61360Code "0112/2///62720#UAA628" ;
   qudt:symbol "kg/mol" ;
   qudt:ucumCode "kg.mol-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "kg/mol"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D74" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q28924753> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -25973,7 +25718,7 @@ unit:KiloGM-PER-MegaBTU_IT
   qudt:hasQuantityKind quantitykind:MassPerEnergy ;
   qudt:plainTextDescription "Kilogram per Mega BTU is an Imperial Unit for 'Mass Per Energy." ;
   qudt:symbol "kg/MBtu{IT}" ;
-  qudt:ucumCode "k[g].[MBtu_IT]-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "kg.M[Btu_IT]-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Kilogram per Mega British Thermal Unit (international Definition)" ;
   rdfs:label "Kilogram per Mega British Thermal Unit (international Definition)"@en .
@@ -26091,7 +25836,6 @@ unit:KiloGM-PER-SEC
   qudt:iec61360Code "0112/2///62720#UAA629" ;
   qudt:symbol "kg/s" ;
   qudt:ucumCode "kg.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "kg/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "KGS" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q25381181> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -26173,9 +25917,7 @@ unit:KiloGM-PER-SEC-M2
   qudt:iec61360Code "0112/2///62720#UAA618" ;
   qudt:plainTextDescription "SI base unit kilogram divided by the product of the power of the SI base unit metre with the exponent 2 and the SI base unit second" ;
   qudt:symbol "kg/(s·m²)" ;
-  qudt:ucumCode "kg.(s.m2)-1"^^qudt:UCUMcs ;
   qudt:ucumCode "kg.s-1.m-2"^^qudt:UCUMcs ;
-  qudt:ucumCode "kg/(s.m2)"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H56" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q92011107> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -26244,7 +25986,6 @@ unit:KiloGM-PER-SEC2
   qudt:latexSymbol "$kg \\cdot s^2$"^^qudt:LatexString ;
   qudt:symbol "kg/s²" ;
   qudt:ucumCode "kg.s-2"^^qudt:UCUMcs ;
-  qudt:ucumCode "kg/s2"^^qudt:UCUMcs ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q106682321> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Chiliogramma per Secundum Quadratum"@la ;
@@ -26517,6 +26258,7 @@ unit:KiloGRAY
   qudt:hasQuantityKind quantitykind:Kerma ;
   qudt:iec61360Code "0112/2///62720#UAB504" ;
   qudt:symbol "kGy" ;
+  qudt:ucumCode "kGy"^^qudt:UCUMcs ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q94487750> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Chilogray"@it ;
@@ -26542,6 +26284,7 @@ unit:KiloH
   qudt:hasQuantityKind quantitykind:Inductance ;
   qudt:iec61360Code "0112/2///62720#UAB386" ;
   qudt:symbol "kH" ;
+  qudt:ucumCode "kH"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P24" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Chilohenry"@it ;
@@ -26700,7 +26443,6 @@ unit:KiloJ-PER-K
   qudt:plainTextDescription "1 000-fold of the SI derived unit joule divided by the SI base unit kelvin" ;
   qudt:symbol "kJ/K" ;
   qudt:ucumCode "kJ.K-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "kJ/K"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B41" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Chilojoule per Kelvin"@it ;
@@ -26731,7 +26473,6 @@ unit:KiloJ-PER-KiloGM
   qudt:plainTextDescription "1 000-fold of the SI derived unit joule divided by the SI base unit kilogram" ;
   qudt:symbol "kJ/kg" ;
   qudt:ucumCode "kJ.kg-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "kJ/kg"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B42" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q21077849> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -26763,9 +26504,7 @@ unit:KiloJ-PER-KiloGM-K
   qudt:iec61360Code "0112/2///62720#UAA571" ;
   qudt:plainTextDescription "1 000-fold of the SI derived unit joule divided by the product of the SI base unit kilogram and the SI base unit kelvin" ;
   qudt:symbol "kJ/(kg·K)" ;
-  qudt:ucumCode "kJ.(kg.K)-1"^^qudt:UCUMcs ;
   qudt:ucumCode "kJ.kg-1.K-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "kJ/(kg.K)"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B43" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q108834064> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -26833,7 +26572,6 @@ unit:KiloJ-PER-MOL
   qudt:plainTextDescription "1 000-fold of the SI derived unit joule divided by the SI base unit mol" ;
   qudt:symbol "kJ/mol" ;
   qudt:ucumCode "kJ.mol-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "kJ/mol"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B44" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q752197> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -26913,7 +26651,6 @@ unit:KiloL-PER-HR
   qudt:plainTextDescription "unit of the volume kilolitres divided by the unit hour" ;
   qudt:symbol "kL/h" ;
   qudt:ucumCode "kL.h-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "kL/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "4X" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q107313807> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -26928,6 +26665,7 @@ unit:KiloLB
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Mass ;
   qudt:symbol "klbm" ;
+  qudt:ucumCode "k[lb_av]"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Kilo Pound Mass" ;
   rdfs:label "Kilo Pound Mass"@en .
@@ -26942,6 +26680,7 @@ unit:KiloLB-PER-HR
   qudt:hasQuantityKind quantitykind:MassPerTime ;
   qudt:iec61360Code "0112/2///62720#UAB391" ;
   qudt:symbol "klbm/h" ;
+  qudt:ucumCode "k[lb_av].h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M90" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Kilo Pound Mass per Hour" ;
@@ -26958,6 +26697,7 @@ unit:KiloLB_F
   qudt:hasQuantityKind quantitykind:Force ;
   qudt:iec61360Code "0112/2///62720#UAB232" ;
   qudt:symbol "klbf" ;
+  qudt:ucumCode "k[lbf_av]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M75" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Kilo Pound Force" ;
@@ -26973,7 +26713,7 @@ unit:KiloLB_F-FT-PER-A
   qudt:iec61360Code "0112/2///62720#UAB483" ;
   qudt:plainTextDescription "product of the Anglo-American unit pound-force and foot divided by the SI base unit ampere" ;
   qudt:symbol "klbf·ft/A" ;
-  qudt:ucumCode "[lbf_av].[ft_i].A-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "k[lbf_av].[ft_i].A-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F22" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Kilo Pound Force Foot per Ampere" ;
@@ -26991,7 +26731,7 @@ unit:KiloLB_F-FT-PER-LB
   qudt:iec61360Code "0112/2///62720#UAB484" ;
   qudt:plainTextDescription "product of the Anglo-American unit pound-force and the Anglo-American unit foot divided by the Anglo-American unit pound (US) of mass" ;
   qudt:symbol "klbf·ft/lbm" ;
-  qudt:ucumCode "[lbf_av].[ft_i].[lb_av]-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "k[lbf_av].[ft_i].[lb_av]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G20" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Kilo Pound Force Foot per Pound Mass" ;
@@ -27009,7 +26749,7 @@ unit:KiloLB_F-PER-FT
   qudt:iec61360Code "0112/2///62720#UAB192" ;
   qudt:plainTextDescription "unit of the length-related force" ;
   qudt:symbol "klbf/ft" ;
-  qudt:ucumCode "[klbf_av].[ft_i]-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "k[lbf_av].[ft_i]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F17" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Kilo Pound Force per Foot" ;
@@ -27030,7 +26770,7 @@ unit:KiloLB_F-PER-IN2
   qudt:iec61360Code "0112/2///62720#UAB138" ;
   qudt:plainTextDescription "1 000-fold of the unit for pressure psi as a compounded unit pound-force according to the Anglo-American system of units divided by the power of the unit Inch according to the Anglo-American and Imperial system of units by exponent 2" ;
   qudt:symbol "klbf/in²" ;
-  qudt:ucumCode "k[lbf_av].[sin_i]-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "k[lbf_av].[in_i]-2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "84" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Kilo Pound Force per Square Inch" ;
@@ -27136,7 +26876,6 @@ unit:KiloM-PER-HR
   qudt:informativeReference "http://en.wikipedia.org/wiki/Kilometres_per_hour?oldid=487674812"^^xsd:anyURI ;
   qudt:symbol "km/h" ;
   qudt:ucumCode "km.h-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "km/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "KMH" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q180154> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -27160,7 +26899,6 @@ unit:KiloM-PER-SEC
   qudt:iec61360Code "0112/2///62720#UAB392" ;
   qudt:symbol "km/s" ;
   qudt:ucumCode "km.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "km/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M62" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q3674704> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -27261,7 +26999,6 @@ unit:KiloM2-PER-SEC2
   qudt:hasQuantityKind quantitykind:SpecificModulus ;
   qudt:symbol "km²/s²" ;
   qudt:ucumCode "km2.s-2"^^qudt:UCUMcs ;
-  qudt:ucumCode "km2/s2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Chilometro Quadrato per Secondo Quadrato"@it ;
   rdfs:label "Kilometer Persegi per Saat Persegi"@ms ;
@@ -27291,7 +27028,6 @@ unit:KiloM3-PER-SEC2
   qudt:hasQuantityKind quantitykind:StandardGravitationalParameter ;
   qudt:symbol "km³/s²" ;
   qudt:ucumCode "km3.s-2"^^qudt:UCUMcs ;
-  qudt:ucumCode "km3/s2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Chilometro Cubo per Secondo Quadrato"@it ;
   rdfs:label "Cubic Kilometer per Square Second"@en-US ;
@@ -27316,6 +27052,7 @@ unit:KiloMIL_Circ
   qudt:hasQuantityKind quantitykind:Area ;
   qudt:iec61360Code "0112/2///62720#UAD931" ;
   qudt:symbol "kcmil" ;
+  qudt:ucumCode "k[cml_i]"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Kilo Circular Mil" ;
   rdfs:label "Kilo Circular Mil"@en .
@@ -27361,7 +27098,6 @@ unit:KiloMOL-PER-HR
   qudt:plainTextDescription "1 000-fold of the SI base unit mole divided by the unit for time hour" ;
   qudt:symbol "kmol/h" ;
   qudt:ucumCode "kmol.h-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "kmol/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K58" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Kilomole per Hour" ;
@@ -27383,7 +27119,6 @@ unit:KiloMOL-PER-KiloGM
   qudt:iec61360Code "0112/2///62720#UAB404" ;
   qudt:symbol "kmol/kg" ;
   qudt:ucumCode "kmol.kg-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "kmol/kg"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P47" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q107440698> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -27501,7 +27236,6 @@ unit:KiloMOL-PER-SEC
   qudt:plainTextDescription "1 000-fold of the SI base unit mol divided by the SI base unit second" ;
   qudt:symbol "kmol/s" ;
   qudt:ucumCode "kmol.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "kmol/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E94" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Chilomole per Secondo"@it ;
@@ -27702,7 +27436,7 @@ unit:KiloN-PER-CentiM2
   qudt:hasQuantityKind quantitykind:ForcePerArea ;
   qudt:hasQuantityKind quantitykind:ModulusOfElasticity ;
   qudt:symbol "kN/cm²" ;
-  qudt:ucumCode "kN.mm-2"^^qudt:UCUMcs ;
+  qudt:ucumCode "kN.cm-2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Chilonewton per Centimetro Quadrato"@it ;
   rdfs:label "Kilonewton na Kvadratni Centimeter"@sl ;
@@ -28293,6 +28027,7 @@ unit:KiloT
   qudt:hasQuantityKind quantitykind:MagneticFluxDensity ;
   qudt:iec61360Code "0112/2///62720#UAB385" ;
   qudt:symbol "kT" ;
+  qudt:ucumCode "kT"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P13" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Chilotesla"@it ;
@@ -28321,6 +28056,7 @@ unit:KiloTONNE
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Mass ;
   qudt:symbol "kt" ;
+  qudt:ucumCode "kt"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "KTN" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q53952048> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -28656,7 +28392,7 @@ unit:KiloVAR-HR
   qudt:iec61360Code "0112/2///62720#UAB195" ;
   qudt:plainTextDescription "product of the 1 000-fold of the unit volt ampere reactive and the unit hour" ;
   qudt:symbol "kVA{Reactive}·h" ;
-  qudt:ucumCode "kVA.h{reactive}"^^qudt:UCUMcs ;
+  qudt:ucumCode "kVA{reactive}.h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K3" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Kilo Volt Ampere Reactive Hour" ;
@@ -28671,6 +28407,7 @@ unit:KiloVAR-PER-K
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAD904" ;
   qudt:symbol "kVA{Reactive}/K" ;
+  qudt:ucumCode "kVA{reactive}.K-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Kilo Volt Ampere Reactive per Kelvin" ;
   rdfs:label "Kilo Volt Ampere Reactive per Kelvin"@en .
@@ -28879,6 +28616,7 @@ unit:KiloWB
   qudt:hasQuantityKind quantitykind:MagneticFlux ;
   qudt:iec61360Code "0112/2///62720#UAB358" ;
   qudt:symbol "kWb" ;
+  qudt:ucumCode "kWb"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P11" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q94489494> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -28940,6 +28678,7 @@ unit:KiloYR
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:Time ;
   qudt:symbol "ka" ;
+  qudt:ucumCode "ka"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Kiloyear" ;
   rdfs:label "Kiloyear"@en .
@@ -28986,7 +28725,6 @@ unit:L-PER-BAR
   qudt:iec61360Code "0112/2///62720#UAA651" ;
   qudt:symbol "L/bar" ;
   qudt:ucumCode "L.bar-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "L/bar"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G95" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Liter per Bar"@en-US ;
@@ -29009,7 +28747,6 @@ unit:L-PER-DAY
   qudt:plainTextDescription "unit litre divided by the unit day" ;
   qudt:symbol "L/d" ;
   qudt:ucumCode "L.d-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "L/d"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "LD" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q61992237> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -29065,7 +28802,6 @@ unit:L-PER-HR
   qudt:plainTextDescription "Unit litre divided by the unit hour" ;
   qudt:symbol "L/h" ;
   qudt:ucumCode "L.h-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "L/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E32" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q104907522> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -29117,7 +28853,6 @@ unit:L-PER-K
   qudt:plainTextDescription "unit litre divided by the SI base unit kelvin" ;
   qudt:symbol "L/K" ;
   qudt:ucumCode "L.K-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "L/K"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G28" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Liter per Kelvin"@en-US ;
@@ -29141,7 +28876,6 @@ unit:L-PER-KiloGM
   qudt:plainTextDescription "unit of the volume litre divided by the SI base unit kilogram" ;
   qudt:symbol "L/kg" ;
   qudt:ucumCode "L.kg-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "L/kg"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H83" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q57175557> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -29164,7 +28898,6 @@ unit:L-PER-L
   qudt:plainTextDescription "volume ratio consisting of the unit litre divided by the unit litre" ;
   qudt:symbol "L/L" ;
   qudt:ucumCode "L.L-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "L/L"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K62" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q106629979> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -29188,7 +28921,6 @@ unit:L-PER-MIN
   qudt:plainTextDescription "unit litre divided by the unit minute" ;
   qudt:symbol "L/min" ;
   qudt:ucumCode "L.min-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "L/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L2" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q107313814> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -29242,7 +28974,6 @@ unit:L-PER-MOL
   qudt:plainTextDescription "unit litre divided by the SI base unit mol" ;
   qudt:symbol "L/mol" ;
   qudt:ucumCode "L.mol-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "L/mol"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B58" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q107538768> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -29278,7 +29009,6 @@ unit:L-PER-MicroMOL
   qudt:hasReciprocalUnit unit:MicroMOL-PER-L ;
   qudt:symbol "L/μmol" ;
   qudt:ucumCode "L.umol-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "L/umol"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Liter per Micromole"@en-US ;
   rdfs:label "Litre per Micromole" ;
@@ -29300,7 +29030,6 @@ unit:L-PER-SEC
   qudt:plainTextDescription "unit litre divided by the SI base unit second" ;
   qudt:symbol "L/s" ;
   qudt:ucumCode "L.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "L/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G51" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q61996348> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -29370,12 +29099,12 @@ unit:LA
   qudt:factorUnitScalar 0.31830988618 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I1M0H0T0D0 ;
   qudt:hasFactorUnit [
-    qudt:exponent -2 ;
-    qudt:hasUnit unit:M ;
-  ] ;
-  qudt:hasFactorUnit [
     qudt:exponent 1 ;
     qudt:hasUnit unit:CD ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent -2 ;
+    qudt:hasUnit unit:M ;
   ] ;
   qudt:hasQuantityKind quantitykind:Luminance ;
   qudt:iec61360Code "0112/2///62720#UAB259" ;
@@ -29418,12 +29147,12 @@ unit:LA_FT
   qudt:factorUnitScalar 0.31830988618 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I1M0H0T0D0 ;
   qudt:hasFactorUnit [
-    qudt:exponent -2 ;
-    qudt:hasUnit unit:FT ;
-  ] ;
-  qudt:hasFactorUnit [
     qudt:exponent 1 ;
     qudt:hasUnit unit:CD ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent -2 ;
+    qudt:hasUnit unit:FT ;
   ] ;
   qudt:hasQuantityKind quantitykind:Luminance ;
   qudt:symbol "ft-L" ;
@@ -29521,7 +29250,7 @@ unit:LB-FT2
   qudt:iec61360Code "0112/2///62720#UAA671" ;
   qudt:plainTextDescription "product of the unit pound according to the avoirdupois system of units and the power of the unit foot according to the Anglo-American and the Imperial system of units with the exponent 2" ;
   qudt:symbol "lbm·ft²" ;
-  qudt:ucumCode "[lb_av].[sft_i]"^^qudt:UCUMcs ;
+  qudt:ucumCode "[lb_av].[ft_i]2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K65" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Pound Mass Square Foot" ;
@@ -29867,7 +29596,7 @@ unit:LB-IN2
   qudt:iec61360Code "0112/2///62720#UAA672" ;
   qudt:plainTextDescription "product of the unit pound according to the avoirdupois system of units and the power of the unit inch according to the Anglo-American and the Imperial system of units with the exponent 2" ;
   qudt:symbol "lbm·in²" ;
-  qudt:ucumCode "[lb_av].[sin_i]"^^qudt:UCUMcs ;
+  qudt:ucumCode "[lb_av].[in_i]2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F20" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Pound Mass Square Inch" ;
@@ -30192,8 +29921,7 @@ unit:LB-PER-AC
   qudt:hasQuantityKind quantitykind:MassPerArea ;
   qudt:plainTextDescription "mass per area as pounds of mass (based on the international standard definition of the pound of mass as exactly 0.45359237 kg) divided by area as acres (a unit of area in a number of different systems, including the imperial and U.S. customary systems. The most commonly used acres today are the international acre and, in the United States, the survey acre. The most common use of the acre is to measure tracts of land. One international acre is equal to 4046.8564224 square metres." ;
   qudt:symbol "lbm/acre" ;
-  qudt:ucumCode "lb.[acr_br]-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "lb/[acr_br]"^^qudt:UCUMcs ;
+  qudt:ucumCode "[lb_av].[acr_br]-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Pound Mass per Acre" ;
   rdfs:label "Pound Mass per Acre"@en .
@@ -30375,7 +30103,7 @@ unit:LB-PER-FT3
   qudt:hasReciprocalUnit unit:FT3-PER-LB ;
   qudt:iec61360Code "0112/2///62720#UAA676" ;
   qudt:symbol "lbm/ft³" ;
-  qudt:ucumCode "[lb_av].[cft_i]-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[lb_av].[ft_i]-3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "87" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q106623674> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -30583,7 +30311,7 @@ unit:LB-PER-IN2
   qudt:iec61360Code "0112/2///62720#UAB137" ;
   qudt:plainTextDescription "unit of the areal-related mass as avoirdupois pound according to the avoirdupois system of units related to the area square inch according to the Anglo-American and Imperial system of units" ;
   qudt:symbol "lbm/in²" ;
-  qudt:ucumCode "[lb_av].[sin_i]-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[lb_av].[in_i]-2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "80" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Pound Mass per Square Inch" ;
@@ -30605,7 +30333,7 @@ unit:LB-PER-IN3
   qudt:hasReciprocalUnit unit:IN3-PER-LB ;
   qudt:iec61360Code "0112/2///62720#UAA685" ;
   qudt:symbol "lbm/in³" ;
-  qudt:ucumCode "[lb_av].[cin_i]-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[lb_av].[in_i]-3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "LA" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q106623879> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -30838,7 +30566,7 @@ unit:LB-PER-YD3
   qudt:hasQuantityKind quantitykind:MassDensity ;
   qudt:iec61360Code "0112/2///62720#UAA695" ;
   qudt:symbol "lbm/yd³" ;
-  qudt:ucumCode "[lb_av].[cyd_i]-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[lb_av].[yd_i]-3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K84" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q106623974> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -31109,16 +30837,16 @@ unit:LB_F
   qudt:definedUnitOfSystem sou:USCS ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H0T-2D0 ;
   qudt:hasFactorUnit [
-    qudt:exponent 1 ;
-    qudt:hasUnit unit:FT ;
-  ] ;
-  qudt:hasFactorUnit [
     qudt:exponent -2 ;
     qudt:hasUnit unit:SEC ;
   ] ;
   qudt:hasFactorUnit [
     qudt:exponent 1 ;
     qudt:hasUnit unit:SLUG ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent 1 ;
+    qudt:hasUnit unit:FT ;
   ] ;
   qudt:hasQuantityKind quantitykind:Force ;
   qudt:iec61360Code "0112/2///62720#UAA696" ;
@@ -31238,7 +30966,7 @@ unit:LB_F-PER-FT2
   qudt:hasQuantityKind quantitykind:VaporPressure ;
   qudt:iec61360Code "0112/2///62720#UAA698" ;
   qudt:symbol "lbf/ft²" ;
-  qudt:ucumCode "[lbf_av].[sft_i]-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[lbf_av].[ft_i]-2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K85" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Pound Force per Square Foot" ;
@@ -31284,7 +31012,7 @@ unit:LB_F-PER-IN2
   qudt:iec61360Code "0112/2///62720#UAA701" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Pounds_per_square_inch?oldid=485678341"^^xsd:anyURI ;
   qudt:symbol "lbf/in²" ;
-  qudt:ucumCode "[lbf_av].[sin_i]-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[lbf_av].[in_i]-2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "PS" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q626299> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -31303,7 +31031,7 @@ unit:LB_F-PER-IN2-DEG_F
   qudt:iec61360Code "0112/2///62720#UAA702" ;
   qudt:plainTextDescription "composed unit for pressure (pound-force per square inch) divided by the unit degree Fahrenheit for temperature" ;
   qudt:symbol "lbf/(in²·°F)" ;
-  qudt:ucumCode "[lbf_av].[sin_i]-1.[degF]-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[lbf_av].[in_i]-2.[degF]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K86" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Pound Force per Square Inch Degree Fahrenheit" ;
@@ -31320,7 +31048,7 @@ unit:LB_F-PER-IN2-SEC
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:ForcePerAreaTime ;
   qudt:symbol "lbf/(in²·s)" ;
-  qudt:ucumCode "[lbf_av].[sin_i]-1.s-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[lbf_av].[in_i]-2.s-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Pound Force per Square Inch Second" ;
   rdfs:label "Pound Force per Square Inch Second"@en .
@@ -31373,7 +31101,7 @@ unit:LB_F-SEC-PER-FT2
   qudt:hasQuantityKind quantitykind:Viscosity ;
   qudt:iec61360Code "0112/2///62720#UAA707" ;
   qudt:symbol "lbf·s/ft²" ;
-  qudt:ucumCode "[lbf_av].s.[sft_i]-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[lbf_av].s.[ft_i]-2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K91" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Pound Force Second per Square Foot" ;
@@ -31394,7 +31122,7 @@ unit:LB_F-SEC-PER-IN2
   qudt:hasQuantityKind quantitykind:Viscosity ;
   qudt:iec61360Code "0112/2///62720#UAA708" ;
   qudt:symbol "lbf·s/in²" ;
-  qudt:ucumCode "[lbf_av].s.[sin_i]-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[lbf_av].s.[in_i]-2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K92" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Pound Force Second per Square Inch" ;
@@ -31455,11 +31183,11 @@ unit:LM
   qudt:hasDimensionVector qkdv:A0E0L0I1M0H0T0D0 ;
   qudt:hasFactorUnit [
     qudt:exponent 1 ;
-    qudt:hasUnit unit:SR ;
+    qudt:hasUnit unit:CD ;
   ] ;
   qudt:hasFactorUnit [
     qudt:exponent 1 ;
-    qudt:hasUnit unit:CD ;
+    qudt:hasUnit unit:SR ;
   ] ;
   qudt:hasQuantityKind quantitykind:LuminousFlux ;
   qudt:iec61360Code "0112/2///62720#UAA718" ;
@@ -31572,7 +31300,6 @@ unit:LM-PER-W
   qudt:iec61360Code "0112/2///62720#UAA719" ;
   qudt:symbol "lm/W" ;
   qudt:ucumCode "lm.W-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "lm/W"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B61" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q83386886> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -31989,7 +31716,6 @@ unit:M-PER-DAY
   qudt:hasQuantityKind quantitykind:Velocity ;
   qudt:symbol "m/d" ;
   qudt:ucumCode "m.d-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "m/d"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Meter per Day"@en-US ;
   rdfs:label "Metre per Day" ;
@@ -32076,7 +31802,7 @@ unit:M-PER-HA
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:InverseLength ;
   qudt:symbol "m/ha" ;
-  qudt:ucumCode "m.hm-2"^^qudt:UCUMcs ;
+  qudt:ucumCode "m.har-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Meter per Hectare"@en-US ;
   rdfs:label "Metre per Hectare" ;
@@ -32099,7 +31825,6 @@ unit:M-PER-HR
   qudt:iec61360Code "0112/2///62720#UAB328" ;
   qudt:symbol "m/h" ;
   qudt:ucumCode "m.h-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "m/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M60" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q17093295> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -32120,7 +31845,7 @@ unit:M-PER-K
   qudt:hasReciprocalUnit unit:K-PER-M ;
   qudt:iec61360Code "0112/2///62720#UAA728" ;
   qudt:symbol "m/K" ;
-  qudt:ucumCode "m/K"^^qudt:UCUMcs ;
+  qudt:ucumCode "m.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F52" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Meter na Kelvin"@sl ;
@@ -32193,7 +31918,6 @@ unit:M-PER-MIN
   qudt:iec61360Code "0112/2///62720#UAA732" ;
   qudt:symbol "m/min" ;
   qudt:ucumCode "m.min-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "m/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "2X" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q21014455> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -32287,7 +32011,6 @@ The official SI symbolic abbreviation is mu00b7s-1, or equivalently either m/s."
   qudt:iec61360Code "0112/2///62720#UAA733" ;
   qudt:symbol "m/s" ;
   qudt:ucumCode "m.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "m/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "MTS" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q182429> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -32413,7 +32136,6 @@ unit:M-PER-SEC2
   qudt:iec61360Code "0112/2///62720#UAA736" ;
   qudt:symbol "m/s²" ;
   qudt:ucumCode "m.s-2"^^qudt:UCUMcs ;
-  qudt:ucumCode "m/s2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "MSK" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q1051665> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -32610,7 +32332,7 @@ unit:M2-HR-DEG_C-PER-KiloCAL_IT
   qudt:iec61360Code "0112/2///62720#UAA749" ;
   qudt:plainTextDescription "product of the power of the SI base unit metre with the exponent 2, of the unit hour for time and the unit degree Celsius for temperature divided by the 1000-fold of the out of use unit for energy international calorie" ;
   qudt:symbol "m²·h·°C/kcal{IT}" ;
-  qudt:ucumCode "m2.h.Cel/kcal_IT"^^qudt:UCUMcs ;
+  qudt:ucumCode "m2.h.Cel.kcal_IT-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L14" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Square Meter Hour Degree Celsius per Kilo International Table Calorie"@en-US ;
@@ -33204,7 +32926,6 @@ unit:M2-PER-MOL
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
   qudt:symbol "m²/mol" ;
   qudt:ucumCode "m2.mol-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "m2/mol"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D22" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q86203731> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -33291,7 +33012,6 @@ unit:M2-PER-SEC
   qudt:iec61360Code "0112/2///62720#UAA752" ;
   qudt:symbol "m²/s" ;
   qudt:ucumCode "m2.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "m2/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "S4" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q3332099> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -33428,7 +33148,6 @@ unit:M2-PER-SEC2
   qudt:iec61360Code "0112/2///62720#UAD501" ;
   qudt:symbol "m²/s²" ;
   qudt:ucumCode "m2.s-2"^^qudt:UCUMcs ;
-  qudt:ucumCode "m2/s2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Kvadratni Meter na Kvadratni Sekunda"@sl ;
   rdfs:label "Meter Persegi per Saat Persegi"@ms ;
@@ -33458,7 +33177,7 @@ unit:M2-PER-SEC2-K
   qudt:hasQuantityKind quantitykind:SpecificHeatCapacity ;
   qudt:plainTextDescription "Unit for expressing the specific heat capacity." ;
   qudt:symbol "m²/(s²·K)" ;
-  qudt:ucumCode "m2.s2-1.K-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "m2.s-2.K-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Kvadratni Meter na Kvadratni Sekunda Kelvin"@sl ;
   rdfs:label "Meter Persegi per Saat Persegi Kelvin"@ms ;
@@ -33894,7 +33613,6 @@ unit:M3-PER-HR
   qudt:iec61360Code "0112/2///62720#UAA763" ;
   qudt:symbol "m³/h" ;
   qudt:ucumCode "m3.h-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "m3/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "MQH" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q107313770> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -33986,7 +33704,6 @@ unit:M3-PER-KiloGM
   qudt:iec61360Code "0112/2///62720#UAA766" ;
   qudt:symbol "m³/kg" ;
   qudt:ucumCode "m3.kg-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "m3/kg"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A39" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q3332095> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -34023,9 +33740,7 @@ unit:M3-PER-KiloGM-SEC2
   qudt:hasDimensionVector qkdv:A0E0L3I0M-1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:symbol "m³/(kg·s²)" ;
-  qudt:ucumCode "m3.(kg.s2)-1"^^qudt:UCUMcs ;
   qudt:ucumCode "m3.kg-1.s-2"^^qudt:UCUMcs ;
-  qudt:ucumCode "m3/(kg.s2)"^^qudt:UCUMcs ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q78336909> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Cubic Meter per Kilogram Square Second"@en-US ;
@@ -34189,7 +33904,6 @@ unit:M3-PER-MOL
   qudt:iec61360Code "0112/2///62720#UAA771" ;
   qudt:symbol "m³/mol" ;
   qudt:ucumCode "m3.mol-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "m3/mol"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "A40" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q21615967> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -34299,7 +34013,6 @@ unit:M3-PER-SEC
   qudt:iec61360Code "0112/2///62720#UAA772" ;
   qudt:symbol "m³/s" ;
   qudt:ucumCode "m3.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "m3/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "MQS" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q794261> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -34446,7 +34159,6 @@ unit:M3-PER-SEC2
   qudt:hasQuantityKind quantitykind:StandardGravitationalParameter ;
   qudt:symbol "m³/s²" ;
   qudt:ucumCode "m3.s-2"^^qudt:UCUMcs ;
-  qudt:ucumCode "m3/s2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Cubic Meter per Square Second"@en-US ;
   rdfs:label "Cubic Metre per Square Second" ;
@@ -34694,7 +34406,6 @@ unit:MI-PER-HR
   qudt:informativeReference "http://en.wikipedia.org/wiki/Miles_per_hour?oldid=482840548"^^xsd:anyURI ;
   qudt:symbol "mi/h" ;
   qudt:ucumCode "[mi_i].h-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[mi_i]/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "HM" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q211256> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -34718,7 +34429,6 @@ unit:MI-PER-MIN
   qudt:iec61360Code "0112/2///62720#UAB229" ;
   qudt:symbol "mi/min" ;
   qudt:ucumCode "[mi_i].min-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[mi_i]/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M57" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q106611642> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -34740,8 +34450,7 @@ unit:MI-PER-SEC
   qudt:hasQuantityKind quantitykind:Velocity ;
   qudt:iec61360Code "0112/2///62720#UAB230" ;
   qudt:symbol "mi/s" ;
-  qudt:ucumCode "[mi_i].sec-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[mi_i]/sec"^^qudt:UCUMcs ;
+  qudt:ucumCode "[mi_i].s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M58" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q106611669> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -34765,8 +34474,6 @@ unit:MI2
   qudt:iec61360Code "0112/2///62720#UAB208" ;
   qudt:symbol "mi²" ;
   qudt:ucumCode "[mi_i]2"^^qudt:UCUMcs ;
-  qudt:ucumCode "[mi_us]2"^^qudt:UCUMcs ;
-  qudt:ucumCode "[smi_us]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M48" ;
   qudt:uneceCommonCode "MIK" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q232291> ;
@@ -34896,7 +34603,6 @@ unit:MIN-PER-KiloM
   qudt:iec61360Code "0112/2///62720#UAD709" ;
   qudt:symbol "min/km" ;
   qudt:ucumCode "min.km-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "min/km"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Minute per Kilometer"@en-US ;
   rdfs:label "Minute per Kilometre" ;
@@ -34912,8 +34618,7 @@ unit:MIN-PER-MI
   qudt:hasReciprocalUnit unit:MI-PER-MIN ;
   qudt:iec61360Code "0112/2///62720#UAD709" ;
   qudt:symbol "min/mi" ;
-  qudt:ucumCode "min.mi-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "min/mi"^^qudt:UCUMcs ;
+  qudt:ucumCode "min.[mi_i]-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Minute per International Mile" ;
   rdfs:label "Minute per International Mile"@en .
@@ -35009,7 +34714,6 @@ unit:MI_N-PER-HR
   qudt:hasQuantityKind quantitykind:Velocity ;
   qudt:symbol "nmi/h" ;
   qudt:ucumCode "[nmi_i].h-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[nmi_i]/h"^^qudt:UCUMcs ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q104907390> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Nautical Mile per Hour" ;
@@ -35028,7 +34732,6 @@ unit:MI_N-PER-MIN
   qudt:hasQuantityKind quantitykind:Velocity ;
   qudt:symbol "nmi/min" ;
   qudt:ucumCode "[nmi_i].min-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[nmi_i]/min"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Nautical Mile per Minute" ;
   rdfs:label "Nautical Mile per Minute"@en .
@@ -35343,7 +35046,6 @@ unit:MOL-PER-HR
   qudt:plainTextDescription "SI base unit mole divided by the unit for time hour" ;
   qudt:symbol "mol/h" ;
   qudt:ucumCode "mol.h-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mol/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L23" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Mole per Hour" ;
@@ -35366,7 +35068,6 @@ unit:MOL-PER-KiloGM
   qudt:iec61360Code "0112/2///62720#UAA885" ;
   qudt:symbol "mol/kg" ;
   qudt:ucumCode "mol.kg-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mol/kg"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C19" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q88957663> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -35412,7 +35113,7 @@ unit:MOL-PER-KiloGM-K
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA886" ;
   qudt:symbol "mol/(kg·K)" ;
-  qudt:ucumCode "mol.K-1.kg-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "mol.kg-1.K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L24" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Mol na Kilogram Kelvin"@cs ;
@@ -35479,7 +35180,6 @@ unit:MOL-PER-L
   qudt:plainTextDescription "SI base unit mol divided by the unit litre" ;
   qudt:symbol "mol/L" ;
   qudt:ucumCode "mol.L-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mol/L"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C38" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q21064845> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -35698,7 +35398,6 @@ unit:MOL-PER-M3
   qudt:iec61360Code "0112/2///62720#UAA891" ;
   qudt:symbol "mol/m³" ;
   qudt:ucumCode "mol.m-3"^^qudt:UCUMcs ;
-  qudt:ucumCode "mol/m3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C36" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q2415352> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -35841,7 +35540,6 @@ unit:MOL-PER-MIN
   qudt:plainTextDescription "SI base unit mole divided by the unit for time minute" ;
   qudt:symbol "mol/min" ;
   qudt:ucumCode "mol.min-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mol/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L30" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Mole per Minute" ;
@@ -35859,7 +35557,6 @@ unit:MOL-PER-MOL
   qudt:qkdvNumerator qkdv:A1E0L0I0M0H0T0D0 ;
   qudt:symbol "mol/mol" ;
   qudt:ucumCode "mol.mol-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mol/mol"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Mol na Mol"@cs ;
   rdfs:label "Mol na Mol"@pl ;
@@ -35891,7 +35588,6 @@ unit:MOL-PER-SEC
   qudt:plainTextDescription "SI base unit mol divided by the SI base unit second" ;
   qudt:symbol "mol/s" ;
   qudt:ucumCode "mol.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mol/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E95" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q85178038> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -35923,7 +35619,6 @@ unit:MOL-PER-TONNE
   qudt:plainTextDescription "Mole Per Tonne (mol/t) is a unit of Molality" ;
   qudt:symbol "mol/t" ;
   qudt:ucumCode "mol.t-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mol/t"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Mole per Tonne" ;
   rdfs:label "Mole per Tonne"@en .
@@ -36131,6 +35826,7 @@ unit:MebiBIT
   qudt:hasQuantityKind quantitykind:DatasetOfBits ;
   qudt:iec61360Code "0112/2///62720#UAB167" ;
   qudt:symbol "Mib" ;
+  qudt:ucumCode "Mibit"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D11" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q1194580> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -36203,6 +35899,7 @@ unit:MebiBYTE
   qudt:iec61360Code "0112/2///62720#UAA233" ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Byte#Multiple-byte_units"^^xsd:anyURI ;
   qudt:symbol "MiB" ;
+  qudt:ucumCode "MiBy"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E63" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q79758> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -36310,6 +36007,7 @@ unit:MegaBIT
   qudt:hasQuantityKind quantitykind:DatasetOfBits ;
   qudt:iec61360Code "0112/2///62720#UAB171" ;
   qudt:symbol "Mb" ;
+  qudt:ucumCode "Mbit"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D36" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q3332814> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -36326,8 +36024,7 @@ unit:MegaBIT-PER-SEC
   qudt:iec61360Code "0112/2///62720#UAA226" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Data_rate_units"^^xsd:anyURI ;
   qudt:symbol "Mb/s" ;
-  qudt:ucumCode "MBd"^^qudt:UCUMcs ;
-  qudt:ucumCode "Mbit/s"^^qudt:UCUMcs ;
+  qudt:ucumCode "Mbit.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E20" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q7350781> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -36402,6 +36099,7 @@ unit:MegaBTU_IT
   qudt:hasQuantityKind quantitykind:Energy ;
   qudt:hasQuantityKind quantitykind:ThermalEnergy ;
   qudt:symbol "MBtu{IT}" ;
+  qudt:ucumCode "M[Btu_IT]"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Mega British Thermal Unit (international Definition)" ;
   rdfs:label "Mega British Thermal Unit (international Definition)"@en .
@@ -36420,7 +36118,6 @@ unit:MegaBTU_IT-PER-HR
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:symbol "MBtu{IT}/h" ;
   qudt:ucumCode "M[Btu_IT].h-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "M[Btu_IT]/h"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Mega British Thermal Unit (international Definition) per Hour" ;
   rdfs:label "Mega British Thermal Unit (international Definition) per Hour"@en .
@@ -36780,7 +36477,7 @@ unit:MegaGM-PER-HA-YR
   qudt:hasQuantityKind quantitykind:MassPerAreaTime ;
   qudt:plainTextDescription "Annual flux equivalent to 1000kg per hectare (10000 square meters) or one tonne per hectare per year, typically used to express a  crop yield." ;
   qudt:symbol "Mg/(ha·a)" ;
-  qudt:ucumCode "Mg.ha-1.yr-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "Mg.har-1.a-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Megagram per Hectare Year" ;
   rdfs:label "Megagram per Hectare Year"@en .
@@ -36828,6 +36525,7 @@ unit:MegaGRAY
   qudt:hasQuantityKind quantitykind:Kerma ;
   qudt:iec61360Code "0112/2///62720#UAB505" ;
   qudt:symbol "MGy" ;
+  qudt:ucumCode "MGy"^^qudt:UCUMcs ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q94942602> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Megagray" ;
@@ -36886,6 +36584,7 @@ unit:MegaHZ-KiloM
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAD911" ;
   qudt:symbol "MHz·km" ;
+  qudt:ucumCode "MHz.km"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H39" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Megaherc Kilometr"@pl ;
@@ -37218,6 +36917,7 @@ unit:MegaK
   qudt:hasQuantityKind quantitykind:Temperature ;
   qudt:hasQuantityKind quantitykind:ThermodynamicTemperature ;
   qudt:symbol "MK" ;
+  qudt:ucumCode "MK"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Megakelvin" ;
   rdfs:label "Megakelvin"@cs ;
@@ -37346,7 +37046,7 @@ unit:MegaN-M-PER-M2
   qudt:hasQuantityKind quantitykind:ForcePerLength ;
   qudt:iec61360Code "0112/2///62720#UAB553" ;
   qudt:symbol "MN·m/m²" ;
-  qudt:ucumCode "m.MN.m-2"^^qudt:UCUMcs ;
+  qudt:ucumCode "MN.m.m-2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Meganewton Meter na Kvadratni Meter"@sl ;
   rdfs:label "Meganewton Meter per Meter Persegi"@ms ;
@@ -37481,7 +37181,7 @@ unit:MegaOHM-M
   qudt:hasQuantityKind quantitykind:Resistivity ;
   qudt:iec61360Code "0112/2///62720#UAA200" ;
   qudt:symbol "MΩ·m" ;
-  qudt:ucumCode "m.MOhm"^^qudt:UCUMcs ;
+  qudt:ucumCode "MOhm.m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B76" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Megaohm Meter"@de ;
@@ -37638,7 +37338,6 @@ unit:MegaPA-L-PER-SEC
   qudt:plainTextDescription "product out of the 1,000,000-fold of the SI derived unit pascal and the unit litre divided by the SI base unit second" ;
   qudt:symbol "MPa·L/s" ;
   qudt:ucumCode "MPa.L.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "MPa.L/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F97" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Megapascal Liter per Second"@en-US ;
@@ -37754,7 +37453,7 @@ unit:MegaPSI
   qudt:hasQuantityKind quantitykind:VaporPressure ;
   qudt:plainTextDescription "Megapounds of force per square inch is a unit for pressure in the Anglo-American system of units." ;
   qudt:symbol "Mpsi" ;
-  qudt:ucumCode "[Mpsi]"^^qudt:UCUMcs ;
+  qudt:ucumCode "M[psi]"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Megapsi" ;
   rdfs:label "Megapsi"@en .
@@ -37771,6 +37470,7 @@ unit:MegaS
   qudt:hasQuantityKind quantitykind:Admittance ;
   qudt:hasQuantityKind quantitykind:Conductance ;
   qudt:symbol "MS" ;
+  qudt:ucumCode "MS"^^qudt:UCUMcs ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q94693918> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Megasiemens" ;
@@ -37828,6 +37528,7 @@ unit:MegaSEC
   qudt:hasQuantityKind quantitykind:Time ;
   qudt:iec61360Code "0112/2///62720#UAC698" ;
   qudt:symbol "Ms" ;
+  qudt:ucumCode "Ms"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Megamásodperc"@hu ;
   rdfs:label "Megasaat"@ms ;
@@ -37866,6 +37567,7 @@ unit:MegaTON
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Mass ;
   qudt:symbol "Mtn" ;
+  qudt:ucumCode "Mston_av"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Megaton" ;
   rdfs:label "Megaton"@en .
@@ -37879,6 +37581,7 @@ unit:MegaTONNE
   qudt:hasQuantityKind quantitykind:Mass ;
   qudt:iec61360Code "0112/2///62720#UAB833" ;
   qudt:symbol "Mt" ;
+  qudt:ucumCode "Mt"^^qudt:UCUMcs ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q53951982> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Megatonne" ;
@@ -37897,7 +37600,7 @@ unit:MegaTONNE-PER-YR
   qudt:hasQuantityKind quantitykind:MassFlowRate ;
   qudt:plainTextDescription "1,000,000 metric tonne divided by the unit year with 365 days" ;
   qudt:symbol "Mt/a" ;
-  qudt:ucumCode "Mt/a"^^qudt:UCUMcs ;
+  qudt:ucumCode "Mt.a-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Megatonne per Year" ;
   rdfs:label "Megatonne per Year"@en ;
@@ -38371,7 +38074,6 @@ unit:MicroBQ-PER-L
   qudt:hasQuantityKind quantitykind:ActivityConcentration ;
   qudt:symbol "μBq/L" ;
   qudt:ucumCode "uBq.L-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "uBq/L"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Microbecquerel per Liter"@en-US ;
   rdfs:label "Microbecquerel per Litre" ;
@@ -38634,7 +38336,6 @@ unit:MicroGAL-PER-M
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:symbol "µGal/m" ;
   qudt:ucumCode "uGal.m-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "uGal/m"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "MicroGals per Metre" ;
   rdfs:label "MicroGals per Metre"@en .
@@ -38648,7 +38349,6 @@ unit:MicroGALILEO-PER-M
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:symbol "µGal/m" ;
   qudt:ucumCode "uGal.m-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "uGal/m"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Microgalileo per metre" ;
   rdfs:label "Microgalileo per metre"@en .
@@ -38696,7 +38396,6 @@ unit:MicroGM-PER-CentiM2
   qudt:hasQuantityKind quantitykind:MassPerArea ;
   qudt:plainTextDescription "A unit of mass per area, equivalent to 0.01 grammes per square metre" ;
   qudt:symbol "μg/cm²" ;
-  qudt:ucumCode "u[g].cm-2"^^qudt:UCUMcs ;
   qudt:ucumCode "ug.cm-2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Microgram na Centimetr Kwadratowy"@pl ;
@@ -38725,7 +38424,7 @@ unit:MicroGM-PER-CentiM2-WK
   qudt:hasDimensionVector qkdv:A0E0L-2I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:MassPerAreaTime ;
   qudt:symbol "μg/(cm²·wk)" ;
-  qudt:ucumCode "µg.cm-2.wk-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "ug.cm-2.wk-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Microgram per Square Centimeter Week"@en-US ;
   rdfs:label "Microgram per Square Centimetre Week" ;
@@ -38745,7 +38444,6 @@ unit:MicroGM-PER-DeciL
   qudt:plainTextDescription "0.0000000001-fold of the SI base unit kilogram divided by the unit decilitre" ;
   qudt:symbol "μg/dL" ;
   qudt:ucumCode "ug.dL-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "ug/dL"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Microgram per Deciliter"@en-US ;
   rdfs:label "Microgram per Decilitre" ;
@@ -38796,7 +38494,6 @@ unit:MicroGM-PER-GM-DAY
   qudt:qkdvNumerator qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:symbol "μg/(g·d)" ;
   qudt:ucumCode "ug.g-1.d-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "ug/g/d"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Microgram per Gram Day" ;
   rdfs:label "Microgram per Gram Day"@en .
@@ -38811,7 +38508,7 @@ unit:MicroGM-PER-GM-HR
   qudt:hasQuantityKind quantitykind:MassSpecificBiogeochemicalRate ;
   qudt:plainTextDescription "0.0000000001-fold of the SI base unit kilogram divided by 0.0001-fold of the SI base unit kilogram over a period of 1 hour " ;
   qudt:symbol "μg/(g·h)" ;
-  qudt:ucumCode "ug.g-1.hr-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "ug.g-1.h-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Microgram per Gram Hour" ;
   rdfs:label "Microgram per Gram Hour"@en .
@@ -38831,8 +38528,7 @@ unit:MicroGM-PER-IN2
   qudt:hasQuantityKind quantitykind:MassPerArea ;
   qudt:hasQuantityKind quantitykind:SurfaceDensity ;
   qudt:symbol "μg/in²" ;
-  qudt:ucumCode "µg.in-2"^^qudt:UCUMcs ;
-  qudt:ucumCode "µg/in2"^^qudt:UCUMcs ;
+  qudt:ucumCode "ug.[in_i]-2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Microgram per Square Inch" ;
   rdfs:label "Microgram per Square Inch"@en .
@@ -38854,7 +38550,6 @@ unit:MicroGM-PER-KiloGM
   qudt:qkdvNumerator qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:symbol "μg/kg" ;
   qudt:ucumCode "ug.kg-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "ug/kg"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J33" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q107313731> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -38888,7 +38583,6 @@ unit:MicroGM-PER-L
   qudt:plainTextDescription "0.000000001-fold of the SI base unit kilogram divided by the unit litre" ;
   qudt:symbol "μg/L" ;
   qudt:ucumCode "ug.L-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "ug/L"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H29" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q104907187> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -38966,7 +38660,6 @@ unit:MicroGM-PER-M3
   qudt:plainTextDescription "0.000000001-fold of the SI base unit kilogram divided by the power of the SI base unit metre with the exponent 3" ;
   qudt:symbol "μg/m³" ;
   qudt:ucumCode "ug.m-3"^^qudt:UCUMcs ;
-  qudt:ucumCode "ug/m3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "GQ" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q106623548> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -39059,7 +38752,6 @@ unit:MicroGM-PER-MilliGM
   qudt:qkdvNumerator qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:symbol "μg/mg" ;
   qudt:ucumCode "ug.mg-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "ug/mg"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Microgram na Milligram"@cs ;
   rdfs:label "Microgram na Milligram"@pl ;
@@ -39090,7 +38782,6 @@ unit:MicroGM-PER-MilliL
   qudt:plainTextDescription "0.000000000001-fold of the SI base unit kilogram divided by the unit microlitre" ;
   qudt:symbol "μg/mL" ;
   qudt:ucumCode "ug.mL-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "ug/mL"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Microgram per Milliliter"@en-US ;
   rdfs:label "Microgram per Millilitre" ;
@@ -39349,6 +39040,7 @@ unit:MicroJ
   qudt:iec61360Code "0112/2///62720#UAB740" ;
   qudt:plainTextDescription "0.000001-fold of the SI derived unit joule" ;
   qudt:symbol "μJ" ;
+  qudt:ucumCode "uJ"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Micro Joule"@en-US ;
   rdfs:label "Microdżul"@pl ;
@@ -39397,6 +39089,7 @@ unit:MicroKAT
   qudt:hasDimensionVector qkdv:A1E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:CatalyticActivity ;
   qudt:symbol "μkat" ;
+  qudt:ucumCode "ukat"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Microkatal" ;
   rdfs:label "Microkatal"@cs ;
@@ -39423,7 +39116,7 @@ unit:MicroKAT-PER-L
   qudt:hasQuantityKind quantitykind:CatalyticActivityConcentration ;
   qudt:plainTextDescription "A unit of catalytic activity used especially in the chemistry of enzymes. A catalyst is a substance that starts or speeds a chemical reaction. Enzymes are proteins that act as catalysts within the bodies of living plants and animals. A catalyst has an activity of one katal if it enables a reaction to proceed at the rate of one mole per second. " ;
   qudt:symbol "μkat/L" ;
-  qudt:ucumCode "ukat/L"^^qudt:UCUMcs ;
+  qudt:ucumCode "ukat.L-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Microkatal per Liter"@en-US ;
   rdfs:label "Microkatal per Litre" ;
@@ -39466,7 +39159,6 @@ unit:MicroL-PER-L
   qudt:plainTextDescription "volume ratio as 0.000001-fold of the unit litre divided by the unit litre" ;
   qudt:symbol "μL/L" ;
   qudt:ucumCode "uL.L-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "uL/L"^^qudt:UCUMcs ;
   qudt:udunitsCode "ppmv" ;
   qudt:uneceCommonCode "J36" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q106998052> ;
@@ -39521,7 +39213,6 @@ unit:MicroM-PER-K
   qudt:plainTextDescription "0.000001-fold of the SI base unit metre divided by the SI base unit kelvin" ;
   qudt:symbol "μm/K" ;
   qudt:ucumCode "um.K-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "um/K"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F50" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Micrometer na Kelvin"@sl ;
@@ -39599,7 +39290,6 @@ unit:MicroM-PER-MIN
   qudt:hasQuantityKind quantitykind:Velocity ;
   qudt:symbol "μm/min" ;
   qudt:ucumCode "um.min-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "um/min"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Micrometer per Minute"@en-US ;
   rdfs:label "Micrometre per Minute" ;
@@ -39618,8 +39308,7 @@ unit:MicroM-PER-MilliL
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:symbol "μm/mL" ;
-  qudt:ucumCode "um2.mL-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "um2/mL"^^qudt:UCUMcs ;
+  qudt:ucumCode "um.mL-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Micrometer per Milliliter"@en-US ;
   rdfs:label "Micrometre per Millilitre" ;
@@ -39674,7 +39363,6 @@ unit:MicroM-PER-SEC
   qudt:hasQuantityKind quantitykind:Velocity ;
   qudt:symbol "μm/s" ;
   qudt:ucumCode "um.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "um/s"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Micrometer na Sekunda"@sl ;
   rdfs:label "Micrometer per Saat"@ms ;
@@ -39703,7 +39391,6 @@ unit:MicroM-PER-SEC2
   qudt:plainTextDescription "Micro metres measured per second squared" ;
   qudt:symbol "μm/s²" ;
   qudt:ucumCode "um.s-2"^^qudt:UCUMcs ;
-  qudt:ucumCode "um/s2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
   rdfs:label "Micrometer na Kvadratni Sekunda"@sl ;
   rdfs:label "Micrometer per Saat Persegi"@ms ;
@@ -39823,7 +39510,6 @@ unit:MicroM3-PER-MilliL
   qudt:qkdvNumerator qkdv:A0E0L3I0M0H0T0D0 ;
   qudt:symbol "μm³/mL" ;
   qudt:ucumCode "um3.mL-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "um3/mL"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Cubic Micrometer per Milliliter"@en-US ;
   rdfs:label "Cubic Micrometre per Millilitre" ;
@@ -39890,7 +39576,6 @@ unit:MicroMOL-PER-GM
   qudt:plainTextDescription "0.000001-fold of the SI base unit mol divided by the 0.001-fold of the SI base unit kilogram" ;
   qudt:symbol "μmol/g" ;
   qudt:ucumCode "umol.g-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "umol/g"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Micromol na Gram"@cs ;
   rdfs:label "Micromol na Gram"@pl ;
@@ -39914,7 +39599,6 @@ unit:MicroMOL-PER-GM-HR
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:symbol "μmol/(g·h)" ;
   qudt:ucumCode "umol.g-1.h-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "umol/g/h"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Micromole per Gram Hour" ;
   rdfs:label "Micromole per Gram Hour"@en .
@@ -39928,7 +39612,6 @@ unit:MicroMOL-PER-GM-SEC
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:symbol "μmol/(g·s)" ;
   qudt:ucumCode "umol.g-1.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "umol/g/s"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Micromol na Gram Sekunda"@cs ;
   rdfs:label "Micromol na Gram Sekunda"@pl ;
@@ -39952,7 +39635,6 @@ unit:MicroMOL-PER-KiloGM
   qudt:hasQuantityKind quantitykind:AmountOfSubstancePerMass ;
   qudt:symbol "μmol/kg" ;
   qudt:ucumCode "umol.kg-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "umol/kg"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Micromol na Kilogram"@cs ;
   rdfs:label "Micromol na Kilogram"@pl ;
@@ -39978,7 +39660,6 @@ unit:MicroMOL-PER-L
   qudt:hasReciprocalUnit unit:L-PER-MicroMOL ;
   qudt:symbol "μmol/L" ;
   qudt:ucumCode "umol.L-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "umol/L"^^qudt:UCUMcs ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q126870286> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Micromole per Liter"@en-US ;
@@ -39994,7 +39675,6 @@ unit:MicroMOL-PER-L-HR
   qudt:hasQuantityKind quantitykind:CatalyticActivityConcentration ;
   qudt:symbol "μmol/(L·h)" ;
   qudt:ucumCode "umol.L-1.h-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "umol/L/h"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Micromole per Liter Hour"@en-US ;
   rdfs:label "Micromole per Litre Hour" ;
@@ -40010,7 +39690,6 @@ unit:MicroMOL-PER-M2
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:symbol "μmol/m²" ;
   qudt:ucumCode "umol.m-2"^^qudt:UCUMcs ;
-  qudt:ucumCode "umol/m2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Micromol na Kvadratni Meter"@sl ;
   rdfs:label "Micromol na Metr Kwadratowy"@pl ;
@@ -40035,7 +39714,6 @@ unit:MicroMOL-PER-M2-DAY
   qudt:hasQuantityKind quantitykind:PhotosyntheticPhotonFluxDensity ;
   qudt:symbol "μmol/(m²·d)" ;
   qudt:ucumCode "umol.m-2.d-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "umol/m2/d"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Micromole per Square Meter Day"@en-US ;
   rdfs:label "Micromole per Square Metre Day" ;
@@ -40050,7 +39728,6 @@ unit:MicroMOL-PER-M2-HR
   qudt:hasQuantityKind quantitykind:PhotosyntheticPhotonFluxDensity ;
   qudt:symbol "μmol/(m²·h)" ;
   qudt:ucumCode "umol.m-2.h-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "umol/m2/h"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Micromole per Square Meter Hour"@en-US ;
   rdfs:label "Micromole per Square Metre Hour" ;
@@ -40066,7 +39743,6 @@ unit:MicroMOL-PER-M2-SEC
   qudt:hasQuantityKind quantitykind:PhotosyntheticPhotonFluxDensity ;
   qudt:symbol "μmol/(m²·s)" ;
   qudt:ucumCode "umol.m-2.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "umol/m2/s"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Micromol na Kvadratni Meter Sekunda"@sl ;
   rdfs:label "Micromol na Metr Kwadratowy Sekunda"@pl ;
@@ -40119,7 +39795,6 @@ unit:MicroMOL-PER-MOL
   qudt:qkdvNumerator qkdv:A1E0L0I0M0H0T0D0 ;
   qudt:symbol "μmol/mol" ;
   qudt:ucumCode "umol.mol-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "umol/mol"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Micromol na Mol"@cs ;
   rdfs:label "Micromol na Mol"@pl ;
@@ -40143,7 +39818,6 @@ unit:MicroMOL-PER-MicroMOL-DAY
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:symbol "μmol/(μmol·d)" ;
   qudt:ucumCode "umol.umol-1.d-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "umol/umol/d"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Micromole per Micromole Day" ;
   rdfs:label "Micromole per Micromole Day"@en .
@@ -40158,7 +39832,6 @@ unit:MicroMOL-PER-SEC
   qudt:hasQuantityKind quantitykind:PhotosyntheticPhotonFlux ;
   qudt:symbol "μmol/s" ;
   qudt:ucumCode "umol.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "umol/s"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Micromol na Sekunda"@cs ;
   rdfs:label "Micromol na Sekunda"@pl ;
@@ -40264,7 +39937,7 @@ unit:MicroN-M-PER-M2
   qudt:hasQuantityKind quantitykind:ForcePerLength ;
   qudt:iec61360Code "0112/2///62720#UAB548" ;
   qudt:symbol "μN·m/m²" ;
-  qudt:ucumCode "m.uN.m-2"^^qudt:UCUMcs ;
+  qudt:ucumCode "uN.m.m-2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Micronewton Meter na Kvadratni Meter"@sl ;
   rdfs:label "Micronewton Meter per Meter Persegi"@ms ;
@@ -40321,7 +39994,7 @@ unit:MicroOHM-M
   qudt:hasQuantityKind quantitykind:Resistivity ;
   qudt:iec61360Code "0112/2///62720#UAA056" ;
   qudt:symbol "μΩ·m" ;
-  qudt:ucumCode "m.uOhm"^^qudt:UCUMcs ;
+  qudt:ucumCode "uOhm.m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "B95" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Microohm Meter"@de ;
@@ -40476,7 +40149,6 @@ unit:MicroS-PER-CentiM
   qudt:qkdvNumerator qkdv:A0E2L-2I0M-1H0T3D0 ;
   qudt:symbol "μS/cm" ;
   qudt:ucumCode "uS.cm-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "uS/cm"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G42" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q106636307> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -40540,7 +40212,6 @@ unit:MicroS2-PER-CentiM2
   qudt:plainTextDescription "Conductivity variance, or (MicroS-PER-CentiM)2" ;
   qudt:symbol "μS²/cm²" ;
   qudt:ucumCode "uS2.cm-2"^^qudt:UCUMcs ;
-  qudt:ucumCode "uS2/cm2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Kvadratni Microsiemens na Kvadratni Centimeter"@sl ;
   rdfs:label "Microsiemens Carré par Centimètre Carré"@fr ;
@@ -40931,6 +40602,7 @@ unit:MicroVAR
   qudt:hasQuantityKind quantitykind:ReactivePower ;
   qudt:iec61360Code "0112/2///62720#UAC506" ;
   qudt:symbol "μVA{Reactive}" ;
+  qudt:ucumCode "uVA{reactive}"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Micro Volt Ampere Reactive" ;
   rdfs:label "Micro Volt Ampere Reactive"@en .
@@ -40944,6 +40616,7 @@ unit:MicroVAR-PER-K
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAD903" ;
   qudt:symbol "μVA{Reactive}/K" ;
+  qudt:ucumCode "uVA{reactive}.K-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Micro Volt Ampere Reactive per Kelvin" ;
   rdfs:label "Micro Volt Ampere Reactive per Kelvin"@en .
@@ -40990,6 +40663,7 @@ unit:MicroW-PER-CentiM2-MicroM-SR
   qudt:hasQuantityKind quantitykind:SpectralRadiance ;
   qudt:plainTextDescription "A unit of spectral radiance that is the power radiating from a surface per unit of solid angle per unit of wavelength, measured in units of watts per centimeter squared per micrometer per steradian" ;
   qudt:symbol "μW/(cm²·μm·sr)" ;
+  qudt:ucumCode "uW.cm-2.um-1.sr-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Microvatio por Centimetro Cuadrado Micrometro Estereorradián"@es ;
   rdfs:label "Microwat na Centimetr Kwadratowy Micrometr Steradian"@pl ;
@@ -41325,7 +40999,6 @@ unit:MilliBAR-L-PER-SEC
   qudt:plainTextDescription "product out of the 0.001-fold of the unit bar and the unit litre divided by the SI base unit second" ;
   qudt:symbol "mbar·L/s" ;
   qudt:ucumCode "mbar.L.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mbar.L/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F95" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Millibar Liter per Second"@en-US ;
@@ -41415,6 +41088,7 @@ unit:MilliBQ
   qudt:hasQuantityKind quantitykind:Activity ;
   qudt:iec61360Code "0112/2///62720#UAC503" ;
   qudt:symbol "mBq" ;
+  qudt:ucumCode "mBq"^^qudt:UCUMcs ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q95866767> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Millibecquerel" ;
@@ -41498,7 +41172,6 @@ unit:MilliBQ-PER-L
   qudt:hasQuantityKind quantitykind:ActivityConcentration ;
   qudt:symbol "mBq/L" ;
   qudt:ucumCode "mBq.L-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mBq/L"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Millibecquerel per Liter"@en-US ;
   rdfs:label "Millibecquerel per Litre" ;
@@ -41660,6 +41333,7 @@ unit:MilliCD
   qudt:hasQuantityKind quantitykind:LuminousIntensity ;
   qudt:iec61360Code "0112/2///62720#UAB369" ;
   qudt:symbol "mcd" ;
+  qudt:ucumCode "mcd"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P34" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Millicandela" ;
@@ -41853,7 +41527,6 @@ unit:MilliGAL-PER-MO
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:symbol "mgal/mo" ;
   qudt:ucumCode "mGal.mo-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mGal/mo"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Milligalileo per Month" ;
   rdfs:label "Milligalileo per Month"@en .
@@ -41884,7 +41557,6 @@ unit:MilliGALILEO-PER-MO
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:symbol "mGal/mo" ;
   qudt:ucumCode "mGal.mo-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mGal/mo"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Milligalileo per Month" ;
   rdfs:label "Milligalileo per Month"@en .
@@ -42215,7 +41887,6 @@ unit:MilliGM-PER-DeciL
   qudt:hasQuantityKind quantitykind:MassDensity ;
   qudt:symbol "mg/dL" ;
   qudt:ucumCode "mg.dL-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mg/dL"^^qudt:UCUMcs ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q55435156> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Milligram per Deciliter"@en-US ;
@@ -42268,7 +41939,6 @@ unit:MilliGM-PER-GM
   qudt:qkdvNumerator qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:symbol "mg/g" ;
   qudt:ucumCode "mg.g-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mg/g"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H64" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q106645210> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -42301,7 +41971,6 @@ unit:MilliGM-PER-GM-HR
   qudt:qkdvNumerator qkdv:A0E0L0I0M1H0T1D0 ;
   qudt:symbol "mg/(g·h)" ;
   qudt:ucumCode "mg.g-1.h-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mg/g/h"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Milligram per Gram Hour" ;
   rdfs:label "Milligram per Gram Hour"@en .
@@ -42320,7 +41989,6 @@ unit:MilliGM-PER-HA
   qudt:plainTextDescription "0.000001-fold of the SI base unit kilogram divided by the 10,000-fold of the power of the SI base unit metre with the exponent 2" ;
   qudt:symbol "mg/ha" ;
   qudt:ucumCode "mg.har-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mg/har"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Milligram per Hectare" ;
   rdfs:label "Milligram per Hectare"@en .
@@ -42340,7 +42008,6 @@ unit:MilliGM-PER-HR
   qudt:plainTextDescription "0.000001-fold of the SI base unit kilogram divided by the unit hour" ;
   qudt:symbol "mg/h" ;
   qudt:ucumCode "mg.h-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mg/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "4M" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Milligram per Hour" ;
@@ -42386,7 +42053,6 @@ unit:MilliGM-PER-K
   qudt:iec61360Code "0112/2///62720#UAA816" ;
   qudt:symbol "mg/K" ;
   qudt:ucumCode "mg.K-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mg/K"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F16" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Milligram na Kelvin"@cs ;
@@ -42419,7 +42085,6 @@ unit:MilliGM-PER-KiloGM
   qudt:qkdvNumerator qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:symbol "mg/kg" ;
   qudt:ucumCode "mg.kg-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mg/kg"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "NA" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q21091747> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -42452,7 +42117,6 @@ unit:MilliGM-PER-KiloGM-DAY
   qudt:qkdvNumerator qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:symbol "mg/(kg·d)" ;
   qudt:ucumCode "mg.kg-1.d-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mg/kg/d"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Milligram per Kilogram Day" ;
   rdfs:label "Milligram per Kilogram Day"@en .
@@ -42474,7 +42138,6 @@ unit:MilliGM-PER-L
   qudt:plainTextDescription "0.000001-fold of the SI base unit kilogram divided by the unit litre" ;
   qudt:symbol "mg/L" ;
   qudt:ucumCode "mg.L-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mg/L"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M1" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q55726194> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -42558,7 +42221,6 @@ unit:MilliGM-PER-M
   qudt:plainTextDescription "0.000001-fold of the SI base unit kilogram divided by the SI base unit metre" ;
   qudt:symbol "mg/m" ;
   qudt:ucumCode "mg.m-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mg/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C12" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q106645241> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -42591,7 +42253,6 @@ unit:MilliGM-PER-M2
   qudt:plainTextDescription "0.000001-fold of the SI base unit kilogram divided by the power of the SI base unit metre with the exponent 2" ;
   qudt:symbol "mg/m²" ;
   qudt:ucumCode "mg.m-2"^^qudt:UCUMcs ;
-  qudt:ucumCode "mg/m2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "GO" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q107133620> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -42687,7 +42348,6 @@ unit:MilliGM-PER-M3
   qudt:plainTextDescription "0.000001-fold of the SI base unit kilogram divided by the power of the SI base unit metre with the exponent 3" ;
   qudt:symbol "mg/m³" ;
   qudt:ucumCode "mg.m-3"^^qudt:UCUMcs ;
-  qudt:ucumCode "mg/m3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "GP" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q21077820> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -42903,7 +42563,7 @@ unit:MilliGM-PER-MIN
   qudt:iec61360Code "0112/2///62720#UAA833" ;
   qudt:plainTextDescription "0.000001-fold of the SI base unit kilogram divided by the unit minute" ;
   qudt:symbol "mg/min" ;
-  qudt:ucumCode "mg/min"^^qudt:UCUMcs ;
+  qudt:ucumCode "mg.min-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F33" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q107210295> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -42956,7 +42616,6 @@ unit:MilliGM-PER-MilliL
   qudt:plainTextDescription "0.000001-fold of the SI base unit kilogram divided by the unit millilitre" ;
   qudt:symbol "mg/mL" ;
   qudt:ucumCode "mg.mL-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mg/mL"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Milligram per Milliliter"@en-US ;
   rdfs:label "Milligram per Millilitre" ;
@@ -42976,7 +42635,7 @@ unit:MilliGM-PER-SEC
   qudt:iec61360Code "0112/2///62720#UAA836" ;
   qudt:plainTextDescription "0.000001-fold of the SI base unit kilogram divided by the SI base unit second" ;
   qudt:symbol "mg/s" ;
-  qudt:ucumCode "mg/s"^^qudt:UCUMcs ;
+  qudt:ucumCode "mg.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F34" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q107210344> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -43178,7 +42837,6 @@ unit:MilliGRAY-PER-HR
   qudt:iec61360Code "0112/2///62720#UAB477" ;
   qudt:symbol "mGy/h" ;
   qudt:ucumCode "mGy.h-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mGy/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P62" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q106617521> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -43197,7 +42855,6 @@ unit:MilliGRAY-PER-MIN
   qudt:iec61360Code "0112/2///62720#UAB473" ;
   qudt:symbol "mGy/min" ;
   qudt:ucumCode "mGy.min-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mGy/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P58" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Milligray per Minute" ;
@@ -43215,7 +42872,6 @@ unit:MilliGRAY-PER-SEC
   qudt:iec61360Code "0112/2///62720#UAB298" ;
   qudt:symbol "mGy/s" ;
   qudt:ucumCode "mGy.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mGy/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P54" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q106617513> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -43276,7 +42932,6 @@ unit:MilliH-PER-KiloOHM
   qudt:plainTextDescription "0.001-fold of the SI derived unit henry divided by the 1 000-fold of the SI derived unit ohm" ;
   qudt:symbol "mH/kΩ" ;
   qudt:ucumCode "mH.kOhm-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mH/kOhm"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H05" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Millihenr na Kiloom"@pl ;
@@ -43306,7 +42961,6 @@ unit:MilliH-PER-OHM
   qudt:plainTextDescription "0.001-fold of the SI derived unit henry divided by the SI derived unit ohm" ;
   qudt:symbol "mH/Ω" ;
   qudt:ucumCode "mH.Ohm-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mH/Ohm"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H06" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Millihenr na Om"@pl ;
@@ -43331,6 +42985,7 @@ unit:MilliHZ
   qudt:hasQuantityKind quantitykind:Frequency ;
   qudt:iec61360Code "0112/2///62720#UAB698" ;
   qudt:symbol "mHz" ;
+  qudt:ucumCode "mHz"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "MTZ" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Milliherc"@pl ;
@@ -43414,7 +43069,6 @@ unit:MilliJ-PER-GM
   qudt:plainTextDescription "The 0.001-fold of the SI base unit joule divided by the 0.001-fold of the SI base unit kilogram" ;
   qudt:symbol "mJ/g" ;
   qudt:ucumCode "mJ.g-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mJ/g"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Millidżul na Gram"@pl ;
   rdfs:label "Millijoule na Gram"@cs ;
@@ -43447,7 +43101,6 @@ unit:MilliJ-PER-M2
   qudt:hasQuantityKind quantitykind:StrainEnergyReleaseRate ;
   qudt:symbol "mJ/m²" ;
   qudt:ucumCode "mJ.m-2"^^qudt:UCUMcs ;
-  qudt:ucumCode "mJ/m2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Millidżul na Metr Kwadratowy"@pl ;
   rdfs:label "Millijoule na Kvadratni Meter"@sl ;
@@ -43473,7 +43126,6 @@ unit:MilliJ-PER-SEC
   qudt:iec61360Code "0112/2///62720#UAB511" ;
   qudt:symbol "mJ/s" ;
   qudt:ucumCode "mJ.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mJ/s"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Millidżul na Sekunda"@pl ;
   rdfs:label "Millijoule na Sekunda"@cs ;
@@ -43500,6 +43152,7 @@ unit:MilliK
   qudt:hasQuantityKind quantitykind:Temperature ;
   qudt:hasQuantityKind quantitykind:ThermodynamicTemperature ;
   qudt:symbol "mK" ;
+  qudt:ucumCode "mK"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Millikelvin" ;
   rdfs:label "Millikelvin"@cs ;
@@ -43524,6 +43177,7 @@ unit:MilliK-PER-BAR
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAB841" ;
   qudt:symbol "mK/bar" ;
+  qudt:ucumCode "mK.bar-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Millikelvin per Bar" ;
   rdfs:label "Millikelvin per Bar"@en .
@@ -43537,6 +43191,7 @@ unit:MilliK-PER-K
   qudt:hasQuantityKind quantitykind:TemperatureRatio ;
   qudt:iec61360Code "0112/2///62720#UAB842" ;
   qudt:symbol "mK/K" ;
+  qudt:ucumCode "mK.K-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Millikelvin na Kelvin"@cs ;
   rdfs:label "Millikelvin na Kelvin"@sl ;
@@ -43558,6 +43213,7 @@ unit:MilliKAT
   qudt:hasDimensionVector qkdv:A1E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:CatalyticActivity ;
   qudt:symbol "mkat" ;
+  qudt:ucumCode "mkat"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Millikatal" ;
   rdfs:label "Millikatal"@cs ;
@@ -43584,7 +43240,7 @@ unit:MilliKAT-PER-L
   qudt:hasQuantityKind quantitykind:CatalyticActivityConcentration ;
   qudt:plainTextDescription "A unit of catalytic activity used especially in the chemistry of enzymes. A catalyst is a substance that starts or speeds a chemical reaction. Enzymes are proteins that act as catalysts within the bodies of living plants and animals. A catalyst has an activity of one katal if it enables a reaction to proceed at the rate of one mole per second. " ;
   qudt:symbol "mkat/L" ;
-  qudt:ucumCode "mkat/L"^^qudt:UCUMcs ;
+  qudt:ucumCode "mkat.L-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Millikatal per Liter"@en-US ;
   rdfs:label "Millikatal per Litre" ;
@@ -43622,7 +43278,6 @@ unit:MilliL-PER-BAR
   qudt:iec61360Code "0112/2///62720#UAA846" ;
   qudt:symbol "mL/bar" ;
   qudt:ucumCode "mL.bar-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mL/bar"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G97" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Milliliter per Bar"@en-US ;
@@ -43643,7 +43298,7 @@ unit:MilliL-PER-CentiM2-MIN
   qudt:iec61360Code "0112/2///62720#UAA858" ;
   qudt:plainTextDescription "quotient of the 0.001-fold of the unit litre and the unit minute divided by the 0.0001-fold of the power of the SI base unit metre with the exponent 2" ;
   qudt:symbol "mL/(cm²·min)" ;
-  qudt:ucumCode "mL.cm-2"^^qudt:UCUMcs ;
+  qudt:ucumCode "mL.cm-2.min-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "35" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Milliliter per Square Centimeter Minute"@en-US ;
@@ -43687,7 +43342,6 @@ unit:MilliL-PER-DAY
   qudt:plainTextDescription "0.001-fold of the unit litre divided by the unit day" ;
   qudt:symbol "mL/d" ;
   qudt:ucumCode "mL.d-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mL/d"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G54" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q113681609> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -43744,7 +43398,6 @@ unit:MilliL-PER-GM
   qudt:hasReciprocalUnit unit:GM-PER-MilliL ;
   qudt:symbol "mL/g" ;
   qudt:ucumCode "mL.g-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mL/g"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Milliliter per Gram"@en-US ;
   rdfs:label "Millilitre per Gram" ;
@@ -43766,7 +43419,6 @@ unit:MilliL-PER-HR
   qudt:plainTextDescription "0.001-fold of the unit litre divided by the unit hour" ;
   qudt:symbol "mL/h" ;
   qudt:ucumCode "mL.h-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mL/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G55" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q107028496> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -43818,7 +43470,6 @@ unit:MilliL-PER-K
   qudt:plainTextDescription "0.001-fold of the unit litre divided by the SI base unit kelvin" ;
   qudt:symbol "mL/K" ;
   qudt:ucumCode "mL.K-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mL/K"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G30" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Milliliter per Kelvin"@en-US ;
@@ -43840,7 +43491,6 @@ unit:MilliL-PER-KiloGM
   qudt:plainTextDescription "0.001-fold of the unit of the volume litre divided by the SI base unit kilogram" ;
   qudt:symbol "mL/kg" ;
   qudt:ucumCode "mL.kg-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mL/kg"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "KX" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q106639777> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -43863,7 +43513,6 @@ unit:MilliL-PER-L
   qudt:plainTextDescription "volume ratio consisting of the 0.001-fold of the unit litre divided by the unit litre" ;
   qudt:symbol "mL/L" ;
   qudt:ucumCode "mL.L-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mL/L"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L19" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q21075844> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -43903,7 +43552,6 @@ unit:MilliL-PER-M3
   qudt:plainTextDescription "0.001-fold of the unit litre divided by the power of the SI base unit metre with the exponent 3" ;
   qudt:symbol "mL/m³" ;
   qudt:ucumCode "mL.m-3"^^qudt:UCUMcs ;
-  qudt:ucumCode "mL/m3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H65" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q106639711> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -43927,7 +43575,6 @@ unit:MilliL-PER-MIN
   qudt:plainTextDescription "0.001-fold of the unit litre divided by the unit minute" ;
   qudt:symbol "mL/min" ;
   qudt:ucumCode "mL.min-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mL/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "41" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q107313788> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -43983,7 +43630,6 @@ unit:MilliL-PER-SEC
   qudt:plainTextDescription "0.001-fold of the unit litre divided by the SI base unit second" ;
   qudt:symbol "mL/s" ;
   qudt:ucumCode "mL.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mL/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "40" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q107313780> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -44069,7 +43715,6 @@ unit:MilliM-PER-BAR
   qudt:iec61360Code "0112/2///62720#UAA865" ;
   qudt:symbol "mm/bar" ;
   qudt:ucumCode "mm.bar-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mm/bar"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G06" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Millimeter per Bar"@en-US ;
@@ -44092,7 +43737,6 @@ unit:MilliM-PER-DAY
   qudt:plainTextDescription "A measure of change in depth over time for a specific area, typically used to express precipitation intensity or evaporation (the amount of liquid water evaporated per unit of time from the area)" ;
   qudt:symbol "mm/d" ;
   qudt:ucumCode "mm.d-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mm/d"^^qudt:UCUMcs ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q104907387> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Millimeter per Day"@en-US ;
@@ -44142,7 +43786,6 @@ unit:MilliM-PER-HR
   qudt:plainTextDescription "0001-fold of the SI base unit metre divided by the unit hour" ;
   qudt:symbol "mm/h" ;
   qudt:ucumCode "mm.h-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mm/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H67" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q104907383> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -44162,7 +43805,6 @@ unit:MilliM-PER-K
   qudt:plainTextDescription "0.001-fold of the SI base unit metre divided by the SI base unit kelvin" ;
   qudt:symbol "mm/K" ;
   qudt:ucumCode "mm.K-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mm/K"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F53" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Millimeter na Kelvin"@sl ;
@@ -44189,7 +43831,6 @@ unit:MilliM-PER-M
   qudt:iec61360Code "0112/2///62720#UAC001" ;
   qudt:symbol "mm/m" ;
   qudt:ucumCode "mm.m-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mm/m"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Millimeter na Meter"@sl ;
   rdfs:label "Millimeter per Meter"@en-US ;
@@ -44221,7 +43862,6 @@ unit:MilliM-PER-M2
   qudt:qkdvNumerator qkdv:A0E0L-2I0M0H0T0D0 ;
   qudt:symbol "mm/m²" ;
   qudt:ucumCode "mm.m-2"^^qudt:UCUMcs ;
-  qudt:ucumCode "mm/m2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Millimeter na Kvadratni Meter"@sl ;
   rdfs:label "Millimeter per Meter Persegi"@ms ;
@@ -44253,7 +43893,6 @@ unit:MilliM-PER-MIN
   qudt:plainTextDescription "0.001-fold of the SI base unit metre divided by the unit minute" ;
   qudt:symbol "mm/min" ;
   qudt:ucumCode "mm.min-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mm/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H81" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q57273614> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -44277,7 +43916,6 @@ unit:MilliM-PER-SEC
   qudt:plainTextDescription "0.001-fold of the SI base unit metre divided by the SI base unit second" ;
   qudt:symbol "mm/s" ;
   qudt:ucumCode "mm.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mm/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C16" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q102130688> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -44338,7 +43976,6 @@ unit:MilliM-PER-YR
   qudt:plainTextDescription "0.001-fold of the SI base unit metre divided by the unit year" ;
   qudt:symbol "mm/a" ;
   qudt:ucumCode "mm.a-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mm/a"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H66" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q65028392> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -44394,7 +44031,6 @@ unit:MilliM2-PER-SEC
   qudt:plainTextDescription "0.000001-fold of the power of the SI base unit metre with the exponent 2 divided by the SI base unit second" ;
   qudt:symbol "mm²/s" ;
   qudt:ucumCode "mm2.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mm2/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C17" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q26162546> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -44461,7 +44097,6 @@ unit:MilliM3-PER-GM
   qudt:hasQuantityKind quantitykind:SpecificVolume ;
   qudt:symbol "mm³/g" ;
   qudt:ucumCode "mm3.g-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mm3/g"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Cubic Millimeter per Gram"@en-US ;
   rdfs:label "Cubic Millimetre per Gram" ;
@@ -44489,7 +44124,6 @@ unit:MilliM3-PER-KiloGM
   qudt:hasQuantityKind quantitykind:SpecificVolume ;
   qudt:symbol "mm³/kg" ;
   qudt:ucumCode "mm3.kg-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mm3/kg"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Cubic Millimeter per Kilogram"@en-US ;
   rdfs:label "Cubic Millimetre per Kilogram" ;
@@ -44603,7 +44237,6 @@ unit:MilliMOL-PER-GM
   qudt:plainTextDescription "0.001-fold of the SI base unit mol divided by the 0.001-fold of the SI base unit kilogram" ;
   qudt:symbol "mmol/g" ;
   qudt:ucumCode "mmol.g-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mmol/g"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H68" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q107440685> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -44633,7 +44266,6 @@ unit:MilliMOL-PER-KiloGM
   qudt:plainTextDescription "0.001-fold of the SI base unit mol divided by the SI base unit kilogram" ;
   qudt:symbol "mmol/kg" ;
   qudt:ucumCode "mmol.kg-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mmol/kg"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D87" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q107440662> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -44665,7 +44297,6 @@ unit:MilliMOL-PER-L
   qudt:iec61360Code "0112/2///62720#UAB500" ;
   qudt:symbol "mmol/L" ;
   qudt:ucumCode "mmol.L-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mmol/L"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M33" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q55435387> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -44741,7 +44372,6 @@ unit:MilliMOL-PER-M2-SEC
   qudt:hasQuantityKind quantitykind:PhotosyntheticPhotonFluxDensity ;
   qudt:symbol "mmol/(m²·s)" ;
   qudt:ucumCode "mmol.m-2.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mmol/m2/s1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Millimol na Kvadratni Meter Sekunda"@sl ;
   rdfs:label "Millimol na Metr Kwadratowy Sekunda"@pl ;
@@ -44809,7 +44439,6 @@ unit:MilliMOL-PER-MOL
   qudt:qkdvNumerator qkdv:A1E0L0I0M0H0T0D0 ;
   qudt:symbol "mmol/mol" ;
   qudt:ucumCode "mmol.mol-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mmol/mol"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Millimol na Mol"@cs ;
   rdfs:label "Millimol na Mol"@pl ;
@@ -44963,7 +44592,7 @@ unit:MilliN-M-PER-M2
   qudt:hasQuantityKind quantitykind:ForcePerLength ;
   qudt:iec61360Code "0112/2///62720#UAB549" ;
   qudt:symbol "mN·m/m²" ;
-  qudt:ucumCode "m.mN.m-2"^^qudt:UCUMcs ;
+  qudt:ucumCode "mN.m.m-2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Millinewton Meter na Kvadratni Meter"@sl ;
   rdfs:label "Millinewton Meter per Meter Persegi"@ms ;
@@ -44994,7 +44623,6 @@ unit:MilliN-PER-M
   qudt:plainTextDescription "0.001-fold of the SI derived unit newton divided by the SI base unit metre" ;
   qudt:symbol "mN/m" ;
   qudt:ucumCode "mN.m-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mN/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C22" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q26156132> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -45053,7 +44681,7 @@ unit:MilliOHM-M
   qudt:hasQuantityKind quantitykind:Resistivity ;
   qudt:iec61360Code "0112/2///62720#UAA742" ;
   qudt:symbol "mΩ·m" ;
-  qudt:ucumCode "m.mOhm"^^qudt:UCUMcs ;
+  qudt:ucumCode "mOhm.m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C23" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Milliohm Meter"@de ;
@@ -45080,7 +44708,6 @@ unit:MilliOHM-PER-BAR
   qudt:iec61360Code "0112/2///62720#UAD878" ;
   qudt:symbol "mΩ/bar" ;
   qudt:ucumCode "mOhm.bar-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mOhm/bar"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Milliohm per Bar" ;
   rdfs:label "Milliohm per Bar"@en .
@@ -45095,7 +44722,6 @@ unit:MilliOHM-PER-K
   qudt:iec61360Code "0112/2///62720#UAD874" ;
   qudt:symbol "mΩ/K" ;
   qudt:ucumCode "mOhm.K-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mOhm/K"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Milliohm na Kelvin"@cs ;
   rdfs:label "Milliohm na Kelvin"@sl ;
@@ -45120,7 +44746,6 @@ unit:MilliOHM-PER-M
   qudt:iec61360Code "0112/2///62720#UAA743" ;
   qudt:symbol "mΩ/m" ;
   qudt:ucumCode "mOhm.m-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mOhm/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F54" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Milliohm na Meter"@sl ;
@@ -45144,6 +44769,7 @@ unit:MilliOSM
   qudt:hasDimensionVector qkdv:A1E0L0I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:AmountOfSubstance ;
   qudt:symbol "mOsmol" ;
+  qudt:ucumCode "mOsmol"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Milliosmole" ;
   rdfs:label "Milliosmole"@en .
@@ -45157,7 +44783,6 @@ unit:MilliOSM-PER-KiloGM
   qudt:hasQuantityKind quantitykind:AmountOfSubstancePerMass ;
   qudt:symbol "mOsmol/kg" ;
   qudt:ucumCode "mOsmol.kg-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mOsmol/kg"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Milliosmole per Kilogram" ;
   rdfs:label "Milliosmole per Kilogram"@en .
@@ -45207,7 +44832,6 @@ unit:MilliPA-PER-M
   qudt:iec61360Code "0112/2///62720#UAB420" ;
   qudt:symbol "mPa/m" ;
   qudt:ucumCode "mPa.m-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mPa/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P80" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Millipascal na Meter"@sl ;
@@ -45268,7 +44892,6 @@ unit:MilliPA-SEC-PER-BAR
   qudt:plainTextDescription "0.001-fold of the product of the SI derived unit pascal and the SI base unit second divided by the unit of the pressure bar" ;
   qudt:symbol "mPa·s/bar" ;
   qudt:ucumCode "mPa.s.bar-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mPa.s/bar"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L16" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Millipascal Second per Bar" ;
@@ -45284,7 +44907,6 @@ unit:MilliPA-SEC-PER-K
   qudt:iec61360Code "0112/2///62720#UAA798" ;
   qudt:symbol "mPa·s/K" ;
   qudt:ucumCode "mPa.s.K-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mPa.s/K"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L15" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Millipascal Saat per Kelvin"@ms ;
@@ -45362,6 +44984,7 @@ unit:MilliRAD_R
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:AbsorbedDose ;
   qudt:symbol "mrad" ;
+  qudt:ucumCode "mRAD"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Millirad" ;
   rdfs:label "Millirad"@en .
@@ -45378,7 +45001,6 @@ unit:MilliRAD_R-PER-HR
   qudt:hasQuantityKind quantitykind:SpecificPower ;
   qudt:symbol "mrad/h" ;
   qudt:ucumCode "mRAD.h-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mRAD/h"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Millirad per Hour" ;
   rdfs:label "Millirad per Hour"@en .
@@ -45448,7 +45070,6 @@ unit:MilliS-PER-CentiM
   qudt:plainTextDescription "0.001-fold of the SI derived unit Siemens divided by the 0.01-fold of the SI base unit metre" ;
   qudt:symbol "mS/cm" ;
   qudt:ucumCode "mS.cm-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mS/cm"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H61" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q106777923> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -45477,7 +45098,6 @@ unit:MilliS-PER-M
   qudt:hasQuantityKind quantitykind:Conductivity ;
   qudt:symbol "mS/m" ;
   qudt:ucumCode "mS.m-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mS/m"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Millisiemens na Meter"@sl ;
   rdfs:label "Millisiemens na Metr"@cs ;
@@ -45574,7 +45194,6 @@ unit:MilliSV-PER-HR
   qudt:iec61360Code "0112/2///62720#UAB465" ;
   qudt:symbol "mSv/h" ;
   qudt:ucumCode "mSv.h-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mSv/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P71" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Millisievert per Hour" ;
@@ -45592,7 +45211,6 @@ unit:MilliSV-PER-MIN
   qudt:iec61360Code "0112/2///62720#UAB469" ;
   qudt:symbol "mSv/min" ;
   qudt:ucumCode "mSv.min-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mSv/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P75" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Millisievert per Minute" ;
@@ -45610,7 +45228,6 @@ unit:MilliSV-PER-SEC
   qudt:iec61360Code "0112/2///62720#UAB302" ;
   qudt:symbol "mSv/s" ;
   qudt:ucumCode "mSv.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mSv/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P66" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Millisievert na Sekunda"@cs ;
@@ -45743,7 +45360,6 @@ unit:MilliV-A-PER-K
   qudt:iec61360Code "0112/2///62720#UAD906" ;
   qudt:symbol "mV·A/K" ;
   qudt:ucumCode "mV.A.K-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mV.A/K"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Millivolt Amper na Kelvin"@sl ;
   rdfs:label "Millivolt Amper pe Kelvin"@ro ;
@@ -45802,7 +45418,6 @@ unit:MilliV-PER-M
   qudt:plainTextDescription "0.000001-fold of the SI derived unit volt divided by the SI base unit metre" ;
   qudt:symbol "mV/m" ;
   qudt:ucumCode "mV.m-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mV/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C30" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Millivolt na Meter"@sl ;
@@ -45833,7 +45448,6 @@ unit:MilliV-PER-MIN
   qudt:plainTextDescription "0.001-fold of the SI derived unit volt divided by the unit minute" ;
   qudt:symbol "mV/min" ;
   qudt:ucumCode "mV.min-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mV/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H62" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Millivolt per Minute" ;
@@ -45849,7 +45463,6 @@ unit:MilliV-PER-V
   qudt:iec61360Code "0112/2///62720#UAD863" ;
   qudt:symbol "mV/V" ;
   qudt:ucumCode "mV.V-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mV/V"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Millivolt na Volt"@cs ;
   rdfs:label "Millivolt na Volt"@sl ;
@@ -45892,7 +45505,6 @@ unit:MilliVA-PER-K
   qudt:iec61360Code "0112/2///62720#UAD906" ;
   qudt:symbol "mVA/K" ;
   qudt:ucumCode "mVA.K-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mVA/K"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Milli Volt Ampere per Kelvin" ;
   rdfs:label "Milli Volt Ampere per Kelvin"@en ;
@@ -45910,6 +45522,7 @@ unit:MilliVAR
   qudt:hasQuantityKind quantitykind:ReactivePower ;
   qudt:iec61360Code "0112/2///62720#UAC507" ;
   qudt:symbol "mVA{Reactive}" ;
+  qudt:ucumCode "mVA{reactive}"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Milli Volt Ampere Reactive" ;
   rdfs:label "Milli Volt Ampere Reactive"@en .
@@ -45923,6 +45536,7 @@ unit:MilliVAR-PER-K
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAD902" ;
   qudt:symbol "mVA{Reactive}/K" ;
+  qudt:ucumCode "mVA{reactive}.K-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Milli Volt Ampere Reactive per Kelvin" ;
   rdfs:label "Milli Volt Ampere Reactive per Kelvin"@en .
@@ -46088,7 +45702,6 @@ unit:MilliW-PER-MilliGM
   qudt:plainTextDescription "SI derived unit milliwatt divided by the SI derived unit milligram" ;
   qudt:symbol "mW/mg" ;
   qudt:ucumCode "mW.mg-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "mW/mg"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Millivatio por Milligramo"@es ;
   rdfs:label "Milliwat na Milligram"@pl ;
@@ -46162,16 +45775,16 @@ unit:N
   qudt:exactMatch unit:KiloGM-M-PER-SEC2 ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H0T-2D0 ;
   qudt:hasFactorUnit [
+    qudt:exponent 1 ;
+    qudt:hasUnit unit:KiloGM ;
+  ] ;
+  qudt:hasFactorUnit [
     qudt:exponent -2 ;
     qudt:hasUnit unit:SEC ;
   ] ;
   qudt:hasFactorUnit [
     qudt:exponent 1 ;
     qudt:hasUnit unit:M ;
-  ] ;
-  qudt:hasFactorUnit [
-    qudt:exponent 1 ;
-    qudt:hasUnit unit:KiloGM ;
   ] ;
   qudt:hasQuantityKind quantitykind:Force ;
   qudt:iec61360Code "0112/2///62720#UAA235" ;
@@ -46304,7 +45917,6 @@ unit:N-M-PER-A
   qudt:plainTextDescription "product of the SI derived unit newton and the SI base unit metre divided by the SI base unit ampere" ;
   qudt:symbol "N·m/A" ;
   qudt:ucumCode "N.m.A-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "N.m/A"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F90" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Newton Meter na Amper"@sl ;
@@ -46354,7 +45966,6 @@ unit:N-M-PER-DEG
   qudt:iec61360Code "0112/2///62720#UAB308" ;
   qudt:symbol "N·m/°" ;
   qudt:ucumCode "N.m.deg-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "N.m/deg"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F89" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Newton Meter per Degree"@en-US ;
@@ -46391,7 +46002,6 @@ unit:N-M-PER-KiloGM
   qudt:plainTextDescription "product of the derived SI unit newton and the SI base unit metre divided by the SI base unit kilogram" ;
   qudt:symbol "N·m/kg" ;
   qudt:ucumCode "N.m.kg-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "N.m/kg"^^qudt:UCUMcs ;
   qudt:udunitsCode "gp" ;
   qudt:uneceCommonCode "G19" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q108535211> ;
@@ -46432,7 +46042,6 @@ unit:N-M-PER-M
   qudt:plainTextDescription "This is the SI unit for the rolling resistance, which is equivalent to drag force in newton" ;
   qudt:symbol "N·m/m" ;
   qudt:ucumCode "N.m.m-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "N.m/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "Q27" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Newton Meter na Meter"@sl ;
@@ -46559,7 +46168,6 @@ unit:N-M-PER-RAD
   qudt:plainTextDescription "Newton Meter per Radian is the SI unit for Torsion Constant" ;
   qudt:symbol "N·m/rad" ;
   qudt:ucumCode "N.m.rad-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "N.m/rad"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M93" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q106886160> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -46659,7 +46267,6 @@ unit:N-M-SEC-PER-M
   qudt:plainTextDescription "Newton metre seconds measured per metre" ;
   qudt:symbol "N·m·s/m" ;
   qudt:ucumCode "N.m.s.m-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "N.m.s/m"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Newton Meter Saat per Meter"@ms ;
   rdfs:label "Newton Meter Second per Meter"@en-US ;
@@ -46696,7 +46303,6 @@ unit:N-M-SEC-PER-RAD
   qudt:plainTextDescription "Newton metre seconds measured per radian" ;
   qudt:symbol "N·m·s/rad" ;
   qudt:ucumCode "N.m.s.rad-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "N.m.s/rad"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Newton Meter Saat per Radian"@ms ;
   rdfs:label "Newton Meter Second per Radian"@en-US ;
@@ -46763,7 +46369,6 @@ unit:N-M2-PER-A
   qudt:iec61360Code "0112/2///62720#UAB332" ;
   qudt:symbol "N·m²/A" ;
   qudt:ucumCode "N.m2.A-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "N.m2/A"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P49" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Newton Kvadratni Meter na Amper"@sl ;
@@ -46836,7 +46441,6 @@ unit:N-PER-A
   qudt:plainTextDescription "SI derived unit newton divided by the SI base unit ampere" ;
   qudt:symbol "N/A" ;
   qudt:ucumCode "N.A-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "N/A"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H40" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Newton na Amper"@sl ;
@@ -46873,7 +46477,6 @@ unit:N-PER-C
   qudt:hasQuantityKind quantitykind:ForcePerElectricCharge ;
   qudt:symbol "N/C" ;
   qudt:ucumCode "N.C-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "N/C"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Newton na Coulomb"@cs ;
   rdfs:label "Newton na Coulomb"@sl ;
@@ -46908,7 +46511,6 @@ unit:N-PER-CentiM
   qudt:plainTextDescription "SI derived unit newton divided by the 0.01-fold of the SI base unit metre" ;
   qudt:symbol "N/cm" ;
   qudt:ucumCode "N.cm-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "N/cm"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M23" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Newton na Centimeter"@sl ;
@@ -46973,7 +46575,6 @@ unit:N-PER-KiloGM
   qudt:hasQuantityKind quantitykind:ThrustToMassRatio ;
   qudt:symbol "N/kg" ;
   qudt:ucumCode "N.kg-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "N/kg"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Newton na Kilogram"@cs ;
   rdfs:label "Newton na Kilogram"@sl ;
@@ -47010,7 +46611,6 @@ unit:N-PER-M
   qudt:iec61360Code "0112/2///62720#UAA246" ;
   qudt:symbol "N/m" ;
   qudt:ucumCode "N.m-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "N/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "4P" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q26156113> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -47131,7 +46731,6 @@ unit:N-PER-MilliM
   qudt:plainTextDescription "SI derived unit newton divided by the 0.001-fold of the SI base unit metre" ;
   qudt:symbol "N/mm" ;
   qudt:ucumCode "N.mm-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "N/mm"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F47" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q106885926> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -47199,7 +46798,6 @@ unit:N-PER-RAD
   qudt:plainTextDescription "A one-newton force applied for one angle/torsional torque" ;
   qudt:symbol "N/rad" ;
   qudt:ucumCode "N.rad-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "N/rad"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Newton na Radian"@sl ;
   rdfs:label "Newton na Radián"@cs ;
@@ -47280,7 +46878,6 @@ unit:N-SEC-PER-M
   qudt:plainTextDescription "Newton second measured per metre" ;
   qudt:symbol "N·s/m" ;
   qudt:ucumCode "N.s.m-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "N.s/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C58" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q87049028> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -47392,7 +46989,6 @@ unit:N-SEC-PER-RAD
   qudt:plainTextDescription "Newton seconds measured per radian" ;
   qudt:symbol "N·s/rad" ;
   qudt:ucumCode "N.s.rad-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "N.s/rad"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Newton Saat per Radian"@ms ;
   rdfs:label "Newton Saniye per Radyan"@tr ;
@@ -47524,7 +47120,6 @@ unit:NP-PER-SEC
   qudt:iec61360Code "0112/2///62720#UAA254" ;
   qudt:symbol "Np/s" ;
   qudt:ucumCode "Np.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "Np/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C51" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Neper per Second" ;
@@ -47603,7 +47198,6 @@ unit:NUM
   qudt:hasQuantityKind quantitykind:StoichiometricNumber ;
   qudt:hasQuantityKind quantitykind:TotalAngularMomentumQuantumNumber ;
   qudt:symbol "#" ;
-  qudt:ucumCode "1"^^qudt:UCUMcs ;
   qudt:ucumCode "{#}"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Number" ;
@@ -47616,7 +47210,7 @@ unit:NUM-PER-CentiM-KiloYR
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:symbol "#/(cm·ka)" ;
-  qudt:ucumCode "{#}.cm-2.ka-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "{#}.cm-1.ka-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Number per Centimeter Kiloyear"@en-US ;
   rdfs:label "Number per Centimetre Kiloyear" ;
@@ -47630,9 +47224,7 @@ unit:NUM-PER-GM
   qudt:hasDimensionVector qkdv:A0E0L0I0M-1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:symbol "#/g" ;
-  qudt:ucumCode "/g"^^qudt:UCUMcs ;
   qudt:ucumCode "{#}.g-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "{#}/g"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Number per Gram" ;
   rdfs:label "Number per Gram"@en .
@@ -47645,9 +47237,7 @@ unit:NUM-PER-HA
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:ParticleFluence ;
   qudt:symbol "#/ha" ;
-  qudt:ucumCode "/har"^^qudt:UCUMcs ;
   qudt:ucumCode "{#}.har-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "{#}/har"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Number per Hectare" ;
   rdfs:label "Number per Hectare"@en .
@@ -47675,9 +47265,7 @@ unit:NUM-PER-HR
   qudt:hasQuantityKind quantitykind:Frequency ;
   qudt:hasReciprocalUnit unit:HR-PER-NUM ;
   qudt:symbol "#/h" ;
-  qudt:ucumCode "/h"^^qudt:UCUMcs ;
   qudt:ucumCode "{#}.h-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "{#}/h"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Number per Hour" ;
   rdfs:label "Number per Hour"@en .
@@ -47690,9 +47278,7 @@ unit:NUM-PER-HectoGM
   qudt:hasDimensionVector qkdv:A0E0L0I0M-1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:symbol "#/hg" ;
-  qudt:ucumCode "/hg"^^qudt:UCUMcs ;
   qudt:ucumCode "{#}.hg-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "{#}/hg"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Number per Hectogram" ;
   rdfs:label "Number per Hectogram"@en .
@@ -47732,9 +47318,7 @@ unit:NUM-PER-L
   qudt:hasDimensionVector qkdv:A0E0L-3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:NumberDensity ;
   qudt:symbol "#/L" ;
-  qudt:ucumCode "/L"^^qudt:UCUMcs ;
   qudt:ucumCode "{#}.L-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "{#}/L"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Number per Liter"@en-US ;
   rdfs:label "Number per Litre" ;
@@ -47749,9 +47333,7 @@ unit:NUM-PER-M
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:InverseLength ;
   qudt:symbol "#/m" ;
-  qudt:ucumCode "/m"^^qudt:UCUMcs ;
   qudt:ucumCode "{#}.m-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "{#}/m"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Number per Meter"@en-US ;
   rdfs:label "Number per Metre" ;
@@ -47765,7 +47347,6 @@ unit:NUM-PER-M2
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:ParticleFluence ;
   qudt:symbol "#/m²" ;
-  qudt:ucumCode "/m2"^^qudt:UCUMcs ;
   qudt:ucumCode "{#}.m-2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Number per Square Meter"@en-US ;
@@ -47793,7 +47374,6 @@ unit:NUM-PER-M3
   qudt:hasDimensionVector qkdv:A0E0L-3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:NumberDensity ;
   qudt:symbol "#/m³" ;
-  qudt:ucumCode "/m3"^^qudt:UCUMcs ;
   qudt:ucumCode "{#}.m-3"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Number per Cubic Meter"@en-US ;
@@ -47809,6 +47389,7 @@ unit:NUM-PER-MIN
   qudt:hasQuantityKind quantitykind:CountRate ;
   qudt:hasReciprocalUnit unit:MIN-PER-NUM ;
   qudt:symbol "#/min" ;
+  qudt:ucumCode "{#}.min-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Number per Minute" ;
   rdfs:label "Number per Minute"@en .
@@ -47820,7 +47401,6 @@ unit:NUM-PER-MicroL
   qudt:hasDimensionVector qkdv:A0E0L-3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:NumberDensity ;
   qudt:symbol "#/μL" ;
-  qudt:ucumCode "/uL"^^qudt:UCUMcs ;
   qudt:ucumCode "{#}.uL-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Number per Microliter"@en-US ;
@@ -47836,7 +47416,6 @@ unit:NUM-PER-MilliGM
   qudt:hasDimensionVector qkdv:A0E0L0I0M-1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:symbol "#/mg" ;
-  qudt:ucumCode "/mg"^^qudt:UCUMcs ;
   qudt:ucumCode "{#}.mg-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Number per Milligram" ;
@@ -47850,7 +47429,6 @@ unit:NUM-PER-MilliL
   qudt:hasDimensionVector qkdv:A0E0L-3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:NumberDensity ;
   qudt:symbol "#/mL" ;
-  qudt:ucumCode "/mL"^^qudt:UCUMcs ;
   qudt:ucumCode "{#}.mL-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Number per Milliliter"@en-US ;
@@ -47865,7 +47443,6 @@ unit:NUM-PER-MilliM3
   qudt:hasDimensionVector qkdv:A0E0L-3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:NumberDensity ;
   qudt:symbol "#/mm³" ;
-  qudt:ucumCode "/mm3"^^qudt:UCUMcs ;
   qudt:ucumCode "{#}.mm-3"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Number per Cubic Millimeter"@en-US ;
@@ -47879,7 +47456,6 @@ unit:NUM-PER-NanoL
   qudt:hasDimensionVector qkdv:A0E0L-3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:NumberDensity ;
   qudt:symbol "#/nL" ;
-  qudt:ucumCode "/nL"^^qudt:UCUMcs ;
   qudt:ucumCode "{#}.nL-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Number per Nanoliter"@en-US ;
@@ -47893,7 +47469,6 @@ unit:NUM-PER-PicoL
   qudt:hasDimensionVector qkdv:A0E0L-3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:NumberDensity ;
   qudt:symbol "#/pL" ;
-  qudt:ucumCode "/pL"^^qudt:UCUMcs ;
   qudt:ucumCode "{#}.pL-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Number per Picoliter"@en-US ;
@@ -47910,9 +47485,7 @@ unit:NUM-PER-SEC
   qudt:hasQuantityKind quantitykind:Frequency ;
   qudt:hasReciprocalUnit unit:SEC-PER-NUM ;
   qudt:symbol "#/s" ;
-  qudt:ucumCode "/s"^^qudt:UCUMcs ;
   qudt:ucumCode "{#}.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "{#}/s"^^qudt:UCUMcs ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q115536343> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Number per Second" ;
@@ -47931,9 +47504,7 @@ unit:NUM-PER-YR
   qudt:hasQuantityKind quantitykind:Frequency ;
   qudt:hasReciprocalUnit unit:YR-PER-NUM ;
   qudt:symbol "#/a" ;
-  qudt:ucumCode "/a"^^qudt:UCUMcs ;
   qudt:ucumCode "{#}.a-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "{#}/a"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Number per Year" ;
   rdfs:label "Number per Year"@en .
@@ -47974,7 +47545,6 @@ unit:NanoA-PER-K
   qudt:iec61360Code "0112/2///62720#UAD899" ;
   qudt:symbol "nA/K" ;
   qudt:ucumCode "nA.K-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "nA/K"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Nanoamper na Kelvin"@sl ;
   rdfs:label "Nanoamper na Kelwin"@pl ;
@@ -48002,6 +47572,7 @@ unit:NanoBQ
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Activity ;
   qudt:symbol "nBq" ;
+  qudt:ucumCode "nBq"^^qudt:UCUMcs ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q95866344> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Nanobecquerel" ;
@@ -48030,7 +47601,6 @@ unit:NanoBQ-PER-L
   qudt:hasQuantityKind quantitykind:ActivityConcentration ;
   qudt:symbol "nBq/L" ;
   qudt:ucumCode "nBq.L-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "nBq/L"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Nanobecquerel per Liter"@en-US ;
   rdfs:label "Nanobecquerel per Litre" ;
@@ -48119,7 +47689,6 @@ unit:NanoFARAD-PER-M
   qudt:plainTextDescription "0.000000001-fold of the SI derived unit farad divided by the SI base unit metre" ;
   qudt:symbol "nF/m" ;
   qudt:ucumCode "nF.m-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "nF/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C42" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Nanofarad na Meter"@sl ;
@@ -48180,7 +47749,6 @@ unit:NanoGM-PER-CentiM2
   qudt:plainTextDescription "0,000,000,000,001-fold of the SI base unit kilogram divided by the 0.0001-fold of the power of the SI base unit metre and exponent 2" ;
   qudt:symbol "ng/cm²" ;
   qudt:ucumCode "ng.cm-2"^^qudt:UCUMcs ;
-  qudt:ucumCode "ng/cm2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Nanogram na Centimetr Kwadratowy"@pl ;
   rdfs:label "Nanogram na Kvadratni Centimeter"@sl ;
@@ -48226,7 +47794,6 @@ unit:NanoGM-PER-DAY
   qudt:hasQuantityKind quantitykind:MassPerTime ;
   qudt:symbol "ng/d" ;
   qudt:ucumCode "ng.d-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "ng/d"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Nanogram per Day" ;
   rdfs:label "Nanogram per Day"@en .
@@ -48246,7 +47813,6 @@ unit:NanoGM-PER-DeciL
   qudt:hasQuantityKind quantitykind:MassDensity ;
   qudt:symbol "ng/dL" ;
   qudt:ucumCode "ng.dL-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "ng/dL"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Nanogram per Deciliter"@en-US ;
   rdfs:label "Nanogram per Decilitre" ;
@@ -48269,7 +47835,6 @@ unit:NanoGM-PER-KiloGM
   qudt:qkdvNumerator qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:symbol "ng/kg" ;
   qudt:ucumCode "ng.kg-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "ng/kg"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L32" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q107313738> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -48300,7 +47865,6 @@ unit:NanoGM-PER-L
   qudt:hasQuantityKind quantitykind:MassDensity ;
   qudt:symbol "ng/L" ;
   qudt:ucumCode "ng.L-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "ng/L"^^qudt:UCUMcs ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q104907186> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Nanogram per Liter"@en-US ;
@@ -48380,7 +47944,6 @@ unit:NanoGM-PER-MicroL
   qudt:hasQuantityKind quantitykind:MassDensity ;
   qudt:symbol "ng/μL" ;
   qudt:ucumCode "ng.uL-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "ng/uL"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Nanogram per Microliter"@en-US ;
   rdfs:label "Nanogram per Microlitre" ;
@@ -48402,7 +47965,6 @@ unit:NanoGM-PER-MilliGM
   qudt:qkdvNumerator qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:symbol "ng/mg" ;
   qudt:ucumCode "ng.mg-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "ng/mg"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Nanogram na Milligram"@cs ;
   rdfs:label "Nanogram na Milligram"@pl ;
@@ -48432,7 +47994,6 @@ unit:NanoGM-PER-MilliL
   qudt:hasQuantityKind quantitykind:MassDensity ;
   qudt:symbol "ng/mL" ;
   qudt:ucumCode "ng.mL-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "ng/mL"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Nanogram per Milliliter"@en-US ;
   rdfs:label "Nanogram per Millilitre" ;
@@ -48446,6 +48007,7 @@ unit:NanoGRAY
   qudt:hasQuantityKind quantitykind:AbsorbedDose ;
   qudt:hasQuantityKind quantitykind:Kerma ;
   qudt:symbol "nGy" ;
+  qudt:ucumCode "nGy"^^qudt:UCUMcs ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q94734593> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Nanogray" ;
@@ -48473,6 +48035,7 @@ unit:NanoGRAY-PER-HR
   qudt:hasQuantityKind quantitykind:SpecificPower ;
   qudt:iec61360Code "0112/2///62720#UAB479" ;
   qudt:symbol "nGy/h" ;
+  qudt:ucumCode "nGy.h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P64" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q106617523> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -48490,6 +48053,7 @@ unit:NanoGRAY-PER-MIN
   qudt:hasQuantityKind quantitykind:SpecificPower ;
   qudt:iec61360Code "0112/2///62720#UAB475" ;
   qudt:symbol "nGy/min" ;
+  qudt:ucumCode "nGy.min-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P60" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Nanogray per Minute" ;
@@ -48506,6 +48070,7 @@ unit:NanoGRAY-PER-SEC
   qudt:hasQuantityKind quantitykind:SpecificPower ;
   qudt:iec61360Code "0112/2///62720#UAB300" ;
   qudt:symbol "nGy/s" ;
+  qudt:ucumCode "nGy.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P56" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q106617515> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -48570,7 +48135,6 @@ unit:NanoH-PER-M
   qudt:plainTextDescription "0.000000001-fold of the SI derived unit henry divided by the SI base unit metre" ;
   qudt:symbol "nH/m" ;
   qudt:ucumCode "nH.m-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "nH/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C44" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q107538724> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -48602,6 +48166,7 @@ unit:NanoJ
   qudt:hasQuantityKind quantitykind:ThermalEnergy ;
   qudt:iec61360Code "0112/2///62720#UAB739" ;
   qudt:symbol "nJ" ;
+  qudt:ucumCode "nJ"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Nanodżul"@pl ;
   rdfs:label "Nanojoule" ;
@@ -48627,7 +48192,6 @@ unit:NanoJ-PER-SEC
   qudt:iec61360Code "0112/2///62720#UAB509" ;
   qudt:symbol "nJ/s" ;
   qudt:ucumCode "nJ.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "nJ/s"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Nanodżul na Sekunda"@pl ;
   rdfs:label "Nanojoule na Sekunda"@cs ;
@@ -48649,6 +48213,7 @@ unit:NanoKAT
   qudt:hasDimensionVector qkdv:A1E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:CatalyticActivity ;
   qudt:symbol "nkat" ;
+  qudt:ucumCode "nkat"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Nanokatal" ;
   rdfs:label "Nanokatal"@cs ;
@@ -48674,7 +48239,7 @@ unit:NanoKAT-PER-L
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:CatalyticActivityConcentration ;
   qudt:symbol "nkat/L" ;
-  qudt:ucumCode "nkat/L"^^qudt:UCUMcs ;
+  qudt:ucumCode "nkat.L-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Nanokatal per Liter"@en-US ;
   rdfs:label "Nanokatal per Litre" ;
@@ -48774,7 +48339,7 @@ unit:NanoM-PER-CentiM-PSI
   qudt:qkdvNumerator qkdv:A0E0L1I0M0H0T0D0 ;
   qudt:siUnitsExpression "nm/cm/PSI" ;
   qudt:symbol "nm/(cm·psi)" ;
-  qudt:ucumCode "nm.cm-1.PSI-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "nm.cm-1.[psi]-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Nanometer per Centimeter Psi"@en-US ;
   rdfs:label "Nanometre per Centimetre Psi" ;
@@ -48855,6 +48420,7 @@ unit:NanoMOL
   qudt:hasQuantityKind quantitykind:ExtentOfReaction ;
   qudt:iec61360Code "0112/2///62720#UAB523" ;
   qudt:symbol "nmol" ;
+  qudt:ucumCode "nmol"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "Z9" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q56157046> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -48899,7 +48465,6 @@ unit:NanoMOL-PER-GM
   qudt:plainTextDescription "0.000000001-fold of the SI base unit mol divided by the 0.001-fold of the SI base unit kilogram" ;
   qudt:symbol "nmol/g" ;
   qudt:ucumCode "nmol.g-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "nmol/g"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Nanomol na Gram"@cs ;
   rdfs:label "Nanomol na Gram"@pl ;
@@ -48960,7 +48525,6 @@ unit:NanoMOL-PER-KiloGM
   qudt:hasQuantityKind quantitykind:AmountOfSubstancePerMass ;
   qudt:symbol "nmol/kg" ;
   qudt:ucumCode "nmol.kg-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "nmol/kg"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Nanomol na Kilogram"@cs ;
   rdfs:label "Nanomol na Kilogram"@pl ;
@@ -48985,7 +48549,6 @@ unit:NanoMOL-PER-L
   qudt:hasQuantityKind quantitykind:Concentration ;
   qudt:symbol "nmol/L" ;
   qudt:ucumCode "nmol.L-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "nmol/L"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Nanomole per Liter"@en-US ;
   rdfs:label "Nanomole per Litre" ;
@@ -49087,7 +48650,6 @@ unit:NanoMOL-PER-MicroMOL
   qudt:qkdvNumerator qkdv:A1E0L0I0M0H0T0D0 ;
   qudt:symbol "nmol/μmol" ;
   qudt:ucumCode "nmol.umol-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "nmol/umol"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Nanomol na Micromol"@cs ;
   rdfs:label "Nanomol na Micromol"@pl ;
@@ -49123,6 +48685,7 @@ unit:NanoN
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Force ;
   qudt:symbol "nN" ;
+  qudt:ucumCode "nN"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Nanonewton" ;
   rdfs:label "Nanonewton"@cs ;
@@ -49148,6 +48711,7 @@ unit:NanoN-M-PER-M2
   qudt:hasQuantityKind quantitykind:ForcePerLength ;
   qudt:iec61360Code "0112/2///62720#UAB547" ;
   qudt:symbol "nN·m/m²" ;
+  qudt:ucumCode "nN.m.m-2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Nanonewton Meter na Kvadratni Meter"@sl ;
   rdfs:label "Nanonewton Meter per Meter Persegi"@ms ;
@@ -49172,6 +48736,7 @@ unit:NanoOHM
   qudt:hasQuantityKind quantitykind:ElectricalResistance ;
   qudt:iec61360Code "0112/2///62720#UAB359" ;
   qudt:symbol "nΩ" ;
+  qudt:ucumCode "nOhm"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P22" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q94480254> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -49227,6 +48792,7 @@ unit:NanoS
   qudt:hasQuantityKind quantitykind:Admittance ;
   qudt:hasQuantityKind quantitykind:Conductance ;
   qudt:symbol "nS" ;
+  qudt:ucumCode "nS"^^qudt:UCUMcs ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q94694154> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Nanosiemens" ;
@@ -49257,7 +48823,6 @@ unit:NanoS-PER-CentiM
   qudt:plainTextDescription "0.000000001-fold of the SI derived unit Siemens by the 0.01 fol of the SI base unit metre" ;
   qudt:symbol "nS/cm" ;
   qudt:ucumCode "nS.cm-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "nS/cm"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G44" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q106777952> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -49289,7 +48854,6 @@ unit:NanoS-PER-M
   qudt:plainTextDescription "0.000000001-fold of the SI derived unit Siemens divided by the SI base unit metre" ;
   qudt:symbol "nS/m" ;
   qudt:ucumCode "nS.m-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "nS/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G45" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q106777943> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -49349,6 +48913,7 @@ unit:NanoSV
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:DoseEquivalent ;
   qudt:symbol "nSv" ;
+  qudt:ucumCode "nSv"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Nanosievert" ;
   rdfs:label "Nanosievert"@cs ;
@@ -49375,6 +48940,7 @@ unit:NanoSV-PER-HR
   qudt:hasQuantityKind quantitykind:SpecificPower ;
   qudt:iec61360Code "0112/2///62720#UAB467" ;
   qudt:symbol "nSv/h" ;
+  qudt:ucumCode "nSv.h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P73" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Nanosievert per Hour" ;
@@ -49391,6 +48957,7 @@ unit:NanoSV-PER-MIN
   qudt:hasQuantityKind quantitykind:SpecificPower ;
   qudt:iec61360Code "0112/2///62720#UAB471" ;
   qudt:symbol "nSv/min" ;
+  qudt:ucumCode "nSv.min-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P77" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Nanosievert per Minute" ;
@@ -49407,6 +48974,7 @@ unit:NanoSV-PER-SEC
   qudt:hasQuantityKind quantitykind:SpecificPower ;
   qudt:iec61360Code "0112/2///62720#UAB304" ;
   qudt:symbol "nSv/s" ;
+  qudt:ucumCode "nSv.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P68" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Nanosievert na Sekunda"@cs ;
@@ -49465,6 +49033,7 @@ unit:NanoV
   qudt:hasQuantityKind quantitykind:Voltage ;
   qudt:iec61360Code "0112/2///62720#UAC771" ;
   qudt:symbol "nV" ;
+  qudt:ucumCode "nV"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Nanovolt" ;
   rdfs:label "Nanovolt"@cs ;
@@ -49548,6 +49117,7 @@ unit:NanoVAR
   qudt:hasQuantityKind quantitykind:ReactivePower ;
   qudt:iec61360Code "0112/2///62720#UAC505" ;
   qudt:symbol "nVA{Reactive}" ;
+  qudt:ucumCode "nVA{reactive}"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Nano Volt Ampere Reactive" ;
   rdfs:label "Nano Volt Ampere Reactive"@en .
@@ -49882,7 +49452,7 @@ unit:OHM-M2-PER-M
   qudt:hasDimensionVector qkdv:A0E-2L3I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:Resistivity ;
   qudt:symbol "Ω·m²/m" ;
-  qudt:ucumCode "Ohm2.m.m-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "Ohm.m2.m-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Ohm Kvadratni Meter na Meter"@sl ;
   rdfs:label "Ohm Meter Persegi per Meter"@ms ;
@@ -49913,7 +49483,6 @@ unit:OHM-PER-BAR
   qudt:iec61360Code "0112/2///62720#UAD879" ;
   qudt:symbol "Ω/bar" ;
   qudt:ucumCode "Ohm.bar-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "Ohm/bar"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Ohm per Bar" ;
   rdfs:label "Ohm per Bar"@en .
@@ -49928,7 +49497,6 @@ unit:OHM-PER-K
   qudt:iec61360Code "0112/2///62720#UAD875" ;
   qudt:symbol "Ω/K" ;
   qudt:ucumCode "Ohm.K-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "Ohm/K"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Ohm na Kelvin"@cs ;
   rdfs:label "Ohm na Kelvin"@sl ;
@@ -49958,7 +49526,6 @@ unit:OHM-PER-KiloM
   qudt:iec61360Code "0112/2///62720#UAA019" ;
   qudt:symbol "Ω/km" ;
   qudt:ucumCode "Ohm.km-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "Ohm/km"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F56" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Ohm na Kilometer"@sl ;
@@ -49985,7 +49552,6 @@ unit:OHM-PER-M
   qudt:iec61360Code "0112/2///62720#UAA021" ;
   qudt:symbol "Ω/m" ;
   qudt:ucumCode "Ohm.m-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "Ohm/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H26" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Ohm na Meter"@sl ;
@@ -50017,7 +49583,6 @@ unit:OHM-PER-MI
   qudt:iec61360Code "0112/2///62720#UAA022" ;
   qudt:symbol "Ω/mi" ;
   qudt:ucumCode "Ohm.[mi_i]-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "Ohm/[mi_i]"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F55" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Ohm per International Mile" ;
@@ -50426,7 +49991,6 @@ unit:OZ-PER-DAY
   qudt:plainTextDescription "traditional unit of the mass avoirdupois ounce according to the avoirdupois system of units divided by the unit for time day" ;
   qudt:symbol "oz/d" ;
   qudt:ucumCode "[oz_av].d-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[oz_av]/d"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L33" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Ounce Mass per Day" ;
@@ -50446,7 +50010,7 @@ unit:OZ-PER-FT2
   qudt:hasQuantityKind quantitykind:MassPerArea ;
   qudt:iec61360Code "0112/2///62720#UAB105" ;
   qudt:symbol "oz/ft²" ;
-  qudt:ucumCode "[oz_av].[sft_i]-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[oz_av].[ft_i]-2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "37" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Ounce Mass per Square Foot" ;
@@ -50523,7 +50087,6 @@ unit:OZ-PER-HR
   qudt:plainTextDescription "traditional unit of the mass avoirdupois ounce according to the avoirdupois system of units divided by the unit for time hour" ;
   qudt:symbol "oz/h" ;
   qudt:ucumCode "[oz_av].h-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[oz_av]/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L34" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Ounce Mass per Hour" ;
@@ -50561,8 +50124,7 @@ unit:OZ-PER-IN3
   qudt:hasQuantityKind quantitykind:Density ;
   qudt:hasQuantityKind quantitykind:MassDensity ;
   qudt:symbol "oz/in³" ;
-  qudt:ucumCode "[oz_av].[cin_i]-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[oz_av]/[cin_i]"^^qudt:UCUMcs ;
+  qudt:ucumCode "[oz_av].[in_i]-3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L39" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Ounce Mass per Cubic Inch" ;
@@ -50581,7 +50143,6 @@ unit:OZ-PER-MIN
   qudt:plainTextDescription "traditional unit of the mass avoirdupois ounce according to the avoirdupois system of units divided by the unit for time minute" ;
   qudt:symbol "oz/min" ;
   qudt:ucumCode "[oz_av].min-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[oz_av]/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L35" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Ounce Mass per Minute" ;
@@ -50600,7 +50161,6 @@ unit:OZ-PER-SEC
   qudt:plainTextDescription "traditional unit of the mass avoirdupois ounce according to the avoirdupois system of units divided by the SI base unit second" ;
   qudt:symbol "oz/s" ;
   qudt:ucumCode "[oz_av].s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[oz_av]/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L36" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Ounce Mass per Second" ;
@@ -50620,8 +50180,7 @@ unit:OZ-PER-YD2
   qudt:hasQuantityKind quantitykind:MassPerArea ;
   qudt:iec61360Code "0112/2///62720#UAB104" ;
   qudt:symbol "oz/yd²" ;
-  qudt:ucumCode "[oz_av].[syd_i]-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[oz_av]/[syd_i]"^^qudt:UCUMcs ;
+  qudt:ucumCode "[oz_av].[yd_i]-2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "ON" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Ounce Mass per Square Yard" ;
@@ -50640,8 +50199,7 @@ unit:OZ-PER-YD3
   qudt:iec61360Code "0112/2///62720#UAA918" ;
   qudt:plainTextDescription "unit ounce  according to the avoirdupois system of units divided by the power of the unit yard according to the Anglo-American and the Imperial system of units with the exponent 3" ;
   qudt:symbol "oz/yd³" ;
-  qudt:ucumCode "[oz_av].[cyd_i]-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[oz_av]/[cyd_i]"^^qudt:UCUMcs ;
+  qudt:ucumCode "[oz_av].[yd_i]-3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G32" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Ounce Mass per Cubic Yard" ;
@@ -50845,7 +50403,6 @@ unit:OZ_VOL_UK-PER-DAY
   qudt:plainTextDescription "unit of the volume fluid ounce (UK) for fluids according to the Imperial system of units divided by the unit for time day" ;
   qudt:symbol "oz{UK}/d" ;
   qudt:ucumCode "[foz_br].d-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[foz_br]/d"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J95" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Fluid Ounce (UK) per Day" ;
@@ -50864,7 +50421,6 @@ unit:OZ_VOL_UK-PER-HR
   qudt:plainTextDescription "unit of the volume fluid ounce (UK) for fluids according to the Imperial system of units divided by the unit for time hour" ;
   qudt:symbol "oz{UK}/h" ;
   qudt:ucumCode "[foz_br].h-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[foz_br]/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J96" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Fluid Ounce (UK) per Hour" ;
@@ -50883,7 +50439,6 @@ unit:OZ_VOL_UK-PER-MIN
   qudt:plainTextDescription "unit of the volume fluid ounce (UK) for fluids according to the Imperial system of units divided by the unit for time minute" ;
   qudt:symbol "oz{UK}/min" ;
   qudt:ucumCode "[foz_br].min-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[foz_br]/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J97" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Fluid Ounce (UK) per Minute" ;
@@ -50902,7 +50457,6 @@ unit:OZ_VOL_UK-PER-SEC
   qudt:plainTextDescription "unit of the volume fluid ounce (UK) for fluids according to the Imperial system of units divided by the SI base unit second" ;
   qudt:symbol "oz{UK}/s" ;
   qudt:ucumCode "[foz_br].s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[foz_br]/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J98" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Fluid Ounce (UK) per Second" ;
@@ -50941,7 +50495,6 @@ unit:OZ_VOL_US-PER-DAY
   qudt:plainTextDescription "unit of the volume fluid ounce (US) for fluids according to the Anglo-American system of units divided by unit for time day" ;
   qudt:symbol "fl oz{US}/d" ;
   qudt:ucumCode "[foz_us].d-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[foz_us]/d"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J99" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Us Liquid Ounce per Day" ;
@@ -50960,7 +50513,6 @@ unit:OZ_VOL_US-PER-HR
   qudt:plainTextDescription "unit of the volume fluid ounce (US) for fluids according to the Anglo-American system of units divided by the unit for time hour" ;
   qudt:symbol "fl oz{US}/h" ;
   qudt:ucumCode "[foz_us].h-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[foz_us]/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K10" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Us Liquid Ounce per Hour" ;
@@ -50979,7 +50531,6 @@ unit:OZ_VOL_US-PER-MIN
   qudt:plainTextDescription "unit of the volume fluid ounce (US) for fluids according to the Anglo-American system of units divided by the unit for time minute" ;
   qudt:symbol "fl oz{US}/min" ;
   qudt:ucumCode "[foz_us].min-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[foz_us]/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K11" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Us Liquid Ounce per Minute" ;
@@ -50998,7 +50549,6 @@ unit:OZ_VOL_US-PER-SEC
   qudt:plainTextDescription "unit of the volume fluid ounce (US) for fluids according to the Anglo-American system of units divided by the SI base unit second" ;
   qudt:symbol "fl oz{US}/s" ;
   qudt:ucumCode "[foz_us].s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[foz_us]/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K12" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Us Liquid Ounce per Second" ;
@@ -51090,7 +50640,6 @@ unit:PA-L-PER-SEC
   qudt:plainTextDescription "product out of the SI derived unit pascal and the unit litre divided by the SI base unit second" ;
   qudt:symbol "Pa·L/s" ;
   qudt:ucumCode "Pa.L.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "Pa.L/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F99" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Pascal Liter per Second"@en-US ;
@@ -51141,7 +50690,6 @@ unit:PA-M-PER-SEC
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:symbol "Pa·m/s" ;
   qudt:ucumCode "Pa.m.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "Pa.m/s"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Pascal Meter na Sekunda"@sl ;
   rdfs:label "Pascal Meter per Saat"@ms ;
@@ -51258,7 +50806,6 @@ unit:PA-M3-PER-SEC
   qudt:plainTextDescription "product out of the SI derived unit pascal and the power of the SI base unit metre with the exponent 3 divided by the SI base unit second" ;
   qudt:symbol "Pa·m³/s" ;
   qudt:ucumCode "Pa.m3.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "Pa.m3/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G01" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Pascal Cubic Meter per Second"@en-US ;
@@ -51292,7 +50839,6 @@ unit:PA-PER-BAR
   qudt:plainTextDescription "SI derived unit pascal divided by the unit bar" ;
   qudt:symbol "Pa/bar" ;
   qudt:ucumCode "Pa.bar-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "Pa/bar"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F07" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Pascal per Bar" ;
@@ -51312,7 +50858,6 @@ unit:PA-PER-HR
   qudt:hasQuantityKind quantitykind:ForcePerAreaTime ;
   qudt:symbol "Pa/h" ;
   qudt:ucumCode "Pa.h-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "Pa/h"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Pascal per Hour" ;
   rdfs:label "Pascal per Hour"@en .
@@ -51329,7 +50874,6 @@ unit:PA-PER-K
   qudt:iec61360Code "0112/2///62720#UAA259" ;
   qudt:symbol "Pa/K" ;
   qudt:ucumCode "Pa.K-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "Pa/K"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C64" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q79398638> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -51367,7 +50911,6 @@ unit:PA-PER-M
   qudt:plainTextDescription "SI derived unit pascal divided by the SI base unit metre" ;
   qudt:symbol "Pa/m" ;
   qudt:ucumCode "Pa.m-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "Pa/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H42" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Pascal na Meter"@sl ;
@@ -51403,7 +50946,6 @@ unit:PA-PER-MIN
   qudt:hasQuantityKind quantitykind:ForcePerAreaTime ;
   qudt:symbol "Pa/min" ;
   qudt:ucumCode "Pa.min-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "Pa/min"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Pascal per Minute" ;
   rdfs:label "Pascal per Minute"@en .
@@ -51423,7 +50965,6 @@ unit:PA-PER-SEC
   qudt:hasQuantityKind quantitykind:ForcePerAreaTime ;
   qudt:symbol "Pa/s" ;
   qudt:ucumCode "Pa.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "Pa/s"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Pascal na Sekunda"@cs ;
   rdfs:label "Pascal na Sekunda"@sl ;
@@ -51501,7 +51042,6 @@ unit:PA-SEC-PER-BAR
   qudt:plainTextDescription "product out of the SI derived unit pascal and the SI base unit second divided by the unit bar" ;
   qudt:symbol "Pa·s/bar" ;
   qudt:ucumCode "Pa.s.bar-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "Pa.s/bar"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H07" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Pascal Second per Bar" ;
@@ -51517,7 +51057,6 @@ unit:PA-SEC-PER-K
   qudt:iec61360Code "0112/2///62720#UAA266" ;
   qudt:symbol "Pa·s/K" ;
   qudt:ucumCode "Pa.s.K-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "Pa.s/K"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F77" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Pascal Saat per Kelvin"@ms ;
@@ -51548,7 +51087,6 @@ unit:PA-SEC-PER-L
   qudt:iec61360Code "0112/2///62720#UAB499" ;
   qudt:symbol "Pa·s/L" ;
   qudt:ucumCode "Pa.s.L-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "Pa.s/L"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M32" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Pascal Second per Liter"@en-US ;
@@ -51573,7 +51111,6 @@ unit:PA-SEC-PER-M
   qudt:siUnitsExpression "Pa.s/m" ;
   qudt:symbol "Pa·s/m" ;
   qudt:ucumCode "Pa.s.m-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "Pa.s/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C67" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q87051580> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -51826,7 +51363,7 @@ unit:PDL-PER-FT2
   qudt:iec61360Code "0112/2///62720#UAB243" ;
   qudt:informativeReference "http://www.efunda.com/glossary/units/units--pressure--poundal_per_square_foot.cfm"^^xsd:anyURI ;
   qudt:symbol "pdl/ft²" ;
-  qudt:ucumCode "[lb_av].[ft_i].s-2.[sft_i]-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[lb_av].[ft_i].s-2.[ft_i]-2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "N21" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q107410782> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -51924,7 +51461,6 @@ unit:PER-ANGSTROM
   qudt:iec61360Code "0112/2///62720#UAB058" ;
   qudt:plainTextDescription "reciprocal of the unit angstrom" ;
   qudt:symbol "/Å" ;
-  qudt:ucumCode "/Ao"^^qudt:UCUMcs ;
   qudt:ucumCode "Ao-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C85" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q107378436> ;
@@ -51945,7 +51481,6 @@ unit:PER-BAR
   qudt:iec61360Code "0112/2///62720#UAA328" ;
   qudt:plainTextDescription "reciprocal of the metrical unit with the name bar" ;
   qudt:symbol "/bar" ;
-  qudt:ucumCode "/bar"^^qudt:UCUMcs ;
   qudt:ucumCode "bar-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F58" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -51966,7 +51501,6 @@ unit:PER-CentiM
   qudt:iec61360Code "0112/2///62720#UAA382" ;
   qudt:plainTextDescription "reciprocal of the 0.01-fold of the SI base unit metre" ;
   qudt:symbol "/cm" ;
-  qudt:ucumCode "/cm"^^qudt:UCUMcs ;
   qudt:ucumCode "cm-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E90" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q107226391> ;
@@ -52034,7 +51568,6 @@ unit:PER-DAY
   qudt:iec61360Code "0112/2///62720#UAA408" ;
   qudt:plainTextDescription "reciprocal of the unit day" ;
   qudt:symbol "/d" ;
-  qudt:ucumCode "/d"^^qudt:UCUMcs ;
   qudt:ucumCode "d-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E91" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q102129592> ;
@@ -52052,8 +51585,7 @@ unit:PER-DEG_C
   qudt:iec61360Code "0112/2///62720#UAB840" ;
   qudt:plainTextDescription "Unit for expressing the change of some quantity relative to a unit change in temperature." ;
   qudt:symbol "/°C" ;
-  qudt:ucumCode ".Cel-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "/Cel"^^qudt:UCUMcs ;
+  qudt:ucumCode "Cel-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Aνά Βαθμός Κελσίου"@el ;
   rdfs:label "Na Stopień Celsjusza"@pl ;
@@ -52086,7 +51618,6 @@ unit:PER-DEG_F
   qudt:hasQuantityKind quantitykind:ThermalExpansionCoefficient ;
   qudt:iec61360Code "0112/2///62720#UAA047" ;
   qudt:symbol "/°F" ;
-  qudt:ucumCode "/[degF]"^^qudt:UCUMcs ;
   qudt:ucumCode "[degF]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J26" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -52140,8 +51671,7 @@ unit:PER-FT3
   qudt:iec61360Code "0112/2///62720#UAA453" ;
   qudt:plainTextDescription "reciprocal value of the power of the unit foot according to the Anglo-American and the Imperial system of units with the exponent 3" ;
   qudt:symbol "/ft³" ;
-  qudt:ucumCode "/[cft_i]"^^qudt:UCUMcs ;
-  qudt:ucumCode "[cft_i]-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[ft_i]-3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K20" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Reciprocal Cubic Foot" ;
@@ -52161,7 +51691,6 @@ unit:PER-GM
   qudt:hasQuantityKind quantitykind:InverseMass ;
   qudt:iec61360Code "0112/2///62720#UAC004" ;
   qudt:symbol "/g" ;
-  qudt:ucumCode "/g"^^qudt:UCUMcs ;
   qudt:ucumCode "g-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Na Gram"@cs ;
@@ -52209,7 +51738,6 @@ unit:PER-H
   qudt:hasQuantityKind quantitykind:Reluctance ;
   qudt:iec61360Code "0112/2///62720#UAA169" ;
   qudt:symbol "/H" ;
-  qudt:ucumCode "/H"^^qudt:UCUMcs ;
   qudt:ucumCode "H-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C89" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q77996931> ;
@@ -52249,7 +51777,6 @@ unit:PER-HR
   qudt:hasQuantityKind quantitykind:Frequency ;
   qudt:iec61360Code "0112/2///62720#UAA526" ;
   qudt:symbol "/h" ;
-  qudt:ucumCode "/h"^^qudt:UCUMcs ;
   qudt:ucumCode "h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H10" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q102129428> ;
@@ -52266,7 +51793,6 @@ unit:PER-IN
   qudt:hasQuantityKind quantitykind:Repetency ;
   qudt:iec61360Code "0112/2///62720#UAB360" ;
   qudt:symbol "/in" ;
-  qudt:ucumCode "/[in_i]"^^qudt:UCUMcs ;
   qudt:ucumCode "[in_i]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "Q24" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -52302,8 +51828,7 @@ unit:PER-IN3
   qudt:iec61360Code "0112/2///62720#UAA546" ;
   qudt:plainTextDescription "reciprocal value of the power of the unit inch according to the Anglo-American and the Imperial system of units with the exponent 3" ;
   qudt:symbol "/in³" ;
-  qudt:ucumCode "/[cin_i]"^^qudt:UCUMcs ;
-  qudt:ucumCode "[cin_i]-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[in_i]-3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K49" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Reciprocal Cubic Inch" ;
@@ -52318,7 +51843,6 @@ unit:PER-J
   qudt:hasQuantityKind quantitykind:InverseEnergy ;
   qudt:iec61360Code "0112/2///62720#UAB324" ;
   qudt:symbol "/J" ;
-  qudt:ucumCode "/J"^^qudt:UCUMcs ;
   qudt:ucumCode "J-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "N91" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -52427,7 +51951,6 @@ unit:PER-K
   qudt:hasQuantityKind quantitykind:ThermalExpansionCoefficient ;
   qudt:iec61360Code "0112/2///62720#UAA193" ;
   qudt:symbol "/K" ;
-  qudt:ucumCode "/K"^^qudt:UCUMcs ;
   qudt:ucumCode "K-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C91" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q107028673> ;
@@ -52459,7 +51982,6 @@ unit:PER-KiloGM
   qudt:hasQuantityKind quantitykind:InverseMass ;
   qudt:iec61360Code "0112/2///62720#UAC003" ;
   qudt:symbol "/kg" ;
-  qudt:ucumCode "/kg"^^qudt:UCUMcs ;
   qudt:ucumCode "kg-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Aνά Χιλιόγραμμο"@el ;
@@ -52560,7 +52082,6 @@ unit:PER-KiloM
   qudt:hasQuantityKind quantitykind:PhaseCoefficient ;
   qudt:hasQuantityKind quantitykind:PropagationCoefficient ;
   qudt:symbol "/km" ;
-  qudt:ucumCode "/km"^^qudt:UCUMcs ;
   qudt:ucumCode "km-1"^^qudt:UCUMcs ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q107244557> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -52633,7 +52154,6 @@ unit:PER-L
   qudt:iec61360Code "0112/2///62720#UAA667" ;
   qudt:plainTextDescription "reciprocal value of the unit litre" ;
   qudt:symbol "/L" ;
-  qudt:ucumCode "/L"^^qudt:UCUMcs ;
   qudt:ucumCode "L-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K63" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -52650,7 +52170,6 @@ unit:PER-LB
   qudt:hasQuantityKind quantitykind:InverseMass ;
   qudt:iec61360Code "0112/2///62720#UAC008" ;
   qudt:symbol "/lbm" ;
-  qudt:ucumCode "/[lb_av]"^^qudt:UCUMcs ;
   qudt:ucumCode "[lb_av]-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Reciprocal Pound Mass" ;
@@ -52680,7 +52199,6 @@ unit:PER-M
   qudt:hasQuantityKind quantitykind:PropagationCoefficient ;
   qudt:iec61360Code "0112/2///62720#UAA738" ;
   qudt:symbol "/m" ;
-  qudt:ucumCode "/m"^^qudt:UCUMcs ;
   qudt:ucumCode "m-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C92" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q11547251> ;
@@ -52874,7 +52392,6 @@ unit:PER-M2
   qudt:iec61360Code "0112/2///62720#UAD611" ;
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
   qudt:symbol "/m²" ;
-  qudt:ucumCode "/m2"^^qudt:UCUMcs ;
   qudt:ucumCode "m-2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C93" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q11547252> ;
@@ -52955,7 +52472,6 @@ unit:PER-M3
   qudt:hasReciprocalUnit unit:M3 ;
   qudt:iec61360Code "0112/2///62720#UAA740" ;
   qudt:symbol "/m³" ;
-  qudt:ucumCode "/m3"^^qudt:UCUMcs ;
   qudt:ucumCode "m-3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C86" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q21401573> ;
@@ -53052,7 +52568,6 @@ unit:PER-MIN
   qudt:hasQuantityKind quantitykind:Frequency ;
   qudt:iec61360Code "0112/2///62720#UAA843" ;
   qudt:symbol "/min" ;
-  qudt:ucumCode "/min"^^qudt:UCUMcs ;
   qudt:ucumCode "min-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C94" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q102129339> ;
@@ -53076,7 +52591,6 @@ unit:PER-MO
   qudt:iec61360Code "0112/2///62720#UAA881" ;
   qudt:plainTextDescription "reciprocal of the unit month" ;
   qudt:symbol "/mo" ;
-  qudt:ucumCode "/mo"^^qudt:UCUMcs ;
   qudt:ucumCode "mo-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H11" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q106623462> ;
@@ -53097,7 +52611,6 @@ unit:PER-MOL
   qudt:hasQuantityKind quantitykind:InverseAmountOfSubstance ;
   qudt:iec61360Code "0112/2///62720#UAD514" ;
   qudt:symbol "/mol" ;
-  qudt:ucumCode "/mol"^^qudt:UCUMcs ;
   qudt:ucumCode "mol-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C95" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q68712008> ;
@@ -53133,6 +52646,7 @@ unit:PER-MegaK
   qudt:hasQuantityKind quantitykind:ThermalExpansionCoefficient ;
   qudt:iec61360Code "0112/2///62720#UAA100" ;
   qudt:symbol "/MK" ;
+  qudt:ucumCode "MK-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M20" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Na Megakelvin"@cs ;
@@ -53161,7 +52675,6 @@ unit:PER-MegaPA
   qudt:hasQuantityKind quantitykind:StressOpticCoefficient ;
   qudt:iec61360Code "0112/2///62720#UAD929" ;
   qudt:symbol "/MPa" ;
-  qudt:ucumCode "/MPa"^^qudt:UCUMcs ;
   qudt:ucumCode "MPa-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Na Megapascal"@cs ;
@@ -53198,7 +52711,6 @@ unit:PER-MicroM
   qudt:hasQuantityKind quantitykind:PhaseCoefficient ;
   qudt:hasQuantityKind quantitykind:PropagationCoefficient ;
   qudt:symbol "/μm" ;
-  qudt:ucumCode "/um"^^qudt:UCUMcs ;
   qudt:ucumCode "um-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Na Micrometer"@sl ;
@@ -53240,7 +52752,6 @@ unit:PER-MilliGM
   qudt:hasQuantityKind quantitykind:InverseMass ;
   qudt:iec61360Code "0112/2///62720#UAC005" ;
   qudt:symbol "/mg" ;
-  qudt:ucumCode "/mg"^^qudt:UCUMcs ;
   qudt:ucumCode "mg-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Na Milligram"@cs ;
@@ -53269,7 +52780,6 @@ unit:PER-MilliL
   qudt:hasQuantityKind quantitykind:InverseVolume ;
   qudt:plainTextDescription "reciprocal value of the unit millilitre" ;
   qudt:symbol "/mL" ;
-  qudt:ucumCode "/mL"^^qudt:UCUMcs ;
   qudt:ucumCode "mL-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Reciprocal Milliliter"@en-US ;
@@ -53297,7 +52807,6 @@ unit:PER-MilliM
   qudt:hasQuantityKind quantitykind:PhaseCoefficient ;
   qudt:hasQuantityKind quantitykind:PropagationCoefficient ;
   qudt:symbol "/mm" ;
-  qudt:ucumCode "/mm"^^qudt:UCUMcs ;
   qudt:ucumCode "mm-1"^^qudt:UCUMcs ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q107244316> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -53331,7 +52840,6 @@ unit:PER-MilliM3
   qudt:iec61360Code "0112/2///62720#UAA870" ;
   qudt:plainTextDescription "reciprocal value of the 0.000000001-fold of the power of the SI base unit metre with the exponent 3" ;
   qudt:symbol "/mm³" ;
-  qudt:ucumCode "/mm3"^^qudt:UCUMcs ;
   qudt:ucumCode "mm-3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L20" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -53398,7 +52906,6 @@ unit:PER-NanoM
   qudt:hasQuantityKind quantitykind:PhaseCoefficient ;
   qudt:hasQuantityKind quantitykind:PropagationCoefficient ;
   qudt:symbol "/nm" ;
-  qudt:ucumCode "/nm"^^qudt:UCUMcs ;
   qudt:ucumCode "nm-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Na Nanometer"@sl ;
@@ -53424,7 +52931,6 @@ unit:PER-OZ
   qudt:hasQuantityKind quantitykind:InverseMass ;
   qudt:iec61360Code "0112/2///62720#UAC007" ;
   qudt:symbol "/oz" ;
-  qudt:ucumCode "/[oz_av]"^^qudt:UCUMcs ;
   qudt:ucumCode "[oz_av]-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Reciprocal Ounce Mass" ;
@@ -53451,7 +52957,6 @@ unit:PER-PA
   qudt:informativeReference "http://en.wikipedia.org/wiki/Pascal?oldid=492989202"^^xsd:anyURI ;
   qudt:siUnitsExpression "m^2/N" ;
   qudt:symbol "/Pa" ;
-  qudt:ucumCode "/Pa"^^qudt:UCUMcs ;
   qudt:ucumCode "Pa-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C96" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q79104611> ;
@@ -53562,7 +53067,6 @@ unit:PER-PicoM
   qudt:hasQuantityKind quantitykind:PhaseCoefficient ;
   qudt:hasQuantityKind quantitykind:PropagationCoefficient ;
   qudt:symbol "/pm" ;
-  qudt:ucumCode "/pm"^^qudt:UCUMcs ;
   qudt:ucumCode "pm-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Na Picometer"@sl ;
@@ -53605,7 +53109,6 @@ unit:PER-RAD
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAB327" ;
   qudt:symbol "/rad" ;
-  qudt:ucumCode "/rad"^^qudt:UCUMcs ;
   qudt:ucumCode "rad-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P97" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -53649,7 +53152,6 @@ unit:PER-SEC
   qudt:hasQuantityKind quantitykind:RotationalVelocity ;
   qudt:iec61360Code "0112/2///62720#UAD544" ;
   qudt:symbol "/s" ;
-  qudt:ucumCode "/s"^^qudt:UCUMcs ;
   qudt:ucumCode "s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C97" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q6137407> ;
@@ -53686,7 +53188,6 @@ unit:PER-SEC-M2
   qudt:hasQuantityKind quantitykind:Flux ;
   qudt:iec61360Code "0112/2///62720#UAA974" ;
   qudt:symbol "/(s·m²)" ;
-  qudt:ucumCode "/(s1.m2)"^^qudt:UCUMcs ;
   qudt:ucumCode "s-1.m-2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C99" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -53722,7 +53223,6 @@ unit:PER-SEC-M2-SR
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:PhotonRadiance ;
   qudt:symbol "/(s·m²·sr)" ;
-  qudt:ucumCode "/(s.m2.sr)"^^qudt:UCUMcs ;
   qudt:ucumCode "s-1.m-2.sr-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D2" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q83855084> ;
@@ -53793,7 +53293,6 @@ unit:PER-SEC-SR
   qudt:hasQuantityKind quantitykind:TemporalSummationFunction ;
   qudt:iec61360Code "0112/2///62720#UAA976" ;
   qudt:symbol "/(s·sr)" ;
-  qudt:ucumCode "/(s.sr)"^^qudt:UCUMcs ;
   qudt:ucumCode "s-1.sr-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D1" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q83853845> ;
@@ -53893,7 +53392,6 @@ unit:PER-SR
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:symbol "/sr" ;
-  qudt:ucumCode "/sr"^^qudt:UCUMcs ;
   qudt:ucumCode "sr-1"^^qudt:UCUMcs ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q108533173> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -54009,7 +53507,6 @@ unit:PER-TONNE
   qudt:hasQuantityKind quantitykind:InverseMass ;
   qudt:iec61360Code "0112/2///62720#UAC006" ;
   qudt:symbol "/t" ;
-  qudt:ucumCode "/t"^^qudt:UCUMcs ;
   qudt:ucumCode "t-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Reciprocal Tonne" ;
@@ -54024,7 +53521,6 @@ unit:PER-V
   qudt:hasQuantityKind quantitykind:ReciprocalVoltage ;
   qudt:iec61360Code "0112/2///62720#UAB326" ;
   qudt:symbol "/V" ;
-  qudt:ucumCode "/V"^^qudt:UCUMcs ;
   qudt:ucumCode "V-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P96" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -54111,7 +53607,6 @@ unit:PER-WB
   qudt:iec61360Code "0112/2///62720#UAB354" ;
   qudt:informativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
   qudt:symbol "/Wb" ;
-  qudt:ucumCode "/Wb"^^qudt:UCUMcs ;
   qudt:ucumCode "Wb-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "Q23" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -54149,7 +53644,6 @@ unit:PER-WK
   qudt:iec61360Code "0112/2///62720#UAA099" ;
   qudt:plainTextDescription "reciprocal of the unit week" ;
   qudt:symbol "/wk" ;
-  qudt:ucumCode "/wk"^^qudt:UCUMcs ;
   qudt:ucumCode "wk-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H85" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q106623447> ;
@@ -54170,7 +53664,7 @@ unit:PER-YD3
   qudt:iec61360Code "0112/2///62720#UAB033" ;
   qudt:plainTextDescription "reciprocal value of the unit yard according to the Anglo-American and the Imperial system of units with the exponent 3" ;
   qudt:symbol "/yd³" ;
-  qudt:ucumCode "[cyd_i]-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[yd_i]-3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M10" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Reciprocal Cubic Yard" ;
@@ -54193,7 +53687,6 @@ unit:PER-YR
   qudt:iec61360Code "0112/2///62720#UAB027" ;
   qudt:plainTextDescription "reciprocal of the unit year" ;
   qudt:symbol "/a" ;
-  qudt:ucumCode "/a"^^qudt:UCUMcs ;
   qudt:ucumCode "a-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H09" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q102129764> ;
@@ -54254,7 +53747,7 @@ unit:PERCENT-FT-HR-PER-LB
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAC808" ;
   qudt:symbol "%·ft·h/lbm" ;
-  qudt:ucumCode "[ft_i].h.%.[lb_av]-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "%.[ft_i].h.[lb_av]-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Percent Foot Hour per Pound Mass" ;
   rdfs:label "Percent Foot Hour per Pound Mass"@en .
@@ -54268,7 +53761,7 @@ unit:PERCENT-FT-SEC-PER-LB
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAC809" ;
   qudt:symbol "%·ft·s/lbm" ;
-  qudt:ucumCode "[ft_i].%.s.[lb_av]-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "%.[ft_i].s.[lb_av]-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Percent Foot Second per Pound Mass" ;
   rdfs:label "Percent Foot Second per Pound Mass"@en .
@@ -54282,7 +53775,7 @@ unit:PERCENT-FT2-PER-LB_F-SEC
   qudt:hasQuantityKind quantitykind:Fluidity ;
   qudt:iec61360Code "0112/2///62720#UAC810" ;
   qudt:symbol "%·ft²/(lbf·s)" ;
-  qudt:ucumCode "[ft_i]2.%.[lbf_av]-1.s-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "%.[ft_i]2.[lbf_av]-1.s-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Percent Square Foot per Pound Force Second" ;
   rdfs:label "Percent Square Foot per Pound Force Second"@en .
@@ -54296,7 +53789,7 @@ unit:PERCENT-HR-PER-CentiM3
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAC781" ;
   qudt:symbol "%·h/cm³" ;
-  qudt:ucumCode "h.%.cm-3"^^qudt:UCUMcs ;
+  qudt:ucumCode "%.h.cm-3"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Percent Hour per Cubic Centimeter"@en-US ;
   rdfs:label "Percent Hour per Cubic Centimetre" ;
@@ -54311,7 +53804,7 @@ unit:PERCENT-HR-PER-FT3
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAC786" ;
   qudt:symbol "%·h/ft³" ;
-  qudt:ucumCode "h.%.[ft_i]-3"^^qudt:UCUMcs ;
+  qudt:ucumCode "%.h.[ft_i]-3"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Percent Hour per Cubic Foot" ;
   rdfs:label "Percent Hour per Cubic Foot"@en .
@@ -54325,7 +53818,7 @@ unit:PERCENT-HR-PER-GAL_UK
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAC784" ;
   qudt:symbol "%·h/gal{UK}" ;
-  qudt:ucumCode "h.%.[gal_br]-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "%.h.[gal_br]-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Percent Hour per Gallon (UK)" ;
   rdfs:label "Percent Hour per Gallon (UK)"@en .
@@ -54339,7 +53832,7 @@ unit:PERCENT-HR-PER-GAL_US
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAC783" ;
   qudt:symbol "%·h/gal{US}" ;
-  qudt:ucumCode "h.%.[gal_us]-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "%.h.[gal_us]-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Percent Hour per Us Gallon" ;
   rdfs:label "Percent Hour per Us Gallon"@en .
@@ -54353,7 +53846,7 @@ unit:PERCENT-HR-PER-IN3
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAC785" ;
   qudt:symbol "%·h/in³" ;
-  qudt:ucumCode "h.%.[in_i]-3"^^qudt:UCUMcs ;
+  qudt:ucumCode "%.h.[in_i]-3"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Percent Hour per Cubic Inch" ;
   rdfs:label "Percent Hour per Cubic Inch"@en .
@@ -54367,8 +53860,7 @@ unit:PERCENT-HR-PER-L
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAC782" ;
   qudt:symbol "%·h/L" ;
-  qudt:ucumCode "h.%.L-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "h.%/L"^^qudt:UCUMcs ;
+  qudt:ucumCode "%.h.L-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Percent Hour per Liter"@en-US ;
   rdfs:label "Percent Hour per Litre" ;
@@ -54383,7 +53875,7 @@ unit:PERCENT-HR-PER-M3
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAC780" ;
   qudt:symbol "%·h/m³" ;
-  qudt:ucumCode "h.%.m-3"^^qudt:UCUMcs ;
+  qudt:ucumCode "%.h.m-3"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Percent Hour per Cubic Meter"@en-US ;
   rdfs:label "Percent Hour per Cubic Metre" ;
@@ -54398,7 +53890,7 @@ unit:PERCENT-HR-PER-YD3
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAC787" ;
   qudt:symbol "%·h/yd³" ;
-  qudt:ucumCode "h.%.[yd_i]-3"^^qudt:UCUMcs ;
+  qudt:ucumCode "%.h.[yd_i]-3"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Percent Hour per Cubic Yard" ;
   rdfs:label "Percent Hour per Cubic Yard"@en .
@@ -54412,7 +53904,7 @@ unit:PERCENT-IN2-PER-LB_F-SEC
   qudt:hasQuantityKind quantitykind:Fluidity ;
   qudt:iec61360Code "0112/2///62720#UAC811" ;
   qudt:symbol "%·in²/(lbf·s)" ;
-  qudt:ucumCode "[in_i]2.%.[lbf_av]-1.s-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "%.[in_i]2.[lbf_av]-1.s-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Percent Square Inch per Pound Force Second" ;
   rdfs:label "Percent Square Inch per Pound Force Second"@en .
@@ -54426,7 +53918,7 @@ unit:PERCENT-MIN-PER-CentiM3
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAC789" ;
   qudt:symbol "%·min/cm³" ;
-  qudt:ucumCode "min.%.cm-3"^^qudt:UCUMcs ;
+  qudt:ucumCode "%.min.cm-3"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Percent Minute per Cubic Centimeter"@en-US ;
   rdfs:label "Percent Minute per Cubic Centimetre" ;
@@ -54441,7 +53933,7 @@ unit:PERCENT-MIN-PER-FT3
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAC794" ;
   qudt:symbol "%·min/ft³" ;
-  qudt:ucumCode "min.%.[ft_i]-3"^^qudt:UCUMcs ;
+  qudt:ucumCode "%.min.[ft_i]-3"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Percent Minute per Cubic Foot" ;
   rdfs:label "Percent Minute per Cubic Foot"@en .
@@ -54455,7 +53947,7 @@ unit:PERCENT-MIN-PER-GAL_UK
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAC792" ;
   qudt:symbol "%·min/gal{UK}" ;
-  qudt:ucumCode "min.%.[gal_br]-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "%.min.[gal_br]-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Percent Minute per Gallon (UK)" ;
   rdfs:label "Percent Minute per Gallon (UK)"@en .
@@ -54469,7 +53961,7 @@ unit:PERCENT-MIN-PER-GAL_US
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAC791" ;
   qudt:symbol "%·min/gal{US}" ;
-  qudt:ucumCode "min.%.[gal_us]-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "%.min.[gal_us]-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Percent Minute per Us Gallon" ;
   rdfs:label "Percent Minute per Us Gallon"@en .
@@ -54483,7 +53975,7 @@ unit:PERCENT-MIN-PER-IN3
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAC793" ;
   qudt:symbol "%·min/in³" ;
-  qudt:ucumCode "min.%.[in_i]-3"^^qudt:UCUMcs ;
+  qudt:ucumCode "%.min.[in_i]-3"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Percent Minute per Cubic Inch" ;
   rdfs:label "Percent Minute per Cubic Inch"@en .
@@ -54497,7 +53989,7 @@ unit:PERCENT-MIN-PER-L
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAC790" ;
   qudt:symbol "%·min/L" ;
-  qudt:ucumCode "min.%.L-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "%.min.L-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Percent Minute per Liter"@en-US ;
   rdfs:label "Percent Minute per Litre" ;
@@ -54512,7 +54004,7 @@ unit:PERCENT-MIN-PER-M3
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAC788" ;
   qudt:symbol "%·min/m³" ;
-  qudt:ucumCode "min.%.m-3"^^qudt:UCUMcs ;
+  qudt:ucumCode "%.min.m-3"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Percent Minute per Cubic Meter"@en-US ;
   rdfs:label "Percent Minute per Cubic Metre" ;
@@ -54527,7 +54019,7 @@ unit:PERCENT-MIN-PER-YD3
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAC795" ;
   qudt:symbol "%·min/yd³" ;
-  qudt:ucumCode "min.%.[yd_i]-3"^^qudt:UCUMcs ;
+  qudt:ucumCode "%.min.[yd_i]-3"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Percent Minute per Cubic Yard" ;
   rdfs:label "Percent Minute per Cubic Yard"@en .
@@ -54587,7 +54079,6 @@ unit:PERCENT-PER-CentiPOISE
   qudt:iec61360Code "0112/2///62720#UAC807" ;
   qudt:symbol "%/cP" ;
   qudt:ucumCode "%.cP-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "%/cP"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Percent per Centipoise" ;
   rdfs:label "Percent per Centipoise"@en .
@@ -54600,7 +54091,6 @@ unit:PERCENT-PER-DAY
   qudt:hasQuantityKind quantitykind:Frequency ;
   qudt:symbol "%/d" ;
   qudt:ucumCode "%.d-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "%/d"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Percent per Day" ;
   rdfs:label "Percent per Day"@en .
@@ -54615,7 +54105,6 @@ unit:PERCENT-PER-DEG
   qudt:iec61360Code "0112/2///62720#UAA002" ;
   qudt:symbol "%/°" ;
   qudt:ucumCode "%.deg-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "%/deg"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H90" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Percent per Degree" ;
@@ -54631,7 +54120,6 @@ unit:PERCENT-PER-DEG_C
   qudt:iec61360Code "0112/2///62720#UAA003" ;
   qudt:symbol "%/°C" ;
   qudt:ucumCode "%.Cel-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "%/Cel"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M25" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Percent per Degree Celsius" ;
@@ -54646,6 +54134,7 @@ unit:PERCENT-PER-DecaK
   qudt:hasQuantityKind quantitykind:LinearExpansionCoefficient ;
   qudt:iec61360Code "0112/2///62720#UAA011" ;
   qudt:symbol "%/daK" ;
+  qudt:ucumCode "%.daK-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H73" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Percent per Decakelvin" ;
@@ -54675,7 +54164,6 @@ unit:PERCENT-PER-HR
   qudt:hasQuantityKind quantitykind:Frequency ;
   qudt:symbol "%/h" ;
   qudt:ucumCode "%.h-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "%/h"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Percent per Hour" ;
   rdfs:label "Percent per Hour"@en .
@@ -54716,7 +54204,6 @@ unit:PERCENT-PER-HectoBAR
   qudt:iec61360Code "0112/2///62720#UAB373" ;
   qudt:symbol "%/hbar" ;
   qudt:ucumCode "%.hbar-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "%/hbar"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H72" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Percent per Hectobar" ;
@@ -54777,7 +54264,6 @@ unit:PERCENT-PER-K
   qudt:iec61360Code "0112/2///62720#UAA008" ;
   qudt:symbol "%/K" ;
   qudt:ucumCode "%.K-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "%/K"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H25" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Percent per Kelvin" ;
@@ -54809,7 +54295,6 @@ unit:PERCENT-PER-M
   qudt:iec61360Code "0112/2///62720#UAA013" ;
   qudt:symbol "%/m" ;
   qudt:ucumCode "%.m-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "%/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H99" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Percent per Meter"@en-US ;
@@ -54826,7 +54311,6 @@ unit:PERCENT-PER-MO
   qudt:iec61360Code "0112/2///62720#UAB372" ;
   qudt:symbol "%/mo" ;
   qudt:ucumCode "%.mo-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "%/mo"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H71" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Percent per Month" ;
@@ -54842,7 +54326,6 @@ unit:PERCENT-PER-MilliM
   qudt:iec61360Code "0112/2///62720#UAA014" ;
   qudt:symbol "%/mm" ;
   qudt:ucumCode "%.mm-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "%/mm"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "J10" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Percent per Millimeter"@en-US ;
@@ -54873,7 +54356,6 @@ unit:PERCENT-PER-OHM
   qudt:iec61360Code "0112/2///62720#UAA001" ;
   qudt:symbol "%/Ω" ;
   qudt:ucumCode "%.Ohm-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "%/Ohm"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H89" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Percent per Ohm" ;
@@ -54903,7 +54385,6 @@ unit:PERCENT-PER-PERCENT
   qudt:iec61360Code "0112/2///62720#UAD871" ;
   qudt:symbol "%/%" ;
   qudt:ucumCode "%.%-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "%/%"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Percent per Percent" ;
   rdfs:label "Percent per Percent"@en .
@@ -54918,7 +54399,6 @@ unit:PERCENT-PER-POISE
   qudt:iec61360Code "0112/2///62720#UAC806" ;
   qudt:symbol "%/P" ;
   qudt:ucumCode "%.P-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "%/P"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Percent per Poise" ;
   rdfs:label "Percent per Poise"@en .
@@ -54963,7 +54443,6 @@ unit:PERCENT-PER-V
   qudt:iec61360Code "0112/2///62720#UAA009" ;
   qudt:symbol "%/V" ;
   qudt:ucumCode "%.V-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "%/V"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H95" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Percent per Volt" ;
@@ -54978,7 +54457,6 @@ unit:PERCENT-PER-WK
   qudt:hasQuantityKind quantitykind:Frequency ;
   qudt:symbol "%/wk" ;
   qudt:ucumCode "%.wk-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "%/wk"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Percent per Week" ;
   rdfs:label "Percent per Week"@en .
@@ -55077,7 +54555,6 @@ unit:PERCENT-SEC-PER-L
   qudt:iec61360Code "0112/2///62720#UAC798" ;
   qudt:symbol "%·s/L" ;
   qudt:ucumCode "%.s.L-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "%.s/L"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Percent Second per Liter"@en-US ;
   rdfs:label "Percent Second per Litre" ;
@@ -55473,7 +54950,7 @@ unit:PINT_UK-PER-DAY
   qudt:iec61360Code "0112/2///62720#UAA953" ;
   qudt:plainTextDescription "unit of the volume pint (UK) (both for fluids and for dry measures) according to the Imperial system of units divided by the unit for time day" ;
   qudt:symbol "pt{UK}/d" ;
-  qudt:ucumCode "[pt_br].d"^^qudt:UCUMcs ;
+  qudt:ucumCode "[pt_br].d-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L53" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Pint (UK) per Day" ;
@@ -55492,7 +54969,6 @@ unit:PINT_UK-PER-HR
   qudt:plainTextDescription "unit of the volume pint (UK) (both for fluids and for dry measures) according to the Imperial system of units divided by the unit for time hour" ;
   qudt:symbol "pt{UK}/h" ;
   qudt:ucumCode "[pt_br].h-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[pt_br]/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L54" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Pint (UK) per Hour" ;
@@ -55511,7 +54987,6 @@ unit:PINT_UK-PER-MIN
   qudt:plainTextDescription "unit of the volume pint (UK) (both for fluids and for dry measures) according to the Imperial system of units divided by the unit for time minute" ;
   qudt:symbol "pt{UK}/min" ;
   qudt:ucumCode "[pt_br].min-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[pt_br]/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L55" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Pint (UK) per Minute" ;
@@ -55530,7 +55005,6 @@ unit:PINT_UK-PER-SEC
   qudt:plainTextDescription "unit of the volume pint (UK) (both for fluids and for dry measures) according to the Imperial system of units divided by the SI base unit second" ;
   qudt:symbol "pt{UK}/s" ;
   qudt:ucumCode "[pt_br].s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[pt_br]/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L56" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Pint (UK) per Second" ;
@@ -55574,7 +55048,6 @@ unit:PINT_US-PER-DAY
   qudt:plainTextDescription "unit of the volume pint (US liquid) according to the Anglo-American system of units divided by the unit for time day" ;
   qudt:symbol "pt{US}/d" ;
   qudt:ucumCode "[pt_us].d-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[pt_us]/d"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L57" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Us Liquid Pint per Day" ;
@@ -55593,7 +55066,6 @@ unit:PINT_US-PER-HR
   qudt:plainTextDescription "unit of the volume pint (US liquid) according to the Anglo-American system of units divided by the unit for time hour" ;
   qudt:symbol "pt{US}/h" ;
   qudt:ucumCode "[pt_us].h-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[pt_us]/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L58" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Us Liquid Pint per Hour" ;
@@ -55612,7 +55084,6 @@ unit:PINT_US-PER-MIN
   qudt:plainTextDescription "unit of the volume pint (US liquid) according to the Anglo-American system of units divided by the unit for time minute" ;
   qudt:symbol "pt{US}/min" ;
   qudt:ucumCode "[pt_us].min-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[pt_us]/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L59" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Us Liquid Pint per Minute" ;
@@ -55631,7 +55102,6 @@ unit:PINT_US-PER-SEC
   qudt:plainTextDescription "unit of the volume pint (US liquid) according to the Anglo-American system of units divided by the SI base unit second" ;
   qudt:symbol "pt{US}/s" ;
   qudt:ucumCode "[pt_us].s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[pt_us]/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L60" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Us Liquid Pint per Second" ;
@@ -55736,7 +55206,6 @@ unit:PK_UK-PER-DAY
   qudt:plainTextDescription "unit of the volume peck (UK) according to the Imperial system of units divided by the unit for time day" ;
   qudt:symbol "peck{UK}/d" ;
   qudt:ucumCode "[pk_br].d-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[pk_br]/d"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L44" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Peck (UK) per Day" ;
@@ -55755,7 +55224,6 @@ unit:PK_UK-PER-HR
   qudt:plainTextDescription "unit of the volume peck (UK) according to the Imperial system of units divided by the unit for time hour" ;
   qudt:symbol "peck{UK}/h" ;
   qudt:ucumCode "[pk_br].h-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[pk_br]/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L45" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Peck (UK) per Hour" ;
@@ -55774,7 +55242,6 @@ unit:PK_UK-PER-MIN
   qudt:plainTextDescription "unit of the volume peck (UK) according to the Imperial system of units divided by the unit for time minute" ;
   qudt:symbol "peck{UK}/min" ;
   qudt:ucumCode "[pk_br].min-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[pk_br]/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L46" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Peck (UK) per Minute" ;
@@ -55793,7 +55260,6 @@ unit:PK_UK-PER-SEC
   qudt:plainTextDescription "unit of the volume peck (UK) according to the Imperial system of units divided by the SI base unit second" ;
   qudt:symbol "peck{UK}/s" ;
   qudt:ucumCode "[pk_br].s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[pk_br]/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L47" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Peck (UK) per Second" ;
@@ -55833,7 +55299,6 @@ unit:PK_US_DRY-PER-DAY
   qudt:plainTextDescription "unit of the volume peck (US dry) as dry measure according to the Anglo-American system of units divided by the unit for time day" ;
   qudt:symbol "peck{US Dry}/d" ;
   qudt:ucumCode "[pk_us].d-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[pk_us]/d"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L48" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Us Peck per Day" ;
@@ -55852,7 +55317,6 @@ unit:PK_US_DRY-PER-HR
   qudt:plainTextDescription "unit of the volume peck (US dry) as dry measure according to the Anglo-American system of units divided by the unit for time hour" ;
   qudt:symbol "peck{US Dry}/h" ;
   qudt:ucumCode "[pk_us].h-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[pk_us]/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L49" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Us Peck per Hour" ;
@@ -55871,7 +55335,6 @@ unit:PK_US_DRY-PER-MIN
   qudt:plainTextDescription "unit of the volume peck (US dry) as dry measure according to the Anglo-American system of units divided by the unit for time minute" ;
   qudt:symbol "peck{US Dry}/min" ;
   qudt:ucumCode "[pk_us].min-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[pk_us]/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L50" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Us Peck per Minute" ;
@@ -55890,7 +55353,6 @@ unit:PK_US_DRY-PER-SEC
   qudt:plainTextDescription "unit of the volume peck (US dry) as dry measure according to the Anglo-American system of units divided by the SI base unit second" ;
   qudt:symbol "peck{US Dry}/s" ;
   qudt:ucumCode "[pk_us].s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[pk_us]/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L51" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Us Peck per Second" ;
@@ -55934,7 +55396,6 @@ unit:POISE-PER-BAR
   qudt:plainTextDescription "CGS unit poise divided by the unit bar" ;
   qudt:symbol "P/bar" ;
   qudt:ucumCode "P.bar-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "P/bar"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F06" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Poise per Bar" ;
@@ -55950,7 +55411,6 @@ unit:POISE-PER-K
   qudt:iec61360Code "0112/2///62720#UAA256" ;
   qudt:symbol "P/K" ;
   qudt:ucumCode "P.K-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "P/K"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "F86" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Poise per Kelvin" ;
@@ -55966,7 +55426,6 @@ unit:POISE-PER-PA
   qudt:iec61360Code "0112/2///62720#UAB311" ;
   qudt:symbol "P/Pa" ;
   qudt:ucumCode "P.Pa-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "P/Pa"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "N35" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Poise per Pascal" ;
@@ -56056,8 +55515,7 @@ unit:PPM-PER-K
   qudt:hasQuantityKind quantitykind:ExpansionRatio ;
   qudt:hasQuantityKind quantitykind:ThermalExpansionCoefficient ;
   qudt:symbol "PPM/K" ;
-  qudt:ucumCode "ppm.K-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "ppm/K"^^qudt:UCUMcs ;
+  qudt:ucumCode "[ppm].K-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Parts per Million per Kelvin" ;
   rdfs:label "Parts per Million per Kelvin"@en .
@@ -56148,7 +55606,6 @@ unit:PPTH-PER-HR
   qudt:hasQuantityKind quantitykind:Frequency ;
   qudt:symbol "‰/h" ;
   qudt:ucumCode "[ppth].h-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[ppth]/h"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Parts per Thousand per Hour" ;
   rdfs:label "Parts per Thousand per Hour"@en .
@@ -56247,12 +55704,12 @@ unit:PSI
   qudt:exactMatch unit:LB_F-PER-IN2 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasFactorUnit [
-    qudt:exponent 1 ;
-    qudt:hasUnit unit:LB_F ;
-  ] ;
-  qudt:hasFactorUnit [
     qudt:exponent -2 ;
     qudt:hasUnit unit:IN ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent 1 ;
+    qudt:hasUnit unit:LB_F ;
   ] ;
   qudt:hasQuantityKind quantitykind:ForcePerArea ;
   qudt:hasQuantityKind quantitykind:ModulusOfElasticity ;
@@ -56279,7 +55736,7 @@ unit:PSI-IN3-PER-SEC
   qudt:iec61360Code "0112/2///62720#UAA703" ;
   qudt:plainTextDescription "product of the composed unit for pressure (pound-force per square inch) and the composed unit for volume flow (cubic inch per second)" ;
   qudt:symbol "psi·in³/s" ;
-  qudt:ucumCode "[psi].[cin_i].s-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[psi].[in_i]3.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K87" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Psi Cubic Inch per Second" ;
@@ -56313,7 +55770,6 @@ unit:PSI-M3-PER-SEC
   qudt:plainTextDescription "product of the composed unit for pressure (pound-force per square inch) and the composed unit for volume flow (cubic metre per second)" ;
   qudt:symbol "psi·m³/s" ;
   qudt:ucumCode "[psi].m3.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[psi].m3/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K89" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Psi Cubic Meter per Second"@en-US ;
@@ -56366,7 +55822,7 @@ unit:PSI-YD3-PER-SEC
   qudt:iec61360Code "0112/2///62720#UAA706" ;
   qudt:plainTextDescription "product of the composed unit for pressure (pound-force per square inch) and the square inch) and the composed unit for volume flow (cubic yard per second)" ;
   qudt:symbol "psi·yd³/s" ;
-  qudt:ucumCode "[psi].[cyd_i].s-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[psi].[yd_i]3.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K90" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Psi Cubic Yard per Second" ;
@@ -56545,6 +56001,7 @@ unit:PetaA
   qudt:hasQuantityKind quantitykind:TotalCurrent ;
   qudt:iec61360Code "0112/2///62720#UAB641" ;
   qudt:symbol "PA" ;
+  qudt:ucumCode "PA"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Petaamper"@hu ;
   rdfs:label "Petaamper"@pl ;
@@ -56569,6 +56026,7 @@ unit:PetaBIT
   qudt:hasQuantityKind quantitykind:DatasetOfBits ;
   qudt:iec61360Code "0112/2///62720#UAB190" ;
   qudt:symbol "Pb" ;
+  qudt:ucumCode "Pbit"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E78" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q1152074> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -56585,7 +56043,6 @@ unit:PetaBIT-PER-SEC
   qudt:iec61360Code "0112/2///62720#UAA270" ;
   qudt:symbol "Pb/s" ;
   qudt:ucumCode "Pbit.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "Pbit/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E79" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Petabit per Second" ;
@@ -56600,6 +56057,7 @@ unit:PetaBQ
   qudt:hasQuantityKind quantitykind:Activity ;
   qudt:iec61360Code "0112/2///62720#UAB590" ;
   qudt:symbol "PBq" ;
+  qudt:ucumCode "PBq"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Petabecquerel" ;
   rdfs:label "Petabecquerel"@cs ;
@@ -56695,6 +56153,7 @@ unit:PetaHZ
   qudt:hasQuantityKind quantitykind:Frequency ;
   qudt:iec61360Code "0112/2///62720#UAB699" ;
   qudt:symbol "PHz" ;
+  qudt:ucumCode "PHz"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Petaherc"@pl ;
   rdfs:label "Petahercio"@es ;
@@ -56752,7 +56211,6 @@ unit:PetaJ-PER-SEC
   qudt:iec61360Code "0112/2///62720#UAB514" ;
   qudt:symbol "PJ/s" ;
   qudt:ucumCode "PJ.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "PJ/s"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Petadżul na Sekunda"@pl ;
   rdfs:label "Petajoule na Sekunda"@cs ;
@@ -56777,6 +56235,7 @@ unit:PetaV
   qudt:hasQuantityKind quantitykind:EnergyPerElectricCharge ;
   qudt:hasQuantityKind quantitykind:Voltage ;
   qudt:symbol "PV" ;
+  qudt:ucumCode "PV"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Petavolt" ;
   rdfs:label "Petavolt"@cs ;
@@ -56803,6 +56262,7 @@ unit:PetaV-A
   qudt:hasQuantityKind quantitykind:ApparentPower ;
   qudt:iec61360Code "0112/2///62720#UAB536" ;
   qudt:symbol "PV·A" ;
+  qudt:ucumCode "PV.A"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Petavolt Amper"@ro ;
   rdfs:label "Petavolt Amper"@sl ;
@@ -56826,6 +56286,7 @@ unit:PetaVA
   qudt:hasQuantityKind quantitykind:ApparentPower ;
   qudt:iec61360Code "0112/2///62720#UAB536" ;
   qudt:symbol "PVA" ;
+  qudt:ucumCode "PVA"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Peta Volt Ampere" ;
   rdfs:label "Peta Volt Ampere"@en ;
@@ -56844,6 +56305,7 @@ unit:PetaW
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:iec61360Code "0112/2///62720#UAB506" ;
   qudt:symbol "PW" ;
+  qudt:ucumCode "PW"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Petavatio"@es ;
   rdfs:label "Petawat"@pl ;
@@ -56899,7 +56361,6 @@ unit:PicoA-PER-HectoPA
   qudt:iec61360Code "0112/2///62720#UAD930" ;
   qudt:symbol "pA/hPa" ;
   qudt:ucumCode "pA.hPa-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "pA/hPa"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Picoamper na Hectopascal"@sl ;
   rdfs:label "Picoamper na Hectopaskal"@pl ;
@@ -57011,7 +56472,6 @@ unit:PicoFARAD-PER-M
   qudt:plainTextDescription "0.000000000001-fold of the SI derived unit farad divided by the SI base unit metre" ;
   qudt:symbol "pF/m" ;
   qudt:ucumCode "pF.m-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "pF/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C72" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q21344460> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -57074,7 +56534,6 @@ unit:PicoGM-PER-GM
   qudt:qkdvNumerator qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:symbol "pg/g" ;
   qudt:ucumCode "pg.g-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "pg/g"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Picogram na Gram"@cs ;
   rdfs:label "Picogram na Gram"@pl ;
@@ -57104,7 +56563,6 @@ unit:PicoGM-PER-KiloGM
   qudt:qkdvNumerator qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:symbol "pg/kg" ;
   qudt:ucumCode "pg.kg-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "pg/kg"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Picogram na Kilogram"@cs ;
   rdfs:label "Picogram na Kilogram"@pl ;
@@ -57133,7 +56591,6 @@ unit:PicoGM-PER-L
   qudt:hasQuantityKind quantitykind:MassDensity ;
   qudt:symbol "pg/L" ;
   qudt:ucumCode "pg.L-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "pg/L"^^qudt:UCUMcs ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q104786084> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Picogram per Liter"@en-US ;
@@ -57155,7 +56612,6 @@ unit:PicoGM-PER-MilliGM
   qudt:qkdvNumerator qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:symbol "pg/mg" ;
   qudt:ucumCode "pg.mg-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "pg/mg"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Picogram na Milligram"@cs ;
   rdfs:label "Picogram na Milligram"@pl ;
@@ -57184,7 +56640,7 @@ unit:PicoGM-PER-MilliL
   qudt:hasQuantityKind quantitykind:MassConcentration ;
   qudt:hasQuantityKind quantitykind:MassDensity ;
   qudt:symbol "pg/mL" ;
-  qudt:ucumCode "pg/mL"^^qudt:UCUMcs ;
+  qudt:ucumCode "pg.mL-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Picogram per Milliliter"@en-US ;
   rdfs:label "Picogram per Millilitre" ;
@@ -57235,6 +56691,7 @@ unit:PicoJ
   qudt:hasQuantityKind quantitykind:ThermalEnergy ;
   qudt:iec61360Code "0112/2///62720#UAB738" ;
   qudt:symbol "pJ" ;
+  qudt:ucumCode "pJ"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Picodżul"@pl ;
   rdfs:label "Picojoule" ;
@@ -57260,7 +56717,6 @@ unit:PicoJ-PER-SEC
   qudt:iec61360Code "0112/2///62720#UAB508" ;
   qudt:symbol "pJ/s" ;
   qudt:ucumCode "pJ.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "pJ/s"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Picodżul na Sekunda"@pl ;
   rdfs:label "Picojoule na Sekunda"@cs ;
@@ -57282,6 +56738,7 @@ unit:PicoKAT
   qudt:hasDimensionVector qkdv:A1E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:CatalyticActivity ;
   qudt:symbol "pkat" ;
+  qudt:ucumCode "pkat"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Picokatal" ;
   rdfs:label "Picokatal"@cs ;
@@ -57307,7 +56764,7 @@ unit:PicoKAT-PER-L
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:CatalyticActivityConcentration ;
   qudt:symbol "pkat/L" ;
-  qudt:ucumCode "pkat/L"^^qudt:UCUMcs ;
+  qudt:ucumCode "pkat.L-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Picokatal per Liter"@en-US ;
   rdfs:label "Picokatal per Litre" ;
@@ -57376,6 +56833,7 @@ unit:PicoMOL
   qudt:hasQuantityKind quantitykind:AmountOfSubstance ;
   qudt:hasQuantityKind quantitykind:ExtentOfReaction ;
   qudt:symbol "pmol" ;
+  qudt:ucumCode "pmol"^^qudt:UCUMcs ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q56157048> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Picomol"@cs ;
@@ -57401,7 +56859,6 @@ unit:PicoMOL-PER-KiloGM
   qudt:hasQuantityKind quantitykind:AmountOfSubstancePerMass ;
   qudt:symbol "pmol/kg" ;
   qudt:ucumCode "pmol.kg-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "pmol/kg"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Picomol na Kilogram"@cs ;
   rdfs:label "Picomol na Kilogram"@pl ;
@@ -57426,7 +56883,6 @@ unit:PicoMOL-PER-L
   qudt:hasQuantityKind quantitykind:WaterSolubility ;
   qudt:symbol "pmol/L" ;
   qudt:ucumCode "pmol.L-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "pmol/L"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Picomole per Liter"@en-US ;
   rdfs:label "Picomole per Litre" ;
@@ -57565,6 +57021,7 @@ unit:PicoPA
   qudt:hasQuantityKind quantitykind:ShearModulus ;
   qudt:hasQuantityKind quantitykind:VaporPressure ;
   qudt:symbol "pPa" ;
+  qudt:ucumCode "pPa"^^qudt:UCUMcs ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q53448892> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Picopascal" ;
@@ -57596,7 +57053,6 @@ unit:PicoPA-PER-KiloM
   qudt:plainTextDescription "0.000000000001-fold of the SI derived unit pascal divided by the 1 000-fold of the SI base unit metre" ;
   qudt:symbol "pPa/km" ;
   qudt:ucumCode "pPa.km-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "pPa/km"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H69" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Picopascal na Kilometer"@sl ;
@@ -57628,6 +57084,7 @@ unit:PicoS
   qudt:hasQuantityKind quantitykind:ElectricalConductance ;
   qudt:iec61360Code "0112/2///62720#UAB357" ;
   qudt:symbol "pS" ;
+  qudt:ucumCode "pS"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "N92" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q94694096> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -57659,7 +57116,6 @@ unit:PicoS-PER-M
   qudt:plainTextDescription "0.000000000001-fold of the SI derived unit Siemens divided by the SI base unit metre" ;
   qudt:symbol "pS/m" ;
   qudt:ucumCode "pS.m-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "pS/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L42" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q106777957> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -57723,6 +57179,7 @@ unit:PicoV
   qudt:hasQuantityKind quantitykind:Voltage ;
   qudt:iec61360Code "0112/2///62720#UAB363" ;
   qudt:symbol "pV" ;
+  qudt:ucumCode "pV"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "N99" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Picovolt" ;
@@ -57807,6 +57264,7 @@ unit:PicoVAR
   qudt:hasQuantityKind quantitykind:ReactivePower ;
   qudt:iec61360Code "0112/2///62720#UAC504" ;
   qudt:symbol "pVA{Reactive}" ;
+  qudt:ucumCode "pVA{reactive}"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Pico Volt Ampere Reactive" ;
   rdfs:label "Pico Volt Ampere Reactive"@en .
@@ -58333,7 +57791,7 @@ unit:QT_UK-PER-SEC
   qudt:iec61360Code "0112/2///62720#UAA713" ;
   qudt:plainTextDescription "unit of the volume quart (UK liquid) for fluids according to the Imperial system of units divided by the SI base unit second" ;
   qudt:symbol "qt{UK}/s" ;
-  qudt:ucumCode "[qt_br].h-1.s-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[qt_br].s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K97" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Quart (UK) per Second" ;
@@ -58377,7 +57835,6 @@ unit:QT_US-PER-DAY
   qudt:plainTextDescription "unit fo the volume quart (US liquid) for fluids according to the Anglo-American system of units divided by the unit for time day" ;
   qudt:symbol "qt{US liq}/d" ;
   qudt:ucumCode "[qt_us].d-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[qt_us]/d"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K98" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Us Liquid Quart per Day" ;
@@ -58396,7 +57853,6 @@ unit:QT_US-PER-HR
   qudt:plainTextDescription "unit fo the volume quart (US liquid) for fluids according to the Anglo-American system of units divided by the unit for time hour" ;
   qudt:symbol "qt{US liq}/h" ;
   qudt:ucumCode "[qt_us].h-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[qt_us]/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "K99" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Us Liquid Quart per Hour" ;
@@ -58415,7 +57871,6 @@ unit:QT_US-PER-MIN
   qudt:plainTextDescription "unit fo the volume quart (US liquid) for fluids according to the Anglo-American system of units divided by the unit for time minute" ;
   qudt:symbol "qt{US liq}/min" ;
   qudt:ucumCode "[qt_us].min-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[qt_us]/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L10" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Us Liquid Quart per Minute" ;
@@ -58434,7 +57889,6 @@ unit:QT_US-PER-SEC
   qudt:plainTextDescription "unit fo the volume quart (US liquid) for fluids according to the Anglo-American system of units divided by the SI base unit second" ;
   qudt:symbol "qt{US liq}/s" ;
   qudt:ucumCode "[qt_us].s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[qt_us]/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L11" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Us Liquid Quart per Second" ;
@@ -58521,12 +57975,12 @@ unit:R
   qudt:factorUnitScalar 0.000258 ;
   qudt:hasDimensionVector qkdv:A0E1L0I0M-1H0T1D0 ;
   qudt:hasFactorUnit [
-    qudt:exponent -1 ;
-    qudt:hasUnit unit:KiloGM ;
-  ] ;
-  qudt:hasFactorUnit [
     qudt:exponent 1 ;
     qudt:hasUnit unit:C ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent -1 ;
+    qudt:hasUnit unit:KiloGM ;
   ] ;
   qudt:hasQuantityKind quantitykind:ElectricChargePerMass ;
   qudt:iec61360Code "0112/2///62720#UAA275" ;
@@ -58550,7 +58004,6 @@ unit:R-PER-SEC
   qudt:iec61360Code "0112/2///62720#UAA276" ;
   qudt:symbol "R/s" ;
   qudt:ucumCode "R.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "R/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D6" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Roentgen per Second" ;
@@ -58630,7 +58083,6 @@ unit:RAD-M2-PER-KiloGM
   qudt:iec61360Code "0112/2///62720#UAB162" ;
   qudt:symbol "rad·m²/kg" ;
   qudt:ucumCode "rad.m2.kg-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "rad.m2/kg"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C83" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q96347983> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -58664,7 +58116,6 @@ unit:RAD-M2-PER-MOL
   qudt:iec61360Code "0112/2///62720#UAB161" ;
   qudt:symbol "rad·m²/mol" ;
   qudt:ucumCode "rad.m2.mol-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "rad.m2/mol"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C82" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q96347486> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -58702,7 +58153,6 @@ unit:RAD-PER-HR
   qudt:hasQuantityKind quantitykind:AngularVelocity ;
   qudt:symbol "rad/h" ;
   qudt:ucumCode "rad.h-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "rad/h"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Radian per Hour" ;
   rdfs:label "Radian per Hour"@en .
@@ -58725,7 +58175,6 @@ unit:RAD-PER-M
   qudt:informativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
   qudt:symbol "rad/m" ;
   qudt:ucumCode "rad.m-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "rad/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "C84" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q30338605> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -58768,7 +58217,6 @@ unit:RAD-PER-MIN
   qudt:hasQuantityKind quantitykind:AngularVelocity ;
   qudt:symbol "rad/min" ;
   qudt:ucumCode "rad.min-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "rad/min"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Radian per Minute" ;
   rdfs:label "Radian per Minute"@en .
@@ -58791,7 +58239,6 @@ unit:RAD-PER-SEC
   qudt:iec61360Code "0112/2///62720#UAA968" ;
   qudt:symbol "rad/s" ;
   qudt:ucumCode "rad.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "rad/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "2A" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q1063756> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -58835,7 +58282,6 @@ unit:RAD-PER-SEC2
   qudt:iec61360Code "0112/2///62720#UAA969" ;
   qudt:symbol "rad/s²" ;
   qudt:ucumCode "rad.s-2"^^qudt:UCUMcs ;
-  qudt:ucumCode "rad/s2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "2B" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q30338333> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -58927,7 +58373,6 @@ unit:REM-PER-SEC
   qudt:iec61360Code "0112/2///62720#UAB442" ;
   qudt:symbol "rem/s" ;
   qudt:ucumCode "REM.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "REM/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P69" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Rem per Second" ;
@@ -59152,12 +58597,12 @@ $$\\  \\text{Siemens}\\equiv\\frac{\\text{A}}{\\text{V}}\\equiv\\frac{\\text{amp
   qudt:exactMatch unit:MHO ;
   qudt:hasDimensionVector qkdv:A0E2L-2I0M-1H0T3D0 ;
   qudt:hasFactorUnit [
-    qudt:exponent -1 ;
-    qudt:hasUnit unit:V ;
-  ] ;
-  qudt:hasFactorUnit [
     qudt:exponent 1 ;
     qudt:hasUnit unit:A ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent -1 ;
+    qudt:hasUnit unit:V ;
   ] ;
   qudt:hasQuantityKind quantitykind:Admittance ;
   qudt:hasQuantityKind quantitykind:Conductance ;
@@ -59210,7 +58655,6 @@ unit:S-M2-PER-MOL
   qudt:iec61360Code "0112/2///62720#UAA280" ;
   qudt:symbol "S·m²/mol" ;
   qudt:ucumCode "S.m2.mol-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "S.m2/mol"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D12" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q96309077> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -59247,7 +58691,6 @@ unit:S-PER-CentiM
   qudt:plainTextDescription "SI derived unit Siemens divided by the 0.01-fold of the SI base unit metre" ;
   qudt:symbol "S/cm" ;
   qudt:ucumCode "S.cm-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "S/cm"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H43" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q106777917> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -59282,7 +58725,6 @@ unit:S-PER-M
   qudt:plainTextDescription "SI derived unit siemens divided by the SI base unit metre" ;
   qudt:symbol "S/m" ;
   qudt:ucumCode "S.m-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "S/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D10" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q80842107> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -59558,7 +59000,6 @@ unit:SEC-FT2
   qudt:hasQuantityKind quantitykind:AreaTime ;
   qudt:symbol "s·ft²" ;
   qudt:ucumCode "s.[ft_i]2"^^qudt:UCUMcs ;
-  qudt:ucumCode "s.[sft_i]"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Second Square Foot" ;
   rdfs:label "Second Square Foot"@en .
@@ -59589,7 +59030,6 @@ unit:SEC-PER-KiloGM
   qudt:iec61360Code "0112/2///62720#UAB349" ;
   qudt:symbol "s/kg" ;
   qudt:ucumCode "s.kg-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "s/kg"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "Q20" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Saat per Kilogram"@ms ;
@@ -59624,7 +59064,6 @@ unit:SEC-PER-M
   qudt:iec61360Code "0112/2///62720#UAD709" ;
   qudt:symbol "s/m" ;
   qudt:ucumCode "s.m-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "s/m"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Saat per Meter"@ms ;
   rdfs:label "Saniye per Metre"@tr ;
@@ -60103,12 +59542,12 @@ unit:ST
   qudt:factorUnitScalar 0.0001 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-1D0 ;
   qudt:hasFactorUnit [
-    qudt:exponent 2 ;
-    qudt:hasUnit unit:M ;
-  ] ;
-  qudt:hasFactorUnit [
     qudt:exponent -1 ;
     qudt:hasUnit unit:SEC ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent 2 ;
+    qudt:hasUnit unit:M ;
   ] ;
   qudt:hasQuantityKind quantitykind:KinematicViscosity ;
   qudt:iec61360Code "0112/2///62720#UAA281" ;
@@ -60135,7 +59574,6 @@ unit:ST-PER-BAR
   qudt:iec61360Code "0112/2///62720#UAA283" ;
   qudt:symbol "St/bar" ;
   qudt:ucumCode "St.bar-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "St/bar"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G46" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Stokes per Bar" ;
@@ -60151,7 +59589,6 @@ unit:ST-PER-K
   qudt:iec61360Code "0112/2///62720#UAA282" ;
   qudt:symbol "St/K" ;
   qudt:ucumCode "St.K-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "St/K"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G10" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Stokes per Kelvin" ;
@@ -60167,7 +59604,6 @@ unit:ST-PER-PA
   qudt:iec61360Code "0112/2///62720#UAB314" ;
   qudt:symbol "St/Pa" ;
   qudt:ucumCode "St.Pa-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "St/Pa"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M80" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Stokes per Pascal" ;
@@ -60299,12 +59735,12 @@ unit:SV
   qudt:derivedUnitOfSystem sou:SI ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-2D0 ;
   qudt:hasFactorUnit [
-    qudt:exponent 1 ;
-    qudt:hasUnit unit:J ;
-  ] ;
-  qudt:hasFactorUnit [
     qudt:exponent -1 ;
     qudt:hasUnit unit:KiloGM ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent 1 ;
+    qudt:hasUnit unit:J ;
   ] ;
   qudt:hasQuantityKind quantitykind:DoseEquivalent ;
   qudt:hasReciprocalUnit unit:KiloGM-PER-J ;
@@ -60357,7 +59793,6 @@ unit:SV-PER-HR
   qudt:iec61360Code "0112/2///62720#UAB464" ;
   qudt:symbol "Sv/h" ;
   qudt:ucumCode "Sv.h-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "Sv/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P70" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Sievert per Hour" ;
@@ -60375,7 +59810,6 @@ unit:SV-PER-MIN
   qudt:iec61360Code "0112/2///62720#UAB468" ;
   qudt:symbol "Sv/min" ;
   qudt:ucumCode "Sv.min-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "Sv/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P74" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Sievert per Minute" ;
@@ -60393,7 +59827,6 @@ unit:SV-PER-SEC
   qudt:iec61360Code "0112/2///62720#UAB301" ;
   qudt:symbol "Sv/s" ;
   qudt:ucumCode "Sv.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "Sv/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "P65" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Sievert na Sekunda"@cs ;
@@ -60522,12 +59955,12 @@ unit:T
   qudt:derivedCoherentUnitOfSystem sou:SI ;
   qudt:hasDimensionVector qkdv:A0E-1L0I0M1H0T-2D0 ;
   qudt:hasFactorUnit [
-    qudt:exponent 1 ;
-    qudt:hasUnit unit:WB ;
-  ] ;
-  qudt:hasFactorUnit [
     qudt:exponent -2 ;
     qudt:hasUnit unit:M ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent 1 ;
+    qudt:hasUnit unit:WB ;
   ] ;
   qudt:hasQuantityKind quantitykind:MagneticField ;
   qudt:hasQuantityKind quantitykind:MagneticFluxDensity ;
@@ -60789,8 +60222,7 @@ unit:THM_US-PER-HR
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:informativeReference "http://www.convertunits.com/info/therm%2B%5BU.S.%5D"^^xsd:anyURI ;
   qudt:symbol "thm{US}/h" ;
-  qudt:ucumCode "[thm{US}].h-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[thm{US}]/h"^^qudt:UCUMcs ;
+  qudt:ucumCode "100000.[Btu_59].h-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Therm Us per Hour" ;
   rdfs:label "Therm Us per Hour"@en .
@@ -60891,7 +60323,6 @@ unit:TONNE-PER-BAR
   qudt:iec61360Code "0112/2///62720#UAA990" ;
   qudt:symbol "t/bar" ;
   qudt:ucumCode "t.bar-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "t/bar"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L70" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Tonne per Bar" ;
@@ -60913,7 +60344,6 @@ unit:TONNE-PER-DAY
   qudt:plainTextDescription "metric unit tonne divided by the unit for time day" ;
   qudt:symbol "t/d" ;
   qudt:ucumCode "t.d-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "t/d"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L71" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Tonne per Day" ;
@@ -60967,7 +60397,6 @@ unit:TONNE-PER-HA
   qudt:plainTextDescription "A measure of density equivalent to 1000kg per hectare or one Megagram per hectare, typically used to express a volume of biomass or crop yield." ;
   qudt:symbol "t/ha" ;
   qudt:ucumCode "t.har-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "t/har"^^qudt:UCUMcs ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q107461160> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Tonne per Hectare" ;
@@ -60987,7 +60416,7 @@ unit:TONNE-PER-HA-YR
   qudt:hasQuantityKind quantitykind:MassPerAreaTime ;
   qudt:plainTextDescription "A measure of density equivalent to 1000kg per hectare per year or one Megagram per hectare per year, typically used to express a volume of biomass or crop yield." ;
   qudt:symbol "t/(ha·a)" ;
-  qudt:ucumCode "t.har-1.year-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "t.har-1.a-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Tonne per Hectare Year" ;
   rdfs:label "Tonne per Hectare Year"@en .
@@ -61008,7 +60437,6 @@ unit:TONNE-PER-HR
   qudt:plainTextDescription "unit tonne divided by the unit for time hour" ;
   qudt:symbol "t/h" ;
   qudt:ucumCode "t.h-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "t/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E18" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Tonne per Hour" ;
@@ -61057,7 +60485,6 @@ unit:TONNE-PER-K
   qudt:iec61360Code "0112/2///62720#UAA989" ;
   qudt:symbol "t/K" ;
   qudt:ucumCode "t.K-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "t/K"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L69" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Tonne per Kelvin" ;
@@ -61136,7 +60563,6 @@ unit:TONNE-PER-MIN
   qudt:plainTextDescription "unit tonne divided by the unit for time minute" ;
   qudt:symbol "t/min" ;
   qudt:ucumCode "t.min-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "t/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L78" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Tonne per Minute" ;
@@ -61185,7 +60611,6 @@ unit:TONNE-PER-MO
   qudt:iec61360Code "0112/2///62720#UAB366" ;
   qudt:symbol "t/mo" ;
   qudt:ucumCode "t.mo-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "t/mo"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M88" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Tonne per Month" ;
@@ -61207,7 +60632,6 @@ unit:TONNE-PER-SEC
   qudt:plainTextDescription "unit tonne divided by the SI base unit second" ;
   qudt:symbol "t/s" ;
   qudt:ucumCode "t.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "t/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L81" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Tonne per Second" ;
@@ -61260,7 +60684,6 @@ unit:TONNE-PER-YR
   qudt:iec61360Code "0112/2///62720#UAB367" ;
   qudt:symbol "t/a" ;
   qudt:ucumCode "t.a-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "t/a"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M89" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Ton per Jaar"@nl ;
@@ -61374,7 +60797,7 @@ unit:TON_LONG-PER-YD3
   qudt:hasQuantityKind quantitykind:Density ;
   qudt:hasQuantityKind quantitykind:MassDensity ;
   qudt:symbol "t{long}/yd³" ;
-  qudt:ucumCode "[lton_av]/[cyd_i]"^^qudt:UCUMcs ;
+  qudt:ucumCode "[lton_av].[yd_i]-3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L92" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Long Ton per Cubic Yard" ;
@@ -61416,7 +60839,6 @@ unit:TON_Metric-PER-BAR
   qudt:iec61360Code "0112/2///62720#UAA990" ;
   qudt:symbol "t/bar" ;
   qudt:ucumCode "t.bar-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "t/bar"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L70" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Metric Ton per Bar" ;
@@ -61438,7 +60860,6 @@ unit:TON_Metric-PER-DAY
   qudt:plainTextDescription "metric unit ton divided by the unit for time day" ;
   qudt:symbol "t/d" ;
   qudt:ucumCode "t.d-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "t/d"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L71" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Metric Ton per Day" ;
@@ -61492,7 +60913,6 @@ unit:TON_Metric-PER-HA
   qudt:plainTextDescription "A measure of density equivalent to 1000kg per hectare or one Megagram per hectare, typically used to express a volume of biomass or crop yield." ;
   qudt:symbol "t/ha" ;
   qudt:ucumCode "t.har-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "t/har"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Metric Ton per Hectare" ;
   rdfs:label "Metric Ton per Hectare"@en .
@@ -61513,7 +60933,6 @@ unit:TON_Metric-PER-HR
   qudt:plainTextDescription "unit tonne divided by the unit for time hour" ;
   qudt:symbol "t/h" ;
   qudt:ucumCode "t.h-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "t/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E18" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Metric Ton per Hour" ;
@@ -61562,7 +60981,6 @@ unit:TON_Metric-PER-K
   qudt:iec61360Code "0112/2///62720#UAA989" ;
   qudt:symbol "t/K" ;
   qudt:ucumCode "t.K-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "t/K"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L69" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Metric Ton per Kelvin" ;
@@ -61625,7 +61043,6 @@ unit:TON_Metric-PER-MIN
   qudt:plainTextDescription "unit ton divided by the unit for time minute" ;
   qudt:symbol "t/min" ;
   qudt:ucumCode "t.min-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "t/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L78" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Metric Ton per Minute" ;
@@ -61679,7 +61096,6 @@ unit:TON_Metric-PER-SEC
   qudt:plainTextDescription "unit ton divided by the SI base unit second" ;
   qudt:symbol "t/s" ;
   qudt:ucumCode "t.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "t/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L81" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Metric Ton per Second" ;
@@ -61886,7 +61302,7 @@ unit:TON_SHORT-PER-YD3
   qudt:hasQuantityKind quantitykind:Density ;
   qudt:hasQuantityKind quantitykind:MassDensity ;
   qudt:symbol "ton{short}/yd³" ;
-  qudt:ucumCode "[ston_av].[cyd_i]-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[ston_av].[yd_i]-3"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Short Ton per Cubic Yard" ;
   rdfs:label "Short Ton per Cubic Yard"@en .
@@ -61923,7 +61339,6 @@ unit:TON_UK-PER-DAY
   qudt:plainTextDescription "unit British ton according to the Imperial system of units divided by the unit day" ;
   qudt:symbol "ton{UK}/d" ;
   qudt:ucumCode "[lton_av].d-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[lton_av]/d"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L85" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Ton (UK) per Day" ;
@@ -61942,7 +61357,7 @@ unit:TON_UK-PER-YD3
   qudt:iec61360Code "0112/2///62720#UAB018" ;
   qudt:plainTextDescription "unit of the density according the Imperial system of units" ;
   qudt:symbol "ton{UK}/yd³" ;
-  qudt:ucumCode "[lton_av].[cyd_i]-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[lton_av].[yd_i]-3"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Ton (UK) per Cubic Yard" ;
   rdfs:label "Ton (UK) per Cubic Yard"@en .
@@ -61980,7 +61395,6 @@ unit:TON_US-PER-DAY
   qudt:plainTextDescription "unit American ton according to the Anglo-American system of units divided by the unit day" ;
   qudt:symbol "ton{US}/d" ;
   qudt:ucumCode "[ston_av].d-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[ston_av]/d"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L88" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Ton (US) per Day" ;
@@ -62000,7 +61414,6 @@ unit:TON_US-PER-HR
   qudt:plainTextDescription "unit ton divided by the unit for time hour" ;
   qudt:symbol "ton{US}/h" ;
   qudt:ucumCode "[ston_av].h-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[ston_av]/h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "4W" ;
   qudt:uneceCommonCode "E18" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -62020,7 +61433,7 @@ unit:TON_US-PER-YD3
   qudt:iec61360Code "0112/2///62720#UAB020" ;
   qudt:plainTextDescription "unit of the density according to the Anglo-American system of units" ;
   qudt:symbol "ton{US}/yd³" ;
-  qudt:ucumCode "[ston_av].[cyd_i]-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[ston_av].[yd_i]-3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "L93" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Ton (US) per Cubic Yard" ;
@@ -62112,6 +61525,7 @@ unit:TebiBIT
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:InformationEntropy ;
   qudt:symbol "Tib" ;
+  qudt:ucumCode "Tibit"^^qudt:UCUMcs ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q389062> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Tebibit" ;
@@ -62126,6 +61540,7 @@ unit:TebiBIT-PER-M
   qudt:hasQuantityKind quantitykind:LinearBitDensity ;
   qudt:iec61360Code "0112/2///62720#UAA292" ;
   qudt:symbol "Tib/m" ;
+  qudt:ucumCode "Tibit.m-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E85" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Tebibit per Meter"@en-US ;
@@ -62141,6 +61556,7 @@ unit:TebiBIT-PER-M2
   qudt:hasQuantityKind quantitykind:AreaBitDensity ;
   qudt:iec61360Code "0112/2///62720#UAA293" ;
   qudt:symbol "Tib/m²" ;
+  qudt:ucumCode "Tibit.m-2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E87" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Tebibit per Square Meter"@en-US ;
@@ -62156,6 +61572,7 @@ unit:TebiBIT-PER-M3
   qudt:hasQuantityKind quantitykind:VolumetricBitDensity ;
   qudt:iec61360Code "0112/2///62720#UAA294" ;
   qudt:symbol "Tib/m³" ;
+  qudt:ucumCode "Tibit.m-3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E86" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Tebibit per Cubic Meter"@en-US ;
@@ -62181,6 +61598,7 @@ unit:TebiBYTE
   qudt:iec61360Code "0112/2///62720#UAA295" ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Byte#Multiple-byte_units"^^xsd:anyURI ;
   qudt:symbol "TiB" ;
+  qudt:ucumCode "TiBy"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E61" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q79769> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -62202,6 +61620,7 @@ unit:TeraA
   qudt:hasQuantityKind quantitykind:TotalCurrent ;
   qudt:iec61360Code "0112/2///62720#UAB640" ;
   qudt:symbol "TA" ;
+  qudt:ucumCode "TA"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Teraamper"@hu ;
   rdfs:label "Teraamper"@pl ;
@@ -62226,6 +61645,7 @@ unit:TeraBIT
   qudt:hasQuantityKind quantitykind:DatasetOfBits ;
   qudt:iec61360Code "0112/2///62720#UAB191" ;
   qudt:symbol "Tb" ;
+  qudt:ucumCode "Tbit"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E83" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q1152323> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -62242,7 +61662,6 @@ unit:TeraBIT-PER-SEC
   qudt:iec61360Code "0112/2///62720#UAA291" ;
   qudt:symbol "Tb/s" ;
   qudt:ucumCode "Tbit.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "Tbit/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "E84" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Terabit per Second" ;
@@ -62257,6 +61676,7 @@ unit:TeraBQ
   qudt:hasQuantityKind quantitykind:Activity ;
   qudt:iec61360Code "0112/2///62720#UAB589" ;
   qudt:symbol "TBq" ;
+  qudt:ucumCode "TBq"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Terabecquerel" ;
   rdfs:label "Terabecquerel"@cs ;
@@ -62420,7 +61840,6 @@ unit:TeraJ-PER-SEC
   qudt:iec61360Code "0112/2///62720#UAB513" ;
   qudt:symbol "TJ/s" ;
   qudt:ucumCode "TJ.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "TJ/s"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Teradżul na Sekunda"@pl ;
   rdfs:label "Terajoule na Sekunda"@cs ;
@@ -62479,6 +61898,7 @@ unit:TeraV
   qudt:hasQuantityKind quantitykind:Voltage ;
   qudt:iec61360Code "0112/2///62720#UAC773" ;
   qudt:symbol "TV" ;
+  qudt:ucumCode "TV"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Teravolt" ;
   rdfs:label "Teravolt"@cs ;
@@ -62562,6 +61982,7 @@ unit:TeraVAR
   qudt:hasQuantityKind quantitykind:ReactivePower ;
   qudt:iec61360Code "0112/2///62720#UAC509" ;
   qudt:symbol "TVA{Reactive}" ;
+  qudt:ucumCode "TVA{reactive}"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Tera Volt Ampere Reactive" ;
   rdfs:label "Tera Volt Ampere Reactive"@en .
@@ -62614,7 +62035,7 @@ unit:TeraW-HR
   qudt:iec61360Code "0112/2///62720#UAA290" ;
   qudt:plainTextDescription "1,000,000,000,000-fold of the product of the SI derived unit watt and the unit hour" ;
   qudt:symbol "TW·h" ;
-  qudt:ucumCode "TW/h"^^qudt:UCUMcs ;
+  qudt:ucumCode "TW.h"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D32" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q2659078> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -62634,7 +62055,7 @@ unit:TeraW-HR-PER-YR
   qudt:hasQuantityKind quantitykind:Power ;
   qudt:plainTextDescription "Terawatt hour per year is a unit of energy per time (i.e. power) and denotes the energy (in terawatt hours) created or consumed during one year." ;
   qudt:symbol "TW·h/a" ;
-  qudt:ucumCode "TW.h/a"^^qudt:UCUMcs ;
+  qudt:ucumCode "TW.h.a-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Terawatt Heure Par An"@fr ;
   rdfs:label "Terawatt Hour per Year" ;
@@ -62830,12 +62251,12 @@ unit:V
   qudt:dbpediaMatch "http://dbpedia.org/resource/Volt"^^xsd:anyURI ;
   qudt:hasDimensionVector qkdv:A0E-1L2I0M1H0T-3D0 ;
   qudt:hasFactorUnit [
-    qudt:exponent 1 ;
-    qudt:hasUnit unit:W ;
-  ] ;
-  qudt:hasFactorUnit [
     qudt:exponent -1 ;
     qudt:hasUnit unit:A ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent 1 ;
+    qudt:hasUnit unit:W ;
   ] ;
   qudt:hasQuantityKind quantitykind:ElectricPotential ;
   qudt:hasQuantityKind quantitykind:ElectricPotentialDifference ;
@@ -62950,7 +62371,6 @@ unit:V-A-PER-K
   qudt:iec61360Code "0112/2///62720#UAD905" ;
   qudt:symbol "V·A/K" ;
   qudt:ucumCode "V.A.K-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "V.A/K"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Volt Amper na Kelvin"@sl ;
   rdfs:label "Volt Amper pe Kelvin"@ro ;
@@ -63077,7 +62497,6 @@ unit:V-PER-BAR
   qudt:iec61360Code "0112/2///62720#UAA299" ;
   qudt:symbol "V/bar" ;
   qudt:ucumCode "V.bar-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "V/bar"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "G60" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Volt per Bar" ;
@@ -63097,7 +62516,6 @@ unit:V-PER-CentiM
   qudt:plainTextDescription "derived SI unit volt divided by the 0.01-fold of the SI base unit metre" ;
   qudt:symbol "V/cm" ;
   qudt:ucumCode "V.cm-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "V/cm"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D47" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Volt na Centimeter"@sl ;
@@ -63143,7 +62561,6 @@ unit:V-PER-K
   qudt:informativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
   qudt:symbol "V/K" ;
   qudt:ucumCode "V.K-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "V/K"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D48" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q105761745> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -63205,7 +62622,6 @@ unit:V-PER-M
   qudt:informativeReference "http://www.efunda.com/glossary/units/units--electric_field_strength--volt_per_meter.cfm"^^xsd:anyURI ;
   qudt:symbol "V/m" ;
   qudt:ucumCode "V.m-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "V/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D50" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q3562962> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -63285,7 +62701,6 @@ unit:V-PER-MicroSEC
   qudt:plainTextDescription "SI derived unit volt divided by the 0.000001-fold of the SI base unit second" ;
   qudt:symbol "V/μs" ;
   qudt:ucumCode "V.us-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "V/us"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H24" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Volt na Microsekunda"@cs ;
@@ -63315,7 +62730,6 @@ unit:V-PER-MilliM
   qudt:plainTextDescription "SI derived unit volt divided by the 0.001-fold of the SI base unit metre" ;
   qudt:symbol "V/mm" ;
   qudt:ucumCode "V.mm-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "V/mm"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D51" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Volt na Millimeter"@sl ;
@@ -63342,7 +62756,6 @@ unit:V-PER-PA
   qudt:iec61360Code "0112/2///62720#UAB312" ;
   qudt:symbol "V/Pa" ;
   qudt:ucumCode "V.Pa-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "V/Pa"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "N98" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Volt na Pascal"@cs ;
@@ -63380,7 +62793,6 @@ unit:V-PER-SEC
   qudt:informativeReference "http://www.thefreedictionary.com/Webers"^^xsd:anyURI ;
   qudt:symbol "V/s" ;
   qudt:ucumCode "V.s-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "V/s"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H46" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Volt na Sekunda"@cs ;
@@ -63411,7 +62823,6 @@ unit:V-PER-V
   qudt:iec61360Code "0112/2///62720#UAD862" ;
   qudt:symbol "V/V" ;
   qudt:ucumCode "V.V-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "V/V"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Volt na Volt"@cs ;
   rdfs:label "Volt na Volt"@sl ;
@@ -63450,7 +62861,6 @@ unit:V-SEC-PER-M
   qudt:plainTextDescription "product of the SI derived unit volt and the SI base unit second divided by the SI base unit metre" ;
   qudt:symbol "V·s/m" ;
   qudt:ucumCode "V.s.m-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "V.s/m"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "H45" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Volt Saat per Meter"@ms ;
@@ -63560,7 +62970,6 @@ unit:VA-PER-K
   qudt:iec61360Code "0112/2///62720#UAD905" ;
   qudt:symbol "VA/K" ;
   qudt:ucumCode "VA.K-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "VA/K"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Volt Ampere per Kelvin" ;
   rdfs:label "Volt Ampere per Kelvin"@en ;
@@ -63578,12 +62987,12 @@ unit:VAR
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasFactorUnit [
-    qudt:exponent 1 ;
-    qudt:hasUnit unit:J ;
-  ] ;
-  qudt:hasFactorUnit [
     qudt:exponent -1 ;
     qudt:hasUnit unit:SEC ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent 1 ;
+    qudt:hasUnit unit:J ;
   ] ;
   qudt:hasQuantityKind quantitykind:ReactivePower ;
   qudt:iec61360Code "0112/2///62720#UAB023" ;
@@ -63618,6 +63027,7 @@ unit:VAR-PER-K
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAD901" ;
   qudt:symbol "VA{Reactive}/K" ;
+  qudt:ucumCode "VA{reactive}.K-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Volt Ampere Reactive per Kelvin" ;
   rdfs:label "Volt Ampere Reactive per Kelvin"@en .
@@ -63664,7 +63074,6 @@ unit:V_Ab-PER-CentiM
   qudt:informativeReference "https://encyclopedia2.thefreedictionary.com/abvolt+per+centimeter"^^xsd:anyURI ;
   qudt:symbol "abV/cm" ;
   qudt:ucumCode "10.nV.cm-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "10.nV/cm"^^qudt:UCUMcs ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q30063922> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Abvolt per Centimeter"@en-US ;
@@ -63761,12 +63170,12 @@ unit:W
   qudt:derivedCoherentUnitOfSystem sou:SI ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasFactorUnit [
-    qudt:exponent 1 ;
-    qudt:hasUnit unit:J ;
-  ] ;
-  qudt:hasFactorUnit [
     qudt:exponent -1 ;
     qudt:hasUnit unit:SEC ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent 1 ;
+    qudt:hasUnit unit:J ;
   ] ;
   qudt:hasQuantityKind quantitykind:ElectricPower ;
   qudt:hasQuantityKind quantitykind:Power ;
@@ -63836,7 +63245,6 @@ unit:W-HR-PER-KiloGM
   qudt:iec61360Code "0112/2///62720#UAD888" ;
   qudt:symbol "W·h/kg" ;
   qudt:ucumCode "W.h.kg-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "W.h/kg"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Watt Hour per Kilogram" ;
   rdfs:label "Watt Hour per Kilogram"@en .
@@ -63851,7 +63259,6 @@ unit:W-HR-PER-L
   qudt:iec61360Code "0112/2///62720#UAD887" ;
   qudt:symbol "W·h/L" ;
   qudt:ucumCode "W.h.L-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "W.h/L"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Watt Hour per Liter"@en-US ;
   rdfs:label "Watt Hour per Litre" ;
@@ -63908,7 +63315,7 @@ unit:W-M-PER-M2-SR
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:symbol "W·m/(m²·sr)" ;
-  qudt:ucumCode "W.m-2.m.sr-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "W.m.m-2.sr-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Vatio Metro por Metro Cuadrado Estereorradián"@es ;
   rdfs:label "Wat Metr na Metr Kwadratowy Steradian"@pl ;
@@ -64039,7 +63446,7 @@ unit:W-PER-FT2
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:PowerPerArea ;
   qudt:symbol "W/ft²" ;
-  qudt:ucumCode "W.[sft_i]-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "W.[ft_i]-2"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Watt per Square Foot" ;
   rdfs:label "Watt per Square Foot"@en .
@@ -64060,7 +63467,6 @@ unit:W-PER-GM
   qudt:plainTextDescription "SI derived unit watt divided by the SI derived unit gram" ;
   qudt:symbol "W/g" ;
   qudt:ucumCode "W.g-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "W/g"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Vatio por Gramo"@es ;
   rdfs:label "Wat na Gram"@pl ;
@@ -64088,7 +63494,7 @@ unit:W-PER-IN2
   qudt:hasQuantityKind quantitykind:PowerPerArea ;
   qudt:iec61360Code "0112/2///62720#UAB225" ;
   qudt:symbol "W/in²" ;
-  qudt:ucumCode "W.[sin_i]-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "W.[in_i]-2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "N49" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Watt per Square Inch" ;
@@ -64144,7 +63550,6 @@ unit:W-PER-KiloGM
   qudt:plainTextDescription "SI derived unit watt divided by the SI base unit kilogram" ;
   qudt:symbol "W/kg" ;
   qudt:ucumCode "W.kg-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "W/kg"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "WA" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q67060736> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -64292,7 +63697,6 @@ unit:W-PER-M2
   qudt:informativeReference "http://www.efunda.com/glossary/units/units--energy_flux--watt_per_square_meter.cfm"^^xsd:anyURI ;
   qudt:symbol "W/m²" ;
   qudt:ucumCode "W.m-2"^^qudt:UCUMcs ;
-  qudt:ucumCode "W/m2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "D54" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q3566737> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
@@ -64458,6 +63862,7 @@ unit:W-PER-M2-MicroM
   qudt:hasQuantityKind quantitykind:SpectralRadiance ;
   qudt:plainTextDescription "A unit of spectral radiance, which is the radiance per unit of wavelength. It is watts per square meter per micrometer" ;
   qudt:symbol "W/(m²·μm)" ;
+  qudt:ucumCode "W.m-2.um-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Vatio por Metro Cuadrado Micrometro"@es ;
   rdfs:label "Wat na Metr Kwadratowy Micrometr"@pl ;
@@ -64483,6 +63888,7 @@ unit:W-PER-M2-MicroM-SR
   qudt:hasQuantityKind quantitykind:SpectralRadiance ;
   qudt:plainTextDescription "A unit of spectral radiance that is the power radiating from a surface per unit of solid angle per unit of wavelength, measured in units of watts per meter squared per micrometer per steradian" ;
   qudt:symbol "W/(m²·μm·sr)" ;
+  qudt:ucumCode "W.m-2.um-1.sr-1"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Vatio por Metro Cuadrado Micrometro Estereorradián"@es ;
   rdfs:label "Wat na Metr Kwadratowy Micrometr Steradian"@pl ;
@@ -65129,7 +64535,6 @@ unit:YD2
   qudt:hasQuantityKind quantitykind:Area ;
   qudt:iec61360Code "0112/2///62720#UAB034" ;
   qudt:symbol "yd²" ;
-  qudt:ucumCode "[syd_i]"^^qudt:UCUMcs ;
   qudt:ucumCode "[yd_i]2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "YDK" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q1550511> ;
@@ -65152,7 +64557,6 @@ unit:YD3
   qudt:hasReciprocalUnit unit:PER-YD3 ;
   qudt:iec61360Code "0112/2///62720#UAB035" ;
   qudt:symbol "yd³" ;
-  qudt:ucumCode "[cyd_i]"^^qudt:UCUMcs ;
   qudt:ucumCode "[yd_i]3"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "YDQ" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q2165290> ;
@@ -65173,7 +64577,7 @@ unit:YD3-PER-DAY
   qudt:iec61360Code "0112/2///62720#UAB037" ;
   qudt:plainTextDescription "power of the unit yard according to the Anglo-American and the Imperial system of units with the exponent 3 divided by the unit for time day" ;
   qudt:symbol "yd³/d" ;
-  qudt:ucumCode "[cyd_i].d-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[yd_i]3.d-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M12" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Cubic Yard per Day" ;
@@ -65191,7 +64595,7 @@ unit:YD3-PER-DEG_F
   qudt:iec61360Code "0112/2///62720#UAB036" ;
   qudt:plainTextDescription "power of the unit yard according to the Anglo-American and the Imperial system of units with the exponent 3 divided by the unit for temperature degree Fahrenheit" ;
   qudt:symbol "yd³/°F" ;
-  qudt:ucumCode "[cyd_i].[degF]-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[yd_i]3.[degF]-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M11" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Cubic Yard per Degree Fahrenheit" ;
@@ -65210,7 +64614,7 @@ unit:YD3-PER-HR
   qudt:iec61360Code "0112/2///62720#UAB038" ;
   qudt:plainTextDescription "power of the unit yard according to the Anglo-American and the Imperial system of units with the exponent 3 divided by the unit for the time hour" ;
   qudt:symbol "yd³/h" ;
-  qudt:ucumCode "[cyd_i].h-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[yd_i]3.h-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M13" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Cubic Yard per Hour" ;
@@ -65232,10 +64636,7 @@ unit:YD3-PER-MIN
   qudt:hasQuantityKind quantitykind:VolumePerTime ;
   qudt:iec61360Code "0112/2///62720#UAB040" ;
   qudt:symbol "yd³/min" ;
-  qudt:ucumCode "[cyd_i].min-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[cyd_i]/min"^^qudt:UCUMcs ;
   qudt:ucumCode "[yd_i]3.min-1"^^qudt:UCUMcs ;
-  qudt:ucumCode "[yd_i]3/min"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M15" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Cubic Yard per Minute" ;
@@ -65269,7 +64670,7 @@ unit:YD3-PER-SEC
   qudt:iec61360Code "0112/2///62720#UAB041" ;
   qudt:plainTextDescription "power of the unit and the Anglo-American and Imperial system of units with the exponent 3 divided by the SI base unit second" ;
   qudt:symbol "yd³/s" ;
-  qudt:ucumCode "[cyd_i].s-1"^^qudt:UCUMcs ;
+  qudt:ucumCode "[yd_i]3.s-1"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M16" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Cubic Yard per Second" ;


### PR DESCRIPTION
Includes `qudt:ucumCode` in the autogeneration routines, and changes the SHACL shapes such that only one value for this property is allowed.

UCUM allows multiple ways to write units, the 'canonical' one is the easiest to generate, so that's the one we use throughout the vocabulary.