### PR TITLE
Adding unit:PicoCI, unit:PicoCI-PER-L, unit:GRAIN_AIR

### DIFF
--- a/src/main/rdf/schema/shacl/SCHEMA_QUDT_NoOWL.ttl
+++ b/src/main/rdf/schema/shacl/SCHEMA_QUDT_NoOWL.ttl
@@ -106,6 +106,7 @@ qudt:Concept
   sh:property qudt:Concept-abbreviation ;
   sh:property qudt:Concept-code ;
   sh:property qudt:Concept-deprecated ;
+  sh:property qudt:Concept-deprecatedInVersion ;
   sh:property qudt:Concept-description ;
   sh:property qudt:Concept-exactMatch ;
   sh:property qudt:Concept-guidance ;
@@ -1161,6 +1162,12 @@ qudt:deprecated
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/qudt> ;
   rdfs:label "deprecated" .
 
+qudt:deprecatedInVersion
+  a rdf:Property ;
+  dcterms:description "Version number of the first QUDT release in which an entity was deprecated."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/qudt> ;
+  rdfs:label "deprecated in version" .
+
 qudt:derivedCoherentUnitOfSystem
   a rdf:Property ;
   dcterms:description "This property relates a unit of measure to the unit system in which the unit is derived from the system's base units with a proportionality constant of one."^^rdf:HTML ;
@@ -1946,6 +1953,14 @@ qudt:Concept-deprecated
   sh:datatype xsd:boolean ;
   sh:maxCount 1 ;
   sh:path qudt:deprecated .
+
+qudt:Concept-deprecatedInVersion
+  a sh:PropertyShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/qudt> ;
+  sh:datatype xsd:string ;
+  sh:maxCount 1 ;
+  sh:path qudt:deprecatedInVersion ;
+  sh:pattern "^\\d+\\.\\d+\\.\\d+$" .
 
 qudt:Concept-description
   a sh:PropertyShape ;

--- a/src/main/rdf/vocab/currency/VOCAB_QUDT-UNITS-CURRENCY.ttl
+++ b/src/main/rdf/vocab/currency/VOCAB_QUDT-UNITS-CURRENCY.ttl
@@ -29,6 +29,7 @@ cur:AED
   qudt:currencyNumber "784" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/United_Arab_Emirates_dirham"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$AED$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -45,6 +46,7 @@ cur:AFN
   qudt:currencyNumber "971" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Afghani"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Afghani?oldid=485904590"^^xsd:anyURI ;
@@ -59,6 +61,7 @@ cur:ALL
   qudt:currencyNumber "008" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Lek"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$ALL$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -75,6 +78,7 @@ cur:AMD
   qudt:currencyNumber "051" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Armenian_dram"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Armenian_dram?oldid=492709723"^^xsd:anyURI ;
@@ -90,6 +94,7 @@ cur:ANG
   qudt:currencyNumber "532" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Netherlands_Antillean_guilder"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$ANG$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -105,6 +110,7 @@ cur:AOA
   qudt:currencyNumber "973" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Angolan_kwanza"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$AOA$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -120,6 +126,7 @@ cur:ARS
   qudt:currencyNumber "032" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Argentine_peso"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Argentine_peso?oldid=491431588"^^xsd:anyURI ;
@@ -134,6 +141,7 @@ cur:AUD
   qudt:currencyNumber "036" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Australian_dollar"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Australian_dollar?oldid=495046408"^^xsd:anyURI ;
@@ -150,6 +158,7 @@ cur:AWG
   qudt:currencyNumber "533" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Aruban_florin"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Aruban_florin?oldid=492925638"^^xsd:anyURI ;
@@ -164,6 +173,7 @@ cur:AZN
   qudt:currencyNumber "944" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Azerbaijani_manat"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Azerbaijani_manat?oldid=495479090"^^xsd:anyURI ;
@@ -178,6 +188,7 @@ cur:BAM
   qudt:currencyExponent 2 ;
   qudt:currencyNumber "977" ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$BAM$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -193,6 +204,7 @@ cur:BBD
   qudt:currencyNumber "052" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Barbadian_dollar"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Barbadian_dollar?oldid=494388633"^^xsd:anyURI ;
@@ -207,6 +219,7 @@ cur:BDT
   qudt:currencyNumber "050" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Bangladeshi_taka"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Bangladeshi_taka?oldid=492673895"^^xsd:anyURI ;
@@ -221,6 +234,7 @@ cur:BGN
   qudt:currencyNumber "975" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Bulgarian_lev"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$BGN$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -237,6 +251,7 @@ cur:BHD
   qudt:currencyNumber "048" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Bahraini_dinar"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Bahraini_dinar?oldid=493086643"^^xsd:anyURI ;
@@ -251,6 +266,7 @@ cur:BIF
   qudt:currencyNumber "108" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Burundian_franc"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$BIF$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -266,6 +282,7 @@ cur:BMD
   qudt:currencyNumber "060" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Bermudian_dollar"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$BMD$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -281,6 +298,7 @@ cur:BND
   qudt:currencyNumber "096" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Brunei_dollar"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$BND$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -296,6 +314,7 @@ cur:BOB
   qudt:currencyNumber "068" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Bolivian_boliviano"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$BOB$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -310,6 +329,7 @@ cur:BOV
   qudt:currencyExponent 2 ;
   qudt:currencyNumber "984" ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$BOV$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -324,6 +344,7 @@ cur:BRL
   qudt:currencyNumber "986" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Brazilian_real"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$BRL$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -341,6 +362,7 @@ cur:BSD
   qudt:currencyNumber "044" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Bahamian_dollar"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Bahamian_dollar?oldid=492776024"^^xsd:anyURI ;
@@ -355,6 +377,7 @@ cur:BTN
   qudt:currencyNumber "064" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Bhutanese_ngultrum"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$BTN$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -370,6 +393,7 @@ cur:BWP
   qudt:currencyNumber "072" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Pula"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$BWP$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -385,6 +409,7 @@ cur:BYN
   qudt:currencyNumber "933" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Belarusian_ruble"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Belarusian_ruble?oldid=494143246"^^xsd:anyURI ;
@@ -400,6 +425,7 @@ cur:BZD
   qudt:currencyNumber "084" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Belize_dollar"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$BZD$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -415,6 +441,7 @@ cur:CAD
   qudt:currencyNumber "124" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Canadian_dollar"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Canadian_dollar?oldid=494738466"^^xsd:anyURI ;
@@ -431,6 +458,7 @@ cur:CDF
   qudt:currencyNumber "976" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Congolese_franc"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$CDF$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -445,6 +473,7 @@ cur:CHE
   qudt:currencyExponent 2 ;
   qudt:currencyNumber "947" ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$CHE$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -459,6 +488,7 @@ cur:CHF
   qudt:currencyNumber "756" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Swiss_franc"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$CHF$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -475,6 +505,7 @@ cur:CHW
   qudt:currencyExponent 2 ;
   qudt:currencyNumber "948" ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$CHW$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -488,6 +519,7 @@ cur:CLF
   qudt:currencyExponent 0 ;
   qudt:currencyNumber "990" ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$CLF$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -502,6 +534,7 @@ cur:CLP
   qudt:currencyNumber "152" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Chilean_peso"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$CLP$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -518,6 +551,7 @@ cur:CNY
   qudt:currencyNumber "156" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Renminbi"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$CNY$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -534,6 +568,7 @@ cur:COP
   qudt:currencyNumber "170" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Colombian_peso"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$COP$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -549,6 +584,7 @@ cur:COU
   qudt:currencyExponent 2 ;
   qudt:currencyNumber "970" ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$COU$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -563,6 +599,7 @@ cur:CRC
   qudt:currencyNumber "188" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Costa_Rican_col%C3%B3n"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$CRC$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -578,6 +615,7 @@ cur:CUP
   qudt:currencyNumber "192" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Cuban_peso"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$CUP$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -593,6 +631,7 @@ cur:CVE
   qudt:currencyNumber "132" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Cape_Verdean_escudo"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$CVE$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -608,6 +647,7 @@ cur:CYP
   qudt:currencyNumber "196" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Cypriot_pound"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$CYP$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -623,6 +663,7 @@ cur:CZK
   qudt:currencyNumber "203" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Czech_koruna"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$CZK$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -639,6 +680,7 @@ cur:DJF
   qudt:currencyNumber "262" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Djiboutian_franc"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$DJF$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -654,6 +696,7 @@ cur:DKK
   qudt:currencyNumber "208" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Danish_krone"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$DKK$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -670,6 +713,7 @@ cur:DOP
   qudt:currencyNumber "214" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Dominican_peso"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$DOP$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -685,6 +729,7 @@ cur:DZD
   qudt:currencyNumber "012" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Algerian_dinar"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Algerian_dinar?oldid=492845503"^^xsd:anyURI ;
