### PR TITLE
 Put in place non-integral exponent handling workaround

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
 - Fixed the conversion multiplier inference to fix values in src that incorrectly assert 0.0. As a result, corrected the conversion multiplier for unit:MilliEQ-PER-HectoGM
 - Fixed erroneous dimension vectors found with the validation constraint described above
 - Augmented the type declaration for 5 dimension vectors
+- Not a true fix, but a workaround to leave untouched any units that contain non-integer exponents (e.g. unit:PA-M0dot5). Currently we cannot compute the conversion multipliers and factor declarations for such (rare) occurrences.
 
 ## [3.1.9] - 2025-12-16
 

--- a/src/build/sparql2shacl/conversionMultiplier/query.rq
+++ b/src/build/sparql2shacl/conversionMultiplier/query.rq
@@ -20,6 +20,8 @@ WHERE {
                 (GROUP_CONCAT(?multiplierFound;SEPARATOR="|") AS ?allMultipliersFound)
             WHERE {
               $this a qudt:Unit .
+# Don't process units that contain "dot" in their IRI
+              FILTER( !CONTAINS(STR($this), "dot") )
               OPTIONAL { $this qudt:conversionMultiplier ?actualMultiplier . }
               FILTER(!BOUND(?actualMultiplier)                               # no actual multiplier, or zero? use calculated!
                      || (?actualMultiplier = 0.0))                         

--- a/src/build/sparql2shacl/conversionMultiplierPrecision/query.rq
+++ b/src/build/sparql2shacl/conversionMultiplierPrecision/query.rq
@@ -9,6 +9,8 @@ prefix sh: <http://www.w3.org/ns/shacl#>
 
 SELECT $this (qudt:conversionMultiplier as ?path)  ?actualMultiplier ?calculatedMultiplier
 WHERE {
+# Don't process units that contain "dot" in their IRI
+    FILTER( !CONTAINS(STR($this), "dot") )
     {
         ?this qudt:conversionMultiplier ?actualMultiplier ;
 

--- a/src/build/sparql2shacl/factorUnits/query.rq
+++ b/src/build/sparql2shacl/factorUnits/query.rq
@@ -12,6 +12,8 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             {
                 {
                     $this a qudt:Unit ;
+# Don't process units that contain "dot" in their IRI
+                    FILTER( !CONTAINS(STR($this), "dot") )
                     FILTER NOT EXISTS {
                         $this qudt:hasFactorUnit [
                                 qudt:hasUnit ?baseUnit ;

--- a/src/build/sparql2shacl/scalingOf/query.rq
+++ b/src/build/sparql2shacl/scalingOf/query.rq
@@ -11,10 +11,11 @@ where
         { SELECT DISTINCT $this ?scaledUnitLocalName ?prefixRegex
             WHERE
             {
-
                 # select all base units (not using prefixes)
                 {
                     $this a qudt:Unit .
+ # Don't process units that contain "dot" in their IRI
+                    FILTER( !CONTAINS(STR($this), "dot") )                   
                 } UNION  {
                     ?factor qudt:hasUnit $this ;
                     FILTER NOT EXISTS {

--- a/src/main/rdf/schema/SCHEMA_QUDT.ttl
+++ b/src/main/rdf/schema/SCHEMA_QUDT.ttl
@@ -33,7 +33,10 @@ qudt:FactorUnit
   ] ;
   rdfs:subClassOf [
     a owl:Restriction ;
-    owl:allValuesFrom xsd:integer ;
+    owl:allValuesFrom [
+      a rdfs:Datatype ;
+      owl:unionOf ( xsd:integer xsd:decimal ) ;
+    ] ;
     owl:onProperty qudt:exponent ;
   ] .
 

--- a/src/main/rdf/schema/shacl/SCHEMA_QUDT_NoOWL.ttl
+++ b/src/main/rdf/schema/shacl/SCHEMA_QUDT_NoOWL.ttl
@@ -2096,9 +2096,13 @@ qudt:Enumeration-element
 qudt:FactorUnit-exponent
   a sh:PropertyShape ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/qudt> ;
-  sh:datatype xsd:integer ;
   sh:maxCount 1 ;
   sh:minCount 1 ;
+  sh:or ( [
+    sh:datatype xsd:integer ;
+  ] [
+    sh:datatype xsd:decimal ;
+  ] ) ;
   sh:path qudt:exponent .
 
 qudt:FactorUnit-hasUnit

--- a/src/main/rdf/validation/COLLECTION_QUDT_QA_TESTS_ALL.ttl
+++ b/src/main/rdf/validation/COLLECTION_QUDT_QA_TESTS_ALL.ttl
@@ -376,6 +376,8 @@ qudt:InconsistentDimensionVector
     sh:select """
     SELECT $this ?calculatedDimVec ?actualDimVec
     WHERE {
+# Don't process units that contain "dot" in their IRI
+        FILTER( !CONTAINS(STR($this), "dot") )
         $this qudt:hasDimensionVector ?actualDimVec
         BIND(qfn:unit.dimVec.calculate($this) AS ?calculatedDimVec)
         FILTER(qfn:bound(?calculatedDimVec))

--- a/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
+++ b/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
@@ -1859,12 +1859,12 @@ unit:BARAD
   qudt:exactMatch unit:BARYE ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasFactorUnit [
-    qudt:exponent 1 ;
-    qudt:hasUnit unit:DYN ;
-  ] ;
-  qudt:hasFactorUnit [
     qudt:exponent -2 ;
     qudt:hasUnit unit:CentiM ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent 1 ;
+    qudt:hasUnit unit:DYN ;
   ] ;
   qudt:hasQuantityKind quantitykind:ForcePerArea ;
   qudt:hasQuantityKind quantitykind:VaporPressure ;
@@ -1952,12 +1952,12 @@ unit:BARYE
   qudt:exactMatch unit:BARAD ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasFactorUnit [
-    qudt:exponent -2 ;
-    qudt:hasUnit unit:CentiM ;
-  ] ;
-  qudt:hasFactorUnit [
     qudt:exponent 1 ;
     qudt:hasUnit unit:DYN ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent -2 ;
+    qudt:hasUnit unit:CentiM ;
   ] ;
   qudt:hasQuantityKind quantitykind:ForcePerArea ;
   qudt:hasQuantityKind quantitykind:VaporPressure ;
@@ -13489,12 +13489,12 @@ unit:ERG
   qudt:derivedUnitOfSystem sou:CGS-GAUSS ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:hasFactorUnit [
-    qudt:exponent 2 ;
-    qudt:hasUnit unit:CentiM ;
-  ] ;
-  qudt:hasFactorUnit [
     qudt:exponent 1 ;
     qudt:hasUnit unit:GM ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent 2 ;
+    qudt:hasUnit unit:CentiM ;
   ] ;
   qudt:hasFactorUnit [
     qudt:exponent -2 ;
@@ -16031,12 +16031,12 @@ unit:GALILEO
   qudt:derivedUnitOfSystem sou:CGS-GAUSS ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T-2D0 ;
   qudt:hasFactorUnit [
-    qudt:exponent 1 ;
-    qudt:hasUnit unit:CentiM ;
-  ] ;
-  qudt:hasFactorUnit [
     qudt:exponent -2 ;
     qudt:hasUnit unit:SEC ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent 1 ;
+    qudt:hasUnit unit:CentiM ;
   ] ;
   qudt:hasQuantityKind quantitykind:Acceleration ;
   qudt:hasQuantityKind quantitykind:LinearAcceleration ;
@@ -18531,12 +18531,12 @@ unit:GRAY
   qudt:derivedCoherentUnitOfSystem sou:SI ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-2D0 ;
   qudt:hasFactorUnit [
-    qudt:exponent -1 ;
-    qudt:hasUnit unit:KiloGM ;
-  ] ;
-  qudt:hasFactorUnit [
     qudt:exponent 1 ;
     qudt:hasUnit unit:J ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent -1 ;
+    qudt:hasUnit unit:KiloGM ;
   ] ;
   qudt:hasQuantityKind quantitykind:AbsorbedDose ;
   qudt:hasQuantityKind quantitykind:Kerma ;
@@ -23007,12 +23007,12 @@ unit:KAT
   qudt:derivedCoherentUnitOfSystem sou:SI ;
   qudt:hasDimensionVector qkdv:A1E0L0I0M0H0T-1D0 ;
   qudt:hasFactorUnit [
-    qudt:exponent -1 ;
-    qudt:hasUnit unit:SEC ;
-  ] ;
-  qudt:hasFactorUnit [
     qudt:exponent 1 ;
     qudt:hasUnit unit:MOL ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent -1 ;
+    qudt:hasUnit unit:SEC ;
   ] ;
   qudt:hasQuantityKind quantitykind:CatalyticActivity ;
   qudt:iec61360Code "0112/2///62720#UAB196" ;
@@ -29354,12 +29354,12 @@ unit:LA
   qudt:factorUnitScalar 0.31830988618 ;
   qudt:hasDimensionVector qkdv:A0E0L-2I1M0H0T0D0 ;
   qudt:hasFactorUnit [
-    qudt:exponent 1 ;
-    qudt:hasUnit unit:CD ;
-  ] ;
-  qudt:hasFactorUnit [
     qudt:exponent -2 ;
     qudt:hasUnit unit:M ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent 1 ;
+    qudt:hasUnit unit:CD ;
   ] ;
   qudt:hasQuantityKind quantitykind:Luminance ;
   qudt:iec61360Code "0112/2///62720#UAB259" ;
@@ -31436,11 +31436,11 @@ unit:LM
   qudt:hasDimensionVector qkdv:A0E0L0I1M0H0T0D0 ;
   qudt:hasFactorUnit [
     qudt:exponent 1 ;
-    qudt:hasUnit unit:CD ;
+    qudt:hasUnit unit:SR ;
   ] ;
   qudt:hasFactorUnit [
     qudt:exponent 1 ;
-    qudt:hasUnit unit:SR ;
+    qudt:hasUnit unit:CD ;
   ] ;
   qudt:hasQuantityKind quantitykind:LuminousFlux ;
   qudt:iec61360Code "0112/2///62720#UAA718" ;
@@ -31621,12 +31621,12 @@ unit:LUX
   qudt:derivedCoherentUnitOfSystem sou:SI ;
   qudt:hasDimensionVector qkdv:A0E0L-2I1M0H0T0D0 ;
   qudt:hasFactorUnit [
-    qudt:exponent 1 ;
-    qudt:hasUnit unit:LM ;
-  ] ;
-  qudt:hasFactorUnit [
     qudt:exponent -2 ;
     qudt:hasUnit unit:M ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent 1 ;
+    qudt:hasUnit unit:LM ;
   ] ;
   qudt:hasQuantityKind quantitykind:LuminousFluxPerArea ;
   qudt:iec61360Code "0112/2///62720#UAA723" ;
@@ -32522,16 +32522,6 @@ unit:M-SEC2
   rdfs:label "Μέτρο Τετραγωνικό Δευτερόλεπτο"@el ;
   rdfs:label "Метр Квадратный Секунда"@ru ;
   rdfs:label "Метър Квадратен Секунда"@bg .
-
-unit:M0dot
-  a qudt:ContextualUnit, qudt:Unit ;
-  qudt:conversionMultiplier 0.0 ;
-  qudt:conversionMultiplierSN 0.0E0 ;
-  qudt:hasDimensionVector qkdv:NotApplicable ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
-  rdfs:label "Placeholder" ;
-  rdfs:label "Placeholder"@en .
 
 unit:M2
   a qudt:DerivedUnit, qudt:Unit ;
@@ -37696,15 +37686,23 @@ unit:MegaPA-M0dot5
   qudt:applicableSystem sou:CGS-EMU ;
   qudt:applicableSystem sou:CGS-GAUSS ;
   qudt:applicableSystem sou:SI ;
-  qudt:conversionMultiplier 0.0 ;
-  qudt:conversionMultiplierSN 0.0E0 ;
+  qudt:conversionMultiplier 1.0 ;
+  qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L-0dot5I0M1H0T-2D0 ;
+  qudt:hasFactorUnit [
+    a qudt:FactorUnit ;
+    qudt:exponent 0.5 ;
+    qudt:hasUnit unit:M ;
+  ] ;
+  qudt:hasFactorUnit [
+    a qudt:FactorUnit ;
+    qudt:exponent 1 ;
+    qudt:hasUnit unit:MegaPA ;
+  ] ;
   qudt:hasQuantityKind quantitykind:StressIntensityFactor ;
   qudt:plainTextDescription "1,000,000-fold of the derived unit Pascal Square Root Meter" ;
   qudt:symbol "MPa√m" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
-  rdfs:label "Megapascal Quintic Placeholder" ;
-  rdfs:label "Megapascal Quintic Placeholder"@en ;
   rdfs:label "Megapascal Square Root Meter"@en-US .
 
 unit:MegaPA-M3-PER-SEC
@@ -46595,17 +46593,31 @@ unit:N-M-PER-RAD
 unit:N-M-PER-W0dot5
   a qudt:ContextualUnit, qudt:Unit ;
   dcterms:description "product of the SI derived unit newton and the SI base unit metre divided by the square root out of the SI derived unit watt" ;
-  qudt:conversionMultiplier 0.0 ;
-  qudt:conversionMultiplierSN 0.0E0 ;
+  qudt:conversionMultiplier 1.0 ;
+  qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T0D0 ;
+  qudt:hasFactorUnit [
+    a qudt:FactorUnit ;
+    qudt:exponent -0.5 ;
+    qudt:hasUnit unit:W ;
+  ] ;
+  qudt:hasFactorUnit [
+    a qudt:FactorUnit ;
+    qudt:exponent 1 ;
+    qudt:hasUnit unit:N ;
+  ] ;
+  qudt:hasFactorUnit [
+    a qudt:FactorUnit ;
+    qudt:exponent 1 ;
+    qudt:hasUnit unit:M ;
+  ] ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA242" ;
   qudt:symbol "N·m/√W" ;
   qudt:uneceCommonCode "H41" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
-  rdfs:label "Newton Meter per Quintic Placeholder"@en-US ;
-  rdfs:label "Newton Metre per Quintic Placeholder" ;
-  rdfs:label "Newton Metre per Quintic Placeholder"@en .
+  rdfs:label "Newton Metre per Square Root Watt" ;
+  rdfs:label "Newton Metre per Square Root Watt"@en .
 
 unit:N-M-SEC
   a qudt:DerivedUnit, qudt:Unit ;
@@ -51161,15 +51173,23 @@ unit:PA-M0dot5
   qudt:applicableSystem sou:CGS-EMU ;
   qudt:applicableSystem sou:CGS-GAUSS ;
   qudt:applicableSystem sou:SI ;
-  qudt:conversionMultiplier 0.0 ;
-  qudt:conversionMultiplierSN 0.0E0 ;
+  qudt:conversionMultiplier 1.0 ;
+  qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L-0dot5I0M1H0T-2D0 ;
+  qudt:hasFactorUnit [
+    a qudt:FactorUnit ;
+    qudt:exponent 0.5 ;
+    qudt:hasUnit unit:M ;
+  ] ;
+  qudt:hasFactorUnit [
+    a qudt:FactorUnit ;
+    qudt:exponent 1 ;
+    qudt:hasUnit unit:PA ;
+  ] ;
   qudt:hasQuantityKind quantitykind:StressIntensityFactor ;
   qudt:plainTextDescription "A metric unit for stress intensity factor and fracture toughness." ;
   qudt:symbol "Pa√m" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
-  rdfs:label "Pascal Quintic Placeholder" ;
-  rdfs:label "Pascal Quintic Placeholder"@en ;
   rdfs:label "Pascal Square Root Meter"@en-US .
 
 unit:PA-M2-PER-KiloGM
@@ -58497,11 +58517,11 @@ unit:RAD
   qudt:guidance "<p>See NIST section <a href=\"http://physics.nist.gov/Pubs/SP811/sec07.html#7.10\">SP811 section7.10</a></p>"^^rdf:HTML ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasFactorUnit [
-    qudt:exponent 1 ;
+    qudt:exponent -1 ;
     qudt:hasUnit unit:M ;
   ] ;
   qudt:hasFactorUnit [
-    qudt:exponent -1 ;
+    qudt:exponent 1 ;
     qudt:hasUnit unit:M ;
   ] ;
   qudt:hasQuantityKind quantitykind:Angle ;
@@ -59106,12 +59126,12 @@ $$\\  \\text{Siemens}\\equiv\\frac{\\text{A}}{\\text{V}}\\equiv\\frac{\\text{amp
   qudt:exactMatch unit:MHO ;
   qudt:hasDimensionVector qkdv:A0E2L-2I0M-1H0T3D0 ;
   qudt:hasFactorUnit [
-    qudt:exponent 1 ;
-    qudt:hasUnit unit:A ;
-  ] ;
-  qudt:hasFactorUnit [
     qudt:exponent -1 ;
     qudt:hasUnit unit:V ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent 1 ;
+    qudt:hasUnit unit:A ;
   ] ;
   qudt:hasQuantityKind quantitykind:Admittance ;
   qudt:hasQuantityKind quantitykind:Conductance ;
@@ -60009,11 +60029,11 @@ unit:SR
   qudt:derivedCoherentUnitOfSystem sou:SI ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasFactorUnit [
-    qudt:exponent -2 ;
+    qudt:exponent 2 ;
     qudt:hasUnit unit:M ;
   ] ;
   qudt:hasFactorUnit [
-    qudt:exponent 2 ;
+    qudt:exponent -2 ;
     qudt:hasUnit unit:M ;
   ] ;
   qudt:hasQuantityKind quantitykind:SolidAngle ;
@@ -60064,12 +60084,12 @@ unit:ST
   qudt:factorUnitScalar 0.0001 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-1D0 ;
   qudt:hasFactorUnit [
-    qudt:exponent 2 ;
-    qudt:hasUnit unit:M ;
-  ] ;
-  qudt:hasFactorUnit [
     qudt:exponent -1 ;
     qudt:hasUnit unit:SEC ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent 2 ;
+    qudt:hasUnit unit:M ;
   ] ;
   qudt:hasQuantityKind quantitykind:KinematicViscosity ;
   qudt:iec61360Code "0112/2///62720#UAA281" ;
@@ -60257,12 +60277,12 @@ unit:SV
   qudt:derivedUnitOfSystem sou:SI ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-2D0 ;
   qudt:hasFactorUnit [
-    qudt:exponent -1 ;
-    qudt:hasUnit unit:KiloGM ;
-  ] ;
-  qudt:hasFactorUnit [
     qudt:exponent 1 ;
     qudt:hasUnit unit:J ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent -1 ;
+    qudt:hasUnit unit:KiloGM ;
   ] ;
   qudt:hasQuantityKind quantitykind:DoseEquivalent ;
   qudt:hasReciprocalUnit unit:KiloGM-PER-J ;
@@ -60487,12 +60507,12 @@ unit:T
   qudt:derivedCoherentUnitOfSystem sou:SI ;
   qudt:hasDimensionVector qkdv:A0E-1L0I0M1H0T-2D0 ;
   qudt:hasFactorUnit [
-    qudt:exponent 1 ;
-    qudt:hasUnit unit:WB ;
-  ] ;
-  qudt:hasFactorUnit [
     qudt:exponent -2 ;
     qudt:hasUnit unit:M ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent 1 ;
+    qudt:hasUnit unit:WB ;
   ] ;
   qudt:hasQuantityKind quantitykind:MagneticField ;
   qudt:hasQuantityKind quantitykind:MagneticFluxDensity ;
@@ -62802,12 +62822,12 @@ unit:V
   qudt:dbpediaMatch "http://dbpedia.org/resource/Volt"^^xsd:anyURI ;
   qudt:hasDimensionVector qkdv:A0E-1L2I0M1H0T-3D0 ;
   qudt:hasFactorUnit [
-    qudt:exponent -1 ;
-    qudt:hasUnit unit:A ;
-  ] ;
-  qudt:hasFactorUnit [
     qudt:exponent 1 ;
     qudt:hasUnit unit:W ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent -1 ;
+    qudt:hasUnit unit:A ;
   ] ;
   qudt:hasQuantityKind quantitykind:ElectricPotential ;
   qudt:hasQuantityKind quantitykind:ElectricPotentialDifference ;
@@ -64735,16 +64755,6 @@ unit:W-SEC-PER-M2
   rdfs:label "Βατ Δευτερόλεπτο ανά Τετραγωνικό Μέτρο"@el ;
   rdfs:label "Ват Секунда на Квадратен Метър"@bg ;
   rdfs:label "Ватт Секунда на Квадратный Метр"@ru .
-
-unit:W0dot
-  a qudt:ContextualUnit, qudt:Unit ;
-  qudt:conversionMultiplier 0.0 ;
-  qudt:conversionMultiplierSN 0.0E0 ;
-  qudt:hasDimensionVector qkdv:NotApplicable ;
-  qudt:hasQuantityKind quantitykind:Unknown ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
-  rdfs:label "Placeholder" ;
-  rdfs:label "Placeholder"@en .
 
 unit:WB
   a qudt:DerivedUnit, qudt:Unit ;


### PR DESCRIPTION
@mgberg, this should address your Issue #1354. Please let me know if not. It basically doesn't touch any such units in src, and just copies them over to dist. Eventually we will need to generalize our code to decimals, but SPARQL isn't great at the math.