### PR TITLE
updating the A-HR-PER-DEG_C unit to A-HR-PER-DEG_K based on IEC 61360…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,11 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
 ### Added
 
 - Added quantitykind:ProductOfInertia as a replacement for the deprecated quantitykind:PRODUCT-OF-INERTIA
+- Added `unit:A-HR-PER-K` (ampere hour per kelvin, A·h/K) based on IEC change, a revision of `unit:A-HR-PER-DEG_C`.
 
 ### Changed
+
+- Updated unit `unit:A-HR-PER-DEG_C` to indicate it has been replaced by `unit:A-HR-PER-K`.
 
 ### Deprecated
 

--- a/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
+++ b/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
@@ -139,19 +139,25 @@ unit:A-HR
 
 unit:A-HR-PER-DEG_C
   a qudt:Unit ;
-  dcterms:description """$\\textit{Ampere Hour per Degree Celsius}$ is the product of the SI base unit ampere and the unit hour
- divided by the unit degree Celsius.
+  dcterms:isReplacedBy unit:A-HR-PER-DEG_K ;
+  qudt:deprecatedInVersion "3.2.2" ;
+  qudt:deprecated true .
+
+unit:A-HR-PER-DEG_K
+  a qudt:Unit ;
+  dcterms:description """$\\textit{Ampere Hour per Kelvin}$ is the product of the SI base unit ampere and the unit hour
+ divided by the unit Kelvin.
  """^^qudt:LatexString ;
   qudt:conversionMultiplier 3600.0 ;
   qudt:conversionMultiplierSN 3.6E3 ;
   qudt:hasDimensionVector qkdv:A0E1L0I0M0H-1T1D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAD886" ;
-  qudt:symbol "A·h/°C" ;
-  qudt:ucumCode "A.h.Cel-1"^^qudt:UCUMcs ;
+  qudt:symbol "A·h/K" ;
+  qudt:ucumCode "A.h.K"^^qudt:UCUMcs ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
-  rdfs:label "Ampere Hour per Degree Celsius" ;
-  rdfs:label "Ampere Hour per Degree Celsius"@en .
+  rdfs:label "Ampere Hour per Kelvin" ;
+  rdfs:label "Ampere Hour per Kelvin"@en .
 
 unit:A-HR-PER-DeciM3
   a qudt:Unit ;

--- a/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
+++ b/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
@@ -139,15 +139,24 @@ unit:A-HR
 
 unit:A-HR-PER-DEG_C
   a qudt:Unit ;
+  dcterms:description """$\\textit{Ampere Hour per Kelvin}$ is the product of the SI base unit ampere and the unit hour divided by the unit Kelvin."""^^qudt:LatexString ;
   dcterms:isReplacedBy unit:A-HR-PER-DEG_K ;
   qudt:deprecatedInVersion "3.2.2" ;
-  qudt:deprecated true .
+  qudt:deprecated true ;
+  qudt:conversionMultiplier 3600.0 ;
+  qudt:conversionMultiplierSN 3.6E3 ;
+  qudt:hasDimensionVector qkdv:A0E1L0I0M0H-1T1D0 ;
+  qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:iec61360Code "0112/2///62720#UAD886" ;
+  qudt:symbol "A·h/K" ;
+  qudt:ucumCode "A.h.K"^^qudt:UCUMcs ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
+  rdfs:label "Ampere Hour per Degree Celsius" ;
+  rdfs:label "Ampere Hour per Degree Celsius"@en .
 
 unit:A-HR-PER-DEG_K
   a qudt:Unit ;
-  dcterms:description """$\\textit{Ampere Hour per Kelvin}$ is the product of the SI base unit ampere and the unit hour
- divided by the unit Kelvin.
- """^^qudt:LatexString ;
+  dcterms:description """$\\textit{Ampere Hour per Kelvin}$ is the product of the SI base unit ampere and the unit hour divided by the unit Kelvin."""^^qudt:LatexString ;
   qudt:conversionMultiplier 3600.0 ;
   qudt:conversionMultiplierSN 3.6E3 ;
   qudt:hasDimensionVector qkdv:A0E1L0I0M0H-1T1D0 ;

--- a/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
+++ b/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
@@ -814,7 +814,6 @@ unit:A-SEC
   qudt:hasQuantityKind quantitykind:BatteryCapacity ;
   qudt:hasQuantityKind quantitykind:ElectricCharge ;
   qudt:iec61360Code "0112/2///62720#UAA107" ;
-  qudt:iec61360Code "0112/2///62720#UAD516" ;
   qudt:plainTextDescription "product out of the SI base unit ampere and the SI base unit second" ;
   qudt:symbol "A·s" ;
   qudt:ucumCode "A.s"^^qudt:UCUMcs ;
@@ -25649,7 +25648,6 @@ unit:KiloGM-PER-M2
   qudt:hasQuantityKind quantitykind:SurfaceDensity ;
   qudt:hasReciprocalUnit unit:M2-PER-KiloGM ;
   qudt:iec61360Code "0112/2///62720#UAA617" ;
-  qudt:iec61360Code "0112/2///62720#UAD513" ;
   qudt:symbol "kg/m²" ;
   qudt:ucumCode "kg.m-2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "28" ;
@@ -34856,7 +34854,6 @@ unit:MI2
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Area ;
   qudt:iec61360Code "0112/2///62720#UAB050" ;
-  qudt:iec61360Code "0112/2///62720#UAB208" ;
   qudt:symbol "mi²" ;
   qudt:ucumCode "[mi_i]2"^^qudt:UCUMcs ;
   qudt:uneceCommonCode "M48" ;
@@ -55042,7 +55039,6 @@ unit:PERCENT-PER-TEN-THOUSAND
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
   qudt:iec61360Code "0112/2///62720#UAA004" ;
-  qudt:iec61360Code "0112/2///62720#UAA005" ;
   qudt:symbol "%/10000" ;
   qudt:uneceCommonCode "H91" ;
   qudt:uneceCommonCode "H92" ;
@@ -62211,7 +62207,6 @@ unit:TON_US-PER-HR
   qudt:exactMatch unit:TON_SHORT-PER-HR ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-1D0 ;
   qudt:hasQuantityKind quantitykind:MassFlowRate ;
-  qudt:iec61360Code "0112/2///62720#UAA994" ;
   qudt:iec61360Code "0112/2///62720#UAB019" ;
   qudt:plainTextDescription "unit ton divided by the unit for time hour" ;
   qudt:symbol "ton{US}/h" ;


### PR DESCRIPTION
IEC has revise the unit with code '0112/2///62720#UAD886' to be based on the Kelvin rather than °C.
See: https://cdd.iec.ch/cdd/iec62720/iec62720.nsf/Units/0112-2---62720%23UAD886 .