### PR TITLE
Adding unit:HectoHZ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
 
 - Added quantitykind:ProductOfInertia as a replacement for the deprecated quantitykind:PRODUCT-OF-INERTIA
 - Added unit:OHM-FT (Ohm Foot), the imperial counterpart to unit:OHM-M, for resistivity in well-logging and petrophysics applications
+- Added unit:HectoHZ (Hectohertz), the 100-fold SI prefix scaling of unit:HZ
 
 ### Changed
 

--- a/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
+++ b/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
@@ -20623,6 +20623,27 @@ unit:HectoGM
   rdfs:label "Hectogramme"@fr ;
   rdfs:label "Hectogramo"@es .
 
+unit:HectoHZ
+  a qudt:DerivedUnit, qudt:Unit ;
+  dcterms:description "100-fold of the SI derived unit hertz"^^rdf:HTML ;
+  qudt:applicableSystem sou:CGS ;
+  qudt:applicableSystem sou:CGS-EMU ;
+  qudt:applicableSystem sou:CGS-GAUSS ;
+  qudt:applicableSystem sou:IMPERIAL ;
+  qudt:applicableSystem sou:SI ;
+  qudt:applicableSystem sou:USCS ;
+  qudt:conversionMultiplier 100.0 ;
+  qudt:conversionMultiplierSN 1.0E2 ;
+  qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
+  qudt:hasQuantityKind quantitykind:Frequency ;
+  qudt:plainTextDescription "100-fold of the SI derived unit hertz" ;
+  qudt:symbol "hHz" ;
+  qudt:ucumCode "hHz"^^qudt:UCUMcs ;
+  qudt:wikidataMatch <http://www.wikidata.org/entity/Q53448826> ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
+  rdfs:label "Hectohertz" ;
+  rdfs:label "Hectohertz"@en .
+
 unit:HectoL
   a qudt:Unit ;
   dcterms:description "100-fold of the unit litre"^^rdf:HTML ;

--- a/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
+++ b/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
@@ -20641,8 +20641,19 @@ unit:HectoHZ
   qudt:ucumCode "hHz"^^qudt:UCUMcs ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q53448826> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
+  rdfs:label "Ettohertz"@it ;
+  rdfs:label "Hectoherc"@pl ;
+  rdfs:label "Hectohercio"@es ;
   rdfs:label "Hectohertz" ;
-  rdfs:label "Hectohertz"@en .
+  rdfs:label "Hectohertz"@cs ;
+  rdfs:label "Hectohertz"@de ;
+  rdfs:label "Hectohertz"@en ;
+  rdfs:label "Hectohertz"@fr ;
+  rdfs:label "Hectohertz"@hu ;
+  rdfs:label "Hectohertz"@ms ;
+  rdfs:label "Hectohertz"@ro ;
+  rdfs:label "Hectohertz"@sl ;
+  rdfs:label "Hectohertz"@tr .
 
 unit:HectoL
   a qudt:Unit ;


### PR DESCRIPTION
Adds `unit:HectoHZ` (Hectohertz), the 100-fold SI prefix scaling of `unit:HZ`, for use cases where frequencies are conventionally reported in hundreds of hertz.

I've run `mvn -Pfix install` and all SHACL validations pass (0 violations).