### PR TITLE
Fix ReferenceDatatype, GlobalPositionVector-DP, ONstate, OFFstate, WDST_WET, WDST_DRY, True, Yes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
 
 - Removed some erroneous references from the datatypes schema metadata to the coordinate systems schema under construction
 - Fixed some small errors in qudt:ArrayDataOrder, qudt:MassPropertiesArray, qkdv:A0E1L0I0M-1H0T0D0, and unit:RT
+- Fixed the types of datatype:ONstate, datatype:OFFstate, datatype:WDST_WET, and datatype:WDST_DRY
+- Removed datatype:True and datatype:Yes (use datatype:TRUE and datatype:YES instead)
 
 ## [3.2.1] - 2026-04-02
 

--- a/src/main/rdf/schema/shacl/SCHEMA_QUDT-COORDINATES_NoOWL.ttl
+++ b/src/main/rdf/schema/shacl/SCHEMA_QUDT-COORDINATES_NoOWL.ttl
@@ -351,18 +351,6 @@ qudt:PolarCoordinatesType
   rdfs:label "Polar Coordinate System Type" ;
   rdfs:subClassOf qudt:CoordinateSystem .
 
-qudt:ReferenceDatatype
-  a rdfs:Class, sh:NodeShape ;
-  dcterms:description """
-  <p>A reference is an object containing information which refers to data stored elsewhere, as opposed to containing the data itself. 
-  A reference data type is a data type that specifies how a reference is represented and stored in memory,
-   as well as the operations that can be performed on reference values. 
-  The most common example of a reference data type is a pointer.
-  </p>"""^^rdf:HTML ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/coordinateSystems> ;
-  rdfs:label "Reference Data Type" ;
-  rdfs:subClassOf qudt:StructuredDatatype .
-
 qudt:ReferenceFrame
   a rdfs:Class, sh:NodeShape ;
   dcterms:description """

--- a/src/main/rdf/schema/shacl/SCHEMA_QUDT-DATATYPES_NoOWL.ttl
+++ b/src/main/rdf/schema/shacl/SCHEMA_QUDT-DATATYPES_NoOWL.ttl
@@ -1324,6 +1324,18 @@ qudt:Record
   rdfs:label "Record Type" ;
   rdfs:subClassOf qudt:CompositeDatatype .
 
+qudt:ReferenceDatatype
+  a rdfs:Class, sh:NodeShape ;
+  dcterms:description """
+  <p>A reference is an object containing information which refers to data stored elsewhere, as opposed to containing the data itself. 
+  A reference data type is a data type that specifies how a reference is represented and stored in memory,
+   as well as the operations that can be performed on reference values. 
+  The most common example of a reference data type is a pointer.
+  </p>"""^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;
+  rdfs:label "Reference Data Type" ;
+  rdfs:subClassOf qudt:StructuredDatatype .
+
 qudt:ScalarDatatype
   a rdfs:Class, sh:NodeShape ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/datatype> ;

--- a/src/main/rdf/vocab/coordinates/VOCAB_QUDT-COORDINATES.ttl
+++ b/src/main/rdf/vocab/coordinates/VOCAB_QUDT-COORDINATES.ttl
@@ -3,6 +3,7 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix coords: <http://qudt.org/vocab/coords/> .
+@prefix datatype: <http://qudt.org/vocab/datatype/> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix dtype: <http://www.linkedmodel.org/schema/dtype#> .
 @prefix qudt: <http://qudt.org/schema/qudt/> .
@@ -134,6 +135,15 @@ coords:FT_ROTATING
   dtype:literal "rotating" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/coordinateSystems> ;
   rdfs:label "Rotating Frame Type" .
+
+coords:GlobalPositionVector-DP
+  a qudt:StateSpaceVector ;
+  dtype:code 360 ;
+  qudt:datatype datatype:FLOAT-DP ;
+  qudt:dimensionality 1 ;
+  qudt:dimensions ( 3 ) ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/datatype> ;
+  rdfs:label "Global Position Vector - double precision" .
 
 coords:IERS-TN-32-2004
   a qudt:Citation ;

--- a/src/main/rdf/vocab/types/VOCAB_QUDT-DATATYPES.ttl
+++ b/src/main/rdf/vocab/types/VOCAB_QUDT-DATATYPES.ttl
@@ -600,15 +600,6 @@ datatype:FLOAT_IEEE754-BINARY64
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/datatype> ;
   rdfs:label "IEEE754 BINARY64" .
 
-datatype:GlobalPositionVector-DP
-  a qudt:StateSpaceVector ;
-  dtype:code 360 ;
-  qudt:datatype datatype:FLOAT-DP ;
-  qudt:dimensionality 1 ;
-  qudt:dimensions ( 3 ) ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/datatype> ;
-  rdfs:label "Global Position Vector - double precision" .
-
 datatype:HDF5
   a qudt:MultiDimensionalDataFormat ;
   dcterms:description """
