### PR TITLE
Add property declarations for qudt:base*UnitDimensions and qudt:enumeratedValue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
 - Fixed some small errors in qudt:ArrayDataOrder, qudt:MassPropertiesArray, qkdv:A0E1L0I0M-1H0T0D0, and unit:RT
 - Fixed the types of datatype:ONstate, datatype:OFFstate, datatype:WDST_WET, and datatype:WDST_DRY
 - Removed datatype:True and datatype:Yes (use datatype:TRUE and datatype:YES instead)
+- Added explicit property declarations for qudt:baseCGSUnitDimensions, qudt:baseImperialUnitDimensions, qudt:baseISOUnitDimensions, qudt:baseSIUnitDimensions, and qudt:baseUSCustomaryUnitDimensions
 
 ## [3.2.1] - 2026-04-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
 - Fixed the types of datatype:ONstate, datatype:OFFstate, datatype:WDST_WET, and datatype:WDST_DRY
 - Removed datatype:True and datatype:Yes (use datatype:TRUE and datatype:YES instead)
 - Added explicit property declarations for qudt:baseCGSUnitDimensions, qudt:baseImperialUnitDimensions, qudt:baseISOUnitDimensions, qudt:baseSIUnitDimensions, and qudt:baseUSCustomaryUnitDimensions
+- Added explicit property declaration for qudt:enumeratedValue
 
 ## [3.2.1] - 2026-04-02
 

--- a/src/main/rdf/schema/shacl/SCHEMA_QUDT_NoOWL.ttl
+++ b/src/main/rdf/schema/shacl/SCHEMA_QUDT_NoOWL.ttl
@@ -1028,11 +1028,36 @@ qudt:applicableUnit
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/qudt> ;
   rdfs:label "applicable unit" .
 
+qudt:baseCGSUnitDimensions
+  a rdf:Property ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/qudt> ;
+  rdfs:label "base CGS unit dimensions" .
+
 qudt:baseDimensionEnumeration
   a rdf:Property ;
   dcterms:description "This property associates a system of quantities with an enumeration that enumerates the base dimensions of the system in canonical order."^^rdf:HTML ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/qudt> ;
   rdfs:label "base dimension enumeration" .
+
+qudt:baseISOUnitDimensions
+  a rdf:Property ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/qudt> ;
+  rdfs:label "base ISO unit dimensions" .
+
+qudt:baseImperialUnitDimensions
+  a rdf:Property ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/qudt> ;
+  rdfs:label "base imperial unit dimensions" .
+
+qudt:baseSIUnitDimensions
+  a rdf:Property ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/qudt> ;
+  rdfs:label "base SI unit dimensions" .
+
+qudt:baseUSCustomaryUnitDimensions
+  a rdf:Property ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/qudt> ;
+  rdfs:label "base US customary unit dimensions" .
 
 qudt:baseUnitOfSystem
   a rdf:Property ;

--- a/src/main/rdf/schema/shacl/SCHEMA_QUDT_NoOWL.ttl
+++ b/src/main/rdf/schema/shacl/SCHEMA_QUDT_NoOWL.ttl
@@ -1272,6 +1272,11 @@ qudt:element
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/qudt> ;
   rdfs:label "element" .
 
+qudt:enumeratedValue
+  a rdf:Property ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/qudt> ;
+  rdfs:label "enumerated value" .
+
 qudt:exactConstant
   a rdf:Property ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/schema/shacl/qudt> ;


### PR DESCRIPTION
The released `QUDT-all-in-one-SHACL.ttl` currently refers to the following properties without explicitly declaring them:

- `qudt:baseCGSUnitDimensions`
- `qudt:baseImperialUnitDimensions`
- `qudt:baseISOUnitDimensions`
- `qudt:baseSIUnitDimensions`
- `qudt:baseUSCustomaryUnitDimensions`
- `qudt:enumeratedValue`

This fixes that by adding the missing declarations to [`SCHEMA_QUDT_NoOWL.ttl`](https://github.com/ektrah/qudt-public-repo/blob/f608e8f10fb73299934e143f274f2383c268b98d/src/main/rdf/schema/shacl/SCHEMA_QUDT_NoOWL.ttl).

The declarations are copied from [`SCHEMA_QUDT.ttl`](https://github.com/ektrah/qudt-public-repo/blob/f608e8f10fb73299934e143f274f2383c268b98d/src/main/rdf/schema/SCHEMA_QUDT.ttl).

Resolves #704