### PR TITLE
Adding unit:OHM-FT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
 ### Added
 
 - Added quantitykind:ProductOfInertia as a replacement for the deprecated quantitykind:PRODUCT-OF-INERTIA
+- Added unit:OHM-FT (Ohm Foot), the imperial counterpart to unit:OHM-M, for resistivity in well-logging and petrophysics applications
 
 ### Changed
 

--- a/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
+++ b/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
@@ -49958,6 +49958,21 @@ unit:OHM-CentiM
   rdfs:label "Ohmio Centimetro"@es ;
   rdfs:label "Om Centimetr"@pl .
 
+unit:OHM-FT
+  a qudt:Unit ;
+  dcterms:description "product of the SI derived unit ohm and the imperial unit foot"@en ;
+  qudt:applicableSystem sou:IMPERIAL ;
+  qudt:applicableSystem sou:USCS ;
+  qudt:conversionMultiplier 0.3048 ;
+  qudt:conversionMultiplierSN 3.048E-1 ;
+  qudt:hasDimensionVector qkdv:A0E-2L3I0M1H0T-3D0 ;
+  qudt:hasQuantityKind quantitykind:Resistivity ;
+  qudt:symbol "Ω·ft" ;
+  qudt:ucumCode "Ohm.[ft_i]"^^qudt:UCUMcs ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
+  rdfs:label "Ohm Foot" ;
+  rdfs:label "Ohm Foot"@en .
+
 unit:OHM-KiloM
   a qudt:Unit ;
   dcterms:description "product of the SI derived unit ohm and the 1,000-fold of the SI base unit metre" ;


### PR DESCRIPTION
Adds `unit:OHM-FT` (Ohm Foot), the imperial counterpart to `unit:OHM-M` for resistivity. The unit is commonly used in well-logging and petrophysics. Conversion multiplier is `0.3048` (exact, NIST SP 811, definition of the international foot).

I've run `mvn -Pfix install` and all SHACL validations pass (0 violations).

### Note to reviewers

This is the first in what I hope will be a small series of contributions upstreaming units from the [Cognite unit catalog](https://github.com/cognitedata/units-catalog) into QUDT. It is my first contribution, feedback on naming, metadata or anything else is very welcome.

### A minor observation

While running `mvn -Pfix install`, Spotless reordered `qudt:hasFactorUnit` blank nodes in several unrelated units (like  `BARAD`, `C`, `ERG`, `FARAD`, `J`, `N`, etc). I believe this are pre-existing ordering in the repo. I reverted those to keep the changes from this PR minimal, but I can re-add them if needed.