### PR TITLE
Fix unit:MicroS-PER-M and unit:MicroM-PER-SEC2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
 ### Fixed
 
 - Tracked down and fixed errors in the OWL schema that were causing problems in Protege
+- Fixed the `qudt:hasQuantityKind` of `unit:MicroS-PER-M`
+- Fixed the `rdfs:isDefinedBy` of `unit:MicroM-PER-SEC2`
 
 ## [3.1.11] - 2026-02-19
 

--- a/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
+++ b/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
@@ -39748,7 +39748,7 @@ unit:MicroM-PER-SEC2
   qudt:plainTextDescription "Micro metres measured per second squared" ;
   qudt:symbol "μm/s²" ;
   qudt:ucumCode "um.s-2"^^qudt:UCUMcs ;
-  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Micrometer na Kvadratni Sekunda"@sl ;
   rdfs:label "Micrometer per Saat Persegi"@ms ;
   rdfs:label "Micrometer per Square Second"@en-US ;
@@ -40545,7 +40545,7 @@ unit:MicroS-PER-M
   qudt:conversionMultiplier 0.000001 ;
   qudt:conversionMultiplierSN 1.0E-6 ;
   qudt:hasDimensionVector qkdv:A0E2L-3I0M-1H0T3D0 ;
-  qudt:hasQuantityKind quantitykind:EletricConductivity ;
+  qudt:hasQuantityKind quantitykind:ElectricConductivity ;
   qudt:iec61360Code "0112/2///62720#UAA076" ;
   qudt:plainTextDescription "0.000001-fold of the SI derived unit Siemens divided by the SI base unit metre" ;
   qudt:symbol "μS/m" ;


### PR DESCRIPTION
- Fixes the `qudt:hasQuantityKind` of `unit:MicroS-PER-M`
- Fixes the `rdfs:isDefinedBy` of `unit:MicroM-PER-SEC2`