### PR TITLE
Add quantitykind:LiquidLevel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
 - Added  quantitykind:ApparentEnergy and completed the ElectricEnergy specialization hierarchy
 - Added unit:BAR-PER-M (Bar per Metre), unit:PSI-PER-FT (Psi per Foot), and unit:PSI-PER-M (Psi per Metre) for pressure gradients
 - Added 6 energy intensity units: W-HR-PER-FT2, KiloW-HR-PER-FT2, MegaW-HR-PER-FT2, GigaW-HR-PER-FT2, MegaW-HR-PER-M2, GigaW-HR-PER-M2
+- Added quantitykind:LiquidLevel
 
 ### Changed
 

--- a/src/main/rdf/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL.ttl
+++ b/src/main/rdf/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL.ttl
@@ -7466,6 +7466,16 @@ quantitykind:LinkedFlux
   rdfs:label "Linked Flux"@en ;
   skos:broader quantitykind:MagneticFlux .
 
+quantitykind:LiquidLevel
+  a qudt:QuantityKind ;
+  dcterms:description "Liquid level refers to the measurement of the height of a liquid within a container."^^qudt:LatexString ;
+  qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T0D0 ;
+  qudt:plainTextDescription "Liquid level refers to the measurement of the height of a liquid within a container." ;
+  qudt:wikidataMatch <http://www.wikidata.org/entity/Q1481422> ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
+  rdfs:label "Liquid Level"@en ;
+  skos:broader quantitykind:Length .
+
 quantitykind:LiquidVolume
   a qudt:QuantityKind ;
   dcterms:description "Liquid volume is the volume of a given amount of liquid, that is, the amount of space a liquid takes up. There are a number of different units used to measure liquid volume, but most of them fall under either the metric system of measurement or the Imperial system of measurement."^^qudt:LatexString ;


### PR DESCRIPTION
I'm trying to identify the Quantity Kind that is measured/alarmed by these Brick points:

| @id | ofSubstance | hasQuantityKind | subClassOf |
|:-|:-|:-|:-|
| brick:Collection_Basin_Water_Level_Alarm | Collection_Basin_Water | ? | Alarm |
| brick:Collection_Basin_Water_Level_Sensor | Collection_Basin_Water | ? | Sensor |
| brick:Deionised_Water_Level_Sensor | Deionised_Water | ? | Sensor |
| brick:Max_Water_Level_Alarm | Water | ? | Max_Alarm |
| brick:Min_Water_Level_Alarm | Water | ? | Min_Alarm |
| brick:Refrigerant_Level_Sensor | Refrigerant | ? | Sensor |
| brick:Water_Level_Alarm | Water | ? | Alarm |
| brick:Water_Level_Sensor | Water | ? | Sensor |

Both [`quantitykind:Height`](http://qudt.org/vocab/quantitykind/Height) and [`quantitykind:Depth`](http://qudt.org/vocab/quantitykind/Depth) don't seem 100% appropriate (though `quantitykind:Depth` is very close).

So I'm proposing a new Quantity Kind: `quantitykind:LiquidLevel`

/cc @gtfierro 