@@ -699,6 +744,7 @@ cur:EEK
   qudt:currencyNumber "233" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Estonian_kroon"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$EEK$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -714,6 +760,7 @@ cur:EGP
   qudt:currencyNumber "818" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Egyptian_pound"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$EGP$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -729,6 +776,7 @@ cur:ERN
   qudt:currencyNumber "232" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Nakfa"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$ERN$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -744,6 +792,7 @@ cur:ETB
   qudt:currencyNumber "230" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Ethiopian_birr"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$ETB$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -759,6 +808,7 @@ cur:EUR
   qudt:currencyNumber "978" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Euro"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$EUR$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -776,6 +826,7 @@ cur:FJD
   qudt:currencyNumber "242" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Fijian_dollar"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$FJD$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -791,6 +842,7 @@ cur:FKP
   qudt:currencyNumber "238" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Falkland_Islands_pound"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$FKP$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -806,6 +858,7 @@ cur:GBP
   qudt:currencyNumber "826" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Pound_sterling"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$GBP$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -823,6 +876,7 @@ cur:GEL
   qudt:currencyNumber "981" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Lari"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$GEL$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -839,6 +893,7 @@ cur:GHS
   qudt:currencyNumber "936" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Ghanaian_cedi"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$GHS$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -854,6 +909,7 @@ cur:GIP
   qudt:currencyNumber "292" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Gibraltar_pound"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$GIP$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -869,6 +925,7 @@ cur:GMD
   qudt:currencyNumber "270" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Gambian_dalasi"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$GMD$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -884,6 +941,7 @@ cur:GNF
   qudt:currencyNumber "324" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Guinean_franc"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$GNF$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -899,6 +957,7 @@ cur:GTQ
   qudt:currencyNumber "320" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Quetzal"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$GTQ$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -914,6 +973,7 @@ cur:GYD
   qudt:currencyNumber "328" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Guyanese_dollar"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$GYD$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -929,6 +989,7 @@ cur:HKD
   qudt:currencyNumber "344" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Hong_Kong_dollar"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$HKD$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -946,6 +1007,7 @@ cur:HNL
   qudt:currencyNumber "340" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Lempira"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$HNL$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -961,6 +1023,7 @@ cur:HRK
   qudt:currencyNumber "191" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Croatian_kuna"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$HRK$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -976,6 +1039,7 @@ cur:HTG
   qudt:currencyNumber "332" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Haitian_gourde"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$HTG$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -991,6 +1055,7 @@ cur:HUF
   qudt:currencyNumber "348" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Hungarian_forint"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$HUF$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1007,6 +1072,7 @@ cur:IDR
   qudt:currencyNumber "360" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Indonesian_rupiah"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$IDR$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1023,6 +1089,7 @@ cur:ILS
   qudt:currencyNumber "376" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Israeli_new_sheqel"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$ILS$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1039,6 +1106,7 @@ cur:INR
   qudt:currencyNumber "356" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Indian_rupee"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$INR$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1056,6 +1124,7 @@ cur:IQD
   qudt:currencyNumber "368" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Iraqi_dinar"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$IQD$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1071,6 +1140,7 @@ cur:IRR
   qudt:currencyNumber "364" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Iranian_rial"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$IRR$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1086,6 +1156,7 @@ cur:ISK
   qudt:currencyNumber "352" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Icelandic_kr%C3%B3na"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$ISK$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1102,6 +1173,7 @@ cur:JMD
   qudt:currencyNumber "388" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Jamaican_dollar"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$JMD$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1117,6 +1189,7 @@ cur:JOD
   qudt:currencyNumber "400" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Jordanian_dinar"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$JOD$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1132,6 +1205,7 @@ cur:JPY
   qudt:currencyNumber "392" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Japanese_yen"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$JPY$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1149,6 +1223,7 @@ cur:KES
   qudt:currencyNumber "404" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Kenyan_shilling"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$KES$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1164,6 +1239,7 @@ cur:KGS
   qudt:currencyNumber "417" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Som"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$KGS$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1179,6 +1255,7 @@ cur:KHR
   qudt:currencyNumber "116" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Riel"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$KHR$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1194,6 +1271,7 @@ cur:KMF
   qudt:currencyNumber "174" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Comorian_franc"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$KMF$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1209,6 +1287,7 @@ cur:KPW
   qudt:currencyNumber "408" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/North_Korean_won"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$KPW$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1224,6 +1303,7 @@ cur:KRW
   qudt:currencyNumber "410" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/South_Korean_won"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$KRW$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1241,6 +1321,7 @@ cur:KWD
   qudt:currencyNumber "414" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Kuwaiti_dinar"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$KWD$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1256,6 +1337,7 @@ cur:KYD
   qudt:currencyNumber "136" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Cayman_Islands_dollar"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$KYD$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1271,6 +1353,7 @@ cur:KZT
   qudt:currencyNumber "398" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Kazakhstani_tenge"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$KZT$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1285,6 +1368,7 @@ cur:LAK
   qudt:currencyExponent 0 ;
   qudt:currencyNumber "418" ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
   qudt:symbol " ₭" ;
@@ -1299,6 +1383,7 @@ cur:LBP
   qudt:currencyNumber "422" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Lebanese_pound"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$LBP$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1314,6 +1399,7 @@ cur:LKR
   qudt:currencyNumber "144" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Sri_Lankan_rupee"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$LKR$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1329,6 +1415,7 @@ cur:LRD
   qudt:currencyNumber "430" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Liberian_dollar"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$LRD$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1344,6 +1431,7 @@ cur:LSL
   qudt:currencyNumber "426" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Loti"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$LSL$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1359,6 +1447,7 @@ cur:LTL
   qudt:currencyNumber "440" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Lithuanian_litas"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$LTL$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1374,6 +1463,7 @@ cur:LVL
   qudt:currencyNumber "428" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Latvian_lats"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$LVL$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1389,6 +1479,7 @@ cur:LYD
   qudt:currencyNumber "434" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Libyan_dinar"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$LYD$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1404,6 +1495,7 @@ cur:MAD
   qudt:currencyNumber "504" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Moroccan_dirham"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$MAD$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1419,6 +1511,7 @@ cur:MDL
   qudt:currencyNumber "498" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Moldovan_leu"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$MDL$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1435,6 +1528,7 @@ cur:MGA
   qudt:currencyNumber "969" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Malagasy_ariary"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$MGA$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1450,6 +1544,7 @@ cur:MKD
   qudt:currencyNumber "807" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Macedonian_denar"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$MKD$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1466,6 +1561,7 @@ cur:MMK
   qudt:currencyNumber "104" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Myanma_kyat"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$MMK$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1479,6 +1575,7 @@ cur:MNT
   qudt:currencyExponent 2 ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Mongolian_t%C3%B6gr%C3%B6g"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Mongolian_tögrög?oldid=495408271"^^xsd:anyURI ;
@@ -1493,6 +1590,7 @@ cur:MOP
   qudt:currencyNumber "446" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Pataca"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$MOP$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1508,6 +1606,7 @@ cur:MRU
   qudt:currencyNumber "929" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Mauritanian_ouguiya"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$MRO$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1522,6 +1621,7 @@ cur:MTL
   qudt:currencyNumber "470" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Maltese_lira"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$MTL$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1537,6 +1637,7 @@ cur:MUR
   qudt:currencyNumber "480" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Mauritian_rupee"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$MUR$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1552,6 +1653,7 @@ cur:MVR
   qudt:currencyNumber "462" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Maldivian_rufiyaa"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$MVR$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1566,6 +1668,7 @@ cur:MWK
   qudt:currencyExponent 2 ;
   qudt:currencyNumber "454" ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$MWK$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1580,6 +1683,7 @@ cur:MXN
   qudt:currencyNumber "484" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Mexican_peso"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$MXN$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1596,6 +1700,7 @@ cur:MXV
   qudt:currencyExponent 2 ;
   qudt:currencyNumber "979" ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$MXV$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1610,6 +1715,7 @@ cur:MYR
   qudt:currencyNumber "458" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Malaysian_ringgit"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$MYR$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1626,6 +1732,7 @@ cur:MZN
   qudt:currencyNumber "943" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Mozambican_metical"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$MZN$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1648,6 +1755,7 @@ cur:NAD
   qudt:currencyNumber "516" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Namibian_dollar"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$NAD$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1663,6 +1771,7 @@ cur:NGN
   qudt:currencyNumber "566" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Nigerian_naira"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$NGN$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1678,6 +1787,7 @@ cur:NIO
   qudt:currencyNumber "558" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Nicaraguan_c%C3%B3rdoba"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$NIO$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1693,6 +1803,7 @@ cur:NOK
   qudt:currencyNumber "578" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Norwegian_krone"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$NOK$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1710,6 +1821,7 @@ cur:NPR
   qudt:currencyNumber "524" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Nepalese_rupee"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$NPR$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1725,6 +1837,7 @@ cur:NZD
   qudt:currencyNumber "554" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/New_Zealand_dollar"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$NZD$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1742,6 +1855,7 @@ cur:OMR
   qudt:currencyNumber "512" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Omani_rial"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$OMR$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1757,6 +1871,7 @@ cur:PAB
   qudt:currencyNumber "590" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Balboa"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Balboa?oldid=482550791"^^xsd:anyURI ;
