### PR TITLE
Add maven profile `deprecatedInVersion`

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -106,6 +106,14 @@ mvn seq:run@infer-and-format
 
    - **What it does**: Infers `qudt:scalingOf` triples e.g., how units scale with prefixes like "kilo", merges them into `VOCAB_QUDT-UNITS-ALL.ttl`, and formats it.
    - **When to use**: If validation flags scaling issues (check `target/validation/validationReportSrc-factorUnits.ttl`).
+4. **Get deleted, formerly deprecated entities of an earlier release**
+   - **What it does**: downloads the specified release, unpacks it to `target/deprecated-in-${version}/release` and copies the vocab files to `target/deprecated-in-${version}/deprecated-only`, removing any entities that are not deprecated
+   - **When to use**: Clients who want to migrate to a new major version might need the new major version files and the old deprecated entities that were deleted, to avoid an inconsistent db state
+
+   ```bash
+   # assuming releaseVersion is an existing release, such as "2.1.47"
+   mvn -DdeprecatedInVersion=${releaseVersion} clean install
+   ```
 
 ## How It Works: Key Steps
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
 
 ## [Unreleased]
 
+### Changed
+
+- Build process
+  - with `-DdeprecatedInVersion=[releaseVersion]`, a maven build now generates all vocab files from that `releaseVersion` into
+    `target/deprecated-in-[releaseVersion]`, containing only the entities that are `qudt:deprecated` in that
+    release
+
 ## [3.1.6] - 2025-09-29
 
 ### Added

--- a/pom.xml
+++ b/pom.xml
@@ -416,6 +416,10 @@
                                         <toGraphsPattern>dist:schema:${name}</toGraphsPattern>
                                     </add>
                                     <sparqlQuery>
+                                        <file>src/build/sparql2shacl/dimensionVector/query.rq</file>
+                                        <toFile>target/inspection/dimensionVector/query.txt</toFile>
+                                    </sparqlQuery>
+                                    <sparqlQuery>
                                         <file>src/build/sparql2shacl/ucumCode/query.rq</file>
                                         <toFile>target/inspection/ucumCode/query.txt</toFile>
                                     </sparqlQuery>
@@ -963,7 +967,8 @@
                                                 (unit:J             qkdv:A0E0L2I0M1H0T-2D0  )
                                                 (unit:W             qkdv:A0E0L2I0M1H0T-3D0  )
                                                 (unit:IN            qkdv:A0E0L1I0M0H0T0D0  )
-                                                (unit:M             qfn:Unbound )
+                                                #(unit:M             qkdv:A0E0L1I0M0H0T0D0 )
+                                                #(unit:GM-PER-GM     qkdv:A0E0L0I0M0H0T0D1 )
                                             }
                                             BIND(qfn:unit.dimVec.calculate(?unit) AS ?actualOutput)
                                             FILTER(BOUND(?actualOutput) != BOUND(?expectedOutput) || ?actualOutput != ?expectedOutput)
@@ -3080,6 +3085,163 @@
                             </execution>
                         </executions>
                     </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <!-- generates data that helps client upgrade across a major version upgrade -->
