### PR TITLE
Add query/update that can fix deprecations in client graph

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -415,6 +415,25 @@
                                         </files>
                                         <toGraphsPattern>dist:schema:${name}</toGraphsPattern>
                                     </add>
+                                    <sparqlUpdate>
+                                        <sparql>
+                                            INSERT {
+                                                unit:LB-PER-GAL_IMP qudt:exactMatch unit:LB-PER-GAL
+                                            }
+                                            WHERE {}
+                                        </sparql>
+                                    </sparqlUpdate>
+                                    <sparqlQuery>
+                                        <file>src/build/inspection/deprecation/find-use-of-deprecated.rq</file>
+                                        <toFile>target/inspection/deprecation/deprecated-before-fix.txt</toFile>
+                                    </sparqlQuery>
+                                    <sparqlUpdate>
+                                        <file>src/build/inspection/deprecation/replace-deprecated-with-replacement.rq</file>
+                                    </sparqlUpdate>
+                                    <sparqlQuery>
+                                        <file>src/build/inspection/deprecation/find-use-of-deprecated.rq</file>
+                                        <toFile>target/inspection/deprecation/deprecated-after-fix.txt</toFile>
+                                    </sparqlQuery>
                                     <sparqlQuery>
                                         <file>src/build/sparql2shacl/dimensionVector/query.rq</file>
                                         <toFile>target/inspection/dimensionVector/query.txt</toFile>

--- a/src/build/inspection/deprecation/find-use-of-deprecated.rq
+++ b/src/build/inspection/deprecation/find-use-of-deprecated.rq
@@ -1,0 +1,16 @@
+SELECT DISTINCT ?usedIn ?definedIn ?deprecated ?replacement
+WHERE {
+    graph ?definedIn {
+            ?deprecated
+                qudt:deprecated      true ;
+                dcterms:isReplacedBy ?replacement .
+    }
+    {
+        graph ?usedIn {
+            ?s ?p ?deprecated
+        }
+    } UNION {
+        ?s ?p ?deprecated
+        BIND("[default graph]" as ?usedIn)
+    }
+} ORDER BY ?definedIn ?deprecated ?usedIn

--- a/src/build/inspection/deprecation/replace-deprecated-with-replacement.rq
+++ b/src/build/inspection/deprecation/replace-deprecated-with-replacement.rq
@@ -1,0 +1,27 @@
+DELETE {
+    graph ?usedIn {
+        ?s ?p ?deprecated
+    }
+    ?sDefaultGraph  ?pDefaultGraph ?deprecated
+}
+INSERT {
+    graph ?usedIn {
+        ?s ?p ?replacement
+    }
+    ?sDefaultGraph  ?pDefaultGraph ?replacement
+}
+WHERE {
+    graph ?definedIn {
+            ?deprecated
+                qudt:deprecated true ;
+                dcterms:isReplacedBy ?replacement
+            .
+    }
+    {
+        graph ?usedIn {
+            ?s ?p ?deprecated
+        }
+    } UNION {
+        ?sDefaultGraph ?pDefaultGraph ?deprecated
+    }
+}


### PR DESCRIPTION
Not sure this is the right way to incorportat this in the repo.

Anyway, with this PR, we introduce a query and an update that allow for:
1. finding usages of deprecated entities
2. replacing those usages with the `dcterms:isReplacedBy` entity.

Limitations:
- if the deprecated entity occurs in the subject position, it is not detected/fixed
- if there is no `dcterms:isReplacedBy` entity, the entity is left in the graph as-is.

To test:
``` 
mvn rdfio:pipeline@inspect
```
Then look into `target/inspection/deprecation/`