@@ -1771,6 +1886,7 @@ cur:PEN
   qudt:currencyNumber "604" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Peruvian_nuevo_sol"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$PEN$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1786,6 +1902,7 @@ cur:PGK
   qudt:currencyNumber "598" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Kina"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$PGK$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1801,6 +1918,7 @@ cur:PHP
   qudt:currencyNumber "608" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Philippine_peso"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$PHP$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1817,6 +1935,7 @@ cur:PKR
   qudt:currencyNumber "586" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Pakistani_rupee"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$PKR$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1832,6 +1951,7 @@ cur:PLN
   qudt:currencyNumber "985" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Polish_z%C5%82oty"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$PLN$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1848,6 +1968,7 @@ cur:PYG
   qudt:currencyNumber "600" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Guaran%C3%AD"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$PYG$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1863,6 +1984,7 @@ cur:QAR
   qudt:currencyNumber "634" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Qatari_riyal"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$QAR$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1877,6 +1999,7 @@ cur:RON
   qudt:currencyExponent 2 ;
   qudt:currencyNumber "946" ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$RON$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1892,6 +2015,7 @@ cur:RSD
   qudt:currencyNumber "941" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Serbian_dinar"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$RSD$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1908,6 +2032,7 @@ cur:RUB
   qudt:currencyNumber "643" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Russian_ruble"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$RUB$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1924,6 +2049,7 @@ cur:RWF
   qudt:currencyNumber "646" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Rwandan_franc"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$RWF$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1939,6 +2065,7 @@ cur:SAR
   qudt:currencyNumber "682" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Saudi_riyal"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$SAR$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1955,6 +2082,7 @@ cur:SBD
   qudt:currencyNumber "090" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Solomon_Islands_dollar"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$SBD$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1970,6 +2098,7 @@ cur:SCR
   qudt:currencyNumber "690" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Seychellois_rupee"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$SCR$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -1985,6 +2114,7 @@ cur:SDG
   qudt:currencyNumber "938" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Sudanese_pound"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$SDG$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -2000,6 +2130,7 @@ cur:SEK
   qudt:currencyNumber "752" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Swedish_krona"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$SEK$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -2017,6 +2148,7 @@ cur:SGD
   qudt:currencyNumber "702" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Singapore_dollar"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$SGD$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -2034,6 +2166,7 @@ cur:SHP
   qudt:currencyNumber "654" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Saint_Helena_pound"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$SHP$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -2048,6 +2181,7 @@ cur:SKK
   qudt:currencyNumber "703" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Slovak_koruna"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$SKK$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -2064,6 +2198,7 @@ cur:SLE
   qudt:currencyNumber "925" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Sierra_Leonean_leone"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$SLL$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -2079,6 +2214,7 @@ cur:SOS
   qudt:currencyNumber "706" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Somali_shilling"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$SOS$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -2094,6 +2230,7 @@ cur:SRD
   qudt:currencyNumber "968" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Surinamese_dollar"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$SRD$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -2109,6 +2246,7 @@ cur:STN
   qudt:currencyNumber "930" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Dobra"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$STD$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -2124,6 +2262,7 @@ cur:SYP
   qudt:currencyNumber "760" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Syrian_pound"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$SYP$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -2139,6 +2278,7 @@ cur:SZL
   qudt:currencyNumber "748" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Swazi_lilangeni"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$SZL$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -2154,6 +2294,7 @@ cur:THB
   qudt:currencyNumber "764" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Thai_baht"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Thai_baht?oldid=493286022"^^xsd:anyURI ;
@@ -2169,6 +2310,7 @@ cur:TJS
   qudt:currencyNumber "972" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Tajikistani_somoni"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$TJS$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -2184,6 +2326,7 @@ cur:TMT
   qudt:currencyNumber "934" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Manat"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$TMM$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -2199,6 +2342,7 @@ cur:TND
   qudt:currencyNumber "788" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Tunisian_dinar"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$TND$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -2214,6 +2358,7 @@ cur:TOP
   qudt:currencyNumber "776" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Tongan_pa%CA%BBanga"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$TOP$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -2229,6 +2374,7 @@ cur:TRY
   qudt:currencyNumber "949" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Turkish_lira"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$TRY$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -2245,6 +2391,7 @@ cur:TTD
   qudt:currencyNumber "780" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Trinidad_and_Tobago_dollar"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$TTD$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -2260,6 +2407,7 @@ cur:TWD
   qudt:currencyNumber "901" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/New_Taiwan_dollar"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$TWD$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -2276,6 +2424,7 @@ cur:TZS
   qudt:currencyNumber "834" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Tanzanian_shilling"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$TZS$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -2291,6 +2440,7 @@ cur:UAH
   qudt:currencyNumber "980" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Ukrainian_hryvnia"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$UAH$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -2307,6 +2457,7 @@ cur:UGX
   qudt:currencyNumber "800" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Ugandan_shilling"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$UGX$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -2322,6 +2473,7 @@ cur:USD
   qudt:currencyExponent 2 ;
   qudt:currencyNumber "840" ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
   qudt:symbol "$" ;
@@ -2335,6 +2487,7 @@ cur:USN
   qudt:currencyExponent 2 ;
   qudt:currencyNumber "997" ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$USN$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -2348,6 +2501,7 @@ cur:USS
   qudt:currencyExponent 2 ;
   qudt:currencyNumber "998" ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/currency> ;
@@ -2361,6 +2515,7 @@ cur:UYU
   qudt:currencyNumber "858" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Uruguayan_peso"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$UYU$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -2376,6 +2531,7 @@ cur:UZS
   qudt:currencyNumber "860" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Uzbekistani_som"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$UZS$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -2390,6 +2546,7 @@ cur:VES
   qudt:currencyExponent 2 ;
   qudt:currencyNumber "928" ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$VEB$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -2403,6 +2560,7 @@ cur:VND
   qudt:currencyExponent 0 ;
   qudt:currencyNumber "704" ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$VND$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -2417,6 +2575,7 @@ cur:VUV
   qudt:currencyNumber "548" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Vanuatu_vatu"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$VUV$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -2432,6 +2591,7 @@ cur:WST
   qudt:currencyNumber "882" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Samoan_tala"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$WST$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -2446,6 +2606,7 @@ cur:XAF
   qudt:currencyExponent 0 ;
   qudt:currencyNumber "950" ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/currency> ;
@@ -2457,6 +2618,7 @@ cur:XAG
   qudt:currencyCode "XAG" ;
   qudt:currencyNumber "961" ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$XAG$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -2470,6 +2632,7 @@ cur:XAU
   qudt:currencyCode "XAU" ;
   qudt:currencyNumber "959" ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$XAU$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -2483,6 +2646,7 @@ cur:XBA
   qudt:currencyCode "XBA" ;
   qudt:currencyNumber "955" ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$XBA$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -2495,6 +2659,7 @@ cur:XBB
   qudt:currencyCode "XBB" ;
   qudt:currencyNumber "956" ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$XBB$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -2507,6 +2672,7 @@ cur:XBC
   qudt:currencyCode "XBC" ;
   qudt:currencyNumber "957" ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$XBC$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -2519,6 +2685,7 @@ cur:XBD
   qudt:currencyCode "XBD" ;
   qudt:currencyNumber "958" ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$XBD$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -2533,6 +2700,7 @@ cur:XCD
   qudt:currencyNumber "951" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/East_Caribbean_dollar"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$XCD$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -2547,6 +2715,7 @@ cur:XDR
   qudt:currencyNumber "960" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Special_Drawing_Rights"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$XDR$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -2559,6 +2728,7 @@ cur:XFO
   dcterms:isReplacedBy unit:CCY_XFO ;
   qudt:currencyCode "XFO" ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$XFO$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -2570,6 +2740,7 @@ cur:XFU
   dcterms:isReplacedBy unit:CCY_XFU ;
   qudt:currencyCode "XFU" ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$XFU$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -2583,6 +2754,7 @@ cur:XOF
   qudt:currencyExponent 0 ;
   qudt:currencyNumber "952" ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/currency> ;
@@ -2594,6 +2766,7 @@ cur:XPD
   qudt:currencyCode "XPD" ;
   qudt:currencyNumber "964" ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$XPD$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -2608,6 +2781,7 @@ cur:XPF
   qudt:currencyExponent 0 ;
   qudt:currencyNumber "953" ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/currency> ;
@@ -2619,6 +2793,7 @@ cur:XPT
   qudt:currencyCode "XPT" ;
   qudt:currencyNumber "962" ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$XPT$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -2634,6 +2809,7 @@ cur:YER
   qudt:currencyNumber "886" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Yemeni_rial"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$YER$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -2649,6 +2825,7 @@ cur:ZAR
   qudt:currencyNumber "710" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/South_African_rand"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$ZAR$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -2666,6 +2843,7 @@ cur:ZMW
   qudt:currencyNumber "967" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Zambian_kwacha"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$ZMK$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;