@@ -802,7 +793,7 @@ datatype:OFF
   rdfs:label "Off" .
 
 datatype:OFFstate
-  a qudt:OnOffState ;
+  a qudt:OffOnStateTypeEnumeration ;
   dtype:code "0" ;
   dtype:literal "off" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/datatype> ;
@@ -816,7 +807,7 @@ datatype:ON
   rdfs:label "On" .
 
 datatype:ONstate
-  a qudt:OnOffState ;
+  a qudt:OnOffStateTypeEnumeration ;
   dtype:code "0" ;
   dtype:literal "on" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/datatype> ;
@@ -1185,13 +1176,6 @@ datatype:TotallyOrdered
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/datatype> ;
   rdfs:label "Totally Ordered" .
 
-datatype:True
-  a qudt:BooleanStateType ;
-  dtype:code "1" ;
-  dtype:literal "true" ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/datatype> ;
-  rdfs:label "true" .
-
 datatype:UNARY-FUNCTION
   a qudt:FunctionDatatype ;
   dcterms:description "This type identifies functions that have exactly one argument."^^rdf:HTML ;
@@ -1414,14 +1398,14 @@ datatype:UserModifiableParameter
   rdfs:label "User modifiable parameter" .
 
 datatype:WDST_DRY
-  a qudt:WetDryState ;
+  a qudt:WetDryStateType ;
   dtype:code "2" ;
   dtype:literal "dry" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/datatype> ;
   rdfs:label "Dry" .
 
 datatype:WDST_WET
-  a qudt:WetDryState ;
+  a qudt:WetDryStateType ;
   dtype:code "1" ;
   dtype:literal "wet" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/datatype> ;
@@ -1444,12 +1428,6 @@ datatype:YDT
   rdfs:label "Year Day Time" .
 
 datatype:YES
-  a qudt:YesNoType ;
-  dtype:literal "Y" ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/datatype> ;
-  rdfs:label "Yes" .
-
-datatype:Yes
   a qudt:YesNoType ;
   dtype:literal "Y" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/datatype> ;


### PR DESCRIPTION
* Moved `qudt:ReferenceDatatype` back from  
  SCHEMA_QUDT-COORDINATES_NoOWL.ttl to  
  SCHEMA_QUDT-DATATYPES_NoOWL.ttl because it seems unrelated to coordinates and it is needed by  
  VOCAB_QUDT-DATATYPES.ttl
* Moved `datatype:GlobalPositionVector-DP` from  
  VOCAB_QUDT-DATATYPES.ttl to  
  VOCAB_QUDT-COORDINATES.ttl because it is an instance of `qudt:StateSpaceVector` defined in  
  SCHEMA_QUDT-COORDINATES_NoOWL.ttl
* Made `datatype:WDST_WET` and `datatype:WDST_DRY` instances of `qudt:WetDryStateType` instead of `qudt:WetDryState` because `qudt:WetDryState` does not exist
* Deleted `datatype:True` because neither `qudt:BooleanStateType` nor `datatype:False` exists (both `datatype:TRUE` and `datatype:FALSE` exist)
* Deleted `datatype:Yes` because it looks like a duplication of `datatype:YES`