+            <id>deprecatedInVersion</id>
+            <activation>
+                <property><name>deprecatedInVersion</name></property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.github.ekryd.echo-maven-plugin</groupId>
+                        <artifactId>echo-maven-plugin</artifactId>
+                        <version>2.1.0</version>
+                        <executions>
+                            <execution>
+                                <id>echo-maven-plugin-1</id>
+                                <phase>generate-resources</phase>
+                                <goals>
+                                    <goal>echo</goal>
+                                </goals>
+                                <configuration>
+                                    <message>
+                                        Fetching QUDT data release zip download (release: ${deprecatedInVersion}) ${line.separator}
+                                    </message>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>wagon-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>download-qudt-release</id>
+                                <phase>generate-resources</phase>
+                                <goals>
+                                    <goal>download-single</goal>
+                                </goals>
+                                <configuration>
+                                    <url>https://github.com/</url>
+                                    <fromFile>qudt/qudt-public-repo/releases/download/v${deprecatedInVersion}/qudt-public-repo-${deprecatedInVersion}.zip</fromFile>
+                                    <toDir>${project.build.directory}/deprecated-in-${deprecatedInVersion}/release</toDir>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <version>1.8</version>
+                        <executions>
+                            <execution>
+                                <phase>generate-resources</phase>
+                                <configuration>
+                                    <target>
+                                        <echo message="unzipping file" />
+                                        <unzip src="${project.build.directory}/deprecated-in-${deprecatedInVersion}/release/qudt-public-repo-${deprecatedInVersion}.zip" dest="${project.build.directory}/deprecated-in-${deprecatedInVersion}/release" />
+                                    </target>
+                                </configuration>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>io.github.qudtlib</groupId>
+                        <artifactId>rdfio-maven-plugin</artifactId>
+                        <version>1.5.5</version>
+                        <executions>
+                            <execution>
+                                <!--
+                                    pipeline that generates, for each vocab file, the same vocab file containing only the
+                                    deprecated entities.
+                                -->
+                                <id>deprecations</id>
+                                <phase>process-resources</phase>
+                                <goals>
+                                    <goal>pipeline</goal>
+                                </goals>
+                                <configuration>
+                                    <pipeline>
+                                        <id>deprecations</id>
+                                        <steps>
+                                            <!-- make custom shacl functions available in inference and SPARQL-->
+                                            <shaclFunctions>
+                                                <file>src/build/validation/qudt-shacl-functions.ttl</file>
+                                            </shaclFunctions>
+                                            <add>
+                                                <files>
+                                                    <include>target/deprecated-in-${deprecatedInVersion}/release/vocab/**/*.ttl</include>
+                                                </files>
+                                                <toGraphsPattern>deprecated:vocab:${name}</toGraphsPattern>
+                                            </add>
+                                            <sparqlUpdate>
+                                                <message>change graph-file associations from target/deprecated-in-${deprecatedInVersion}/release to target/deprecated-in-${deprecatedInVersion}/deprecated-only</message>
+                                                <sparql>
+                                                    <![CDATA[
+                                                        prefix rdfio: <https://github.com/qudtlib/rdfio/>
+                                                        DELETE {
+                                                            GRAPH <rdfio:pipeline:metadata> {
+                                                                ?file rdfio:loadsInto ?graph .
+                                                            }
+                                                        } INSERT {
+                                                            GRAPH <rdfio:pipeline:metadata> {
+                                                                ?newFile rdfio:loadsInto ?graph .
+                                                            }
+                                                        } WHERE {
+                                                            GRAPH <rdfio:pipeline:metadata> {
+                                                                ?file rdfio:loadsInto ?graph .
+                                                            }
+                                                            BIND (IRI(REPLACE(STR(?file), "target/deprecated-in-${deprecatedInVersion}/release", "target/deprecated-in-${deprecatedInVersion}/deprecated-only")) AS ?newFile)
+                                                        }
+                                                    ]]>
+                                                </sparql>
+                                            </sparqlUpdate>
+                                            <sparqlUpdate>
+                                                <message>Retaining only deprecated entities in each graph</message>
+                                                <sparql>
+                                                    <![CDATA[
+                                                        DELETE {
+                                                            GRAPH ?graph {
+                                                               ?s1 ?p1 ?o1 .
+                                                               ?s1 ?p1 ?o1 .
+                                                               ?s1 ?p1 ?o1 .
+                                                           }
+                                                        } WHERE {
+                                                            GRAPH ?graph  {
+                                                                ?s1 ?p1 ?o1 .
+                                                                FILTER NOT EXISTS {
+                                                                    ?s1 qudt:deprecated true .
+                                                                }
+                                                                OPTIONAL {
+                                                                   ?o1 ?p2 ?o2
+                                                                   OPTIONAL {
+                                                                        ?o2 ?p2 ?o3 .
+                                                                   }
+                                                                }
+                                                            }
+                                                            FILTER (?graph != <rdfio:pipeline:metadata>)
+                                                        }
+                                                    ]]>
+                                                </sparql>
+                                            </sparqlUpdate>
+                                            <write>
+                                                <graphs>
+                                                    <include>deprecated:vocab:*</include>
+                                                </graphs>
+                                            </write>
+                                        </steps>
+                                    </pipeline>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
                 </plugins>
             </build>
         </profile>


### PR DESCRIPTION
Computes the deprecated entities of a given release version. 

Useful if you want to upgrade to a new major version but e.g. your SHACL constraints don't allow you just to replace your QUDT files because you point to entities that have been removed. By temporarily adding the removed entities (computed with this new functionality) and then replacing the deprecated entities with the new ones in the relevant triples, this situation can be solved gracefully.

The new profile is activated by the presence of the property `deprecatedInVersion`.

Test with 

`mvn -DdeprecatedInVersion=2.1.47 install` and look into `target/deprecated-in-2.1.47`