@@ -2681,6 +2859,7 @@ cur:ZWL
   qudt:currencyNumber "932" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Zimbabwean_dollar"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$ZWD$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Currency ;

--- a/src/main/rdf/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL.ttl
+++ b/src/main/rdf/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL.ttl
@@ -1016,6 +1016,7 @@ quantitykind:AreicChargeDensityOrElectricFluxDensityOrElectricPolarization
   a qudt:QuantityKind ;
   dcterms:description "charge Q presented on an area of size A divided by the area A or vector quantity obtained at a given point by adding the electric polarization P to the product of the electric field strength E and the electric constant (permittivity) ε₀"@en ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.4" ;
   qudt:hasDimensionVector qkdv:A0E1L-2I0M0H0T1D0 ;
   qudt:plainTextDescription "auf einer Fläche mit dem Flächeninhalt A vorhandenen Ladung Q dividiert durch den Flächeninhalt A oder vektorielle Größe, die für einen gegebenen Punkt gleich der Summe der elektrischen Polarisation P und des Produkts aus der elektrischen Feldstärke E und der elektrischen Feldkonstante (Permittivität) ε₀ ist oder räumliche Dichte des elektrischen Moments molekularer Dipole"@de ;
   qudt:symbol "0173-1#Z4-BAJ320#002" ;
@@ -1490,6 +1491,7 @@ quantitykind:BloodGlucoseLevel_Mass
   """^^qudt:LatexString ;
   dcterms:isReplacedBy quantitykind:MassBasedBloodGlucoseLevel ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.3" ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H0T0D0 ;
   qudt:informativeReference "http://www.faqs.org/faqs/diabetes/faq/part1/section-9.html"^^xsd:anyURI ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Blood_sugar_level"^^xsd:anyURI ;
@@ -1651,6 +1653,7 @@ quantitykind:CENTER-OF-GRAVITY_X
   a qudt:QuantityKind ;
   dcterms:isReplacedBy quantitykind:CenterOfGravity_X ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.3" ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T0D0 ;
   qudt:informativeReference "https://www1.grc.nasa.gov/beginners-guide-to-aeronautics/center-of-gravity/"^^xsd:anyURI ;
   qudt:symbol "cg" ;
@@ -1662,6 +1665,7 @@ quantitykind:CENTER-OF-GRAVITY_Y
   a qudt:QuantityKind ;
   dcterms:isReplacedBy quantitykind:CenterOfGravity_Y ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.3" ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T0D0 ;
   qudt:informativeReference "https://www1.grc.nasa.gov/beginners-guide-to-aeronautics/center-of-gravity/"^^xsd:anyURI ;
   qudt:symbol "cg" ;
@@ -1673,6 +1677,7 @@ quantitykind:CENTER-OF-GRAVITY_Z
   a qudt:QuantityKind ;
   dcterms:isReplacedBy quantitykind:CenterOfGravity_Z ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.3" ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T0D0 ;
   qudt:informativeReference "https://www1.grc.nasa.gov/beginners-guide-to-aeronautics/center-of-gravity/"^^xsd:anyURI ;
   qudt:symbol "cg" ;
@@ -2172,6 +2177,7 @@ quantitykind:ComplexPower
   """^^qudt:LatexString ;
   dcterms:isReplacedBy quantitykind:ElectricPower ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.1" ;
   qudt:expression "$complex-power$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:informativeReference "http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=131-11-39"^^xsd:anyURI ;
@@ -2280,6 +2286,7 @@ quantitykind:Conductivity
   """^^qudt:LatexString ;
   dcterms:isReplacedBy quantitykind:ElectricConductivity ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.11" ;
   qudt:hasDimensionVector qkdv:A0E2L-3I0M-1H0T3D0 ;
   qudt:iec61360Code "0112/2///62720#UAD025" ;
   qudt:informativeReference "http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=121-12-03"^^xsd:anyURI ;
@@ -2307,6 +2314,7 @@ quantitykind:ConductivityVariance_NEON
   dcterms:description "Variance for NEON conductivity data measured in MicroS-PER-CM" ;
   dcterms:isReplacedBy quantitykind:ConductivityVariance ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.3" ;
   qudt:hasDimensionVector qkdv:A0E4L-6I0M-2H0T6D0 ;
   qudt:informativeReference "https://www.neonscience.org/data-samples/data-management/data-processing"^^xsd:anyURI ;
   qudt:plainTextDescription "Variance for NEON conductivity data measured in MicroS-PER-CM" ;
@@ -2779,6 +2787,7 @@ quantitykind:DensityOfStates
   dcterms:description "\"Density of States\" is the number of vibrational modes in an infinitesimal interval of angular frequency divided by the range of that interval and by volume."^^qudt:LatexString ;
   dcterms:isReplacedBy quantitykind:VibrationalDensityOfStates ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.5" ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M0H0T1D0 ;
   qudt:iec61360Code "0112/2///62720#UAD030" ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Density_of_states"^^xsd:anyURI ;
@@ -3683,6 +3692,7 @@ quantitykind:ElectricDipoleMoment_CubicPerEnergy_Squared
   a qudt:QuantityKind ;
   dcterms:isReplacedBy quantitykind:CubicElectricDipoleMomentPerSquareEnergy ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.3" ;
   qudt:hasDimensionVector qkdv:A0E3L-3I0M-2H0T7D0 ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Cubic Electric Dipole Moment per Square Energy"@en .
@@ -3691,6 +3701,7 @@ quantitykind:ElectricDipoleMoment_QuarticPerEnergy_Cubic
   a qudt:QuantityKind ;
   dcterms:isReplacedBy quantitykind:QuarticElectricDipoleMomentPerCubicEnergy ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.3" ;
   qudt:hasDimensionVector qkdv:A0E4L-2I0M-3H0T10D0 ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Quartic Electric Dipole Moment per Cubic Energy"@en .
@@ -4534,6 +4545,7 @@ quantitykind:EnergyPerMagneticFluxDensity_Squared
   dcterms:description "\"Energy Per Square Magnetic Flux Density\" is a measure of energy for a unit of magnetic flux density."^^qudt:LatexString ;
   dcterms:isReplacedBy quantitykind:EnergyPerSquareMagneticFluxDensity ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.3" ;
   qudt:hasDimensionVector qkdv:A0E2L2I0M-1H0T2D0 ;
   qudt:plainTextDescription "\"Energy Per Square Magnetic Flux Density\" is a measure of energy for a unit of magnetic flux density." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
@@ -4563,6 +4575,7 @@ quantitykind:Energy_Squared
   a qudt:QuantityKind ;
   dcterms:isReplacedBy quantitykind:SquareEnergy ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.3" ;
   qudt:hasDimensionVector qkdv:A0E0L4I0M2H0T-4D0 ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Square Energy"@en .
@@ -4758,6 +4771,7 @@ quantitykind:Equivalent_Mass
 another substance in a given chemical reaction."""^^rdf:HTML ;
   dcterms:isReplacedBy quantitykind:MassEquivalent ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.3" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T0D0 ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Mass Equivalent" ;
