### PR TITLE
Adding pressure gradient units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
 - Added quantitykind:ProductOfInertia as a replacement for the deprecated quantitykind:PRODUCT-OF-INERTIA
 - Added unit:OHM-FT (Ohm Foot), the imperial counterpart to unit:OHM-M, for resistivity in well-logging and petrophysics applications
 - Added unit:HectoHZ (Hectohertz), the 100-fold SI prefix scaling of unit:HZ
+- Added unit:BAR-PER-M (Bar per Metre), unit:PSI-PER-FT (Psi per Foot), and unit:PSI-PER-M (Psi per Metre) for pressure gradients
 
 ### Changed
 

--- a/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
+++ b/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
@@ -1865,6 +1865,22 @@ unit:BAR-PER-K
   rdfs:label "Bar per Kelvin" ;
   rdfs:label "Bar per Kelvin"@en .
 
+unit:BAR-PER-M
+  a qudt:Unit ;
+  dcterms:description "unit with the name bar divided by the SI base unit metre" ;
+  qudt:conversionMultiplier 100000.0 ;
+  qudt:conversionMultiplierSN 1.0E5 ;
+  qudt:hasDimensionVector qkdv:A0E0L-2I0M1H0T-2D0 ;
+  qudt:hasQuantityKind quantitykind:PressureGradient ;
+  qudt:hasReciprocalUnit unit:M-PER-BAR ;
+  qudt:plainTextDescription "unit with the name bar divided by the SI base unit metre" ;
+  qudt:symbol "bar/m" ;
+  qudt:ucumCode "bar.m-1"^^qudt:UCUMcs ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
+  rdfs:label "Bar per Meter"@en-US ;
+  rdfs:label "Bar per Metre" ;
+  rdfs:label "Bar per Metre"@en .
+
 unit:BARAD
   a qudt:Unit ;
   dcterms:description "A barad is a dyne per square centimetre ($dyn \\cdot cm^{-2}$), and is equal to $0.1 Pa $ ($1 \\, micro \\, bar$, $0.000014504 \\, p.s.i.$). Note that this is precisely the microbar, the confusable bar being related in size to the normal atmospheric pressure, at $100\\,dyn \\cdot cm^{-2}$. Accordingly barad was not abbreviated, so occurs prefixed as in $cbarad = centibarad$. Despite being the coherent unit for pressure in c.g.s., barad was probably much less common than the non-coherent bar. Barad is sometimes called $barye$, a name also used for $bar$."^^qudt:LatexString ;
@@ -56498,6 +56514,20 @@ unit:PSI-M3-PER-SEC
   rdfs:label "Psi Cubic Metre per Second" ;
   rdfs:label "Psi Cubic Metre per Second"@en .
 
+unit:PSI-PER-FT
+  a qudt:Unit ;
+  dcterms:description "compound unit for pressure (pound-force according to the Anglo-American unit system divided by the power of the unit inch according to the Anglo-American and Imperial system of units with the exponent 2) divided by the unit foot according to the Anglo-American and Imperial system of units" ;
+  qudt:conversionMultiplier 22620.59479385945320447071340336905 ;
+  qudt:conversionMultiplierSN 2.262059479385945320447071340336905E4 ;
+  qudt:hasDimensionVector qkdv:A0E0L-2I0M1H0T-2D0 ;
+  qudt:hasQuantityKind quantitykind:PressureGradient ;
+  qudt:hasReciprocalUnit unit:FT-PER-PSI ;
+  qudt:symbol "psi/ft" ;
+  qudt:ucumCode "[psi].[ft_i]-1"^^qudt:UCUMcs ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
+  rdfs:label "Psi per Foot" ;
+  rdfs:label "Psi per Foot"@en .
+
 unit:PSI-PER-IN
   a qudt:Unit ;
   dcterms:description "compound unit for pressure (pound-force according to the Anglo-American unit system divided by the power of the unit inch according to the Anglo-American and Imperial system of units with the exponent 2) divided by the unit inch according to the Anglo-American and Imperial system of units" ;
@@ -56513,6 +56543,20 @@ unit:PSI-PER-IN
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Psi per Inch" ;
   rdfs:label "Psi per Inch"@en .
+
+unit:PSI-PER-M
+  a qudt:Unit ;
+  dcterms:description "compound unit for pressure (pound-force according to the Anglo-American unit system divided by the power of the unit inch according to the Anglo-American and Imperial system of units with the exponent 2) divided by the SI base unit metre" ;
+  qudt:conversionMultiplier 6894.757293168361336722673445346887 ;
+  qudt:conversionMultiplierSN 6.894757293168361336722673445346887E3 ;
+  qudt:hasDimensionVector qkdv:A0E0L-2I0M1H0T-2D0 ;
+  qudt:hasQuantityKind quantitykind:PressureGradient ;
+  qudt:symbol "psi/m" ;
+  qudt:ucumCode "[psi].m-1"^^qudt:UCUMcs ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
+  rdfs:label "Psi per Meter"@en-US ;
+  rdfs:label "Psi per Metre" ;
+  rdfs:label "Psi per Metre"@en .
 
 unit:PSI-PER-PSI
   a qudt:Unit ;

--- a/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
+++ b/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
@@ -15128,6 +15128,7 @@ unit:FT-PER-PSI
   qudt:conversionMultiplierSN 4.420750246016776877901266531952396E-5 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M-1H0T2D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasReciprocalUnit unit:PSI-PER-FT ;
   qudt:iec61360Code "0112/2///62720#UAA447" ;
   qudt:symbol "ft/psi" ;
   qudt:ucumCode "[ft_i].[psi]-1"^^qudt:UCUMcs ;
@@ -32117,6 +32118,7 @@ unit:M-PER-BAR
   qudt:conversionMultiplierSN 1.0E-5 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M-1H0T2D0 ;
   qudt:hasQuantityKind quantitykind:Unknown ;
+  qudt:hasReciprocalUnit unit:BAR-PER-M ;
   qudt:iec61360Code "0112/2///62720#UAA731" ;
   qudt:symbol "m/bar" ;
   qudt:ucumCode "m.bar-1"^^qudt:UCUMcs ;


### PR DESCRIPTION
Adds three pressure-gradient units: `unit:BAR-PER-M`, `unit:PSI-PER-FT`, and `unit:PSI-PER-M`.

These fill gaps around existing pressure-gradient units such as `unit:KiloPA-PER-M`, `unit:HectoPA-PER-M`, `unit:ATM-PER-M`, and `unit:PSI-PER-IN`. The conversions are derived from existing QUDT pressure and length definitions.

I've run `mvn -Pfix install` and all SHACL validations pass (0 violations). I reverted the unrelated factor-unit ordering that were introduced by Spotless, keeping only the new added units.