@@ -4769,6 +4783,7 @@ quantitykind:Equivalent_Molar
 another substance in a given chemical reaction."""^^rdf:HTML ;
   dcterms:isReplacedBy quantitykind:MolarEquivalent ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.3" ;
   qudt:hasDimensionVector qkdv:A1E0L0I0M0H0T0D0 ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Equivalent_(chemistry)"^^xsd:anyURI ;
   qudt:symbol "equiv" ;
@@ -5022,6 +5037,7 @@ quantitykind:FermiTemperature
 quantitykind:FinalOrCurrentVehicleMass
   a qudt:QuantityKind ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.4" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:symbol "M" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
@@ -5560,6 +5576,7 @@ API gravity is thus an inverse measure of a petroleum liquid's density relative 
   dcterms:isReplacedBy quantitykind:APIGravity ;
   qudt:baseSIUnitDimensions "$qkdv:A0E0L0I0M0H0T0D1$"^^qudt:LatexString ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.3" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/API_gravity"^^xsd:anyURI ;
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
@@ -5601,6 +5618,7 @@ quantitykind:GrowingDegreeDay_Cereal
   dcterms:description "The sum of excess temperature over 5.5°C, where the temperature is the mean of the minimum and maximum atmospheric temperature in a day. This measure is appropriate for most cereal crops."^^qudt:LatexString ;
   dcterms:isReplacedBy quantitykind:GrowingDegreeDay ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.3" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H1T1D0 ;
   qudt:plainTextDescription "The sum of excess temperature over 5.5°C, where the temperature is the mean of the minimum and maximum atmospheric temperature in a day. This measure is appropriate for most cereal crops." ;
   rdfs:isDefinedBy <https://data.agrimetrics.co.uk/ontologies/qudt-extension> ;
@@ -6337,6 +6355,7 @@ quantitykind:InverseEnergy_Squared
   a qudt:QuantityKind ;
   dcterms:isReplacedBy quantitykind:InverseSquareEnergy ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.3" ;
   qudt:hasDimensionVector qkdv:A0E0L-4I0M-2H0T4D0 ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Inverse Square Energy"@en .
@@ -6374,6 +6393,7 @@ quantitykind:InverseMass_Squared
   a qudt:QuantityKind ;
   dcterms:isReplacedBy quantitykind:InverseSquareMass ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.3" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M-2H0T0D0 ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Inverse Square Mass"@en .
@@ -6433,6 +6453,7 @@ quantitykind:InverseTime_Squared
   a qudt:QuantityKind ;
   dcterms:isReplacedBy quantitykind:InverseSquareTime ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.3" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-2D0 ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Inverse Square Time"@en .
@@ -6708,6 +6729,7 @@ quantitykind:KinematicViscosityOrDiffusionConstantOrThermalDiffusivity
   a qudt:QuantityKind ;
   dcterms:description "ratio of the dynamic viscosity and the density of a material measured at the same temperature, or ratio of the diffusion current density and carrier density gradient, or ratio of thermal conductivity divided by heat capacity"@en ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.4" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-1D0 ;
   qudt:plainTextDescription "Quotient aus der dynamischen Viskosität und der Dichte eines Stoffes oder Quotient Diffusionsstromdichte durch Gradient der Ladungsträgerdichte oder Quotient Wärmeleitfähigkeit durch Wärmekapazität"@de ;
   qudt:symbol "0173-1#Z4-BAJ328#002" ;
@@ -6734,6 +6756,7 @@ quantitykind:KineticOrThermalEnergy
   a qudt:QuantityKind ;
   dcterms:description "energy presented in the movement of a body, composed of translation and rotation energies, determined by the movement of this body compared to another system and by its mass (mass distribution) or energy in the terms of heat"@en ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.4" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:plainTextDescription "Energie, die in der Bewegung eines Körpers steckt und sich aus Translationsenergie und Rotationsenergie zusammen setzt, die durch die Bewegung dieses Körpers gegenüber einem anderen System und durch seine Masse (Massenverteilung) bestimmt wird oder Energie in Form von Wärme"@de ;
   qudt:symbol "0173-1#Z4-BAJ280#002" ;
@@ -7435,6 +7458,7 @@ quantitykind:LogarithmicMedianInformationFlow_SourceToBase10
   dcterms:description "ratio of the median information content divided by the expected value for the duration of a character, expressed as a logarithm to base 10"@en ;
   dcterms:isReplacedBy quantitykind:CommonLogarithmicMedianInformationFlow ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.3" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:plainTextDescription "Quotient mittlerer Informationsgehalt durch den Erwartungswert für die Dauer eines Zeichens, ausgedrückt als Logarithmus zur Basis 10"@de ;
   qudt:symbol "0173-1#Z4-BAJ470#001" ;
@@ -7446,6 +7470,7 @@ quantitykind:LogarithmicMedianInformationFlow_SourceToBase2
   dcterms:description "ratio of the median information content divided by the expected value for the duration of a character, expressed as a logarithm to base 2"@en ;
   dcterms:isReplacedBy quantitykind:BinaryLogarithmicMedianInformationFlow ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.3" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:plainTextDescription "Quotient mittlerer Informationsgehalt durch den Erwartungswert für die Dauer eines Zeichens, ausgedrückt als Logarithmus zur Basis 2"@de ;
   qudt:symbol "0173-1#Z4-BAJ464#001" ;
@@ -7457,6 +7482,7 @@ quantitykind:LogarithmicMedianInformationFlow_SourceToBaseE
   dcterms:description "ratio of the median information content divided by the expected value for the duration of a character, expressed as a logarithm to base e"@en ;
   dcterms:isReplacedBy quantitykind:NaturalLogarithmicMedianInformationFlow ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.3" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:plainTextDescription "Quotient mittlerer Informationsgehalt durch den Erwartungswert für die Dauer eines Zeichens, ausgedrückt als Logarithmus zur Basis e"@de ;
   qudt:symbol "0173-1#Z4-BAJ471#001" ;
@@ -7795,6 +7821,7 @@ quantitykind:MOMENT-OF-INERTIA_Y
   dcterms:description "The rotational inertia or resistance to change in direction or speed of rotation about a defined axis."^^qudt:LatexString ;
   dcterms:isReplacedBy quantitykind:MomentOfInertia_Y ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.3" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T0D0 ;
   qudt:plainTextDescription "The rotational inertia or resistance to change in direction or speed of rotation about a defined axis." ;
   qudt:symbol "I_{y}" ;
@@ -7808,6 +7835,7 @@ quantitykind:MOMENT-OF-INERTIA_Z
   dcterms:description "The rotational inertia or resistance to change in direction or speed of rotation about a defined axis."^^qudt:LatexString ;
   dcterms:isReplacedBy quantitykind:MomentOfInertia_Z ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.3" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T0D0 ;
   qudt:plainTextDescription "The rotational inertia or resistance to change in direction or speed of rotation about a defined axis." ;
   qudt:symbol "I_{z}" ;
@@ -7992,6 +8020,7 @@ quantitykind:MagneticFieldStrength_H
   dcterms:description "$\\textit{Magnetic Field Strength}$ is a vector quantity obtained at a given point by subtracting the magnetization $M$ from the magnetic flux density $B$ divided by the magnetic constant $\\mu_0$. The magnetic field strength is related to the total current density $J_{tot}$ via: $\\text{rot} H = J_{tot}$."^^qudt:LatexString ;
   dcterms:isReplacedBy quantitykind:MagneticFieldStrength ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.3" ;
   qudt:hasDimensionVector qkdv:A0E1L-1I0M0H0T0D0 ;
   qudt:iec61360Code "0112/2///62720#UAD098" ;
   qudt:informativeReference "http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=121-11-56"^^xsd:anyURI ;
@@ -8102,6 +8131,7 @@ quantitykind:MagneticFluxDensityOrMagneticPolarization
   dcterms:description "field vector B which exhibits a force F on any charged particle which has a velocity v, where the force is the product of the vector product v x B and the electric charge Q of the particle or vector quantity equal to the product of the magnetization M and the magnetic constant µ₀"@en ;
   dcterms:isReplacedBy quantitykind:MagneticFluxDensity ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.4" ;
   qudt:hasDimensionVector qkdv:A0E-1L0I0M1H0T-2D0 ;
   qudt:plainTextDescription "vektorielle Feldgröße B, die auf jedes geladene Teilchen, das eine Geschwindigkeit v hat, eine Kraft F ausübt, die gleich dem Produkt aus dem Vektorprodukt v x B und der elektrischen Ladung Q des Teilchens ist oder vektorielle Größe gleich dem Produkt aus der Magnetisierung M und der magnetischen Feldkonstante µ₀"@de ;
   qudt:symbol "0173-1#Z4-BAJ221#002" ;
@@ -9331,6 +9361,7 @@ quantitykind:MolarFluxDensityVariance_NEON
   dcterms:description "Variance for NEON Molar Flux Denisity data measured in unit:MicroMOL-PER-M2-SEC" ;
   dcterms:isReplacedBy quantitykind:MolarFluxDensityVariance ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.3" ;
   qudt:hasDimensionVector qkdv:A2E0L-4I0M0H0T-2D0 ;
   qudt:informativeReference "https://www.neonscience.org/data-samples/data-management/data-processing"^^xsd:anyURI ;
   qudt:plainTextDescription "Variance for NEON Molar Flux Denisity data measured in unit:MicroMOL-PER-M2-SEC" ;
@@ -10190,6 +10221,7 @@ quantitykind:PRODUCT-OF-INERTIA_X
   """^^qudt:LatexString ;
   dcterms:isReplacedBy quantitykind:ProductOfInertia_X ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.3" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T0D0 ;
   qudt:plainTextDescription "A measure of a body's dynamic (or coupled) imbalance resulting in a precession when rotating about an axis other than the body's principal axis." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
@@ -10205,6 +10237,7 @@ quantitykind:PRODUCT-OF-INERTIA_Y
   """^^qudt:LatexString ;
   dcterms:isReplacedBy quantitykind:ProductOfInertia_Y ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.3" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T0D0 ;
   qudt:plainTextDescription """
   The quantity kind 'Product of Inertia in the Y axis' is a measure of a body's 
@@ -10224,6 +10257,7 @@ quantitykind:PRODUCT-OF-INERTIA_Z
   """^^qudt:LatexString ;
   dcterms:isReplacedBy quantitykind:ProductOfInertia_Z ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.3" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T0D0 ;
   qudt:plainTextDescription "A measure of a body's dynamic (or coupled) imbalance resulting in a precession when rotating about an axis other than the body's principal axis." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
@@ -12578,6 +12612,7 @@ quantitykind:SerumLevel
 quantitykind:SerumOrPlasmaLevel
   a qudt:QuantityKind ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.4" ;
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T0D0 ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Serum or Plasma Level"@en ;
@@ -12784,6 +12819,7 @@ quantitykind:Solubility_Water
   dcterms:description "An amount of substance per unit volume that is the concentration of a saturated solution expressed as the ratio of the solute concentration over the volume of water.  A substance's solubility fundamentally depends on several physical and chemical properties of the solution as well as the environment it is in."^^qudt:LatexString ;
   dcterms:isReplacedBy quantitykind:WaterSolubility ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.3" ;
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T0D0 ;
   qudt:plainTextDescription "An amount of substance per unit volume that is the concentration of a saturated solution expressed as the ratio of the solute concentration over the volume of water.  A substance's solubility fundamentally depends on several physical and chemical properties of the solution as well as the environment it is in." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
@@ -14281,6 +14317,7 @@ quantitykind:TemperaturePerTime_Squared
   a qudt:QuantityKind ;
   dcterms:isReplacedBy quantitykind:TemperaturePerSquareTime ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.3" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H1T-2D0 ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Temperature per Time Squared"@en .
@@ -14337,6 +14374,7 @@ quantitykind:TemperatureVariance_NEON
   dcterms:description "Variance for NEON temperature data measured in degrees celcius" ;
   dcterms:isReplacedBy quantitykind:TemperatureVariance ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.3" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H2T0D0 ;
   qudt:informativeReference "https://www.neonscience.org/data-samples/data-management/data-processing"^^xsd:anyURI ;
   qudt:plainTextDescription "Variance for NEON temperature data measured in degrees celcius" ;
@@ -14834,6 +14872,7 @@ quantitykind:TimeConstant_Inductance
   a qudt:QuantityKind ;
   dcterms:isReplacedBy quantitykind:InductanceBasedTimeConstant ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.3" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T1D0 ;
   qudt:iec61360Code "0112/2///62720#UAD198" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
@@ -14876,6 +14915,7 @@ quantitykind:Time_Squared
   dcterms:isReplacedBy quantitykind:SquareTime ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Time_Squared"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.3" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T2D0 ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Time Squared"@en .
@@ -15226,6 +15266,7 @@ quantitykind:VaporPermeability
   dcterms:description "The moisture transmission rate of a material is referred to as its \"permeability\"."^^qudt:LatexString ;
   dcterms:isReplacedBy quantitykind:VapourPermeability ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.3" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T1D0 ;
   qudt:informativeReference "https://users.encs.concordia.ca/~raojw/crd/essay/essay000287.html"^^xsd:anyURI ;
   qudt:informativeReference "https://www.designingbuildings.co.uk/wiki/Vapour_Permeability"^^xsd:anyURI ;
@@ -15238,6 +15279,7 @@ quantitykind:VaporPermeance
   dcterms:description "A material's \"permeance\", is dependent on thickness much like the R-value in heat transmission. Dividing the permeability of a material by its thickness gives the material's permeance. Permeance is the number that should be used to compare various products in regard to moisture transmission resistance."^^qudt:LatexString ;
   dcterms:isReplacedBy quantitykind:VapourPermeance ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.3" ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T1D0 ;
   qudt:informativeReference "https://users.encs.concordia.ca/~raojw/crd/essay/essay000287.html"^^xsd:anyURI ;
   qudt:informativeReference "https://www.designingbuildings.co.uk/wiki/Vapour_Permeability"^^xsd:anyURI ;
@@ -15477,6 +15519,7 @@ quantitykind:VolumeFlowRate_SurfaceRelated
   a qudt:QuantityKind ;
   dcterms:isReplacedBy quantitykind:SurfaceRelatedVolumeFlowRate ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.3" ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T-1D0 ;
   qudt:iec61360Code "0112/2///62720#UAD183" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
@@ -15518,6 +15561,7 @@ quantitykind:VolumeOrSectionModulus
   a qudt:QuantityKind ;
   dcterms:description "domain completely enclosed by a surface, which can be determined for Cartesian coordinates by integration according to the following equation: V = ∫∫∫ dx dy dz or for a homogeneous material, it is the ratio of the moment of inertia and the distance to any point on the neutral axis at which the stress is to be calculated"@en ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.4" ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T0D0 ;
   qudt:plainTextDescription "der von einer Oberfläche eingeschlossene gesamte Rauminhalt, der für kartesische Koordinaten durch Integration nach folgender Gleichung ermittelt werden kann: V = ∫∫∫ dx dy dz oder bei einem homogenen Werkstoff Quotient Trägheitsmoment dividiert durch den Abstand zu einem Punkt auf der neutralen Achse, bei dem die Belastung berechnet werden soll"@de ;
   qudt:symbol "0173-1#Z4-BAJ251#002" ;

--- a/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
+++ b/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
@@ -32,6 +32,7 @@ unit:2PiRAD
   qudt:conversionMultiplier 0.0 ;
   qudt:conversionMultiplierSN 0.0E0 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.2" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Angle ;
   qudt:hasQuantityKind quantitykind:PlaneAngle ;
@@ -4837,6 +4838,7 @@ unit:CAL_15_DEG_C
   qudt:conversionMultiplier 4.18580 ;
   qudt:conversionMultiplierSN 4.18580E0 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.4" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:ThermalEnergy ;
   qudt:iec61360Code "0112/2///62720#UAB139" ;
@@ -8828,6 +8830,7 @@ unit:CHF-PER-KiloGM
   qudt:conversionMultiplier 1.0 ;
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.3" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M-1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:CostPerMass ;
   qudt:plainTextDescription "Unit for measuring the hardware cost of substance or material" ;
@@ -8896,6 +8899,7 @@ unit:CM_H2O
   qudt:conversionMultiplier 0.0 ;
   qudt:conversionMultiplierSN 0.0E0 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "2.1.26" ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Pressure ;
   qudt:scalingOf unit:PA ;
@@ -10635,6 +10639,7 @@ unit:Ci
   qudt:conversionMultiplierSN 3.7E10 ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Curie"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "2.1.46" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Activity ;
   qudt:iec61360Code "0112/2///62720#UAA138" ;
@@ -12287,6 +12292,7 @@ unit:Da
   qudt:conversionMultiplierSN 1.66053878283E-27 ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Dalton"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:exactMatch unit:AMU ;
   qudt:exactMatch unit:U ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T0D0 ;
@@ -12313,6 +12319,7 @@ unit:Debye
   qudt:conversionMultiplierSN 3.33564E-30 ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Debye"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E1L1I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:ElectricDipoleMoment ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Debye?oldid=492149112"^^xsd:anyURI ;
@@ -13398,6 +13405,7 @@ unit:Denier
   qudt:conversionMultiplierSN 1.1E-7 ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Denier"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:MassPerLength ;
   qudt:iec61360Code "0112/2///62720#UAB244" ;
@@ -14122,6 +14130,7 @@ unit:ExaV-A
   qudt:conversionMultiplier 1000000000000000000.0 ;
   qudt:conversionMultiplierSN 1.0E18 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:ApparentPower ;
   qudt:iec61360Code "0112/2///62720#UAB537" ;
@@ -15605,6 +15614,7 @@ unit:FUR_Long
   qudt:conversionMultiplier 0.0 ;
   qudt:conversionMultiplierSN 0.0E0 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.3" ;
   qudt:expression "$longfur$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Length ;
@@ -18699,6 +18709,7 @@ unit:Gamma
   qudt:conversionMultiplierSN 1.0E-9 ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Gamma"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E-1L0I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:MagneticField ;
   qudt:hasQuantityKind quantitykind:MagneticFluxDensity ;
@@ -19487,6 +19498,7 @@ unit:GigaV-A
   qudt:conversionMultiplier 1000000000.0 ;
   qudt:conversionMultiplierSN 1.0E9 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:ApparentPower ;
   qudt:iec61360Code "0112/2///62720#UAB534" ;
@@ -19513,6 +19525,7 @@ unit:GigaV-A_Reactive
   qudt:conversionMultiplier 0.0 ;
   qudt:conversionMultiplierSN 0.0E0 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:ReactivePower ;
   qudt:iec61360Code "0112/2///62720#UAC508" ;
@@ -19629,6 +19642,7 @@ unit:Gs
   qudt:conversionMultiplierSN 1.0E-4 ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Gauss_%28unit%29"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:derivedUnitOfSystem sou:CGS-EMU ;
   qudt:hasDimensionVector qkdv:A0E-1L0I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:MagneticFluxDensity ;
@@ -20434,6 +20448,7 @@ unit:HeartBeat
   qudt:conversionMultiplier 1.0 ;
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.8" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Dimensionless ;
   qudt:symbol "heartbeat" ;
@@ -20841,6 +20856,7 @@ unit:IN-PER-2PiRAD
   qudt:conversionMultiplier 0.0 ;
   qudt:conversionMultiplierSN 0.0E0 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.2" ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Rotary-TranslatoryMotionConversion ;
   qudt:iec61360Code "0112/2///62720#UAA727" ;
@@ -24251,6 +24267,7 @@ unit:KiloCi
   qudt:conversionMultiplier 37000000000000.0 ;
   qudt:conversionMultiplierSN 3.7E13 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.4" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Activity ;
   qudt:hasQuantityKind quantitykind:DecayConstant ;
@@ -28397,6 +28414,7 @@ unit:KiloV-A
   qudt:conversionMultiplier 1000.0 ;
   qudt:conversionMultiplierSN 1.0E3 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:ApparentPower ;
   qudt:iec61360Code "0112/2///62720#UAA581" ;
@@ -28429,6 +28447,7 @@ unit:KiloV-A-HR
   qudt:conversionMultiplier 3600000.0 ;
   qudt:conversionMultiplierSN 3.6E6 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Energy ;
   qudt:hasReciprocalUnit unit:PER-KiloVA-HR ;
@@ -28449,6 +28468,7 @@ unit:KiloV-A-PER-K
   qudt:conversionMultiplier 1000.0 ;
   qudt:conversionMultiplierSN 1.0E3 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H-1T-3D0 ;
   qudt:hasQuantityKind quantitykind:ThermalConductance ;
   qudt:iec61360Code "0112/2///62720#UAD908" ;
@@ -28475,6 +28495,7 @@ unit:KiloV-A_Reactive
   qudt:conversionMultiplier 1000.0 ;
   qudt:conversionMultiplierSN 1.0E3 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:ReactivePower ;
   qudt:iec61360Code "0112/2///62720#UAA648" ;
@@ -28494,6 +28515,7 @@ unit:KiloV-A_Reactive-HR
   qudt:conversionMultiplier 3600000.0 ;
   qudt:conversionMultiplierSN 3.6E6 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Energy ;
   qudt:iec61360Code "0112/2///62720#UAB195" ;
@@ -28512,6 +28534,7 @@ unit:KiloV-A_Reactive-PER-K
   qudt:conversionMultiplier 0.0 ;
   qudt:conversionMultiplierSN 0.0E0 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H-1T-3D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAD904" ;
@@ -30424,6 +30447,7 @@ unit:LB-PER-GAL
   qudt:definedUnitOfSystem sou:IMPERIAL ;
   qudt:definedUnitOfSystem sou:USCS ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.5" ;
   qudt:exactMatch unit:LB-PER-GAL_IMP ;
   qudt:exactMatch unit:LB-PER-GAL_UK ;
   qudt:expression "$lb/gal$"^^qudt:LatexString ;
@@ -34788,6 +34812,7 @@ unit:MIL
   qudt:conversionMultiplier 0.00098174770424681038701957605727484 ;
   qudt:conversionMultiplierSN 9.8174770424681038701957605727484E-4 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.7" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Angle ;
   qudt:hasQuantityKind quantitykind:PlaneAngle ;
@@ -36659,6 +36684,7 @@ unit:MegaDOLLAR_US-PER-FLIGHT
   qudt:conversionMultiplier 0.0 ;
   qudt:conversionMultiplierSN 0.0E0 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$M\\$/Flight$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:CurrencyPerFlight ;
@@ -38012,6 +38038,7 @@ unit:MegaV-A
   qudt:conversionMultiplier 1000000.0 ;
   qudt:conversionMultiplierSN 1.0E6 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:ApparentPower ;
   qudt:iec61360Code "0112/2///62720#UAA222" ;
@@ -38044,6 +38071,7 @@ unit:MegaV-A-HR
   qudt:conversionMultiplier 3600000000.0 ;
   qudt:conversionMultiplierSN 3.6E9 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Energy ;
   qudt:plainTextDescription "product of the 1,000,000-fold of the unit for apparent by ampere and the unit hour" ;
@@ -38060,6 +38088,7 @@ unit:MegaV-A_Reactive
   qudt:conversionMultiplier 1000000.0 ;
   qudt:conversionMultiplierSN 1.0E6 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:ReactivePower ;
   qudt:iec61360Code "0112/2///62720#UAB199" ;
@@ -38079,6 +38108,7 @@ unit:MegaV-A_Reactive-HR
   qudt:conversionMultiplier 3600000000.0 ;
   qudt:conversionMultiplierSN 3.6E9 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Energy ;
   qudt:iec61360Code "0112/2///62720#UAB198" ;
@@ -38563,6 +38593,7 @@ unit:MicroCi
   qudt:conversionMultiplierSN 3.7E4 ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Curie"^^xsd:anyURI ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.4" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Activity ;
   qudt:iec61360Code "0112/2///62720#UAA062" ;
@@ -38691,6 +38722,7 @@ unit:MicroGAL-PER-M
   qudt:conversionMultiplier 0.00000001 ;
   qudt:conversionMultiplierSN 1.0E-8 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.4" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:symbol "µGal/m" ;
@@ -40840,6 +40872,7 @@ unit:MicroV-A
   qudt:conversionMultiplier 0.000001 ;
   qudt:conversionMultiplierSN 1.0E-6 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:ApparentPower ;
   qudt:iec61360Code "0112/2///62720#UAB532" ;
@@ -40866,6 +40899,7 @@ unit:MicroV-A-PER-K
   qudt:conversionMultiplier 0.000001 ;
   qudt:conversionMultiplierSN 1.0E-6 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H-1T-3D0 ;
   qudt:hasQuantityKind quantitykind:ThermalConductance ;
   qudt:iec61360Code "0112/2///62720#UAD907" ;
@@ -40892,6 +40926,7 @@ unit:MicroV-A_Reactive
   qudt:conversionMultiplier 0.0 ;
   qudt:conversionMultiplierSN 0.0E0 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:ReactivePower ;
   qudt:iec61360Code "0112/2///62720#UAC506" ;
@@ -40907,6 +40942,7 @@ unit:MicroV-A_Reactive-PER-K
   qudt:conversionMultiplier 0.0 ;
   qudt:conversionMultiplierSN 0.0E0 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H-1T-3D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAD903" ;
@@ -41763,6 +41799,7 @@ unit:MilliCi
   qudt:conversionMultiplier 37000000.0 ;
   qudt:conversionMultiplierSN 3.7E7 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.4" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Activity ;
   qudt:iec61360Code "0112/2///62720#UAA786" ;
@@ -41917,6 +41954,7 @@ unit:MilliGAL
   qudt:conversionMultiplier 0.00001 ;
   qudt:conversionMultiplierSN 1.0E-5 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.4" ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Acceleration ;
   qudt:hasQuantityKind quantitykind:LinearAcceleration ;
@@ -41939,6 +41977,7 @@ unit:MilliGAL-PER-MO
   qudt:conversionMultiplier 0.000000000003919350772901616281311709002114104 ;
   qudt:conversionMultiplierSN 3.919350772901616281311709002114104E-12 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.4" ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:symbol "mgal/mo" ;
@@ -45745,6 +45784,7 @@ unit:MilliV-A
   qudt:conversionMultiplier 0.001 ;
   qudt:conversionMultiplierSN 1.0E-3 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:ApparentPower ;
   qudt:iec61360Code "0112/2///62720#UAB533" ;
@@ -45771,6 +45811,7 @@ unit:MilliV-A-PER-K
   qudt:conversionMultiplier 0.001 ;
   qudt:conversionMultiplierSN 1.0E-3 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H-1T-3D0 ;
   qudt:hasQuantityKind quantitykind:ThermalConductance ;
   qudt:iec61360Code "0112/2///62720#UAD906" ;
@@ -45797,6 +45838,7 @@ unit:MilliV-A_Reactive
   qudt:conversionMultiplier 0.0 ;
   qudt:conversionMultiplierSN 0.0E0 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:ReactivePower ;
   qudt:iec61360Code "0112/2///62720#UAC507" ;
@@ -45812,6 +45854,7 @@ unit:MilliV-A_Reactive-PER-K
   qudt:conversionMultiplier 0.0 ;
   qudt:conversionMultiplierSN 0.0E0 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H-1T-3D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAD902" ;
@@ -46169,6 +46212,7 @@ unit:MillionUSD-PER-YR
   qudt:conversionMultiplier 0.0 ;
   qudt:conversionMultiplierSN 0.0E0 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:expression "$M\\$/yr$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
@@ -49484,6 +49528,7 @@ unit:NanoV-A
   qudt:conversionMultiplier 0.000000001 ;
   qudt:conversionMultiplierSN 1.0E-9 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:ApparentPower ;
   qudt:iec61360Code "0112/2///62720#UAB531" ;
@@ -49510,6 +49555,7 @@ unit:NanoV-A_Reactive
   qudt:conversionMultiplier 0.0 ;
   qudt:conversionMultiplierSN 0.0E0 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:ReactivePower ;
   qudt:iec61360Code "0112/2///62720#UAC505" ;
@@ -50058,6 +50104,7 @@ unit:OHM_CIRC-MIL-PER-FT
   qudt:conversionMultiplier 0.000000001662426113 ;
   qudt:conversionMultiplierSN 1.662426113E-9 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.7" ;
   qudt:hasDimensionVector qkdv:A0E-2L3I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:Resistivity ;
   qudt:iec61360Code "0112/2///62720#UAB215" ;
@@ -52555,6 +52602,7 @@ unit:PER-KiloV-A-HR
   qudt:conversionMultiplier 0.0000002777777777777777777777777777777778 ;
   qudt:conversionMultiplierSN 2.777777777777777777777777777777778E-7 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M-1H0T2D0 ;
   qudt:hasQuantityKind quantitykind:InverseEnergy ;
   qudt:hasReciprocalUnit unit:KiloVA-HR ;
@@ -52988,6 +53036,7 @@ unit:PER-MILLE-PSI
   qudt:conversionMultiplier 0.0000001450377 ;
   qudt:conversionMultiplierSN 1.450377E-7 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.7" ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M-1H0T2D0 ;
   qudt:hasQuantityKind quantitykind:Compressibility ;
   qudt:hasQuantityKind quantitykind:InversePressure ;
@@ -53997,6 +54046,7 @@ unit:PER-V-A-SEC
   qudt:conversionMultiplier 1.0 ;
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M-1H0T2D0 ;
   qudt:hasQuantityKind quantitykind:InverseEnergy ;
   qudt:iec61360Code "0112/2///62720#UAB498" ;
@@ -54479,6 +54529,7 @@ unit:PERCENT-PER-100KiloCount
   qudt:conversionMultiplier 0.0000001 ;
   qudt:conversionMultiplierSN 1.0E-7 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:symbol "%/100k" ;
@@ -54493,6 +54544,7 @@ unit:PERCENT-PER-10KiloCount
   qudt:conversionMultiplier 0.000001 ;
   qudt:conversionMultiplierSN 1.0E-6 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA004" ;
@@ -54595,6 +54647,7 @@ unit:PERCENT-PER-DecaKiloCOUNT
   qudt:conversionMultiplier 0.000001 ;
   qudt:conversionMultiplierSN 1.0E-6 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.1" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA005" ;
@@ -54664,6 +54717,7 @@ unit:PERCENT-PER-HectoCOUNT
   qudt:conversionMultiplier 0.0001 ;
   qudt:conversionMultiplierSN 1.0E-4 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.1" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA006" ;
@@ -54680,6 +54734,7 @@ unit:PERCENT-PER-HectoKiloCOUNT
   qudt:conversionMultiplier 0.0000001 ;
   qudt:conversionMultiplierSN 1.0E-7 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.1" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:symbol "%/100k" ;
@@ -54724,6 +54779,7 @@ unit:PERCENT-PER-KiloCOUNT
   qudt:conversionMultiplier 0.00001 ;
   qudt:conversionMultiplierSN 1.0E-5 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.1" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA007" ;
@@ -55187,6 +55243,7 @@ unit:PERM_0DEG_C
   qudt:conversionMultiplier 0.0 ;
   qudt:conversionMultiplierSN 0.0E0 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.3" ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:VapourPermeance ;
   qudt:iec61360Code "0112/2///62720#UAB294" ;
@@ -55202,6 +55259,7 @@ unit:PERM_23DEG_C
   qudt:conversionMultiplier 0.0 ;
   qudt:conversionMultiplierSN 0.0E0 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.3" ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:VapourPermeance ;
   qudt:iec61360Code "0112/2///62720#UAB295" ;
@@ -55232,6 +55290,7 @@ unit:PERM_Metric_0DEG_C
   qudt:conversionMultiplier 0.0 ;
   qudt:conversionMultiplierSN 0.0E0 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.3" ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:VapourPermeance ;
   qudt:iec61360Code "0112/2///62720#UAB294" ;
@@ -55247,6 +55306,7 @@ unit:PERM_Metric_23DEG_C
   qudt:conversionMultiplier 0.0 ;
   qudt:conversionMultiplierSN 0.0E0 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.3" ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T1D0 ;
   qudt:hasQuantityKind quantitykind:VapourPermeance ;
   qudt:iec61360Code "0112/2///62720#UAB295" ;
@@ -55638,6 +55698,7 @@ unit:PIXEL
   qudt:conversionMultiplier 0.0 ;
   qudt:conversionMultiplierSN 0.0E0 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.2" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:PictureElement ;
   qudt:iec61360Code "0112/2///62720#UAA938" ;
@@ -56165,6 +56226,7 @@ unit:PPTR_VOL
   qudt:conversionMultiplier 0.000000000001 ;
   qudt:conversionMultiplierSN 1.0E-12 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:scalingOf unit:NUM ;
@@ -56477,6 +56539,7 @@ unit:Pennyweight
   qudt:conversionMultiplier 0.00155517384 ;
   qudt:conversionMultiplierSN 1.55517384E-3 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:exactMatch unit:DWT ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Mass ;
@@ -56763,6 +56826,7 @@ unit:PetaV-A
   qudt:conversionMultiplier 1000000000000000.0 ;
   qudt:conversionMultiplierSN 1.0E15 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:ApparentPower ;
   qudt:iec61360Code "0112/2///62720#UAB536" ;
@@ -57739,6 +57803,7 @@ unit:PicoV-A
   qudt:conversionMultiplier 0.000000000001 ;
   qudt:conversionMultiplierSN 1.0E-12 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:ApparentPower ;
   qudt:iec61360Code "0112/2///62720#UAB530" ;
@@ -57765,6 +57830,7 @@ unit:PicoV-A_Reactive
   qudt:conversionMultiplier 0.0 ;
   qudt:conversionMultiplierSN 0.0E0 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:ReactivePower ;
   qudt:iec61360Code "0112/2///62720#UAC504" ;
@@ -60504,6 +60570,7 @@ unit:Standard
   qudt:conversionMultiplier 4.672 ;
   qudt:conversionMultiplierSN 4.672E0 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Volume ;
   qudt:iec61360Code "0112/2///62720#UAB116" ;
@@ -62529,6 +62596,7 @@ unit:TeraV-A
   qudt:conversionMultiplier 1000000000000.0 ;
   qudt:conversionMultiplierSN 1.0E12 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:ApparentPower ;
   qudt:iec61360Code "0112/2///62720#UAB535" ;
@@ -62555,6 +62623,7 @@ unit:TeraV-A_Reactive
   qudt:conversionMultiplier 0.0 ;
   qudt:conversionMultiplierSN 0.0E0 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:ReactivePower ;
   qudt:iec61360Code "0112/2///62720#UAC509" ;
@@ -62923,6 +62992,7 @@ unit:V-A
   qudt:conversionMultiplier 1.0 ;
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:ApparentPower ;
   qudt:iec61360Code "0112/2///62720#UAA298" ;
@@ -62962,6 +63032,7 @@ unit:V-A-HR
   qudt:conversionMultiplier 3600.0 ;
   qudt:conversionMultiplierSN 3.6E3 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Energy ;
   qudt:plainTextDescription "product of the unit for apparent by ampere and the unit hour" ;
@@ -62979,6 +63050,7 @@ unit:V-A-PER-K
   qudt:conversionMultiplier 1.0 ;
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H-1T-3D0 ;
   qudt:hasQuantityKind quantitykind:ThermalConductance ;
   qudt:iec61360Code "0112/2///62720#UAD905" ;
@@ -63010,6 +63082,7 @@ unit:V-A_Reactive
   qudt:conversionMultiplier 1.0 ;
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasQuantityKind quantitykind:ReactivePower ;
   qudt:iec61360Code "0112/2///62720#UAB023" ;
@@ -63029,6 +63102,7 @@ unit:V-A_Reactive-HR
   qudt:conversionMultiplier 3600.0 ;
   qudt:conversionMultiplierSN 3.6E3 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:hasQuantityKind quantitykind:Energy ;
   qudt:plainTextDescription "product of the unit volt ampere reactive and the unit hour" ;
@@ -63045,6 +63119,7 @@ unit:V-A_Reactive-PER-K
   qudt:conversionMultiplier 0.0 ;
   qudt:conversionMultiplierSN 0.0E0 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H-1T-3D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAD901" ;
@@ -65571,6 +65646,7 @@ unit:failures-in-time
   qudt:conversionMultiplier 0.0 ;
   qudt:conversionMultiplierSN 0.0E0 ;
   qudt:deprecated true ;
+  qudt:deprecatedInVersion "3.1.0" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:Frequency ;
   qudt:iec61360Code "0112/2///62720#UAB403" ;


### PR DESCRIPTION
Based on suggestions at https://github.com/BrickSchema/Brick/issues/758

Adds:
- unit:PicoCI-PER-L
- unit:GRAIN_AIR (psychrometric mass ratio unit)
- I also added `PicoCI`, but I can remove if you'd rather it not be in there.

I've run the `mvn spotless:apply install` and `mvn -Pfix install` as indicated on the wiki and all tests pass.