### PR TITLE
Srr title case labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
 
 ## [Unreleased]
 
+### Added
+
+- Added code to automatically convert labels for quantity kinds into Title Case
+
+### Changed
+
+### Deprecated
+
+### Fixed
+
 ## [3.3.0] - 2026-05-25
 
 ### Added

--- a/pom.xml
+++ b/pom.xml
@@ -2758,36 +2758,9 @@ validAspectDirs.each { aspectDir ->
                                                     FILTER(STRSTARTS(STR(?g), "dist:"))
                                                     FILTER(LANG(?oldLabel) IN ("", "en", "en-US", "en-UK"))
                                                     FILTER(!REGEX(STR(?oldLabel), "^\\p{Lu}( (al|ανά|на|je|na|par|pe|per|por|pro|za|in|for) |[^\\p{Lu}]|[^\\p{Ll}]\\p{Lu})*$"))
-                                                    # Step 1: insert space before each uppercase letter that follows a lowercase letter (CamelCase split)
-                                                    BIND(REPLACE(STR(?oldLabel), "(\\p{Ll})(\\p{Lu})", "$1 $2") AS ?step1)
-                                                    # Step 2: capitalise the first letter of each word that follows a space (26 single-letter replacements using Java lookbehind)
-                                                    BIND(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(
-                                                         REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(
-                                                         REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(
-                                                         REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(
-                                                         REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(
-                                                         REPLACE(?step1,
-                                                           "(?<= )a","A"),"(?<= )b","B"),"(?<= )c","C"),"(?<= )d","D"),"(?<= )e","E"),
-                                                           "(?<= )f","F"),"(?<= )g","G"),"(?<= )h","H"),"(?<= )i","I"),"(?<= )j","J"),
-                                                           "(?<= )k","K"),"(?<= )l","L"),"(?<= )m","M"),"(?<= )n","N"),"(?<= )o","O"),
-                                                           "(?<= )p","P"),"(?<= )q","Q"),"(?<= )r","R"),"(?<= )s","S"),"(?<= )t","T"),
-                                                           "(?<= )u","U"),"(?<= )v","V"),"(?<= )w","W"),"(?<= )x","X"),"(?<= )y","Y"),
-                                                           "(?<= )z","Z") AS ?step2)
-                                                    # Step 3: restore English prepositions and articles to lowercase
-                                                    BIND(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(
-                                                         ?step2,
-                                                         "(?<= )Of(?= |$)","of"),
-                                                         "(?<= )Per(?= |$)","per"),
-                                                         "(?<= )In(?= |$)","in"),
-                                                         "(?<= )For(?= |$)","for"),
-                                                         "(?<= )And(?= |$)","and"),
-                                                         "(?<= )To(?= |$)","to"),
-                                                         "(?<= )A(?= )","a"),
-                                                         "(?<= )An(?= |$)","an") AS ?step3)
-                                                    # Step 4: capitalise the first character of the whole label
-                                                    BIND(CONCAT(UCASE(SUBSTR(?step3, 1, 1)), SUBSTR(?step3, 2)) AS ?step4)
-                                                    BIND(IF(LANG(?oldLabel) = "", ?step4, STRLANG(?step4, LANG(?oldLabel))) AS ?newLabel)
-                                                    FILTER(STR(?step4) != STR(?oldLabel))
+                                                    BIND(qfn:titleCase(STR(?oldLabel)) AS ?fixed)
+                                                    BIND(IF(LANG(?oldLabel) = "", ?fixed, STRLANG(?fixed, LANG(?oldLabel))) AS ?newLabel)
+                                                    FILTER(STR(?fixed) != STR(?oldLabel))
                                                 }
                                             ]]>
                                         </sparql>

--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,13 @@
             mvn -Dqudt.allInOne.extensions=propulsion,loop3d install
         -->
         <qudt.allInOne.extensions />
+        <!--
+            Sentinel used by the src-errors pipeline step to detect whether the 'fix' profile is
+            active. The fix profile overrides this to "fix.profile.is.active"; the default value
+            here ensures Maven always substitutes a defined string so rdfio does not attempt to
+            resolve the placeholder as a metadata-graph variable (behaviour added in rdfio 1.7.0).
+        -->
+        <fix.profile.is.inactive>fix.profile.is.inactive</fix.profile.is.inactive>
     </properties>
     <scm>
         <connection>scm:git:https://github.com/qudt/qudt-public-repo.git</connection>
@@ -2757,7 +2764,7 @@ validAspectDirs.each { aspectDir ->
                                                     }
                                                     FILTER(STRSTARTS(STR(?g), "dist:"))
                                                     FILTER(LANG(?oldLabel) IN ("", "en", "en-US", "en-UK"))
-                                                    FILTER(!REGEX(STR(?oldLabel), "^\\p{Lu}( (al|ανά|на|je|na|par|pe|per|por|pro|za|in|for) |[^\\p{Lu}]|[^\\p{Ll}]\\p{Lu})*$"))
+                                                    FILTER(!REGEX(STR(?oldLabel), "^\\p{Ll}-"))
                                                     BIND(qfn:titleCase(STR(?oldLabel)) AS ?fixed)
                                                     BIND(IF(LANG(?oldLabel) = "", ?fixed, STRLANG(?fixed, LANG(?oldLabel))) AS ?newLabel)
                                                     FILTER(STR(?fixed) != STR(?oldLabel))

--- a/pom.xml
+++ b/pom.xml
@@ -2739,6 +2739,49 @@ validAspectDirs.each { aspectDir ->
 
                                     <savepoint><id>10-infer-labels-factors</id></savepoint>
 
+                                    <sparqlUpdate>
+                                        <message>Fixing English labels not in title case (capitalize first letter; split CamelCase)</message>
+                                        <sparql>
+                                            <![CDATA[
+                                                DELETE { GRAPH ?g { ?s rdfs:label ?oldLabel } }
+                                                INSERT {
+                                                    GRAPH ?g { ?s rdfs:label ?newLabel }
+                                                    GRAPH <fix:labels:title-case:toDelete> { ?s rdfs:label ?oldLabel }
+                                                    GRAPH <fix:labels:title-case:toAdd>    { ?s rdfs:label ?newLabel }
+                                                }
+                                                WHERE {
+                                                    GRAPH ?g {
+                                                        ?s rdfs:label ?oldLabel .
+                                                        { ?s a qudt:QuantityKind }
+                                                        UNION { ?s a qudt:Prefix }
+                                                        UNION { ?s a qudt:ConstantValue }
+                                                        UNION { ?s a qudt:PhysicalConstant }
+                                                        FILTER NOT EXISTS { ?s qudt:deprecated true }
+                                                    }
+                                                    FILTER(STRSTARTS(STR(?g), "dist:"))
+                                                    FILTER(LANG(?oldLabel) IN ("", "en", "en-US", "en-UK"))
+                                                    FILTER(!REGEX(STR(?oldLabel), "^\\p{Lu}( (al|ανά|на|je|na|par|pe|per|por|pro|za|in|for) |[^\\p{Lu}]|[^\\p{Ll}]\\p{Lu})*$"))
+                                                    # Step 1: insert space before each uppercase letter that follows a lowercase letter (CamelCase split)
+                                                    BIND(REPLACE(STR(?oldLabel), "(\\p{Ll})(\\p{Lu})", "$1 $2") AS ?step1)
+                                                    # Step 2: capitalise the first character
+                                                    BIND(CONCAT(UCASE(SUBSTR(?step1, 1, 1)), SUBSTR(?step1, 2)) AS ?step2)
+                                                    BIND(IF(LANG(?oldLabel) = "", ?step2, STRLANG(?step2, LANG(?oldLabel))) AS ?newLabel)
+                                                    FILTER(STR(?step2) != STR(?oldLabel))
+                                                }
+                                            ]]>
+                                        </sparql>
+                                    </sparqlUpdate>
+                                    <write>
+                                        <graph>fix:labels:title-case:toDelete</graph>
+                                        <toFile>target/fix/labels/title-case/toDelete.ttl</toFile>
+                                    </write>
+                                    <write>
+                                        <graph>fix:labels:title-case:toAdd</graph>
+                                        <toFile>target/fix/labels/title-case/toAdd.ttl</toFile>
+                                    </write>
+
+                                    <savepoint><id>10-infer-labels-title-case</id></savepoint>
+
 
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -2752,10 +2752,7 @@ validAspectDirs.each { aspectDir ->
                                                 WHERE {
                                                     GRAPH ?g {
                                                         ?s rdfs:label ?oldLabel .
-                                                        { ?s a qudt:QuantityKind }
-                                                        UNION { ?s a qudt:Prefix }
-                                                        UNION { ?s a qudt:ConstantValue }
-                                                        UNION { ?s a qudt:PhysicalConstant }
+                                                        { ?s a qudt:QuantityKind } UNION { ?s a qudt:Prefix }
                                                         FILTER NOT EXISTS { ?s qudt:deprecated true }
                                                     }
                                                     FILTER(STRSTARTS(STR(?g), "dist:"))
@@ -2763,10 +2760,34 @@ validAspectDirs.each { aspectDir ->
                                                     FILTER(!REGEX(STR(?oldLabel), "^\\p{Lu}( (al|ανά|на|je|na|par|pe|per|por|pro|za|in|for) |[^\\p{Lu}]|[^\\p{Ll}]\\p{Lu})*$"))
                                                     # Step 1: insert space before each uppercase letter that follows a lowercase letter (CamelCase split)
                                                     BIND(REPLACE(STR(?oldLabel), "(\\p{Ll})(\\p{Lu})", "$1 $2") AS ?step1)
-                                                    # Step 2: capitalise the first character
-                                                    BIND(CONCAT(UCASE(SUBSTR(?step1, 1, 1)), SUBSTR(?step1, 2)) AS ?step2)
-                                                    BIND(IF(LANG(?oldLabel) = "", ?step2, STRLANG(?step2, LANG(?oldLabel))) AS ?newLabel)
-                                                    FILTER(STR(?step2) != STR(?oldLabel))
+                                                    # Step 2: capitalise the first letter of each word that follows a space (26 single-letter replacements using Java lookbehind)
+                                                    BIND(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(
+                                                         REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(
+                                                         REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(
+                                                         REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(
+                                                         REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(
+                                                         REPLACE(?step1,
+                                                           "(?<= )a","A"),"(?<= )b","B"),"(?<= )c","C"),"(?<= )d","D"),"(?<= )e","E"),
+                                                           "(?<= )f","F"),"(?<= )g","G"),"(?<= )h","H"),"(?<= )i","I"),"(?<= )j","J"),
+                                                           "(?<= )k","K"),"(?<= )l","L"),"(?<= )m","M"),"(?<= )n","N"),"(?<= )o","O"),
+                                                           "(?<= )p","P"),"(?<= )q","Q"),"(?<= )r","R"),"(?<= )s","S"),"(?<= )t","T"),
+                                                           "(?<= )u","U"),"(?<= )v","V"),"(?<= )w","W"),"(?<= )x","X"),"(?<= )y","Y"),
+                                                           "(?<= )z","Z") AS ?step2)
+                                                    # Step 3: restore English prepositions and articles to lowercase
+                                                    BIND(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(
+                                                         ?step2,
+                                                         "(?<= )Of(?= |$)","of"),
+                                                         "(?<= )Per(?= |$)","per"),
+                                                         "(?<= )In(?= |$)","in"),
+                                                         "(?<= )For(?= |$)","for"),
+                                                         "(?<= )And(?= |$)","and"),
+                                                         "(?<= )To(?= |$)","to"),
+                                                         "(?<= )A(?= )","a"),
+                                                         "(?<= )An(?= |$)","an") AS ?step3)
+                                                    # Step 4: capitalise the first character of the whole label
+                                                    BIND(CONCAT(UCASE(SUBSTR(?step3, 1, 1)), SUBSTR(?step3, 2)) AS ?step4)
+                                                    BIND(IF(LANG(?oldLabel) = "", ?step4, STRLANG(?step4, LANG(?oldLabel))) AS ?newLabel)
+                                                    FILTER(STR(?step4) != STR(?oldLabel))
                                                 }
                                             ]]>
                                         </sparql>

--- a/src/build/validation/qudt-shacl-functions.ttl
+++ b/src/build/validation/qudt-shacl-functions.ttl
@@ -75,55 +75,6 @@ qfn:
     sh:prefix "rdfio" ;
   ] .
 
-qfn:titleCase
-  a sh:SPARQLFunction ;
-  rdfs:comment """Converts an English string to title case:
-    - splits CamelCase words by inserting a space before each uppercase letter that follows a lowercase letter
-    - capitalises the first letter of every word
-    - restores common English prepositions and articles (of, per, in, for, and, to, a, an) to lowercase
-    - capitalises the first character of the result unconditionally""" ;
-  sh:parameter [
-    sh:datatype xsd:string ;
-    sh:description "Input string" ;
-    sh:order 0 ;
-    sh:path qfn:input ;
-  ] ;
-  sh:prefixes qfn: ;
-  sh:returnType xsd:string ;
-  sh:select """
-    SELECT ?result
-    WHERE {
-      # Step 1: split CamelCase (space before uppercase following lowercase)
-      BIND(REPLACE(?input, "(\\\\p{Ll})(\\\\p{Lu})", "$1 $2") AS ?s1)
-      # Step 2: capitalise first letter of each word following a space (26 lookbehind replacements)
-      BIND(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(
-           REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(
-           REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(
-           REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(
-           REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(
-           REPLACE(?s1,
-             "(?<= )a","A"),"(?<= )b","B"),"(?<= )c","C"),"(?<= )d","D"),"(?<= )e","E"),
-             "(?<= )f","F"),"(?<= )g","G"),"(?<= )h","H"),"(?<= )i","I"),"(?<= )j","J"),
-             "(?<= )k","K"),"(?<= )l","L"),"(?<= )m","M"),"(?<= )n","N"),"(?<= )o","O"),
-             "(?<= )p","P"),"(?<= )q","Q"),"(?<= )r","R"),"(?<= )s","S"),"(?<= )t","T"),
-             "(?<= )u","U"),"(?<= )v","V"),"(?<= )w","W"),"(?<= )x","X"),"(?<= )y","Y"),
-             "(?<= )z","Z") AS ?s2)
-      # Step 3: restore English prepositions and articles to lowercase
-      BIND(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(
-           ?s2,
-           "(?<= )Of(?= |$)","of"),
-           "(?<= )Per(?= |$)","per"),
-           "(?<= )In(?= |$)","in"),
-           "(?<= )For(?= |$)","for"),
-           "(?<= )And(?= |$)","and"),
-           "(?<= )To(?= |$)","to"),
-           "(?<= )A(?= )","a"),
-           "(?<= )An(?= |$)","an") AS ?s3)
-      # Step 4: capitalise first character unconditionally
-      BIND(CONCAT(UCASE(SUBSTR(?s3, 1, 1)), SUBSTR(?s3, 2)) AS ?result)
-    }
-  """ .
-
 qfn:bound
   a sh:SPARQLFunction ;
   rdfs:comment "returns true iff the value is bound and not equal to qfn:Unbound" ;
@@ -595,6 +546,61 @@ qfn:pow
         AS ?result )
     }
     """ .
+
+qfn:titleCase
+  a sh:SPARQLFunction ;
+  rdfs:comment """Converts an English string to title case:
+    - splits CamelCase words by inserting a space before each uppercase letter that follows a lowercase letter
+    - capitalises the first letter of each word that has two or more letters (single-character tokens are left unchanged)
+    - restores common English prepositions, conjunctions, and articles (of, per, in, for, and, to, a, an, by, as, the, at) to lowercase
+    - capitalises the first character of the result unconditionally""" ;
+  sh:parameter [
+    sh:datatype xsd:string ;
+    sh:description "Input string" ;
+    sh:order 0 ;
+    sh:path qfn:input ;
+  ] ;
+  sh:prefixes qfn: ;
+  sh:returnType xsd:string ;
+  sh:select """
+    SELECT ?result
+    WHERE {
+      # Step 1: split CamelCase (space before uppercase following lowercase)
+      BIND(REPLACE(?input, "(\\\\p{Ll})(\\\\p{Lu})", "$1 $2") AS ?s1)
+      # Step 2: capitalise first letter of each word following a space, only if the word has ≥2 letters
+      # (single-character tokens like 'e' in 'base e' are left unchanged)
+      BIND(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(
+           REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(
+           REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(
+           REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(
+           REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(
+           REPLACE(?s1,
+             "(?<= )a(?=[a-zA-Z])","A"),"(?<= )b(?=[a-zA-Z])","B"),"(?<= )c(?=[a-zA-Z])","C"),"(?<= )d(?=[a-zA-Z])","D"),"(?<= )e(?=[a-zA-Z])","E"),
+             "(?<= )f(?=[a-zA-Z])","F"),"(?<= )g(?=[a-zA-Z])","G"),"(?<= )h(?=[a-zA-Z])","H"),"(?<= )i(?=[a-zA-Z])","I"),"(?<= )j(?=[a-zA-Z])","J"),
+             "(?<= )k(?=[a-zA-Z])","K"),"(?<= )l(?=[a-zA-Z])","L"),"(?<= )m(?=[a-zA-Z])","M"),"(?<= )n(?=[a-zA-Z])","N"),"(?<= )o(?=[a-zA-Z])","O"),
+             "(?<= )p(?=[a-zA-Z])","P"),"(?<= )q(?=[a-zA-Z])","Q"),"(?<= )r(?=[a-zA-Z])","R"),"(?<= )s(?=[a-zA-Z])","S"),"(?<= )t(?=[a-zA-Z])","T"),
+             "(?<= )u(?=[a-zA-Z])","U"),"(?<= )v(?=[a-zA-Z])","V"),"(?<= )w(?=[a-zA-Z])","W"),"(?<= )x(?=[a-zA-Z])","X"),"(?<= )y(?=[a-zA-Z])","Y"),
+             "(?<= )z(?=[a-zA-Z])","Z") AS ?s2)
+      # Step 3: restore English prepositions, conjunctions, and articles to lowercase
+      BIND(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(
+           REPLACE(REPLACE(REPLACE(REPLACE(
+           ?s2,
+           "(?<= )Of(?= |$)","of"),
+           "(?<= )Per(?= |$)","per"),
+           "(?<= )In(?= |$)","in"),
+           "(?<= )For(?= |$)","for"),
+           "(?<= )And(?= |$)","and"),
+           "(?<= )To(?= |$)","to"),
+           "(?<= )A(?= )","a"),
+           "(?<= )An(?= |$)","an"),
+           "(?<= )By(?= |$)","by"),
+           "(?<= )As(?= |$)","as"),
+           "(?<= )The(?= |$)","the"),
+           "(?<= )At(?= |$)","at") AS ?s3)
+      # Step 4: capitalise first character unconditionally
+      BIND(CONCAT(UCASE(SUBSTR(?s3, 1, 1)), SUBSTR(?s3, 2)) AS ?result)
+    }
+  """ .
 
 qfn:unit.dimVec.calculate
   a sh:SPARQLFunction ;

--- a/src/build/validation/qudt-shacl-functions.ttl
+++ b/src/build/validation/qudt-shacl-functions.ttl
@@ -75,6 +75,55 @@ qfn:
     sh:prefix "rdfio" ;
   ] .
 
+qfn:titleCase
+  a sh:SPARQLFunction ;
+  rdfs:comment """Converts an English string to title case:
+    - splits CamelCase words by inserting a space before each uppercase letter that follows a lowercase letter
+    - capitalises the first letter of every word
+    - restores common English prepositions and articles (of, per, in, for, and, to, a, an) to lowercase
+    - capitalises the first character of the result unconditionally""" ;
+  sh:parameter [
+    sh:datatype xsd:string ;
+    sh:description "Input string" ;
+    sh:order 0 ;
+    sh:path qfn:input ;
+  ] ;
+  sh:prefixes qfn: ;
+  sh:returnType xsd:string ;
+  sh:select """
+    SELECT ?result
+    WHERE {
+      # Step 1: split CamelCase (space before uppercase following lowercase)
+      BIND(REPLACE(?input, "(\\\\p{Ll})(\\\\p{Lu})", "$1 $2") AS ?s1)
+      # Step 2: capitalise first letter of each word following a space (26 lookbehind replacements)
+      BIND(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(
+           REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(
+           REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(
+           REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(
+           REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(
+           REPLACE(?s1,
+             "(?<= )a","A"),"(?<= )b","B"),"(?<= )c","C"),"(?<= )d","D"),"(?<= )e","E"),
+             "(?<= )f","F"),"(?<= )g","G"),"(?<= )h","H"),"(?<= )i","I"),"(?<= )j","J"),
+             "(?<= )k","K"),"(?<= )l","L"),"(?<= )m","M"),"(?<= )n","N"),"(?<= )o","O"),
+             "(?<= )p","P"),"(?<= )q","Q"),"(?<= )r","R"),"(?<= )s","S"),"(?<= )t","T"),
+             "(?<= )u","U"),"(?<= )v","V"),"(?<= )w","W"),"(?<= )x","X"),"(?<= )y","Y"),
+             "(?<= )z","Z") AS ?s2)
+      # Step 3: restore English prepositions and articles to lowercase
+      BIND(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(
+           ?s2,
+           "(?<= )Of(?= |$)","of"),
+           "(?<= )Per(?= |$)","per"),
+           "(?<= )In(?= |$)","in"),
+           "(?<= )For(?= |$)","for"),
+           "(?<= )And(?= |$)","and"),
+           "(?<= )To(?= |$)","to"),
+           "(?<= )A(?= )","a"),
+           "(?<= )An(?= |$)","an") AS ?s3)
+      # Step 4: capitalise first character unconditionally
+      BIND(CONCAT(UCASE(SUBSTR(?s3, 1, 1)), SUBSTR(?s3, 2)) AS ?result)
+    }
+  """ .
+
 qfn:bound
   a sh:SPARQLFunction ;
   rdfs:comment "returns true iff the value is bound and not equal to qfn:Unbound" ;

--- a/src/main/rdf/validation/COLLECTION_QUDT_QA_TESTS_ALL.ttl
+++ b/src/main/rdf/validation/COLLECTION_QUDT_QA_TESTS_ALL.ttl
@@ -605,10 +605,44 @@ qudt:RdfsLabelInTitleCaseShapeWarning
             $this qudt:deprecated true .
           }
           BIND(LANG(?value) as ?lang)
-          # languages to check (not all languages can be in title case)
-          FILTER ( ?lang IN ("", "bg", "cs", "de", "el", "en", "en-US", "es", "fr", "it", "la", "ms", "nl", "pl", "pt", "ro", "ru", "sl", "tr" ) )
+          # English labels only; non-English title-case issues reported at sh:Info level
+          FILTER ( ?lang IN ("", "en", "en-US", "en-UK") )
           # title case check
-          FILTER ( !REGEX(STR(?value), "^\\\\p{Lu}( (al|ανά|на|je|na|par|pe|per|por|pro|za) |[^\\\\p{Lu}]|[^\\\\p{Ll}]\\\\p{Lu})*$") )
+          FILTER ( !REGEX(STR(?value), "^\\\\p{Lu}( (al|ανά|на|je|na|par|pe|per|por|pro|za|in|for) |[^\\\\p{Lu}]|[^\\\\p{Ll}]\\\\p{Lu})*$") )
+          BIND( CONCAT("'",STR(?value),"'", IF (?lang = "", "", CONCAT("@", ?lang))) AS ?langValue)
+        }
+      """ ;
+  ] ;
+  sh:targetClass qudt:ConstantValue ;
+  sh:targetClass qudt:PhysicalConstant ;
+  sh:targetClass qudt:Prefix ;
+  sh:targetClass qudt:QuantityKind .
+
+qudt:RdfsLabelInTitleCaseShapeInfo
+  a sh:NodeShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/collection/qa/all> ;
+  rdfs:label "Informational notices for non-English labels that are not in title case" ;
+  sh:severity sh:Info ;
+  sh:sparql [
+    a sh:SPARQLConstraint ;
+    sh:message """{$this}: The value of rdfs:label, {?langValue}, is not in title case.
+            - each word must start with an uppercase letter
+            - no uppercase letters allowed directly after a lowercase letter (no CamelCase)
+            - articles and prepositions must be lowercase
+        """ ;
+    sh:prefixes <http://qudt.org/$$QUDT_VERSION$$/collection/qa/allPrefixes> ;
+    sh:select """
+        SELECT $this ?langValue ?value
+        WHERE {
+          $this rdfs:label ?value .
+          FILTER NOT EXISTS {
+            $this qudt:deprecated true .
+          }
+          BIND(LANG(?value) as ?lang)
+          # non-English languages only
+          FILTER ( ?lang IN ("bg", "cs", "de", "el", "es", "fr", "it", "la", "ms", "nl", "pl", "pt", "ro", "ru", "sl", "tr") )
+          # title case check
+          FILTER ( !REGEX(STR(?value), "^\\\\p{Lu}( (al|ανά|на|je|na|par|pe|per|por|pro|za|in|for) |[^\\\\p{Lu}]|[^\\\\p{Ll}]\\\\p{Lu})*$") )
           BIND( CONCAT("'",STR(?value),"'", IF (?lang = "", "", CONCAT("@", ?lang))) AS ?langValue)
         }
       """ ;

--- a/src/main/rdf/validation/COLLECTION_QUDT_QA_TESTS_ALL.ttl
+++ b/src/main/rdf/validation/COLLECTION_QUDT_QA_TESTS_ALL.ttl
@@ -553,11 +553,45 @@ qudt:QuantityKindShape
   ] ;
   sh:targetClass qudt:QuantityKind .
 
+qudt:RdfsLabelInTitleCaseShapeInfo
+  a sh:NodeShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/collection/qa/all> ;
+  rdfs:label "Informational notices for non-English labels that are not in title case" ;
+  sh:severity sh:Info ;
+  sh:sparql [
+    a sh:SPARQLConstraint ;
+    sh:message """{$this}: The value of rdfs:label, {?langValue}, is not in title case.
+            - each word must start with an uppercase letter
+            - no uppercase letters allowed directly after a lowercase letter (no CamelCase)
+            - articles and prepositions must be lowercase
+        """ ;
+    sh:prefixes <http://qudt.org/$$QUDT_VERSION$$/collection/qa/allPrefixes> ;
+    sh:select """
+        SELECT $this ?langValue ?value
+        WHERE {
+          $this rdfs:label ?value .
+          FILTER NOT EXISTS {
+            $this qudt:deprecated true .
+          }
+          BIND(LANG(?value) as ?lang)
+          # non-English languages only
+          FILTER ( ?lang IN ("bg", "cs", "de", "el", "es", "fr", "it", "la", "ms", "nl", "pl", "pt", "ro", "ru", "sl", "tr") )
+          # title case check
+          FILTER ( !REGEX(STR(?value), "^\\\\p{Lu}( (al|ανά|на|je|na|par|pe|per|por|pro|za|in|for) |[^\\\\p{Lu}]|[^\\\\p{Ll}]\\\\p{Lu})*$") )
+          BIND( CONCAT("'",STR(?value),"'", IF (?lang = "", "", CONCAT("@", ?lang))) AS ?langValue)
+        }
+      """ ;
+  ] ;
+  sh:targetClass qudt:ConstantValue ;
+  sh:targetClass qudt:PhysicalConstant ;
+  sh:targetClass qudt:Prefix ;
+  sh:targetClass qudt:QuantityKind .
+
 qudt:RdfsLabelInTitleCaseShapeViolation
   a sh:NodeShape ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/collection/qa/all> ;
-  rdfs:label "Violations for labels that are not in title case" ;
-  sh:severity sh:Violation ;
+  rdfs:label "Warnings for labels that are not in title case (units)" ;
+  sh:severity sh:Warning ;
   sh:sparql [
     a sh:SPARQLConstraint ;
     sh:message """{$this}: The value of rdfs:label, {?langValue}, is not in title case.
@@ -608,47 +642,19 @@ qudt:RdfsLabelInTitleCaseShapeWarning
           # English labels only; non-English title-case issues reported at sh:Info level
           FILTER ( ?lang IN ("", "en", "en-US", "en-UK") )
           # title case check
-          FILTER ( !REGEX(STR(?value), "^\\\\p{Lu}( (al|ανά|на|je|na|par|pe|per|por|pro|za|in|for) |[^\\\\p{Lu}]|[^\\\\p{Ll}]\\\\p{Lu})*$") )
+          # The second condition explicitly catches capitalized exception words (e.g. "Of", "And")
+          # that the first regex cannot reject due to a known limitation with uppercase word starts.
+          FILTER (
+            (
+              !REGEX(STR(?value), "^\\\\p{Lu}( (al|ανά|на|je|na|par|pe|per|por|pro|za|in|for) |[^\\\\p{Lu}]|[^\\\\p{Ll}]\\\\p{Lu}|\\\\p{Lu})*$")
+              || REGEX(STR(?value), "(?<= )(And|An|Of|Per|In|For|To|By|As|The|At)(?= |$)|(?<= )A(?= )")
+            )
+            && !REGEX(STR(?value), "^\\\\p{Ll}-")
+          )
           BIND( CONCAT("'",STR(?value),"'", IF (?lang = "", "", CONCAT("@", ?lang))) AS ?langValue)
         }
       """ ;
   ] ;
-  sh:targetClass qudt:ConstantValue ;
-  sh:targetClass qudt:PhysicalConstant ;
-  sh:targetClass qudt:Prefix ;
-  sh:targetClass qudt:QuantityKind .
-
-qudt:RdfsLabelInTitleCaseShapeInfo
-  a sh:NodeShape ;
-  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/collection/qa/all> ;
-  rdfs:label "Informational notices for non-English labels that are not in title case" ;
-  sh:severity sh:Info ;
-  sh:sparql [
-    a sh:SPARQLConstraint ;
-    sh:message """{$this}: The value of rdfs:label, {?langValue}, is not in title case.
-            - each word must start with an uppercase letter
-            - no uppercase letters allowed directly after a lowercase letter (no CamelCase)
-            - articles and prepositions must be lowercase
-        """ ;
-    sh:prefixes <http://qudt.org/$$QUDT_VERSION$$/collection/qa/allPrefixes> ;
-    sh:select """
-        SELECT $this ?langValue ?value
-        WHERE {
-          $this rdfs:label ?value .
-          FILTER NOT EXISTS {
-            $this qudt:deprecated true .
-          }
-          BIND(LANG(?value) as ?lang)
-          # non-English languages only
-          FILTER ( ?lang IN ("bg", "cs", "de", "el", "es", "fr", "it", "la", "ms", "nl", "pl", "pt", "ro", "ru", "sl", "tr") )
-          # title case check
-          FILTER ( !REGEX(STR(?value), "^\\\\p{Lu}( (al|ανά|на|je|na|par|pe|per|por|pro|za|in|for) |[^\\\\p{Lu}]|[^\\\\p{Ll}]\\\\p{Lu})*$") )
-          BIND( CONCAT("'",STR(?value),"'", IF (?lang = "", "", CONCAT("@", ?lang))) AS ?langValue)
-        }
-      """ ;
-  ] ;
-  sh:targetClass qudt:ConstantValue ;
-  sh:targetClass qudt:PhysicalConstant ;
   sh:targetClass qudt:Prefix ;
   sh:targetClass qudt:QuantityKind .
 

--- a/src/main/rdf/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL.ttl
+++ b/src/main/rdf/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL.ttl
@@ -1801,15 +1801,15 @@ quantitykind:Capacity
 
 quantitykind:CarrierLifetime
   a qudt:QuantityKind ;
-  dcterms:description "\"Carrier LifetIme\" is a time constant for recombination or trapping of minority charge carriers in semiconductors."^^qudt:LatexString ;
+  dcterms:description "\"Carrier Lifetime\" is a time constant for recombination or trapping of minority charge carriers in semiconductors."^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T1D0 ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Carrier_lifetime"^^xsd:anyURI ;
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
   qudt:latexSymbol "$\\tau, \\tau_n, \\tau_p$"^^qudt:LatexString ;
-  qudt:plainTextDescription "\"Carrier LifetIme\" is a time constant for recombination or trapping of minority charge carriers in semiconductors." ;
+  qudt:plainTextDescription "\"Carrier Lifetime\" is a time constant for recombination or trapping of minority charge carriers in semiconductors." ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q5046374> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Carrier LifetIme"@en ;
+  rdfs:label "Carrier Lifetime"@en ;
   skos:broader quantitykind:Time .
 
 quantitykind:CartesianArea

--- a/src/main/rdf/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL.ttl
+++ b/src/main/rdf/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL.ttl
@@ -85,7 +85,7 @@ quantitykind:AbsoluteTypographicMeasurement
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T0D0 ;
   qudt:iec61360Code "0112/2///62720#UAD372" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "absolute typographic measurement" ;
+  rdfs:label "Absolute Typographic Measurement" ;
   skos:broader quantitykind:Length .
 
 quantitykind:AbsorbedDose
@@ -157,11 +157,11 @@ quantitykind:Acceleration
   qudt:siExactMatch si-quantity:ACCE ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q11376> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
+  rdfs:label "Acceleration"@en ;
   rdfs:label "Beschleunigung"@de ;
   rdfs:label "Pecutan"@ms ;
   rdfs:label "Zrychlení"@cs ;
   rdfs:label "acceleratio"@la ;
-  rdfs:label "acceleration"@en ;
   rdfs:label "accelerazione"@it ;
   rdfs:label "accelerație"@ro ;
   rdfs:label "accélération"@fr ;
@@ -186,7 +186,7 @@ quantitykind:AccelerationOfGravity
   qudt:symbol "g" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q30006> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Acceleration Of Gravity"@en ;
+  rdfs:label "Acceleration of Gravity"@en ;
   skos:broader quantitykind:Acceleration .
 
 quantitykind:AcceptorDensity
@@ -378,7 +378,7 @@ quantitykind:ActivityRelatedByMass
   qudt:plainTextDescription "quantitative data of the radioactivity of the amount of a radionuclide in a particular state of energy at a defined point in time, divided by the related mass of this quantity"@en ;
   qudt:symbol "0173-1#Z4-BAJ342#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "activity related by mass"@en-US ;
+  rdfs:label "Activity Related by Mass"@en-US ;
   skos:broader quantitykind:MassicActivity .
 
 quantitykind:ActivityThresholds
@@ -455,7 +455,7 @@ quantitykind:AmountOfBiologicallyActiveSubstance
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:iec61360Code "0112/2///62720#UAD370" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "amount of biologically active substance" .
+  rdfs:label "Amount of Biologically Active Substance" .
 
 quantitykind:AmountOfCloudCover
   a qudt:QuantityKind ;
@@ -464,7 +464,7 @@ quantitykind:AmountOfCloudCover
   qudt:isoNormativeReference "https://library.wmo.int/viewer/68695/?offset=3#page=514&viewer=picture&o=bookmark&n=0&q="^^xsd:anyURI ;
   qudt:plainTextDescription "The amount of the celestial dome covered by all clouds visible." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Amount of cloud cover"@en .
+  rdfs:label "Amount of Cloud Cover"@en .
 
 quantitykind:AmountOfSubstance
   a qudt:QuantityKind ;
@@ -493,10 +493,10 @@ quantitykind:AmountOfSubstance
   qudt:symbol "n" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q104946> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
+  rdfs:label "Amount of Substance"@en ;
   rdfs:label "Jumlah bahan"@ms ;
   rdfs:label "Látkové množství"@cs ;
   rdfs:label "Stoffmenge"@de ;
-  rdfs:label "amount of substance"@en ;
   rdfs:label "anyagmennyiség"@hu ;
   rdfs:label "cantidad de sustancia"@es ;
   rdfs:label "cantitate de substanță"@ro ;
@@ -574,7 +574,7 @@ quantitykind:AmountOfSubstancePerMassPressure
   qudt:qkdvDenominator qkdv:A0E0L-1I0M2H0T-2D0 ;
   qudt:qkdvNumerator qkdv:A1E0L0I0M0H0T0D0 ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Molar Mass variation due to Pressure"@en .
+  rdfs:label "Molar Mass Variation Due to Pressure"@en .
 
 quantitykind:AmountOfSubstancePerVolume
   a qudt:QuantityKind ;
@@ -609,7 +609,7 @@ quantitykind:AngleOfAttack
   qudt:plainTextDescription "Angle of attack  is the angle between the oncoming air or relative wind and a reference line on the airplane or wing." ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q370906> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Angle Of Attack"@en ;
+  rdfs:label "Angle of Attack"@en ;
   skos:broader quantitykind:Angle .
 
 quantitykind:AngleOfOpticalRotation
@@ -637,6 +637,7 @@ quantitykind:AngularAcceleration
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q186300> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Accelerație unghiulară"@ro ;
+  rdfs:label "Angular Acceleration"@en ;
   rdfs:label "Açısal ivme"@tr ;
   rdfs:label "Pecutan bersudut"@ms ;
   rdfs:label "Przyspieszenie kątowe"@pl ;
@@ -645,7 +646,6 @@ quantitykind:AngularAcceleration
   rdfs:label "accélération angulaire"@fr ;
   rdfs:label "aceleración angular"@es ;
   rdfs:label "aceleração angular"@pt ;
-  rdfs:label "angular acceleration"@en ;
   rdfs:label "Úhlové zrychlení"@cs ;
   rdfs:label "Угловое ускорение"@ru ;
   rdfs:label "تسارع زاوي"@ar ;
@@ -691,9 +691,9 @@ quantitykind:AngularFrequency
   qudt:latexSymbol "$\\omega$"^^qudt:LatexString ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q834020> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
+  rdfs:label "Angular Frequency"@en ;
   rdfs:label "Kreisfrequenz"@de ;
   rdfs:label "Pulsación"@fr ;
-  rdfs:label "angular frequency"@en ;
   rdfs:label "frequenza angolare"@it ;
   rdfs:label "frequência angular"@pt ;
   rdfs:label "pulsación"@es ;
@@ -723,8 +723,8 @@ quantitykind:AngularImpulse
   qudt:symbol "H" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q73428743> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
+  rdfs:label "Angular Impulse"@en ;
   rdfs:label "Drehstoß"@de ;
-  rdfs:label "angular impulse"@en ;
   rdfs:label "impulsion angulaire"@fr ;
   rdfs:label "impulso angolare"@it ;
   rdfs:label "impulso angular"@es ;
@@ -786,12 +786,12 @@ quantitykind:AngularVelocity
   qudt:siExactMatch si-quantity:VELA ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q161635> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
+  rdfs:label "Angular Velocity"@en ;
   rdfs:label "Açısal hız"@tr ;
   rdfs:label "Halaju bersudut"@ms ;
   rdfs:label "Prędkość kątowa"@pl ;
   rdfs:label "Viteză unghiulară"@ro ;
   rdfs:label "Winkelgeschwindigkeit"@de ;
-  rdfs:label "angular velocity"@en ;
   rdfs:label "kotna hitrost"@sl ;
   rdfs:label "velocidad angular"@es ;
   rdfs:label "velocidade angular"@pt ;
@@ -824,8 +824,8 @@ $k = \\frac{p}{\\hbar}$, where $p$ is the linear momentum of quasi free electron
   qudt:symbol "k" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q30338487> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
+  rdfs:label "Angular Wavenumber"@en ;
   rdfs:label "Kreisrepetenz"@de ;
-  rdfs:label "angular wavenumber"@en ;
   rdfs:label "liczba falowa kątowa"@pl ;
   rdfs:label "nombre d'onde angulaire"@fr ;
   rdfs:label "numero d'onda angolare"@it ;
@@ -861,8 +861,8 @@ quantitykind:ApparentEnergy
   qudt:plainTextDescription "Apparent energy is the integral of apparent power over a time interval. It is commonly measured in volt-ampere hours (VA·h) or kilovolt-ampere hours (kVA·h)." ;
   qudt:symbol "W_a" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
+  rdfs:label "Apparent Energy"@en ;
   rdfs:label "Scheinenergie"@de ;
-  rdfs:label "apparent energy"@en ;
   rdfs:label "energia aparente"@pt ;
   rdfs:label "energia apparente"@it ;
   rdfs:label "energia pozorna"@pl ;
@@ -888,8 +888,8 @@ quantitykind:ApparentPower
   qudt:latexSymbol "$\\left | \\underline{S} \\right |$"^^qudt:LatexString ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q1930258> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
+  rdfs:label "Apparent Power"@en ;
   rdfs:label "Scheinleistung"@de ;
-  rdfs:label "apparent power"@en ;
   rdfs:label "moc pozorna"@pl ;
   rdfs:label "potencia aparente"@es ;
   rdfs:label "potenza apparente"@it ;
@@ -909,7 +909,7 @@ quantitykind:ApparentThermalInertia
   qudt:informativeReference "https://en.wikipedia.org/wiki/Thermal_inertia"^^xsd:anyURI ;
   qudt:plainTextDescription "Thermal inertia is a term used to describe the observed delays in a body's temperature response during heat transfers" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Measurement Unit for a quantity approximately proportional to Thermal Inertia" .
+  rdfs:label "Measurement Unit for a Quantity Approximately Proportional to Thermal Inertia" .
 
 quantitykind:Area
   a qudt:QuantityKind ;
@@ -923,11 +923,11 @@ quantitykind:Area
   qudt:siExactMatch si-quantity:AREA ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q11500> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
+  rdfs:label "Area"@en ;
   rdfs:label "Fläche"@de ;
   rdfs:label "Keluasan"@ms ;
   rdfs:label "aire"@fr ;
   rdfs:label "alan"@tr ;
-  rdfs:label "area"@en ;
   rdfs:label "area"@it ;
   rdfs:label "arie"@ro ;
   rdfs:label "plocha"@cs ;
@@ -957,14 +957,14 @@ quantitykind:AreaBitDensity
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T0D0 ;
   qudt:iec61360Code "0112/2///62720#UAD012" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "areic bit density" .
+  rdfs:label "Areic Bit Density" .
 
 quantitykind:AreaChargeDensity
   a qudt:QuantityKind ;
   qudt:hasDimensionVector qkdv:A0E1L-2I0M0H0T1D0 ;
   qudt:iec61360Code "0112/2///62720#UAD013" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "areic charge density" ;
+  rdfs:label "Areic Charge Density" ;
   skos:broader quantitykind:ElectricChargePerArea .
 
 quantitykind:AreaMass
@@ -972,7 +972,7 @@ quantitykind:AreaMass
   qudt:hasDimensionVector qkdv:A0E0L-2I0M1H0T0D0 ;
   qudt:iec61360Code "0112/2///62720#UAD014" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "areic mass" ;
+  rdfs:label "Areic Mass" ;
   skos:broader quantitykind:MassPerArea .
 
 quantitykind:AreaPerLength
@@ -983,16 +983,16 @@ quantitykind:AreaPerLength
   qudt:qkdvDenominator qkdv:A0E0L1I0M0H0T0D0 ;
   qudt:qkdvNumerator qkdv:A0E0L2I0M0H0T0D0 ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Fläche pro Längeneinheit"@de ;
-  rdfs:label "area per length"@en .
+  rdfs:label "Area per Length"@en ;
+  rdfs:label "Fläche pro Längeneinheit"@de .
 
 quantitykind:AreaPerPower
   a qudt:QuantityKind ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M-1H0T3D0 ;
   qudt:plainTextDescription "The ratio of an area and the power required for maintaining room temperature at a given level" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Fläche pro Heizlast"@de ;
-  rdfs:label "area per heating load"@en .
+  rdfs:label "Area per Heating Load"@en ;
+  rdfs:label "Fläche pro Heizlast"@de .
 
 quantitykind:AreaPerTime
   a qudt:QuantityKind ;
@@ -1057,7 +1057,7 @@ quantitykind:AreicDataVolume
   qudt:plainTextDescription "Anzahl von Daten, die in der Regel abhängig von der jeweiligen Komplexität der Information oder deren Codierungsverfahren ist, dividiert durch die zugehörige Fläche"@de ;
   qudt:symbol "0173-1#Z4-BAJ321#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "areic data volume"@en-US .
+  rdfs:label "Areic Data Volume"@en-US .
 
 quantitykind:AreicEnergyFlow
   a qudt:QuantityKind ;
@@ -1066,7 +1066,7 @@ quantitykind:AreicEnergyFlow
   qudt:plainTextDescription "Leistung in festgelegter Ausbreitungsrichtung durch ein dazu senkrechtes Oberflächenelement, dividiert durch dessen Fläche"@de ;
   qudt:symbol "0173-1#Z4-BAJ322#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "areic energy flow"@en-US ;
+  rdfs:label "Areic Energy Flow"@en-US ;
   skos:broader quantitykind:PowerPerArea .
 
 quantitykind:AreicHeatFlowRate
@@ -1091,7 +1091,7 @@ quantitykind:AreicMass
   qudt:plainTextDescription "Masse dividiert durch die zugehörige Fläche"@de ;
   qudt:symbol "0173-1#Z4-BAJ288#004" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "areic mass"@en-US ;
+  rdfs:label "Areic Mass"@en-US ;
   skos:broader quantitykind:MassPerArea .
 
 quantitykind:AreicTorque
@@ -1101,7 +1101,7 @@ quantitykind:AreicTorque
   qudt:plainTextDescription "Quotient aus dem auf eine Fläche wirkenden, eine Verdrehung bzw. Abscherung verursachenden  Drehmoment dividiert durch diese Fläche"@de ;
   qudt:symbol "0173-1#Z4-BAJ420#001" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "areic torque"@en-US .
+  rdfs:label "Areic Torque"@en-US .
 
 quantitykind:Asset
   a qudt:QuantityKind ;
@@ -1176,7 +1176,7 @@ quantitykind:AtomicEnergy
   qudt:plainTextDescription "skalare Größe von Elementarteilchen, die bei beliebiger Umwandlung innerhalb eines Systems erhalten bleibt und als gespeichertes Arbeitsvermögen die Fähigkeit eines physikalischen Systems darstellt, Arbeit zu verrichten"@de ;
   qudt:symbol "0173-1#Z4-BAJ291#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "atomic energy"@en-US ;
+  rdfs:label "Atomic Energy"@en-US ;
   skos:broader quantitykind:Energy .
 
 quantitykind:AtomicMass
@@ -1213,7 +1213,7 @@ quantitykind:AtomicStoppingPower
   qudt:plainTextDescription "Quotient aus dem linearen Bremsvermögen und der Anzahldichte der Atome in dem Medium"@de ;
   qudt:symbol "0173-1#Z4-BAJ292#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "atomic stopping power"@en-US .
+  rdfs:label "Atomic Stopping Power"@en-US .
 
 quantitykind:AttenuationCoefficient
   a qudt:QuantityKind ;
@@ -1314,7 +1314,7 @@ quantitykind:BandwidthDistanceProduct
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T-1D0 ;
   qudt:iec61360Code "0112/2///62720#UAD016" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "bandwidth distance product" .
+  rdfs:label "Bandwidth Distance Product" .
 
 quantitykind:BandwidthLengthProduct
   a qudt:QuantityKind ;
@@ -1323,7 +1323,7 @@ quantitykind:BandwidthLengthProduct
   qudt:plainTextDescription "Parameter von Übertragungsmedien zur Bestimmung der Frequenz- und Längenrestriktionen als reziproke Wert der Modendispersion entsprechend dem Produkt aus maximaler Impulsfrequenz mal maximaler Übertragungsstrecke"@de ;
   qudt:symbol "0173-1#Z4-BAJ293#003" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "bandwidth length product"@en-US .
+  rdfs:label "Bandwidth Length Product"@en-US .
 
 quantitykind:Basicity
   a qudt:QuantityKind ;
@@ -1348,8 +1348,8 @@ quantitykind:BatteryCapacity
   qudt:plainTextDescription "Elektrizitätsmenge oder elektrische Ladung, die eine vollgeladenen Batterie unter festgelegten Bedingungen abgeben kann als Produkt aus Entladestrom und Entladezeit"@de ;
   qudt:symbol "0173-1#Z4-BAJ270#003" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "battery capacity" ;
-  rdfs:label "battery capacity"@en-US .
+  rdfs:label "Battery Capacity" ;
+  rdfs:label "Battery Capacity"@en-US .
 
 quantitykind:BendingMomentOfForce
   a qudt:QuantityKind ;
@@ -1396,7 +1396,7 @@ quantitykind:BinaryLogarithmicMedianInformationFlow
   qudt:plainTextDescription "Quotient mittlerer Informationsgehalt durch den Erwartungswert für die Dauer eines Zeichens, ausgedrückt als Logarithmus zur Basis 2"@de ;
   qudt:symbol "0173-1#Z4-BAJ464#001" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "median information flow (from a source of information), expressed as a binary logarithm"@en-US .
+  rdfs:label "Median Information Flow (from a Source of Information), Expressed as a Binary Logarithm"@en-US .
 
 quantitykind:BindingFraction
   a qudt:QuantityKind ;
@@ -1446,14 +1446,14 @@ quantitykind:BitDataVolume
   qudt:plainTextDescription "Bezeichnung für eine bestimmte Anzahl von Daten auf Basis der Binärziffer Bit (en: Basic Indissoluble Information Unit, dt: kleinstmögliche Informationseinheit), welche nur den Zustand 1 oder 0 annehmen kann"@de ;
   qudt:symbol "0173-1#Z4-BAJ436#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "bit data volume"@en-US .
+  rdfs:label "Bit Data Volume"@en-US .
 
 quantitykind:BitRate
   a qudt:QuantityKind ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:iec61360Code "0112/2///62720#UAD018" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "bit rate" .
+  rdfs:label "Bit Rate" .
 
 quantitykind:BitTransmissionRate
   a qudt:QuantityKind ;
@@ -1462,7 +1462,7 @@ quantitykind:BitTransmissionRate
   qudt:plainTextDescription "Geschwindigkeit, mit der Binärzeichen übertragen werden"@de ;
   qudt:symbol "0173-1#Z4-BAJ295#003" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "bit transmission rate"@en-US ;
+  rdfs:label "Bit Transmission Rate"@en-US ;
   skos:broader quantitykind:BitRate .
 
 quantitykind:BloodGlucoseLevel
@@ -1571,9 +1571,9 @@ quantitykind:Breadth
   qudt:symbol "b" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q77835705> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
+  rdfs:label "Breadth"@en ;
   rdfs:label "Breite"@de ;
   rdfs:label "ancho"@es ;
-  rdfs:label "breadth"@en ;
   rdfs:label "genişliği"@tr ;
   rdfs:label "largeur"@fr ;
   rdfs:label "larghezza"@it ;
@@ -1646,8 +1646,8 @@ quantitykind:BurstFactor
   qudt:plainTextDescription "Quotient Berstdruck dividiert durch die flächenbezogene Masse"@de ;
   qudt:symbol "0173-1#Z4-BAJ434#001" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "burst factor" ;
-  rdfs:label "burst factor"@en-US .
+  rdfs:label "Burst Factor" ;
+  rdfs:label "Burst Factor"@en-US .
 
 quantitykind:ByteDataVolume
   a qudt:QuantityKind ;
@@ -1656,7 +1656,7 @@ quantitykind:ByteDataVolume
   qudt:plainTextDescription "Anzahl von Daten auf Basis einer Zeichenfolge, die aus je 8 Bit besteht"@de ;
   qudt:symbol "0173-1#Z4-BAJ435#004" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "byte data volume"@en-US ;
+  rdfs:label "Byte Data Volume"@en-US ;
   skos:broader quantitykind:Count .
 
 quantitykind:ByteRate
@@ -1664,7 +1664,7 @@ quantitykind:ByteRate
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:iec61360Code "0112/2///62720#UAD020" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "byte rate" .
+  rdfs:label "Byte Rate" .
 
 quantitykind:ByteTransmissionRate
   a qudt:QuantityKind ;
@@ -1673,7 +1673,7 @@ quantitykind:ByteTransmissionRate
   qudt:plainTextDescription "Geschwindigkeit, mit der 8 Binärzeichen übertragen werden"@de ;
   qudt:symbol "0173-1#Z4-BAJ297#003" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "byte transmission rate"@en-US ;
+  rdfs:label "Byte Transmission Rate"@en-US ;
   skos:broader quantitykind:ByteRate .
 
 quantitykind:CENTER-OF-GRAVITY_X
@@ -1836,7 +1836,7 @@ quantitykind:CartesianCoordinates
   qudt:plainTextDescription "\"Cartesian Coordinates\" specify each point uniquely in a plane by a pair of numerical coordinates, which are the signed distances from the point to two fixed perpendicular directed lines, measured in the same unit of length. " ;
   qudt:symbol "x, y, z" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Cartesian coordinates"@en ;
+  rdfs:label "Cartesian Coordinates"@en ;
   rdfs:label "Kartézská soustava souřadnic"@cs ;
   rdfs:label "Koordiant Kartesius"@ms ;
   rdfs:label "coordenadas cartesianas"@pt ;
@@ -1861,12 +1861,12 @@ quantitykind:CartesianVolume
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Isipadu"@ms ;
   rdfs:label "Objem"@cs ;
+  rdfs:label "Volume"@en ;
   rdfs:label "Volumen"@de ;
   rdfs:label "hacim"@tr ;
   rdfs:label "objętość"@pl ;
   rdfs:label "prostornina"@sl ;
   rdfs:label "volum"@ro ;
-  rdfs:label "volume"@en ;
   rdfs:label "volume"@fr ;
   rdfs:label "volume"@it ;
   rdfs:label "volume"@pt ;
@@ -1926,8 +1926,8 @@ $t = T - T_0$, where $T$ is Thermodynamic Temperature and $T_0 = 273.15 K$."""^^
   qudt:siExactMatch si-quantity:TEMC ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q74758530> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
+  rdfs:label "Celsius Temperature"@en ;
   rdfs:label "Celsius sıcaklık"@tr ;
-  rdfs:label "Celsius temperature"@en ;
   rdfs:label "Celsius-Temperatur"@de ;
   rdfs:label "Suhu Celsius"@ms ;
   rdfs:label "temperatura Celsius"@es ;
@@ -1953,7 +1953,7 @@ quantitykind:CenterOfGravity_X
   qudt:informativeReference "https://www1.grc.nasa.gov/beginners-guide-to-aeronautics/center-of-gravity/"^^xsd:anyURI ;
   qudt:symbol "cg" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Center of Gravity in the X axis"@en ;
+  rdfs:label "Center of Gravity in the X Axis"@en ;
   skos:broader quantitykind:Length .
 
 quantitykind:CenterOfGravity_Y
@@ -1962,7 +1962,7 @@ quantitykind:CenterOfGravity_Y
   qudt:informativeReference "https://www1.grc.nasa.gov/beginners-guide-to-aeronautics/center-of-gravity/"^^xsd:anyURI ;
   qudt:symbol "cg" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Center of Gravity in the Y axis"@en ;
+  rdfs:label "Center of Gravity in the Y Axis"@en ;
   skos:broader quantitykind:Length .
 
 quantitykind:CenterOfGravity_Z
@@ -1971,7 +1971,7 @@ quantitykind:CenterOfGravity_Z
   qudt:informativeReference "https://www1.grc.nasa.gov/beginners-guide-to-aeronautics/center-of-gravity/"^^xsd:anyURI ;
   qudt:symbol "cg" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Center of Gravity in the Z axis"@en ;
+  rdfs:label "Center of Gravity in the Z Axis"@en ;
   skos:broader quantitykind:Length .
 
 quantitykind:CharacteristicAcousticImpedance
@@ -1994,7 +1994,7 @@ quantitykind:CharacteristicNumber
   qudt:plainTextDescription "Größe der Dimension 1 (als Ergebnis der metrisierenden Messtheorie), die Sachverhalte, Zustände oder Entwicklungen verdeutlicht und als Maßstab dient, um z. B. Ursache und Wirkung von Vorgängen in kausalem Zusammenhang darzustellen"@de ;
   qudt:symbol "0173-1#Z4-BAJ279#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "characteristic number"@en-US ;
+  rdfs:label "Characteristic Number"@en-US ;
   skos:broader quantitykind:Dimensionless .
 
 quantitykind:CharacteristicVelocity
@@ -2051,11 +2051,11 @@ quantitykind:ChemicalPotential
   qudt:plainTextDescription "\"Chemical Potential\", also known as partial molar free energy, is a form of potential energy that can be absorbed or released during a chemical reaction." ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q737004> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
+  rdfs:label "Chemical Potential"@en ;
   rdfs:label "Chemický potenciál"@cs ;
   rdfs:label "Keupayaan kimia"@ms ;
   rdfs:label "Potencjał chemiczny"@pl ;
   rdfs:label "Potențial chimic"@ro ;
-  rdfs:label "chemical potential"@en ;
   rdfs:label "chemisches Potential des Stoffs B"@de ;
   rdfs:label "kimyasal potansiyel"@tr ;
   rdfs:label "potencial químico"@es ;
@@ -2110,7 +2110,7 @@ $K = \\frac{\\varphi}{T}$, where $\\varphi$ is areic heat flow rate and $T$ is t
   qudt:latexSymbol "$\\kappa$"^^qudt:LatexString ;
   qudt:plainTextDescription "\"Coefficient of Heat Transfer\", in thermodynamics and in mechanical and chemical engineering, is used in calculating the heat transfer, typically by convection or phase transition between a fluid and a solid. The heat transfer coefficient is the proportionality coefficient between the heat flux, that is heat flow per unit area, q/A, and the thermodynamic driving force for the flow of heat (that is, the temperature difference, (Delta T).  Areic heat flow rate divided by thermodynamic temperature difference. In building technology, the \"Coefficient of Heat Transfer\", is often called \"thermal transmittance}\" with the symbol \"U\". It has SI units in watts per squared meter kelvin." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Coefficient of heat transfer"@en .
+  rdfs:label "Coefficient of Heat Transfer"@en .
 
 quantitykind:CoefficientOfPerformance
   a qudt:QuantityKind ;
@@ -2121,7 +2121,7 @@ quantitykind:CoefficientOfPerformance
   qudt:plainTextDescription "\"\"Coefficient of Performance\",is a measure of the efficiency of a heating or cooling system, defined as the ratio of useful heating or cooling output to the energy input required to achieve it." ;
   qudt:symbol "COP" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "CoefficientOfPerformance"@en ;
+  rdfs:label "Coefficient of Performance"@en ;
   skos:broader quantitykind:DimensionlessRatio .
 
 quantitykind:Coercivity
@@ -2176,13 +2176,13 @@ quantitykind:CommonLogarithmicMedianInformationFlow
   qudt:plainTextDescription "Quotient mittlerer Informationsgehalt durch den Erwartungswert für die Dauer eines Zeichens, ausgedrückt als Logarithmus zur Basis 10"@de ;
   qudt:symbol "0173-1#Z4-BAJ470#001" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "median information flow (from a source of information), expressed as a common logarithm "@en-US .
+  rdfs:label "Median Information Flow (from a Source of Information), Expressed as a Common Logarithm "@en-US .
 
 quantitykind:ComplexFrequency_Imaginary
   a qudt:QuantityKind ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "imaginary part of complex frequency" ;
+  rdfs:label "Imaginary Part of Complex Frequency" ;
   skos:broader quantitykind:Frequency .
 
 quantitykind:ComplexFrequency_Real
@@ -2190,7 +2190,7 @@ quantitykind:ComplexFrequency_Real
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:iec61360Code "0112/2///62720#UAD199" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "real part of complex frequency" ;
+  rdfs:label "Real Part of Complex Frequency" ;
   skos:broader quantitykind:Frequency .
 
 quantitykind:ComplexPower
@@ -2396,8 +2396,8 @@ quantitykind:CostPerArea
   qudt:informativeReference "https://www.designingbuildings.co.uk/wiki/Cost_per_m2_of_gross_internal_floor_area"^^xsd:anyURI ;
   qudt:plainTextDescription "In the construction industry, cost per area is the unit rate which, when multiplied by the gross internal floor area (GIFA), gives the total building works estimate (i.e.works cost estimate less main contractor’s preliminaries and main contractor’s overheads and profit)." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Kosten pro Fläche"@de ;
-  rdfs:label "cost per area"@en .
+  rdfs:label "Cost per Area"@en ;
+  rdfs:label "Kosten pro Fläche"@de .
 
 quantitykind:CostPerEnergy
   a qudt:QuantityKind ;
@@ -2406,15 +2406,15 @@ quantitykind:CostPerEnergy
   qudt:plainTextDescription "The monetary cost of a unit of energy" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Energiekosten"@de ;
-  rdfs:label "energy cost"@en .
+  rdfs:label "Energy Cost"@en .
 
 quantitykind:CostPerMass
   a qudt:QuantityKind ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M-1H0T0D0 ;
   qudt:plainTextDescription "Represents the cost associated with a unit mass of a substance or material. It is typically used in economic and engineering contexts to evaluate the expense incurred per kilogram, gram, or other units of mass. This measure helps in comparing the economic efficiency of different materials or substances based on their mass." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Kosten pro Masse"@de ;
-  rdfs:label "cost per mass"@en .
+  rdfs:label "Cost per Mass"@en ;
+  rdfs:label "Kosten pro Masse"@de .
 
 quantitykind:CostPerPower
   a qudt:QuantityKind ;
@@ -2423,7 +2423,7 @@ quantitykind:CostPerPower
   qudt:plainTextDescription "In photovoltaics, cost per power of electricity produced measures the cost of installing the hardware relative to the power produced." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Anschaffungskosten pro Watt"@de ;
-  rdfs:label "cost per power"@en .
+  rdfs:label "Cost per Power"@en .
 
 quantitykind:Count
   a qudt:QuantityKind ;
@@ -2443,7 +2443,7 @@ quantitykind:CountRate
   qudt:qkdvDenominator qkdv:A0E0L0I0M0H0T1D0 ;
   qudt:qkdvNumerator qkdv:A0E0L0I0M0H0T0D1 ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "CountRate"@en ;
+  rdfs:label "Count Rate"@en ;
   skos:broader quantitykind:Frequency .
 
 quantitykind:CouplingFactor
@@ -2457,9 +2457,9 @@ quantitykind:CouplingFactor
   qudt:symbol "k" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Constantă de cuplaj"@ro ;
+  rdfs:label "Coupling Factor"@en ;
   rdfs:label "constante de acoplamiento"@es ;
   rdfs:label "constante de couplage"@fr ;
-  rdfs:label "coupling factor"@en ;
   rdfs:label "fattore di accoppiamento"@it ;
   rdfs:label "stała sprzężenia"@pl ;
   rdfs:label "Çiftlenim sabiti"@tr ;
@@ -2507,13 +2507,13 @@ quantitykind:CubicExpansionCoefficient
   qudt:qkdvNumerator qkdv:A0E0L3I0M0H0T0D0 ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q74761076> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
+  rdfs:label "Cubic Expansion Coefficient"@en ;
   rdfs:label "Hullámszám"@hu ;
   rdfs:label "Volumenausdehnungskoeffizient"@de ;
   rdfs:label "coefficient de dilatation volumique"@fr ;
   rdfs:label "coefficiente di dilatazione volumica"@it ;
   rdfs:label "coeficiente de dilatación cúbica"@es ;
   rdfs:label "coeficiente de dilatação volúmica"@pt ;
-  rdfs:label "cubic expansion coefficient"@en ;
   rdfs:label "kübik genleşme katsayısı"@tr ;
   rdfs:label "współczynnik rozszerzalności objętościowej"@pl ;
   rdfs:label "Κυματαριθμός"@el ;
@@ -2536,8 +2536,8 @@ quantitykind:CurieTemperature
   qudt:symbol "T_C" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q191073> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
+  rdfs:label "Curie Temperature"@en ;
   rdfs:label "Curie sıcaklığı"@tr ;
-  rdfs:label "Curie temperature"@en ;
   rdfs:label "Curie-Temperatur"@de ;
   rdfs:label "Curieova teplota"@cs ;
   rdfs:label "Punct Curie"@ro ;
@@ -2573,7 +2573,7 @@ quantitykind:CurrencyPerFlight
   qudt:qkdvDenominator qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:qkdvNumerator qkdv:A0E0L0I0M0H0T0D1 ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Currency Per Flight"@en ;
+  rdfs:label "Currency per Flight"@en ;
   skos:broader quantitykind:DimensionlessRatio .
 
 quantitykind:CurrentLinkage
@@ -2595,7 +2595,7 @@ quantitykind:CurrentOfTheAmountOfSubstance
   qudt:plainTextDescription "Quotient Stoffmenge dividiert durch die zugehörige Zeit"@de ;
   qudt:symbol "0173-1#Z4-BAJ384#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "current of the amount of substance"@en-US .
+  rdfs:label "Current of the Amount of Substance"@en-US .
 
 quantitykind:Curvature
   a qudt:QuantityKind ;
@@ -2685,21 +2685,21 @@ quantitykind:DataTransmissionRate
   a qudt:QuantityKind ;
   qudt:hasDimensionVector qkdv:NotApplicable ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "data transmission rate"@en-US .
+  rdfs:label "Data Transmission Rate"@en-US .
 
 quantitykind:DatasetOfBits
   a qudt:QuantityKind ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:iec61360Code "0112/2///62720#UAD027" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "dataset of bits" .
+  rdfs:label "Dataset of Bits" .
 
 quantitykind:DatasetOfBytes
   a qudt:QuantityKind ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:iec61360Code "0112/2///62720#UAD028" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "dataset of bytes" .
+  rdfs:label "Dataset of Bytes" .
 
 quantitykind:Debye-WallerFactor
   a qudt:QuantityKind ;
@@ -2824,7 +2824,7 @@ quantitykind:DensityInCombustionChamber
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H0T0D0 ;
   qudt:latexSymbol "$\\rho_c$"^^qudt:LatexString ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Density In Combustion Chamber"@en ;
+  rdfs:label "Density in Combustion Chamber"@en ;
   skos:broader quantitykind:MassDensity .
 
 quantitykind:DensityOfStates
@@ -2876,8 +2876,8 @@ quantitykind:Diameter
   qudt:symbol "d" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q37221> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
+  rdfs:label "Diameter"@en ;
   rdfs:label "Durchmesser"@de ;
-  rdfs:label "diameter"@en ;
   rdfs:label "diametro"@it ;
   rdfs:label "diamètre"@fr ;
   rdfs:label "diámetro"@es ;
@@ -2930,12 +2930,12 @@ quantitykind:DiffusionCoefficient
   qudt:symbol "D" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q604008> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
+  rdfs:label "Diffusion Coefficient"@en ;
   rdfs:label "Diffusionskoeffizient"@de ;
   rdfs:label "coefficient de diffusion"@fr ;
   rdfs:label "coefficiente di diffusione"@it ;
   rdfs:label "coeficiente de difusión"@es ;
   rdfs:label "coeficiente de difusão"@pt ;
-  rdfs:label "diffusion coefficient"@en ;
   rdfs:label "difuzijski koeficient"@sl .
 
 quantitykind:DiffusionCoefficientForFluenceRate
@@ -2972,7 +2972,7 @@ quantitykind:DigitRate
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:iec61360Code "0112/2///62720#UAD032" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "digit rate" .
+  rdfs:label "Digit Rate" .
 
 quantitykind:Dimensionless
   a qudt:QuantityKind ;
@@ -3073,10 +3073,10 @@ quantitykind:Distance
   qudt:symbol "d" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q126017> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
+  rdfs:label "Distance"@en ;
   rdfs:label "Entfernung"@de ;
   rdfs:label "Jarak"@ms ;
   rdfs:label "Vzdálenost"@cs ;
-  rdfs:label "distance"@en ;
   rdfs:label "distance"@fr ;
   rdfs:label "distancia"@es ;
   rdfs:label "distanza"@it ;
@@ -3153,14 +3153,14 @@ quantitykind:DoseEquivalentRate
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-3D0 ;
   qudt:iec61360Code "0112/2///62720#UAD034" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "dose equivalent rate" .
+  rdfs:label "Dose Equivalent Rate" .
 
 quantitykind:DotsPerInch
   a qudt:QuantityKind ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T0D0 ;
   qudt:iec61360Code "0112/2///62720#UAD255" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "dots per inch" ;
+  rdfs:label "Dots per Inch" ;
   skos:broader quantitykind:InverseLength .
 
 quantitykind:DragCoefficient
@@ -3283,11 +3283,11 @@ quantitykind:DynamicViscosity
   qudt:siExactMatch si-quantity:DYVI ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q15152757> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
+  rdfs:label "Dynamic Viscosity"@en ;
   rdfs:label "Kelikatan dinamik"@ms ;
   rdfs:label "Viscozitate dinamică"@ro ;
   rdfs:label "dinamik akmazlık"@tr ;
   rdfs:label "dinamična viskoznost"@sl ;
-  rdfs:label "dynamic viscosity"@en ;
   rdfs:label "dynamische Viskosität"@de ;
   rdfs:label "lepkość dynamiczna"@pl ;
   rdfs:label "viscosidad dinámica"@es ;
@@ -3308,7 +3308,7 @@ quantitykind:EarthquakeMagnitude
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:iec61360Code "0112/2///62720#UAD365" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "earthquake magnitude" .
+  rdfs:label "Earthquake Magnitude" .
 
 quantitykind:EccentricityOfOrbit
   a qudt:QuantityKind ;
@@ -3317,7 +3317,7 @@ quantitykind:EccentricityOfOrbit
   qudt:latexSymbol "$\\varepsilon$"^^qudt:LatexString ;
   qudt:plainTextDescription "The orbital eccentricity of an astronomical object is a parameter that determines the amount by which its orbit around another body deviates from a perfect circle. In a two-body problem with inverse-square-law force, every orbit is a Kepler orbit. The eccentricity of this Kepler orbit is a positive number that defines its shape." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Eccentricity Of Orbit"@en ;
+  rdfs:label "Eccentricity of Orbit"@en ;
   skos:broader quantitykind:DimensionlessRatio .
 
 quantitykind:EffectiveMass
@@ -3358,8 +3358,8 @@ quantitykind:Efficiency
   qudt:plainTextDescription "Efficiency is the ratio of output power to input power." ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q11945244> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
+  rdfs:label "Efficiency"@en ;
   rdfs:label "Wirkungsgrad"@de ;
-  rdfs:label "efficiency"@en ;
   rdfs:label "efficienza"@it ;
   rdfs:label "eficiência"@pt ;
   rdfs:label "rendement"@fr ;
@@ -3377,7 +3377,7 @@ quantitykind:EinsteinCoefficients
   qudt:hasDimensionVector qkdv:A0E0L0I0M-1H0T1D0 ;
   qudt:iec61360Code "0112/2///62720#UAD036" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Einstein coefficients" .
+  rdfs:label "Einstein Coefficients" .
 
 quantitykind:EinsteinTransitionProbability
   a qudt:QuantityKind ;
@@ -3396,7 +3396,7 @@ quantitykind:EinsteinTransitionProbabilityForSpontaneousOrInducedEmissionAndAbso
   qudt:plainTextDescription "atomare Konstante für den speziellen Übergang, wobei die Wahrscheinlichkeit der Absorption, der spontanen Emission und der induzierte Emission von Energie abhängig ist von der Zahl der vorhandenen Lichtquanten, ausgedrückt als Energiedichte im Wellenmodell des Lichtes: Energie durch Volumen und Frequenz"@de ;
   qudt:symbol "0173-1#Z4-BAJ456#001" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Einstein transition probability for spontaneous or induced emission and absorption"@en-US .
+  rdfs:label "Einstein Transition Probability for Spontaneous Or Induced Emission and Absorption"@en-US .
 
 quantitykind:ElectricCharge
   a qudt:QuantityKind ;
@@ -3413,11 +3413,11 @@ quantitykind:ElectricCharge
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Cas elektrik"@ms ;
   rdfs:label "Charge électrique"@fr ;
+  rdfs:label "Electric Charge"@en ;
   rdfs:label "Elektrický náboj"@cs ;
   rdfs:label "carga eléctrica"@es ;
   rdfs:label "carga elétrica"@pt ;
   rdfs:label "carica elettrica"@it ;
-  rdfs:label "electric charge"@en ;
   rdfs:label "elektrik yükü"@tr ;
   rdfs:label "elektrische Ladung"@de ;
   rdfs:label "električni naboj"@sl ;
@@ -3487,7 +3487,7 @@ quantitykind:ElectricChargePerAmountOfSubstance
   qudt:hasDimensionVector qkdv:A-1E1L0I0M0H0T1D0 ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q97061171> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Electric charge per amount of substance"@en .
+  rdfs:label "Electric Charge per Amount of Substance"@en .
 
 quantitykind:ElectricChargePerArea
   a qudt:QuantityKind ;
@@ -3496,14 +3496,14 @@ quantitykind:ElectricChargePerArea
   qudt:informativeReference "https://en.wikipedia.org/wiki/Charge_density"^^xsd:anyURI ;
   qudt:latexSymbol "$\\sigma$"^^qudt:LatexString ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Electric charge per area"@en .
+  rdfs:label "Electric Charge per Area"@en .
 
 quantitykind:ElectricChargePerMass
   a qudt:QuantityKind ;
   dcterms:description "\"Electric Charge Per Mass\" is the charge associated with a specific mass of a substance. In the SI and ISO systems this is $1 kg$."^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E1L0I0M-1H0T1D0 ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Electric Charge Per Mass"@en .
+  rdfs:label "Electric Charge per Mass"@en .
 
 quantitykind:ElectricChargeSurfaceDensity
   a qudt:QuantityKind ;
@@ -3546,12 +3546,12 @@ quantitykind:ElectricConductivity
   qudt:latexSymbol "$\\sigma$"^^qudt:LatexString ;
   qudt:plainTextDescription "\"Electric Conductivity\" is a scalar or tensor quantity the product of which by the electric field strength in a medium is equal to the electric current density. For an isotropic medium the conductivity is a scalar quantity; for an anisotropic medium it is a tensor quantity." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
+  rdfs:label "Electric Conductivity"@en ;
   rdfs:label "Kekonduksian elektrik"@ms ;
   rdfs:label "conducibilità elettrica"@it ;
   rdfs:label "conductividad eléctrica"@es ;
   rdfs:label "conductivité électrique"@fr ;
   rdfs:label "condutividade elétrica"@pt ;
-  rdfs:label "electric conductivity"@en ;
   rdfs:label "elektrik iletkenliği"@tr ;
   rdfs:label "elektrische Leitfähigkeit"@de ;
   rdfs:label "električna prevodnost"@sl ;
@@ -3578,12 +3578,12 @@ quantitykind:ElectricCurrent
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q29996> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Arus elektrik"@ms ;
+  rdfs:label "Electric Current"@en ;
   rdfs:label "Elektrický proud"@cs ;
   rdfs:label "corrente elettrica"@it ;
   rdfs:label "corrente elétrica"@pt ;
   rdfs:label "corriente eléctrica"@es ;
   rdfs:label "curent electric"@ro ;
-  rdfs:label "electric current"@en ;
   rdfs:label "elektrik akımı"@tr ;
   rdfs:label "elektrische Stromstärke"@de ;
   rdfs:label "električni tok"@sl ;
@@ -3616,6 +3616,7 @@ quantitykind:ElectricCurrentDensity
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Akım yoğunluğu"@tr ;
   rdfs:label "Densitate de curent"@ro ;
+  rdfs:label "Electric Current Density"@en ;
   rdfs:label "Gęstość prądu elektrycznego"@pl ;
   rdfs:label "Hustota elektrického proudu"@cs ;
   rdfs:label "Ketumpatan arus elektrik"@ms ;
@@ -3623,7 +3624,6 @@ quantitykind:ElectricCurrentDensity
   rdfs:label "densidade de corrente elétrica"@pt ;
   rdfs:label "densità di corrente elettrica"@it ;
   rdfs:label "densité de courant"@fr ;
-  rdfs:label "electric current density"@en ;
   rdfs:label "elektrische Stromdichte"@de ;
   rdfs:label "gostota električnega toka"@sl ;
   rdfs:label "плотность тока"@ru ;
@@ -3706,8 +3706,8 @@ $p = q(r_+ - r_i)$, where $r_+$ and $r_-$ are the position vectors to carriers o
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q735135> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Dipólový moment"@cs ;
+  rdfs:label "Electric Dipole Moment"@en ;
   rdfs:label "Momen dwikutub elektrik"@ms ;
-  rdfs:label "electric dipole moment"@en ;
   rdfs:label "elektrik dipol momenti"@tr ;
   rdfs:label "elektrisches Dipolmoment"@de ;
   rdfs:label "elektryczny moment dipolowy"@pl ;
@@ -3800,10 +3800,10 @@ quantitykind:ElectricFieldStrength
   qudt:symbol "E" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q20989> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
+  rdfs:label "Electric Field Strength"@en ;
   rdfs:label "Elektromos mező"@hu ;
   rdfs:label "Kekuatan medan elektrik"@ms ;
   rdfs:label "câmp electric"@ro ;
-  rdfs:label "electric field strength"@en ;
   rdfs:label "elektrické pole"@cs ;
   rdfs:label "elektriksel alan kuvveti"@tr ;
   rdfs:label "elektrische Feldstärke"@de ;
@@ -3851,13 +3851,13 @@ quantitykind:ElectricFluxDensity
   qudt:siExactMatch si-quantity:ELFD ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Densidad de flujo eléctrico"@es ;
+  rdfs:label "Electric Flux Density"@en ;
   rdfs:label "Elektrická indukce"@cs ;
   rdfs:label "Induction électrique"@fr ;
   rdfs:label "Inducție electrică"@ro ;
   rdfs:label "Indukcja elektryczna"@pl ;
   rdfs:label "Ketumpatan fluks elektrik"@ms ;
   rdfs:label "campo de deslocamento elétrico"@pt ;
-  rdfs:label "electric flux density"@en ;
   rdfs:label "elektrik akı yoğunluğu"@tr ;
   rdfs:label "elektrische Flussdichte"@de ;
   rdfs:label "spostamento elettrico"@it ;
@@ -3885,13 +3885,13 @@ quantitykind:ElectricPolarizability
   qudt:latexSymbol "$\\alpha$"^^qudt:LatexString ;
   qudt:plainTextDescription "\"Electric Polarizability\" is the relative tendency of a charge distribution, like the electron cloud of an atom or molecule, to be distorted from its normal shape by an external electric field, which is applied typically by inserting the molecule in a charged parallel-plate capacitor, but may also be caused by the presence of a nearby ion or dipole." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
+  rdfs:label "Electric Polarizability"@en ;
   rdfs:label "Kepengkutuban elektrik"@ms ;
   rdfs:label "Kutuplanabilirlik"@tr ;
   rdfs:label "Polarisabilité"@fr ;
   rdfs:label "Polarizabilidad"@es ;
   rdfs:label "Polarizovatelnost"@cs ;
   rdfs:label "Polaryzowalność"@pl ;
-  rdfs:label "electric polarizability"@en ;
   rdfs:label "elektrische Polarisierbarkeit"@de ;
   rdfs:label "polarizabilidade"@pt ;
   rdfs:label "polarizzabilità elettrica"@it ;
@@ -3913,7 +3913,7 @@ quantitykind:ElectricPolarization
   qudt:symbol "P" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q1050425> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "electric polarization"@en ;
+  rdfs:label "Electric Polarization"@en ;
   rdfs:label "elektrische Polarisation"@de ;
   rdfs:label "polarisation électrique"@fr ;
   rdfs:label "polarización eléctrica"@es ;
@@ -3940,8 +3940,8 @@ quantitykind:ElectricPotential
   qudt:symbol "V" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q55451> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
+  rdfs:label "Electric Potential"@en ;
   rdfs:label "Keupayaan elektrik"@ms ;
-  rdfs:label "electric potential"@en ;
   rdfs:label "elektrický potenciál"@cs ;
   rdfs:label "elektrik potansiyeli"@tr ;
   rdfs:label "elektrisches Potenzial"@de ;
@@ -3978,10 +3978,10 @@ quantitykind:ElectricPotentialDifference
   qudt:symbol "V_{ab}" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q77597807> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
+  rdfs:label "Electric Potential Difference"@en ;
   rdfs:label "Voltan Perbezaan keupayaan elektrik"@ms ;
   rdfs:label "diferență de potențial electric"@ro ;
   rdfs:label "differenza di potenziale elettrico"@it ;
-  rdfs:label "electric potential difference"@en ;
   rdfs:label "elektrické napětí"@cs ;
   rdfs:label "elektrische Spannung"@de ;
   rdfs:label "električna napetost"@sl ;
@@ -4013,8 +4013,8 @@ quantitykind:ElectricPower
   qudt:symbol "P_E" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q27137> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
+  rdfs:label "Electric Power"@en ;
   rdfs:label "Wirkleistung"@de ;
-  rdfs:label "electric power"@en ;
   rdfs:label "moc czynna"@pl ;
   rdfs:label "potencia activa"@es ;
   rdfs:label "potenza attiva"@it ;
@@ -4032,8 +4032,8 @@ quantitykind:ElectricQuadrupoleMoment
   qudt:plainTextDescription "The Electric Quadrupole Moment is a quantity which describes the effective shape of the ellipsoid of nuclear charge distribution. A non-zero quadrupole moment Q indicates that the charge distribution is not spherically symmetric. By convention, the value of Q is taken to be positive if the ellipsoid is prolate and negative if it is oblate. In general, the electric quadrupole moment is tensor-valued." ;
   qudt:symbol "Q" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
+  rdfs:label "Electric Quadrupole Moment"@en ;
   rdfs:label "Momen kuadrupol elektrik"@ms ;
-  rdfs:label "electric quadrupole moment"@en ;
   rdfs:label "elektrik kuadrupol momenti"@tr ;
   rdfs:label "elektrisches Quadrupolmoment"@de ;
   rdfs:label "elektryczny moment kwadrupolowy"@pl ;
@@ -4058,7 +4058,7 @@ quantitykind:ElectricSusceptibility
   qudt:plainTextDescription "\"Electric Susceptibility\" is the ratio of electric polarization to electric field strength, normalized to the electric constant. The definition applies to an isotropic medium. For an anisotropic medium, electric susceptibility is a second order tensor." ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q598305> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "electric susceptibility"@en ;
+  rdfs:label "Electric Susceptibility"@en ;
   rdfs:label "elektrische Suszeptibilität"@de ;
   rdfs:label "podatność elektryczna"@pl ;
   rdfs:label "susceptibilidad eléctrica"@es ;
@@ -4082,15 +4082,15 @@ quantitykind:ElectricalConductance
   qudt:siExactMatch si-quantity:ELCO ;
   qudt:symbol "0173-1#Z4-BAJ223#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "electrical conductance" ;
-  rdfs:label "electrical conductance"@en-US .
+  rdfs:label "Electrical Conductance" ;
+  rdfs:label "Electrical Conductance"@en-US .
 
 quantitykind:ElectricalPowerToMassRatio
   a qudt:QuantityKind ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-3D0 ;
   qudt:latexSymbol "$\\xi$"^^qudt:LatexString ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Electrical Power To Mass Ratio"@en ;
+  rdfs:label "Electrical Power to Mass Ratio"@en ;
   skos:broader quantitykind:SpecificPower .
 
 quantitykind:ElectricalResistance
@@ -4102,7 +4102,7 @@ quantitykind:ElectricalResistance
   qudt:siExactMatch si-quantity:ELRE ;
   qudt:symbol "0173-1#Z4-BAJ215#003" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "electrical resistance"@en-US .
+  rdfs:label "Electrical Resistance"@en-US .
 
 quantitykind:ElectrolyticConductivity
   a qudt:QuantityKind ;
@@ -4205,9 +4205,9 @@ quantitykind:ElectromotiveForce
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q185329> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Daya gerak elektrik"@ms ;
+  rdfs:label "Electromotive Force"@en ;
   rdfs:label "Elektromotor kuvvet"@tr ;
   rdfs:label "Elektromotorické napětí"@cs ;
-  rdfs:label "electromotive force"@en ;
   rdfs:label "elektromotorische Kraft"@de ;
   rdfs:label "elektromotorna sila"@sl ;
   rdfs:label "force électromotrice"@fr ;
@@ -4276,7 +4276,7 @@ quantitykind:ElectronMobility
   qudt:hasDimensionVector qkdv:A0E1L0I0M-1H0T2D0 ;
   qudt:iec61360Code "0112/2///62720#UAD119" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "electron mobility" ;
+  rdfs:label "Electron Mobility" ;
   skos:broader quantitykind:Mobility .
 
 quantitykind:ElectronRadius
@@ -4303,7 +4303,7 @@ quantitykind:ElevationRelativeToNAP
   qudt:symbol "mNAP" ;
   rdfs:comment "Height measurement relative to the Normaal Amsterdams Peil (NAP) (en: Amsterdam Ordnance System). Being a form of gravity related height" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Elevation relative to NAP"@en ;
+  rdfs:label "Elevation Relative to NAP"@en ;
   rdfs:label "Hoogte ten opzichte van NAP"@nl ;
   skos:broader quantitykind:Altitude ;
   skos:prefLabel "Elevation relative to NAP"@en ;
@@ -4333,6 +4333,7 @@ quantitykind:Energy
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Energie"@cs ;
   rdfs:label "Energie"@de ;
+  rdfs:label "Energy"@en ;
   rdfs:label "Tenaga"@ms ;
   rdfs:label "energia , munka , hő"@hu ;
   rdfs:label "energia"@es ;
@@ -4342,7 +4343,6 @@ quantitykind:Energy
   rdfs:label "energia"@pt ;
   rdfs:label "energie"@ro ;
   rdfs:label "energija"@sl ;
-  rdfs:label "energy"@en ;
   rdfs:label "enerji"@tr ;
   rdfs:label "énergie"@fr ;
   rdfs:label "Έργο - Ενέργεια"@el ;
@@ -4369,8 +4369,8 @@ quantitykind:EnergyContent
   qudt:plainTextDescription "gespeicherte Energiemenge, die physikalisch oder chemisch nutzbar ist"@de ;
   qudt:symbol "0173-1#Z4-BAJ319#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "energy content" ;
-  rdfs:label "energy content"@en-US ;
+  rdfs:label "Energy Content" ;
+  rdfs:label "Energy Content"@en-US ;
   skos:broader quantitykind:Energy .
 
 quantitykind:EnergyDensity
@@ -4553,7 +4553,7 @@ quantitykind:EnergyPerAreaElectricCharge
   qudt:hasDimensionVector qkdv:A0E-1L0I0M1H0T-3D0 ;
   qudt:plainTextDescription "\"Energy Per Area Electric Charge\" is the amount of electric energy associated with a unit of area." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Energy Per Area Electric Charge"@en .
+  rdfs:label "Energy per Area Electric Charge"@en .
 
 quantitykind:EnergyPerElectricCharge
   a qudt:QuantityKind ;
@@ -4565,7 +4565,7 @@ quantitykind:EnergyPerElectricCharge
   qudt:informativeReference "http://physics.about.com/od/glossary/g/voltage.htm"^^xsd:anyURI ;
   qudt:symbol "V" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Energy per electric charge"@en .
+  rdfs:label "Energy per Electric Charge"@en .
 
 quantitykind:EnergyPerMagneticFluxDensity_Squared
   a qudt:QuantityKind ;
@@ -4582,7 +4582,7 @@ quantitykind:EnergyPerMassAmountOfSubstance
   a qudt:QuantityKind ;
   qudt:hasDimensionVector qkdv:A-1E0L2I0M1H0T-2D0 ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Energy and work per mass amount of substance"@en .
+  rdfs:label "Energy and Work per Mass Amount of Substance"@en .
 
 quantitykind:EnergyPerSquareMagneticFluxDensity
   a qudt:QuantityKind ;
@@ -4590,13 +4590,13 @@ quantitykind:EnergyPerSquareMagneticFluxDensity
   qudt:hasDimensionVector qkdv:A0E2L2I0M-1H0T2D0 ;
   qudt:plainTextDescription "\"Energy Per Square Magnetic Flux Density\" is a measure of energy for a unit of magnetic flux density." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Energy Per Square Magnetic Flux Density"@en .
+  rdfs:label "Energy per Square Magnetic Flux Density"@en .
 
 quantitykind:EnergyPerTemperature
   a qudt:QuantityKind ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H-1T-2D0 ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Energy per temperature"@en .
+  rdfs:label "Energy per Temperature"@en .
 
 quantitykind:Energy_Squared
   a qudt:QuantityKind ;
@@ -4623,6 +4623,7 @@ quantitykind:Enthalpy
   rdfs:label "Entalpi"@tr ;
   rdfs:label "Entalpie"@ro ;
   rdfs:label "Enthalpie"@de ;
+  rdfs:label "Enthalpy"@en ;
   rdfs:label "entalpia"@it ;
   rdfs:label "entalpia"@pl ;
   rdfs:label "entalpia"@pt ;
@@ -4630,7 +4631,6 @@ quantitykind:Enthalpy
   rdfs:label "entalpija"@sl ;
   rdfs:label "entalpía"@es ;
   rdfs:label "enthalpie"@fr ;
-  rdfs:label "enthalpy"@en ;
   rdfs:label "энтальпия"@ru ;
   rdfs:label "آنتالپی"@fa ;
   rdfs:label "محتوى حراري"@ar ;
@@ -4651,6 +4651,7 @@ quantitykind:Entropy
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Entropi"@ms ;
   rdfs:label "Entropie"@de ;
+  rdfs:label "Entropy"@en ;
   rdfs:label "entropi"@tr ;
   rdfs:label "entropia"@it ;
   rdfs:label "entropia"@pl ;
@@ -4659,7 +4660,6 @@ quantitykind:Entropy
   rdfs:label "entropie"@fr ;
   rdfs:label "entropie"@ro ;
   rdfs:label "entropija"@sl ;
-  rdfs:label "entropy"@en ;
   rdfs:label "entropía"@es ;
   rdfs:label "Энтропия"@ru ;
   rdfs:label "آنتروپی"@fa ;
@@ -4690,7 +4690,7 @@ quantitykind:EquilibriumConstantBasedOnConcentration
   qudt:plainTextDescription "Kc = ΠB(cB)νB für Lösungen"@de ;
   qudt:symbol "0173-1#Z4-BAJ458#001" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "equilibrium constant based on concentration"@en-US .
+  rdfs:label "Equilibrium Constant Based On Concentration"@en-US .
 
 quantitykind:EquilibriumConstantBasedOnPressure
   a qudt:QuantityKind ;
@@ -4699,7 +4699,7 @@ quantitykind:EquilibriumConstantBasedOnPressure
   qudt:plainTextDescription "Kp = ΠB(pB)νB für Gase"@de ;
   qudt:symbol "0173-1#Z4-BAJ459#001" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "equilibrium constant based on pressure"@en-US .
+  rdfs:label "Equilibrium Constant Based On Pressure"@en-US .
 
 quantitykind:EquilibriumConstantOnConcentrationBasis
   a qudt:QuantityKind ;
@@ -4716,7 +4716,7 @@ quantitykind:EquilibriumConstantOnConcentrationBasis
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q96096049> ;
   rdfs:comment "The unit is unit:MOL-PER-M3 raised to the N where N is the summation of stoichiometric numbers. I don't know what to do with this." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Equilibrium Constant on Concentration Basis"@en ;
+  rdfs:label "Equilibrium Constant On Concentration Basis"@en ;
   skos:broader quantitykind:EquilibriumConstant .
 
 quantitykind:EquilibriumConstantOnPressureBasis
@@ -4733,7 +4733,7 @@ quantitykind:EquilibriumConstantOnPressureBasis
   qudt:qkdvNumerator qkdv:A0E0L-2I0M1H0T0D0 ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q96096019> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Equilibrium Constant on Pressure Basis"@en ;
+  rdfs:label "Equilibrium Constant On Pressure Basis"@en ;
   skos:broader quantitykind:EquilibriumConstant .
 
 quantitykind:EquilibriumPositionVectorOfIon
@@ -4756,7 +4756,7 @@ quantitykind:EquivalenceDoseOutput
   qudt:plainTextDescription "Quotient aus der Äquivalenzdosis in einer angemessenen kleinen Zeitspanne und dieser Zeitspanne, berechenbar als Differentialquotient: q • D = q • ∂D/∂t als Maß für die aktuelle Strahlenbelastung"@de ;
   qudt:symbol "0173-1#Z4-BAJ450#001" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "equivalence dose output"@en-US .
+  rdfs:label "Equivalence Dose Output"@en-US .
 
 quantitykind:EquivalentAbsorptionArea
   a qudt:QuantityKind ;
@@ -4768,7 +4768,7 @@ quantitykind:EquivalentAbsorptionArea
   qudt:symbol "A" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q87745170> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Equivalent absorption area"@en ;
+  rdfs:label "Equivalent Absorption Area"@en ;
   skos:broader quantitykind:Area ;
   vaem:todo "belongs to SOQ-ISO" .
 
@@ -4880,7 +4880,7 @@ quantitykind:ExposureOfIonizingRadiation
   qudt:plainTextDescription "Maß für die Wirkung eines elektromagnetischen Feldes auf Materie in Form der Ionisation, die die Strahlung im Referenzmaterial Luft erzeugt, ausgedrückt als Quotient aus ∂Q und ∂m, wobei ∂Q der Absolutwert der gesamten elektrischen Ladung der Ionen eines Vorzeichens ist, die in Luft der Masse ∂m gebildet wird, wenn in diesem Massenelement alle Elektronen (und Positronen), die durch die Photonen freigesetzt werden, komplett gestoppt werden"@de ;
   qudt:symbol "0173-1#Z4-BAJ326#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "exposure of ionizing radiation"@en-US .
+  rdfs:label "Exposure of Ionizing Radiation"@en-US .
 
 quantitykind:ExposureRate
   a qudt:QuantityKind ;
@@ -4903,7 +4903,7 @@ quantitykind:ExposureRateOfIonizingRadiation
   qudt:plainTextDescription "Quotient Ionendosis dJ in einem Zeitintervall durch Dauer dt dieses Zeitintervalls"@de ;
   qudt:symbol "0173-1#Z4-BAJ327#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "exposure rate of ionizing radiation"@en-US .
+  rdfs:label "Exposure Rate of Ionizing Radiation"@en-US .
 
 quantitykind:ExtentOfReaction
   a qudt:QuantityKind ;
@@ -4949,8 +4949,8 @@ quantitykind:FahrenheitTemperature
   qudt:plainTextDescription "Größe, deren Nullpunkt durch die Mischungstemperatur von Eis, Wasser und Salmiak (Ammoniumchlorid) definiert ist (-17,8 °C) und deren Fixpunkte auf der Fahrenheit-Skala 32 °F (Schmelztemperatur von Eis) und 212 °F (Siedetemperatur des Wassers) sind"@de ;
   qudt:symbol "0173-1#Z4-BAJ278#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Fahrenheit temperature" ;
-  rdfs:label "Fahrenheit temperature"@en-US ;
+  rdfs:label "Fahrenheit Temperature" ;
+  rdfs:label "Fahrenheit Temperature"@en-US ;
   skos:broader quantitykind:Temperature .
 
 quantitykind:FailureRate
@@ -4961,8 +4961,8 @@ quantitykind:FailureRate
   qudt:plainTextDescription "Grenzwert - falls er existiert - des Quotienten aus der bedingten Wahrscheinlichkeit, dass der Ausfallzeitpunkt t eines Betriebsmittels in ein gegebenes Zeitintervall (t, t + Δt) fällt, und der Dauer dieses Zeitintervalls, wenn Δt gegen null geht und das Betriebsmittel sich zu Beginn des Zeitintervalls im betriebsfähigen Zustand befindet"@de ;
   qudt:symbol "0173-1#Z4-BAJ466#003" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "failure rate" ;
-  rdfs:label "failure rate"@en-US ;
+  rdfs:label "Failure Rate" ;
+  rdfs:label "Failure Rate"@en-US ;
   skos:broader quantitykind:Incidence .
 
 quantitykind:FastFissionFactor
@@ -5051,7 +5051,7 @@ quantitykind:FissionCoreRadiusToHeightRatio
   qudt:qkdvNumerator qkdv:A0E0L1I0M0H0T0D0 ;
   qudt:symbol "R/H" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Fission Core Radius To Height Ratio"@en ;
+  rdfs:label "Fission Core Radius to Height Ratio"@en ;
   skos:broader quantitykind:DimensionlessRatio .
 
 quantitykind:FissionFuelUtilizationFactor
@@ -5094,7 +5094,7 @@ quantitykind:FloatingPointCalculationCapability
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:iec61360Code "0112/2///62720#UAD363" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "floating point calculation capability" .
+  rdfs:label "Floating Point Calculation Capability" .
 
 quantitykind:Fluidity
   a qudt:QuantityKind ;
@@ -5104,8 +5104,8 @@ quantitykind:Fluidity
   qudt:plainTextDescription "Fließvermögen eines Stoffes als Kehrwert der dynamischen Viskosität"@de ;
   qudt:symbol "0173-1#Z4-BAJ447#001" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "fluidity" ;
-  rdfs:label "fluidity"@en-US .
+  rdfs:label "Fluidity" ;
+  rdfs:label "Fluidity"@en-US .
 
 quantitykind:Flux
   a qudt:QuantityKind ;
@@ -5130,10 +5130,10 @@ quantitykind:Force
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q11402> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Daya"@ms ;
+  rdfs:label "Force"@en ;
   rdfs:label "Kraft"@de ;
   rdfs:label "Síla"@cs ;
   rdfs:label "erő"@hu ;
-  rdfs:label "force"@en ;
   rdfs:label "force"@fr ;
   rdfs:label "forza"@it ;
   rdfs:label "força"@pt ;
@@ -5159,7 +5159,7 @@ quantitykind:ForceConstant
   qudt:hasDimensionVector qkdv:A0E-1L1I0M1H0T-2D0 ;
   qudt:iec61360Code "0112/2///62720#UAD055" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "force constant" .
+  rdfs:label "Force Constant" .
 
 quantitykind:ForceMagnitude
   a qudt:QuantityKind ;
@@ -5187,13 +5187,13 @@ quantitykind:ForcePerArea
   qudt:plainTextDescription "The force applied to a unit area of surface; measured in pascals (SI unit) or in dynes (cgs unit)" ;
   qudt:symbol "p" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Force Per Area"@en .
+  rdfs:label "Force per Area"@en .
 
 quantitykind:ForcePerAreaTime
   a qudt:QuantityKind ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-3D0 ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Force Per Area Time"@en .
+  rdfs:label "Force per Area Time"@en .
 
 quantitykind:ForcePerElectricCharge
   a qudt:QuantityKind ;
@@ -5226,6 +5226,7 @@ $\\nu = 1/T$"""^^qudt:LatexString ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Frekuensi"@ms ;
   rdfs:label "Frekvence"@cs ;
+  rdfs:label "Frequency"@en ;
   rdfs:label "Frequenz"@de ;
   rdfs:label "częstotliwość"@pl ;
   rdfs:label "frecuencia"@es ;
@@ -5233,7 +5234,6 @@ $\\nu = 1/T$"""^^qudt:LatexString ;
   rdfs:label "frekans"@tr ;
   rdfs:label "frekvenca"@sl ;
   rdfs:label "frekvencia"@hu ;
-  rdfs:label "frequency"@en ;
   rdfs:label "frequentia"@la ;
   rdfs:label "frequenza"@it ;
   rdfs:label "frequência"@pt ;
@@ -5287,6 +5287,7 @@ quantitykind:Fugacity
   qudt:plainTextDescription "\"Fugacity\" of a real gas is an effective pressure which replaces the true mechanical pressure in accurate chemical equilibrium calculations. It is equal to the pressure of an ideal gas which has the same chemical potential as the real gas." ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q898412> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
+  rdfs:label "Fugacity"@en ;
   rdfs:label "Fugasiti"@ms ;
   rdfs:label "Fugazität"@de ;
   rdfs:label "Lotność"@pl ;
@@ -5294,7 +5295,6 @@ quantitykind:Fugacity
   rdfs:label "fugacidade"@pt ;
   rdfs:label "fugacita"@cs ;
   rdfs:label "fugacitate"@ro ;
-  rdfs:label "fugacity"@en ;
   rdfs:label "fugacità"@it ;
   rdfs:label "fugacité"@fr ;
   rdfs:label "fügasite"@tr ;
@@ -5313,7 +5313,7 @@ quantitykind:FundamentalLatticeVector
   qudt:symbol "a_1, a_2, a_3" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q105451063> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Fundamental Lattice vector"@en ;
+  rdfs:label "Fundamental Lattice Vector"@en ;
   skos:broader quantitykind:LatticeVector .
 
 quantitykind:FundamentalReciprocalLatticeVector
@@ -5386,8 +5386,8 @@ quantitykind:GasLeakRate
   qudt:plainTextDescription "Quotient aus dem pV-Wert eines Gases (Produkt aus Druck und Volumen einer bestimmten Menge eines Gases bei der jeweils herrschenden Temperatur), das während einer Zeitspanne durch einen Leitungsquerschnitt strömt, und der zugehörigen Zeitspanne"@de ;
   qudt:symbol "0173-1#Z4-BAJ324#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "gas leak rate" ;
-  rdfs:label "gas leak rate"@en-US .
+  rdfs:label "Gas Leak Rate" ;
+  rdfs:label "Gas Leak Rate"@en-US .
 
 quantitykind:GaugePressure
   a qudt:QuantityKind ;
@@ -5483,8 +5483,8 @@ quantitykind:GibbsEnergy
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Energía de Gibbs"@es ;
   rdfs:label "Entalpie liberă"@ro ;
+  rdfs:label "Gibbs Energy"@en ;
   rdfs:label "Gibbs Serbest Enerjisi"@tr ;
-  rdfs:label "Gibbs energy"@en ;
   rdfs:label "Gibbsova volná energie"@cs ;
   rdfs:label "Prosta entalpija"@sl ;
   rdfs:label "Tenaga Gibbs"@ms ;
@@ -5513,7 +5513,7 @@ quantitykind:Gradient
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:iec61360Code "0112/2///62720#UAD058" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "gradient" .
+  rdfs:label "Gradient" .
 
 quantitykind:GrandCanonicalPartitionFunction
   a qudt:QuantityKind ;
@@ -5706,9 +5706,9 @@ quantitykind:HalfLife
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q98118544> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Halbwertszeit"@de ;
+  rdfs:label "Half-life"@en ;
   rdfs:label "Poločas rozpadu"@cs ;
   rdfs:label "Separuh hayat"@ms ;
-  rdfs:label "half-life"@en ;
   rdfs:label "meia-vida"@pt ;
   rdfs:label "semiperiodo"@es ;
   rdfs:label "tempo di dimezzamento"@it ;
@@ -5788,12 +5788,12 @@ quantitykind:Heat
   qudt:symbol "Q" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q44432> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
+  rdfs:label "Heat"@en ;
   rdfs:label "Wärme"@de ;
   rdfs:label "calor"@es ;
   rdfs:label "calore"@it ;
   rdfs:label "cantitate de căldură"@ro ;
   rdfs:label "ciepło"@pl ;
-  rdfs:label "heat"@en ;
   rdfs:label "jednotka tepla"@cs ;
   rdfs:label "kuantiti haba Haba"@ms ;
   rdfs:label "labor"@la ;
@@ -5824,13 +5824,13 @@ quantitykind:HeatCapacity
   qudt:symbol "C_P" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q179388> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
+  rdfs:label "Heat Capacity"@en ;
   rdfs:label "Wärmekapazität"@de ;
   rdfs:label "capacidad calorífica"@es ;
   rdfs:label "capacidade térmica"@pt ;
   rdfs:label "capacitate termică"@ro ;
   rdfs:label "capacità termica"@it ;
   rdfs:label "capacité thermique"@fr ;
-  rdfs:label "heat capacity"@en ;
   rdfs:label "isı kapasitesi"@tr ;
   rdfs:label "muatan haba"@ms ;
   rdfs:label "pojemność cieplna"@pl ;
@@ -5915,6 +5915,7 @@ quantitykind:Height
   qudt:symbol "h" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q208826> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
+  rdfs:label "Height"@en ;
   rdfs:label "Höhe"@de ;
   rdfs:label "Ketinggian"@ms ;
   rdfs:label "Výška"@cs ;
@@ -5922,7 +5923,6 @@ quantitykind:Height
   rdfs:label "altura"@es ;
   rdfs:label "altura"@pt ;
   rdfs:label "hauteur"@fr ;
-  rdfs:label "height"@en ;
   rdfs:label "yükseklik"@tr ;
   rdfs:label "Înălțime"@ro ;
   rdfs:label "высота"@ru ;
@@ -5940,7 +5940,7 @@ quantitykind:HelmholtzEnergy
   qudt:symbol "A" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Energía de Helmholtz"@es ;
-  rdfs:label "Helmholtz energy"@en ;
+  rdfs:label "Helmholtz Energy"@en ;
   rdfs:label "Helmholtz enerjisi"@tr ;
   rdfs:label "Helmholtzova volná energie"@cs ;
   rdfs:label "Prosta energija"@sl ;
@@ -6039,7 +6039,7 @@ quantitykind:IgnitionIntervalTime
   a qudt:QuantityKind ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T1D0 ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Ignition interval time"@en ;
+  rdfs:label "Ignition Interval Time"@en ;
   skos:broader quantitykind:Time .
 
 quantitykind:Illuminance
@@ -6055,11 +6055,11 @@ quantitykind:Illuminance
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q194411> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Beleuchtungsstärke"@de ;
+  rdfs:label "Illuminance"@en ;
   rdfs:label "Intenzita osvětlení"@cs ;
   rdfs:label "Pencahayaan"@ms ;
   rdfs:label "aydınlanma şiddeti"@tr ;
   rdfs:label "illuminamento"@it ;
-  rdfs:label "illuminance"@en ;
   rdfs:label "iluminamento"@pt ;
   rdfs:label "iluminare"@ro ;
   rdfs:label "luminosidad"@es ;
@@ -6105,8 +6105,8 @@ quantitykind:Impulse
   qudt:plainTextDescription "Produkt aus Kraft und Zeit"@de ;
   qudt:symbol "0173-1#Z4-BAJ241#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "impulse" ;
-  rdfs:label "impulse"@en-US .
+  rdfs:label "Impulse" ;
+  rdfs:label "Impulse"@en-US .
 
 quantitykind:Incidence
   a qudt:QuantityKind ;
@@ -6164,10 +6164,10 @@ quantitykind:Inductance
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q177897> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Inductance électrique"@fr ;
+  rdfs:label "Inductance"@en ;
   rdfs:label "Indukstans"@ms ;
   rdfs:label "Induktivität"@de ;
   rdfs:label "Indukčnost"@cs ;
-  rdfs:label "inductance"@en ;
   rdfs:label "inductancia"@es ;
   rdfs:label "inductantia"@la ;
   rdfs:label "inductanță"@ro ;
@@ -6194,7 +6194,7 @@ quantitykind:InductanceBasedTimeConstant
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T1D0 ;
   qudt:iec61360Code "0112/2///62720#UAD198" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Inductance based time constant" .
+  rdfs:label "Inductance Based Time Constant" .
 
 quantitykind:InfiniteMultiplicationFactor
   a qudt:QuantityKind ;
@@ -6215,7 +6215,7 @@ quantitykind:InformationContent
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:iec61360Code "0112/2///62720#UAD066" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "information content" .
+  rdfs:label "Information Content" .
 
 quantitykind:InformationContentExpressedAsALogarithmToBase10
   a qudt:QuantityKind ;
@@ -6224,7 +6224,7 @@ quantitykind:InformationContentExpressedAsALogarithmToBase10
   qudt:plainTextDescription "(xi) als der Informationsgehalt I(xi) eines Ergebnisses xi (z. B. das Auftreten eines Zeichens xi) ist der dekatischer Logarithmus des Kehrwertes der Wahrscheinlichkeit p (xi) für sein eintreten, also: l(x) lg 1/p(x) Hart, dabei ist p(x) die Wahrscheinlichkeit des Ereignisses x"@de ;
   qudt:symbol "0173-1#Z4-BAJ468#001" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "information content expressed as a logarithm to base 10"@en-US .
+  rdfs:label "Information Content Expressed as a Logarithm to Base 10"@en-US .
 
 quantitykind:InformationContentExpressedAsALogarithmToBase2
   a qudt:QuantityKind ;
@@ -6233,7 +6233,7 @@ quantitykind:InformationContentExpressedAsALogarithmToBase2
   qudt:plainTextDescription "I(xi) als der Informationsgehalt I(xi) eines Ergebnisses xi (z. B. das Auftreten eines Zeichens xi) ist der binäre Logarithmus des Kehrwertes der Wahrscheinlichkeit p (xi) für sein eintreten, also: l(x) = lb 1/p(x) Sh, dabei ist p(x) die Wahrscheinlichkeit des Ereignisses x"@de ;
   qudt:symbol "0173-1#Z4-BAJ463#001" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "information content expressed as a logarithm to base 2"@en-US .
+  rdfs:label "Information Content Expressed as a Logarithm to Base 2"@en-US .
 
 quantitykind:InformationContentExpressedAsALogarithmToBaseE
   a qudt:QuantityKind ;
@@ -6242,7 +6242,7 @@ quantitykind:InformationContentExpressedAsALogarithmToBaseE
   qudt:plainTextDescription "I(xi) als der Informationsgehalt I(xi) eines Ergebnisses xi (z. B. das Auftreten eines Zeichens xi) ist der natürliche Logarithmus des Kehrwertes der Wahrscheinlichkeit p (xi) für sein eintreten, also: l(x) = ln 1/p(x) nat, dabei ist p(x) die Wahrscheinlichkeit des Ereignisses x"@de ;
   qudt:symbol "0173-1#Z4-BAJ469#001" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "information content expressed as a logarithm to base e"@en-US .
+  rdfs:label "Information Content Expressed as a Logarithm to Base e"@en-US .
 
 quantitykind:InformationEntropy
   a qudt:QuantityKind ;
@@ -6259,7 +6259,7 @@ quantitykind:InformationFlowRate
   a qudt:QuantityKind ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Information flow rate"@en .
+  rdfs:label "Information Flow Rate"@en .
 
 quantitykind:InitialExpansionRatio
   a qudt:QuantityKind ;
@@ -6324,7 +6324,7 @@ quantitykind:InternalConversionFactor
   qudt:symbol "a" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q6047819> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "InternalConversionFactor"@en .
+  rdfs:label "Internal Conversion Factor"@en .
 
 quantitykind:InternalEnergy
   a qudt:QuantityKind ;
@@ -6341,6 +6341,7 @@ quantitykind:InternalEnergy
   qudt:symbol "U" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q180241> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
+  rdfs:label "Internal Energy"@en ;
   rdfs:label "Notranja energija"@sl ;
   rdfs:label "Tenaga dalaman"@ms ;
   rdfs:label "energia interna"@it ;
@@ -6349,7 +6350,6 @@ quantitykind:InternalEnergy
   rdfs:label "energie internă"@ro ;
   rdfs:label "energía interna"@es ;
   rdfs:label "innere Energie"@de ;
-  rdfs:label "internal energy"@en ;
   rdfs:label "vnitřní energie"@cs ;
   rdfs:label "énergie interne"@fr ;
   rdfs:label "İç enerji"@tr ;
@@ -6404,7 +6404,7 @@ quantitykind:InverseAmountOfSubstance
   qudt:hasDimensionVector qkdv:A-1E0L0I0M0H0T0D0 ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q93421670> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Inverse amount of substance"@en .
+  rdfs:label "Inverse Amount of Substance"@en .
 
 quantitykind:InverseEnergy
   a qudt:QuantityKind ;
@@ -6449,7 +6449,7 @@ quantitykind:InverseMass
   qudt:hasDimensionVector qkdv:A0E0L0I0M-1H0T0D0 ;
   qudt:iec61360Code "0112/2///62720#UAD157" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "reciprocal mass" .
+  rdfs:label "Reciprocal Mass" .
 
 quantitykind:InverseMass_Squared
   a qudt:QuantityKind ;
@@ -6626,8 +6626,8 @@ quantitykind:Irradiance
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Bestrahlungsstärke"@de ;
   rdfs:label "Intenzita záření"@cs ;
+  rdfs:label "Irradiance"@en ;
   rdfs:label "Kepenyinaran"@ms ;
-  rdfs:label "irradiance"@en ;
   rdfs:label "irradiancia"@es ;
   rdfs:label "irradianza"@it ;
   rdfs:label "irradiância"@pt ;
@@ -6676,11 +6676,11 @@ quantitykind:IsentropicExponent
   rdfs:label "Coeficiente de dilatación adiabática"@es ;
   rdfs:label "Coeficiente de expansão adiabática"@pt ;
   rdfs:label "Isentropenexponent"@de ;
+  rdfs:label "Isentropic Exponent"@en ;
   rdfs:label "Poissonova konstanta"@cs ;
   rdfs:label "Wykładnik adiabaty"@pl ;
   rdfs:label "adiabatni eksponent"@sl ;
   rdfs:label "exposant isoentropique"@fr ;
-  rdfs:label "isentropic exponent"@en ;
   rdfs:label "ısı sığası oranı; adyabatik indeks"@tr ;
   rdfs:label "Показатель адиабаты"@ru ;
   rdfs:label "نسبة السعة الحرارية"@ar ;
@@ -6701,13 +6701,13 @@ quantitykind:IsothermalCompressibility
   qudt:plainTextDescription "The isothermal compressibility defines the rate of change of system volume with pressure." ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q2990696> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
+  rdfs:label "Isothermal Compressibility"@en ;
   rdfs:label "Izotermna stisljivost"@sl ;
   rdfs:label "Ketermampatan isotermik"@ms ;
   rdfs:label "compresibilidad isotérmica"@es ;
   rdfs:label "compressibilidade isotérmica"@pt ;
   rdfs:label "compressibilité isotherme"@fr ;
   rdfs:label "comprimibilità isotermica"@it ;
-  rdfs:label "isothermal compressibility"@en ;
   rdfs:label "isotherme Kompressibilität"@de ;
   rdfs:label "objemová stlačitelnost"@cs ;
   rdfs:label "ściśliwość izotermiczna"@pl ;
@@ -6766,9 +6766,9 @@ quantitykind:KinematicViscosity
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q15106259> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Kelikatan kinematik"@ms ;
+  rdfs:label "Kinematic Viscosity"@en ;
   rdfs:label "Kinematik akmazlık"@tr ;
   rdfs:label "Viscozitate cinematică"@ro ;
-  rdfs:label "kinematic viscosity"@en ;
   rdfs:label "kinematische Viskosität"@de ;
   rdfs:label "kinematična viskoznost"@sl ;
   rdfs:label "lepkość kinematyczna"@pl ;
@@ -6813,13 +6813,13 @@ quantitykind:KineticEnergy
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q46276> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Energie cinetică"@ro ;
+  rdfs:label "Kinetic Energy"@en ;
   rdfs:label "Kinetik enerji"@tr ;
   rdfs:label "Tenaga kinetik"@ms ;
   rdfs:label "energia cinetica"@it ;
   rdfs:label "energia cinética"@pt ;
   rdfs:label "energia kinetyczna"@pl ;
   rdfs:label "energía cinética"@es ;
-  rdfs:label "kinetic energy"@en ;
   rdfs:label "kinetická energie"@cs ;
   rdfs:label "kinetische Energie"@de ;
   rdfs:label "énergie cinétique"@fr ;
@@ -6966,13 +6966,13 @@ quantitykind:Length
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q36253> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Délka"@cs ;
+  rdfs:label "Length"@en ;
   rdfs:label "Länge"@de ;
   rdfs:label "Panjang"@ms ;
   rdfs:label "comprimento"@pt ;
   rdfs:label "dolžina"@sl ;
   rdfs:label "długość"@pl ;
   rdfs:label "hossz"@hu ;
-  rdfs:label "length"@en ;
   rdfs:label "longitud"@es ;
   rdfs:label "longitudo"@la ;
   rdfs:label "longueur"@fr ;
@@ -7133,7 +7133,7 @@ quantitykind:LinearBitDensity
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T0D0 ;
   qudt:iec61360Code "0112/2///62720#UAD074" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "lineic bit density" .
+  rdfs:label "Lineic Bit Density" .
 
 quantitykind:LinearCompressibility
   a qudt:QuantityKind ;
@@ -7161,7 +7161,7 @@ quantitykind:LinearElectricCharge
   qudt:hasDimensionVector qkdv:A0E1L-1I0M0H0T1D0 ;
   qudt:iec61360Code "0112/2///62720#UAD075" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "lineic electric charge" .
+  rdfs:label "Lineic Electric Charge" .
 
 quantitykind:LinearElectricChargeDensity
   a qudt:QuantityKind ;
@@ -7229,11 +7229,11 @@ quantitykind:LinearExpansionCoefficient
   qudt:qkdvNumerator qkdv:A0E0L1I0M0H0T0D0 ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q74760821> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
+  rdfs:label "Linear Expansion Coefficient"@en ;
   rdfs:label "coefficient de dilatation linéique"@fr ;
   rdfs:label "coefficiente di dilatazione lineare"@it ;
   rdfs:label "coeficiente de dilatação térmica linear"@pt ;
   rdfs:label "coeficiente de expansión térmica lineal"@es ;
-  rdfs:label "linear expansion coefficient"@en ;
   rdfs:label "linearer Ausdehnungskoeffizient"@de ;
   rdfs:label "współczynnik liniowej rozszerzalności cieplnej"@pl ;
   rdfs:label "معدل التمدد الحراري الخطي"@ar ;
@@ -7270,14 +7270,14 @@ quantitykind:LinearLogarithmicRatio
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T0D0 ;
   qudt:iec61360Code "0112/2///62720#UAD078" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "lineic logarithmic ratio" .
+  rdfs:label "Lineic Logarithmic Ratio" .
 
 quantitykind:LinearMass
   a qudt:QuantityKind ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T0D0 ;
   qudt:iec61360Code "0112/2///62720#UAD079" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "lineic mass" .
+  rdfs:label "Lineic Mass" .
 
 quantitykind:LinearMomentum
   a qudt:QuantityKind ;
@@ -7296,14 +7296,14 @@ quantitykind:LinearPower
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H0T-3D0 ;
   qudt:iec61360Code "0112/2///62720#UAD080" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "lineic power" .
+  rdfs:label "Lineic Power" .
 
 quantitykind:LinearResistance
   a qudt:QuantityKind ;
   qudt:hasDimensionVector qkdv:A0E-2L1I0M1H0T-3D0 ;
   qudt:iec61360Code "0112/2///62720#UAD081" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "lineic resistance" .
+  rdfs:label "Lineic Resistance" .
 
 quantitykind:LinearStiffness
   a qudt:QuantityKind ;
@@ -7348,7 +7348,7 @@ quantitykind:LinearTorque
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H0T-2D0 ;
   qudt:iec61360Code "0112/2///62720#UAD082" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "lineic torque" .
+  rdfs:label "Lineic Torque" .
 
 quantitykind:LinearVelocity
   a qudt:QuantityKind ;
@@ -7368,7 +7368,7 @@ quantitykind:LinearVoltageCoefficient
   qudt:plainTextDescription "Verhältnis, das den Zusammenhang zwischen induzierter Spannung zur Geschwindigkeit kennzeichnet"@de ;
   qudt:symbol "0173-1#Z4-BAJ336#003" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "linear voltage coefficient"@en-US .
+  rdfs:label "Linear Voltage Coefficient"@en-US .
 
 quantitykind:LineicCharge
   a qudt:QuantityKind ;
@@ -7377,7 +7377,7 @@ quantitykind:LineicCharge
   qudt:plainTextDescription "elektrische Ladung dividiert durch dazugehörige Länge"@de ;
   qudt:symbol "0173-1#Z4-BAJ457#001" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "lineic charge"@en-US .
+  rdfs:label "Lineic Charge"@en-US .
 
 quantitykind:LineicDataVolume
   a qudt:QuantityKind ;
@@ -7386,7 +7386,7 @@ quantitykind:LineicDataVolume
   qudt:plainTextDescription "Anzahl von Daten, die in der Regel abhängig von der jeweiligen Komplexität der Information oder deren Codierungsverfahren ist, dividiert durch die zugehörige Länge"@de ;
   qudt:symbol "0173-1#Z4-BAJ331#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "lineic data volume"@en-US .
+  rdfs:label "Lineic Data Volume"@en-US .
 
 quantitykind:LineicLogarithmicRatio
   a qudt:QuantityKind ;
@@ -7395,7 +7395,7 @@ quantitykind:LineicLogarithmicRatio
   qudt:plainTextDescription "Logarithmus des Verhältnisses des Werts einer gegebenen Größe zum Wert einer Bezugsgröße gleicher Art dividiert durch die zugehörige Länge"@de ;
   qudt:symbol "0173-1#Z4-BAJ332#003" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "lineic logarithmic ratio"@en-US .
+  rdfs:label "Lineic Logarithmic Ratio"@en-US .
 
 quantitykind:LineicMass
   a qudt:QuantityKind ;
@@ -7404,7 +7404,7 @@ quantitykind:LineicMass
   qudt:plainTextDescription "Quotient Masse dividiert durch die dazugehörige Länge"@de ;
   qudt:symbol "0173-1#Z4-BAJ341#003" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "lineic mass"@en-US .
+  rdfs:label "Lineic Mass"@en-US .
 
 quantitykind:LineicPower
   a qudt:QuantityKind ;
@@ -7413,13 +7413,13 @@ quantitykind:LineicPower
   qudt:plainTextDescription "Leistung dividiert durch die zugehörige Länge"@de ;
   qudt:symbol "0173-1#Z4-BAJ418#003" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "lineic power"@en-US .
+  rdfs:label "Lineic Power"@en-US .
 
 quantitykind:LineicQuantity
   a qudt:QuantityKind ;
   qudt:hasDimensionVector qkdv:NotApplicable ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "lineic quantity"@en-US .
+  rdfs:label "Lineic Quantity"@en-US .
 
 quantitykind:LineicResistance
   a qudt:QuantityKind ;
@@ -7428,7 +7428,7 @@ quantitykind:LineicResistance
   qudt:plainTextDescription "Quotient Widerstand durch Länge"@de ;
   qudt:symbol "0173-1#Z4-BAJ333#003" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "lineic resistance"@en-US .
+  rdfs:label "Lineic Resistance"@en-US .
 
 quantitykind:LineicResolution
   a qudt:QuantityKind ;
@@ -7437,7 +7437,7 @@ quantitykind:LineicResolution
   qudt:plainTextDescription "grafisches Auflösungsvermögen von Ausgabegeräten wie Druckern oder von Datenerfassungsgeräten wie Scannern als Anzahl der Bildpunkte je Länge"@de ;
   qudt:symbol "0173-1#Z4-BAJ438#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "lineic resolution"@en-US ;
+  rdfs:label "Lineic Resolution"@en-US ;
   skos:broader quantitykind:InverseLength .
 
 quantitykind:LineicTorque
@@ -7447,7 +7447,7 @@ quantitykind:LineicTorque
   qudt:plainTextDescription "Drehmoment dividiert durch die zugehörige Länge"@de ;
   qudt:symbol "0173-1#Z4-BAJ433#001" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "lineic torque"@en-US .
+  rdfs:label "Lineic Torque"@en-US .
 
 quantitykind:LinkedFlux
   a qudt:QuantityKind ;
@@ -7491,21 +7491,21 @@ quantitykind:Log10FrequencyInterval
   qudt:hasDimensionVector qkdv:NotApplicable ;
   qudt:iec61360Code "0112/2///62720#UAD084" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "logarithmic frequency interval to base 10" .
+  rdfs:label "Logarithmic Frequency Interval to Base 10" .
 
 quantitykind:Log10Ratio
   a qudt:QuantityKind ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:iec61360Code "0112/2///62720#UAD085" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "logarithmic ratio to base 10" .
+  rdfs:label "Logarithmic Ratio to Base 10" .
 
 quantitykind:LogERatio
   a qudt:QuantityKind ;
   qudt:hasDimensionVector qkdv:NotApplicable ;
   qudt:iec61360Code "0112/2///62720#UAD086" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "logarithmic ratio to base e" .
+  rdfs:label "Logarithmic Ratio to Base e" .
 
 quantitykind:LogOctanolAirPartitionCoefficient
   a qudt:QuantityKind ;
@@ -7533,7 +7533,7 @@ quantitykind:LogarithmRatioToBase10
   qudt:siExactMatch si-quantity:RLGB ;
   qudt:symbol "0173-1#Z4-BAJ441#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "logarithm ratio to base 10"@en-US .
+  rdfs:label "Logarithm Ratio to Base 10"@en-US .
 
 quantitykind:LogarithmRatioToBaseE
   a qudt:QuantityKind ;
@@ -7542,7 +7542,7 @@ quantitykind:LogarithmRatioToBaseE
   qudt:plainTextDescription "natürlicher Logarithmus des Verhältnisses des Werts einer gegebenen Größe zum Wert einer Bezugsgröße gleicher Art (Basis des Logarithmus: e = 2,718...)"@de ;
   qudt:symbol "0173-1#Z4-BAJ440#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "logarithm ratio to base e"@en-US .
+  rdfs:label "Logarithm Ratio to Base e"@en-US .
 
 quantitykind:LogarithmicFrequencyInterval
   a qudt:QuantityKind ;
@@ -7553,11 +7553,11 @@ quantitykind:LogarithmicFrequencyInterval
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Frequenzmaßintervall"@de ;
   rdfs:label "Interval měření frekvence ?"@cs ;
+  rdfs:label "Logarithmic Frequency Interval"@en ;
   rdfs:label "Selang kekerapan logaritma"@ms ;
   rdfs:label "intervalle de fréquence logarithmique"@fr ;
   rdfs:label "intervallo logaritmico di frequenza"@it ;
   rdfs:label "intervalo logarítmico de frequência"@pt ;
-  rdfs:label "logarithmic frequency interval"@en ;
   rdfs:label "logaritmik frekans aralığı"@tr ;
   rdfs:label "частотный интервал"@ru ;
   rdfs:label "فاصله فرکانس لگاریتمی"@fa ;
@@ -7571,7 +7571,7 @@ quantitykind:LogarithmicFrequencyIntervalToBase10
   qudt:plainTextDescription "dekadischer Logarithmus des Quotienten aus zwei Frequenzen, wobei die im Zähler stehende Frequenz größer als die Frequenz im Nenner ist"@de ;
   qudt:symbol "0173-1#Z4-BAJ472#001" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "logarithmic frequency interval to base 10"@en-US .
+  rdfs:label "Logarithmic Frequency Interval to Base 10"@en-US .
 
 quantitykind:LogarithmicMedianInformationFlow_SourceToBase10
   a qudt:QuantityKind ;
@@ -7698,8 +7698,8 @@ quantitykind:Loudness
   qudt:plainTextDescription "Maß für die Stärke der subjektiven Hörempfindung, welche auf einer Skala \"leise-laut\" in sone skaliert wird; einer frei fortschreitenden monofrequenten Welle mit der Frequenz 1 kHz und dem Schalldruckpegel 40 dB, die frontal auf die Zuhörer trifft, ist die Lautheit 1 sone zugeordnet und ein Laut, welcher von den Zuhörern als n-mal so laut wie derjenige mit 1 sone bezeichnet wird, erhält die Lautheit n sone zugeordnet"@de ;
   qudt:symbol "0173-1#Z4-BAJ334#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "loudness" ;
-  rdfs:label "loudness"@en-US ;
+  rdfs:label "Loudness" ;
+  rdfs:label "Loudness"@en-US ;
   skos:broader quantitykind:Dimensionless .
 
 quantitykind:LoudnessLevel
@@ -7710,8 +7710,8 @@ quantitykind:LoudnessLevel
   qudt:plainTextDescription "in phon angegebener Wert als Maß für die Stärke der subjektiven Wahrnehmung eines Schallvorgange, der zahlenmäßig dem in dB angegebenen Schalldruckpegel eines Referenzschalls entspricht, der aus einer frontal einfallenden ebenen Welle mit der Frequenz 1000 Hz besteht und als gleich laut wie das Geräusch empfunden wird"@de ;
   qudt:symbol "0173-1#Z4-BAJ361#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "loudness level" ;
-  rdfs:label "loudness level"@en-US ;
+  rdfs:label "Loudness Level" ;
+  rdfs:label "Loudness Level"@en-US ;
   skos:broader quantitykind:Dimensionless .
 
 quantitykind:LowerCriticalMagneticFluxDensity
@@ -7792,7 +7792,7 @@ quantitykind:LuminousExitance
   qudt:plainTextDescription "Quotient aus dem Lichtstrom dΦ, der ein den Punkt enthaltendes Element der Oberfläche verlässt, und der Fläche dA dieses Elementes"@de ;
   qudt:symbol "0173-1#Z4-BAJ382#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "luminous exitance"@en-US ;
+  rdfs:label "Luminous Exitance"@en-US ;
   skos:broader quantitykind:LuminousFluxPerArea .
 
 quantitykind:LuminousExposure
@@ -7829,6 +7829,7 @@ quantitykind:LuminousFlux
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Fluks berluminositi"@ms ;
   rdfs:label "Lichtstrom"@de ;
+  rdfs:label "Luminous Flux"@en ;
   rdfs:label "Světelný tok"@cs ;
   rdfs:label "fluctús lucis"@la ;
   rdfs:label "flujo luminoso"@es ;
@@ -7838,7 +7839,6 @@ quantitykind:LuminousFlux
   rdfs:label "fluxo luminoso"@pt ;
   rdfs:label "fényáram"@hu ;
   rdfs:label "işık akısı"@tr ;
-  rdfs:label "luminous flux"@en ;
   rdfs:label "strumień świetlny"@pl ;
   rdfs:label "svetlobni tok"@sl ;
   rdfs:label "Светлинен поток"@bg ;
@@ -7883,6 +7883,7 @@ quantitykind:LuminousIntensity
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Keamatan berluminositi"@ms ;
   rdfs:label "Lichtstärke"@de ;
+  rdfs:label "Luminous Intensity"@en ;
   rdfs:label "Svítivost"@cs ;
   rdfs:label "fényerősség"@hu ;
   rdfs:label "intensidad luminosa"@es ;
@@ -7891,7 +7892,6 @@ quantitykind:LuminousIntensity
   rdfs:label "intensitate luminoasă"@ro ;
   rdfs:label "intensità luminosa"@it ;
   rdfs:label "intensité lumineuse"@fr ;
-  rdfs:label "luminous intensity"@en ;
   rdfs:label "svetilnost"@sl ;
   rdfs:label "ışık şiddeti"@tr ;
   rdfs:label "światłość"@pl ;
@@ -8002,7 +8002,7 @@ quantitykind:MachNumber
   qudt:symbol "Ma" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q160669> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Mach number"@en ;
+  rdfs:label "Mach Number"@en ;
   rdfs:label "Mach sayısı"@tr ;
   rdfs:label "Mach-Zahl"@de ;
   rdfs:label "Machovo číslo"@cs ;
@@ -8065,7 +8065,7 @@ quantitykind:MadelungConstant
   rdfs:label "Constante de Madelung"@es ;
   rdfs:label "Constante de Madelung"@fr ;
   rdfs:label "Costante di Madelung"@it ;
-  rdfs:label "Madelung constant"@en ;
+  rdfs:label "Madelung Constant"@en ;
   rdfs:label "Madelung-Konstante"@de ;
   rdfs:label "Stała Madelunga"@pl ;
   rdfs:label "constante de Madelung"@pt ;
@@ -8116,7 +8116,7 @@ quantitykind:MagneticDipoleMomentOfAMolecule
   qudt:plainTextDescription "Em = -m•B, wobei Em die Interaktionsenergie vom Molekül ist mit dem magnetischem Dipolmoment m und einem Magnetfeld mit der magnetischen Induktionsflussdichte B"@de ;
   qudt:symbol "0173-1#Z4-BAJ460#001" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "magnetic dipole moment of a molecule"@en-US .
+  rdfs:label "Magnetic Dipole Moment of a Molecule"@en-US .
 
 quantitykind:MagneticField
   a qudt:QuantityKind ;
@@ -8140,6 +8140,7 @@ quantitykind:MagneticFieldStrength
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Câmp magnetic"@ro ;
   rdfs:label "Kekuatan medan magnetik"@ms ;
+  rdfs:label "Magnetic Field Strength"@en ;
   rdfs:label "Magnetické pole"@cs ;
   rdfs:label "Manyetik alan"@tr ;
   rdfs:label "intensidad de campo magnético"@es ;
@@ -8147,7 +8148,6 @@ quantitykind:MagneticFieldStrength
   rdfs:label "intensità di campo magnetico"@it ;
   rdfs:label "intensité de champ magnétique"@fr ;
   rdfs:label "jakost magnetnega polja"@sl ;
-  rdfs:label "magnetic field strength"@en ;
   rdfs:label "magnetische Feldstärke"@de ;
   rdfs:label "pole magnetyczne"@pl ;
   rdfs:label "Магнитное поле"@ru ;
@@ -8207,13 +8207,13 @@ quantitykind:MagneticFlux
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Fluks magnet"@ms ;
   rdfs:label "Flux d'induction magnétique"@fr ;
+  rdfs:label "Magnetic Flux"@en ;
   rdfs:label "Magnetický tok"@cs ;
   rdfs:label "flujo magnético"@es ;
   rdfs:label "flusso magnetico"@it ;
   rdfs:label "flux de inducție magnetică"@ro ;
   rdfs:label "fluxo magnético"@pt ;
   rdfs:label "fluxus magneticus"@la ;
-  rdfs:label "magnetic flux"@en ;
   rdfs:label "magnetischer Flux"@de ;
   rdfs:label "magnetni pretok"@sl ;
   rdfs:label "manyetik akı"@tr ;
@@ -8243,6 +8243,8 @@ quantitykind:MagneticFluxDensity
   rdfs:label "Densidad de flujo magnético"@es ;
   rdfs:label "Densité de flux magnétique"@fr ;
   rdfs:label "Ketumpatan fluks magnet"@ms ;
+  rdfs:label "Magnetic Flux Density"@en ;
+  rdfs:label "Magnetic Flux Density"@en-US ;
   rdfs:label "Magnetická indukce"@cs ;
   rdfs:label "densidade de fluxo magnético"@pt ;
   rdfs:label "densitas fluxus magnetici"@la ;
@@ -8250,8 +8252,6 @@ quantitykind:MagneticFluxDensity
   rdfs:label "gostota magnetnega pretoka"@sl ;
   rdfs:label "inducție magnetică"@ro ;
   rdfs:label "indukcja magnetyczna"@pl ;
-  rdfs:label "magnetic flux density"@en ;
-  rdfs:label "magnetic flux density"@en-US ;
   rdfs:label "magnetische Flussdichte"@de ;
   rdfs:label "manyetik akı yoğunluğu"@tr ;
   rdfs:label "mágneses indukció"@hu ;
@@ -8288,7 +8288,7 @@ quantitykind:MagneticFluxPerLength
   qudt:qkdvDenominator qkdv:A0E0L1I0M0H0T0D0 ;
   qudt:qkdvNumerator qkdv:A0E-1L2I0M1H0T-2D0 ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Magnetic flux per length"@en .
+  rdfs:label "Magnetic Flux per Length"@en .
 
 quantitykind:MagneticMoment
   a qudt:QuantityKind ;
@@ -8305,11 +8305,11 @@ quantitykind:MagneticMoment
   qudt:symbol "m" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q242657> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
+  rdfs:label "Magnetic Moment"@en ;
   rdfs:label "Magnetický dipól"@cs ;
   rdfs:label "Manyetik moment"@tr ;
   rdfs:label "Momen magnetik"@ms ;
   rdfs:label "dipol magnetyczny"@pl ;
-  rdfs:label "magnetic moment"@en ;
   rdfs:label "magnetisches Dipolmoment"@de ;
   rdfs:label "moment magnétique"@fr ;
   rdfs:label "momento de dipolo magnético"@es ;
@@ -8411,7 +8411,7 @@ quantitykind:MagneticVectorPotential
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q2299100> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Keupayaan vektor magnetik"@ms ;
-  rdfs:label "magnetic vector potential"@en ;
+  rdfs:label "Magnetic Vector Potential"@en ;
   rdfs:label "magnetický potenciál"@cs ;
   rdfs:label "magnetisches Potenzial"@de ;
   rdfs:label "manyetik potansiyeli"@tr ;
@@ -8439,9 +8439,9 @@ quantitykind:Magnetization
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q856711> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Magnetisierung"@de ;
+  rdfs:label "Magnetization"@en ;
   rdfs:label "aimantation"@fr ;
   rdfs:label "magnetización"@es ;
-  rdfs:label "magnetization"@en ;
   rdfs:label "magnetização"@pt ;
   rdfs:label "magnetizzazione"@it ;
   rdfs:label "magnetyzacia"@pl ;
@@ -8494,12 +8494,12 @@ quantitykind:Mass
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Hmotnost"@cs ;
   rdfs:label "Jisim"@ms ;
+  rdfs:label "Mass"@en ;
   rdfs:label "Masse"@de ;
   rdfs:label "kütle"@tr ;
   rdfs:label "masa"@es ;
   rdfs:label "masa"@pl ;
   rdfs:label "masa"@sl ;
-  rdfs:label "mass"@en ;
   rdfs:label "massa"@it ;
   rdfs:label "massa"@la ;
   rdfs:label "massa"@pt ;
@@ -8630,7 +8630,7 @@ quantitykind:MassConcentrationRateOfChange
   qudt:qkdvDenominator qkdv:A0E0L3I0M1H0T1D0 ;
   qudt:qkdvNumerator qkdv:A0E0L0I0M1H0T0D0 ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Mass Concentration Rate Of Change"@en .
+  rdfs:label "Mass Concentration Rate of Change"@en .
 
 quantitykind:MassDefect
   a qudt:QuantityKind ;
@@ -8661,6 +8661,7 @@ quantitykind:MassDensity
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Gostôta"@sl ;
   rdfs:label "Ketumpatan jisim"@ms ;
+  rdfs:label "Mass Density"@en ;
   rdfs:label "Massendichte"@de ;
   rdfs:label "densidad"@es ;
   rdfs:label "densidade"@pt ;
@@ -8669,7 +8670,6 @@ quantitykind:MassDensity
   rdfs:label "densité"@fr ;
   rdfs:label "gęstość"@pl ;
   rdfs:label "hustota"@cs ;
-  rdfs:label "mass density"@en ;
   rdfs:label "yoğunluk"@tr ;
   rdfs:label "плотность"@ru ;
   rdfs:label "الكثافة"@ar ;
@@ -8743,8 +8743,8 @@ quantitykind:MassFluxDensity
   qudt:plainTextDescription "Produkt aus Strömungsgeschwindigkeit und Dichte"@de ;
   qudt:symbol "0173-1#Z4-BAJ264#003" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "mass flux density" ;
-  rdfs:label "mass flux density"@en-US ;
+  rdfs:label "Mass Flux Density" ;
+  rdfs:label "Mass Flux Density"@en-US ;
   skos:broader quantitykind:MassPerAreaTime .
 
 quantitykind:MassFraction
@@ -8804,7 +8804,7 @@ quantitykind:MassOfElectricalPowerSupply
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:symbol "M_{E}" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Mass Of Electrical Power Supply"@en ;
+  rdfs:label "Mass of Electrical Power Supply"@en ;
   skos:broader quantitykind:Mass .
 
 quantitykind:MassOfSolidBooster
@@ -8812,7 +8812,7 @@ quantitykind:MassOfSolidBooster
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:symbol "M_{SB}" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Mass Of Solid Booster"@en ;
+  rdfs:label "Mass of Solid Booster"@en ;
   skos:broader quantitykind:Mass .
 
 quantitykind:MassOfTheEarth
@@ -8822,7 +8822,7 @@ quantitykind:MassOfTheEarth
   qudt:latexSymbol "$M_{\\oplus}$"^^qudt:LatexString ;
   qudt:plainTextDescription "Earth mass is the unit of mass equal to that of the Earth.  Earth mass is often used to describe masses of rocky terrestrial planets." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Mass Of The Earth"@en ;
+  rdfs:label "Mass of the Earth"@en ;
   skos:broader quantitykind:Mass .
 
 quantitykind:MassPerArea
@@ -8895,7 +8895,7 @@ quantitykind:MassRatioOfWaterToDryMatter
   qudt:plainTextDescription "Mass Ratio of Water to Dry Matter is one of a number of Concentration Ratio quantities defined by ISO 80000." ;
   qudt:symbol "u" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Mass Concentration of Water To Dry Matter"@en .
+  rdfs:label "Mass Concentration of Water to Dry Matter"@en .
 
 quantitykind:MassRatioOfWaterVapourToDryGas
   a qudt:QuantityKind ;
@@ -8916,7 +8916,7 @@ quantitykind:MassRelatedElectricalCurrent
   qudt:plainTextDescription "elektrische Stromstärke dividiert durch die zugehörige Masse"@de ;
   qudt:symbol "0173-1#Z4-BAJ347#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "mass-related electrical current"@en-US .
+  rdfs:label "Mass-related Electrical Current"@en-US .
 
 quantitykind:MassSpecificBiogeochemicalRate
   a qudt:QuantityKind ;
@@ -8935,7 +8935,7 @@ quantitykind:MassStoppingPower
   qudt:iec61360Code "0112/2///62720#UAD130" ;
   qudt:iec61360Code "0112/2///62720#UAD290" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "mass stopping power" .
+  rdfs:label "Mass Stopping Power" .
 
 quantitykind:MassTemperature
   a qudt:QuantityKind ;
@@ -8960,7 +8960,7 @@ quantitykind:MassicElectricCurrent
   qudt:hasDimensionVector qkdv:A0E1L0I0M-1H0T0D0 ;
   qudt:iec61360Code "0112/2///62720#UAD111" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "massic electric current" .
+  rdfs:label "Massic Electric Current" .
 
 quantitykind:MassicHeatCapacity
   a qudt:QuantityKind ;
@@ -8970,8 +8970,8 @@ quantitykind:MassicHeatCapacity
   qudt:plainTextDescription "Quotient Wärmekapazität dividiert durch Masse"@de ;
   qudt:symbol "0173-1#Z4-BAJ345#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "massic heat capacity" ;
-  rdfs:label "massic heat capacity"@en-US .
+  rdfs:label "Massic Heat Capacity" ;
+  rdfs:label "Massic Heat Capacity"@en-US .
 
 quantitykind:MassicPower
   a qudt:QuantityKind ;
@@ -8981,8 +8981,8 @@ quantitykind:MassicPower
   qudt:plainTextDescription "Quotient Energie durch Zeit und durch zugehöriger Masse"@de ;
   qudt:symbol "0173-1#Z4-BAJ343#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "massic power" ;
-  rdfs:label "massic power"@en-US ;
+  rdfs:label "Massic Power" ;
+  rdfs:label "Massic Power"@en-US ;
   skos:broader quantitykind:SpecificPower .
 
 quantitykind:MassicTorque
@@ -8993,8 +8993,8 @@ quantitykind:MassicTorque
   qudt:plainTextDescription "Quotient Drehmoment dividiert durch die Masse, die bewegt oder befördert wird"@de ;
   qudt:symbol "0173-1#Z4-BAJ442#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "massic torque" ;
-  rdfs:label "massic torque"@en-US .
+  rdfs:label "Massic Torque" ;
+  rdfs:label "Massic Torque"@en-US .
 
 quantitykind:MassieuFunction
   a qudt:QuantityKind ;
@@ -9187,7 +9187,7 @@ quantitykind:MechanicalSurfaceImpedance
   qudt:symbol "Z" ;
   rdfs:comment "There are various interpretations of MechanicalSurfaceImpedance: Pressure/Velocity - https://apps.dtic.mil/sti/pdfs/ADA315595.pdf, Force / Speed - https://www.wikidata.org/wiki/Q6421317, and (Pressure / Velocity)**0.5 - https://www.sciencedirect.com/topics/engineering/mechanical-impedance. We are seeking a resolution to these differences." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Mechanical surface impedance"@en ;
+  rdfs:label "Mechanical Surface Impedance"@en ;
   vaem:todo "belongs to SOQ-ISO" .
 
 quantitykind:MechanicalTension
@@ -9197,7 +9197,7 @@ quantitykind:MechanicalTension
   qudt:plainTextDescription "an einem Punkt eines Körpers, an dem eine Kraft angreift, welche die Form des Körpers zu verändern sucht, der Grenzwert des Quotienten Kraft durch Fläche einer ebenen Oberfläche um diesen Punkt, wenn deren Abmessungen gegen null gehen"@de ;
   qudt:symbol "0173-1#Z4-BAJ204#005" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "mechanical tension"@en-US ;
+  rdfs:label "Mechanical Tension"@en-US ;
   skos:broader quantitykind:ForcePerArea .
 
 quantitykind:MeltingPoint
@@ -9268,8 +9268,8 @@ quantitykind:Mobility
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q900648> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Beweglichkeit"@de ;
+  rdfs:label "Mobility"@en ;
   rdfs:label "mobilidade"@pt ;
-  rdfs:label "mobility"@en ;
   rdfs:label "mobilità"@it ;
   rdfs:label "mobilité"@fr ;
   rdfs:label "mobilność"@pl ;
@@ -9304,7 +9304,7 @@ quantitykind:ModulusOfAdmittance
   qudt:symbol "Y" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q79466359> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Modulus Of Admittance"@en ;
+  rdfs:label "Modulus of Admittance"@en ;
   rdfs:seeAlso quantitykind:Admittance .
 
 quantitykind:ModulusOfElasticity
@@ -9332,7 +9332,7 @@ the quotient of rms voltage and rms electric current; it is often denoted by $Z$
   qudt:symbol "Z" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q25457909> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Modulus Of Impedance"@en ;
+  rdfs:label "Modulus of Impedance"@en ;
   rdfs:seeAlso quantitykind:Impedance .
 
 quantitykind:ModulusOfLinearSubgradeReaction
@@ -9442,7 +9442,7 @@ quantitykind:MolarDensity
   qudt:plainTextDescription "Größe, deren Wert sich umgekehrt proportional zu Stoffmengenwert verhält"@de ;
   qudt:symbol "0173-1#Z4-BAJ372#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "molar density"@en-US .
+  rdfs:label "Molar Density"@en-US .
 
 quantitykind:MolarEnergy
   a qudt:QuantityKind ;
@@ -9545,7 +9545,7 @@ quantitykind:MolarInternalEnergy
   qudt:hasDimensionVector qkdv:A-1E0L2I0M1H0T-2D0 ;
   qudt:iec61360Code "0112/2///62720#UAD124" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "molar internal energy" ;
+  rdfs:label "Molar Internal Energy" ;
   skos:broader quantitykind:MolarEnergy .
 
 quantitykind:MolarMass
@@ -9562,6 +9562,7 @@ quantitykind:MolarMass
   rdfs:label "Jisim molar"@ms ;
   rdfs:label "Masa molowa"@pl ;
   rdfs:label "Masă molară"@ro ;
+  rdfs:label "Molar Mass"@en ;
   rdfs:label "Molmasse"@de ;
   rdfs:label "Molární hmotnost"@cs ;
   rdfs:label "masa molar"@es ;
@@ -9569,7 +9570,6 @@ quantitykind:MolarMass
   rdfs:label "massa molare"@it ;
   rdfs:label "masse molaire"@fr ;
   rdfs:label "molar kütle"@tr ;
-  rdfs:label "molar mass"@en ;
   rdfs:label "molska masa"@sl ;
   rdfs:label "Молярная масса"@ru ;
   rdfs:label "جرم مولی"@fa ;
@@ -9587,7 +9587,7 @@ quantitykind:MolarOpticalRotationalAbility
   qudt:plainTextDescription "materialspezifische Größe, die sich als spezifischer Drehwinkel einer Substanz für eine bestimmte Wellenlänge und eine bestimmte Temperatur ergibt durch die Beziehung: Quotient aus gemessener Drehwinkel dividiert durch die Stoffmenegenkonzentration und die durchstrahlte Wegstrecke"@de ;
   qudt:symbol "0173-1#Z4-BAJ426#001" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "molar optical rotational ability"@en-US .
+  rdfs:label "Molar Optical Rotational Ability"@en-US .
 
 quantitykind:MolarOpticalRotatoryPower
   a qudt:QuantityKind ;
@@ -9618,7 +9618,7 @@ quantitykind:MolarThermalCapacity
   qudt:plainTextDescription "auf die Stoffmenge bezogene Wärmekapazität"@de ;
   qudt:symbol "0173-1#Z4-BAJ355#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "molar thermal capacity"@en-US .
+  rdfs:label "Molar Thermal Capacity"@en-US .
 
 quantitykind:MolarThermodynamicEnergy
   a qudt:QuantityKind ;
@@ -9627,7 +9627,7 @@ quantitykind:MolarThermodynamicEnergy
   qudt:plainTextDescription "auf die Stoffmenge bezogene Energie"@de ;
   qudt:symbol "0173-1#Z4-BAJ353#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "molar thermodynamic energy"@en-US ;
+  rdfs:label "Molar Thermodynamic Energy"@en-US ;
   skos:broader quantitykind:MolarEnergy .
 
 quantitykind:MolarVolume
@@ -9643,9 +9643,9 @@ quantitykind:MolarVolume
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q487112> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Isipadu molar"@ms ;
+  rdfs:label "Molar Volume"@en ;
   rdfs:label "Molvolumen"@de ;
   rdfs:label "molar hacim"@tr ;
-  rdfs:label "molar volume"@en ;
   rdfs:label "molski volumen"@sl ;
   rdfs:label "molární objem"@cs ;
   rdfs:label "volum molar"@ro ;
@@ -9748,9 +9748,9 @@ quantitykind:MomentOfInertia
   rdfs:label "Momen inersia"@ms ;
   rdfs:label "Moment bezwładności"@pl ;
   rdfs:label "Moment de inerție"@ro ;
+  rdfs:label "Moment of Inertia"@en ;
   rdfs:label "Moment setrvačnosti"@cs ;
   rdfs:label "moment d'inertie"@fr ;
-  rdfs:label "moment of inertia"@en ;
   rdfs:label "momento de inercia"@es ;
   rdfs:label "momento de inércia"@pt ;
   rdfs:label "momento di inerzia"@it ;
@@ -9769,7 +9769,7 @@ quantitykind:MomentOfInertia_Y
   qudt:plainTextDescription "The rotational inertia or resistance to change in direction or speed of rotation about a defined axis." ;
   qudt:symbol "I_{y}" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Moment of Inertia in the Y axis"@en ;
+  rdfs:label "Moment of Inertia in the Y Axis"@en ;
   skos:altLabel "MOI" ;
   skos:broader quantitykind:MomentOfInertia .
 
@@ -9780,7 +9780,7 @@ quantitykind:MomentOfInertia_Z
   qudt:plainTextDescription "The rotational inertia or resistance to change in direction or speed of rotation about a defined axis." ;
   qudt:symbol "I_{z}" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Moment of Inertia in the Z axis"@en ;
+  rdfs:label "Moment of Inertia in the Z Axis"@en ;
   skos:altLabel "MOI" ;
   skos:broader quantitykind:MomentOfInertia .
 
@@ -9796,6 +9796,7 @@ quantitykind:Momentum
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q41273> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Impuls"@de ;
+  rdfs:label "Momentum"@en ;
   rdfs:label "Momentum"@ms ;
   rdfs:label "Momentum"@tr ;
   rdfs:label "cantidad de movimiento"@es ;
@@ -9803,7 +9804,6 @@ quantitykind:Momentum
   rdfs:label "hybnost"@cs ;
   rdfs:label "impuls"@ro ;
   rdfs:label "momento linear"@pt ;
-  rdfs:label "momentum"@en ;
   rdfs:label "pęd"@pl ;
   rdfs:label "quantità di moto"@it ;
   rdfs:label "quantité de mouvement"@fr ;
@@ -9850,8 +9850,8 @@ quantitykind:MotorConstant
   qudt:plainTextDescription "Größe, die eine Eigenschaft eines Motors kennzeichnet"@de ;
   qudt:symbol "0173-1#Z4-BAJ358#003" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "motor constant" ;
-  rdfs:label "motor constant"@en-US .
+  rdfs:label "Motor Constant" ;
+  rdfs:label "Motor Constant"@en-US .
 
 quantitykind:MultiplicationFactor
   a qudt:QuantityKind ;
@@ -9911,7 +9911,7 @@ quantitykind:NaturalLogarithmicMedianInformationFlow
   qudt:plainTextDescription "Quotient mittlerer Informationsgehalt durch den Erwartungswert für die Dauer eines Zeichens, ausgedrückt als Logarithmus zur Basis e"@de ;
   qudt:symbol "0173-1#Z4-BAJ471#001" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "median information flow (from a source of information), expressed as a natural logarithm "@en-US .
+  rdfs:label "Median Information Flow (from a Source of Information), Expressed as a Natural Logarithm "@en-US .
 
 quantitykind:NeelTemperature
   a qudt:QuantityKind ;
@@ -9949,7 +9949,7 @@ quantitykind:NeutralRatio
   qudt:plainTextDescription "Quotient aus zwei physikalischen Größen gleicher Art als Zahl, welche das Verhältnis dieser Größen zueinander ausdrückt, wobei die einheiten gegeneinander gekürzt sind"@de ;
   qudt:symbol "0173-1#Z4-BAJ359#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "neutral ratio"@en-US ;
+  rdfs:label "Neutral Ratio"@en-US ;
   skos:broader quantitykind:DimensionlessRatio .
 
 quantitykind:NeutronDiffusionCoefficient
@@ -9963,12 +9963,12 @@ quantitykind:NeutronDiffusionCoefficient
   qudt:symbol "D" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q105623303> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
+  rdfs:label "Diffusion Coefficient"@en ;
   rdfs:label "Diffusionskoeffizient"@de ;
   rdfs:label "coefficient de diffusion"@fr ;
   rdfs:label "coefficiente di diffusione"@it ;
   rdfs:label "coeficiente de difusión"@es ;
   rdfs:label "coeficiente de difusão"@pt ;
-  rdfs:label "diffusion coefficient"@en ;
   rdfs:label "difuzijski koeficient"@sl .
 
 quantitykind:NeutronDiffusionLength
@@ -9991,12 +9991,12 @@ quantitykind:NeutronNumber
   qudt:symbol "N" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q970319> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
+  rdfs:label "Neutron Number"@en ;
   rdfs:label "Neutronenzahl"@de ;
   rdfs:label "Neutronové číslo"@cs ;
   rdfs:label "Nombor neutron"@ms ;
   rdfs:label "Nombre de neutrons"@fr ;
   rdfs:label "liczba neutronowa"@pl ;
-  rdfs:label "neutron number"@en ;
   rdfs:label "numero neutronico"@it ;
   rdfs:label "nötron snumarası"@tr ;
   rdfs:label "número de neutrons"@pt ;
@@ -10110,7 +10110,7 @@ quantitykind:NuclearEnergy
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:iec61360Code "0112/2///62720#UAD131" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "nuclear energy" ;
+  rdfs:label "Nuclear Energy" ;
   skos:broader quantitykind:Energy .
 
 quantitykind:NuclearQuadrupoleMoment
@@ -10163,11 +10163,11 @@ quantitykind:NucleonNumber
   qudt:symbol "A" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Nombor nukleon"@ms ;
+  rdfs:label "Nucleon Number"@en ;
   rdfs:label "Nukleonenzahl"@de ;
   rdfs:label "Nukleové číslo"@cs ;
   rdfs:label "liczba masowa"@pl ;
   rdfs:label "nombre de masse"@fr ;
-  rdfs:label "nucleon number"@en ;
   rdfs:label "numero di massa"@it ;
   rdfs:label "número de massa"@pt ;
   rdfs:label "número másico"@es ;
@@ -10324,9 +10324,9 @@ quantitykind:OsmoticPressure
   qudt:symbol "Π" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q193135> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
+  rdfs:label "Osmotic Pressure"@en ;
   rdfs:label "Osmotický tlak"@cs ;
   rdfs:label "Tekanan osmotik"@ms ;
-  rdfs:label "osmotic pressure"@en ;
   rdfs:label "osmotischer Druck"@de ;
   rdfs:label "ozmotik basıç"@tr ;
   rdfs:label "presión osmótica"@es ;
@@ -10344,7 +10344,7 @@ quantitykind:OverRangeDistance
   qudt:plainTextDescription "Additional distance traveled by a rocket because Of excessive initial velocity." ;
   qudt:symbol "s_i" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Over-range distance"@en ;
+  rdfs:label "Over-range Distance"@en ;
   skos:broader quantitykind:Length .
 
 quantitykind:PREDICTED-MASS
@@ -10494,8 +10494,8 @@ quantitykind:ParticleCurrentDensity
   qudt:plainTextDescription "Vektor, dessen Komponente senkrecht zu einer Fläche gleich der Nettoanzahl von Teilchen ist, die flächen- und zeitbezogen in positiver Richtung durch diese Fläche hindurchgehen"@de ;
   qudt:symbol "0173-1#Z4-BAJ388#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "particle current density" ;
-  rdfs:label "particle current density"@en-US .
+  rdfs:label "Particle Current Density" ;
+  rdfs:label "Particle Current Density"@en-US .
 
 quantitykind:ParticleFluence
   a qudt:QuantityKind ;
@@ -10699,7 +10699,7 @@ quantitykind:PhaseCoefficient
   qudt:latexSymbol "$\\beta$"^^qudt:LatexString ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q32745742> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Phase coefficient"@en ;
+  rdfs:label "Phase Coefficient"@en ;
   vaem:todo "belongs to SOQ-ISO" .
 
 quantitykind:PhaseDifference
@@ -10715,11 +10715,11 @@ quantitykind:PhaseDifference
   qudt:latexSymbol "$\\varphi$"^^qudt:LatexString ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q78514588> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
+  rdfs:label "Phase Difference"@en ;
   rdfs:label "Phasenverschiebungswinkel"@de ;
   rdfs:label "diferencia de fase"@es ;
   rdfs:label "diferença de fase"@pt ;
   rdfs:label "différence de phase"@fr ;
-  rdfs:label "phase difference"@en ;
   rdfs:label "przesunięcie fazowe"@pl ;
   rdfs:label "sfasamento angolare"@it ;
   rdfs:label "اختلاف طور"@ar ;
@@ -10738,7 +10738,7 @@ quantitykind:PhaseSpeedOfSound
   qudt:symbol "c" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q86501878> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Phase speed of sound"@en ;
+  rdfs:label "Phase Speed of Sound"@en ;
   skos:broader quantitykind:SpeedOfSound ;
   vaem:todo "belongs to SOQ-ISO" .
 
@@ -10782,8 +10782,8 @@ quantitykind:PhotonLuminance
   qudt:plainTextDescription "Quotient aus dem durch eine Fläche in einer Richtung durchgehenden Photonenstrom und dem Produkt aus dem durchstrahlten Raumwinkel und der Projektion dieser Fläche auf eine Ebene senkrecht zur betrachteten Fläche"@de ;
   qudt:symbol "0173-1#Z4-BAJ363#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "photon luminance" ;
-  rdfs:label "photon luminance"@en-US .
+  rdfs:label "Photon Luminance" ;
+  rdfs:label "Photon Luminance"@en-US .
 
 quantitykind:PhotonRadiance
   a qudt:QuantityKind ;
@@ -10824,15 +10824,15 @@ quantitykind:PictureElement
   qudt:plainTextDescription "kleinstes Element einer Darstellungsfläche (Zellgröße) einer digitalisierten zweidimensionalen Felddarstellung eines Bildes, die eine Adresse (x- und y-Koordinaten entsprechend seiner Position im Feld) und einen spezifischen Helligkeitswert besitzt"@de ;
   qudt:symbol "0173-1#Z4-BAJ437#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "picture element" ;
-  rdfs:label "picture element"@en-US .
+  rdfs:label "Picture Element" ;
+  rdfs:label "Picture Element"@en-US .
 
 quantitykind:Piece
   a qudt:QuantityKind ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:iec61360Code "0112/2///62720#UAD146" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "piece" ;
+  rdfs:label "Piece" ;
   skos:broader quantitykind:Count .
 
 quantitykind:PlanarForce
@@ -10881,6 +10881,7 @@ quantitykind:PlaneAngle
   qudt:qkdvNumerator qkdv:A0E0L1I0M0H0T0D0 ;
   qudt:siExactMatch si-quantity:ANGP ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
+  rdfs:label "Plane Angle"@en ;
   rdfs:label "Rovinný úhel"@cs ;
   rdfs:label "Sudut satah"@ms ;
   rdfs:label "angle plan"@fr ;
@@ -10890,7 +10891,6 @@ quantitykind:PlaneAngle
   rdfs:label "ebener Winkel"@de ;
   rdfs:label "kąt płaski"@pl ;
   rdfs:label "medida angular"@pt ;
-  rdfs:label "plane angle"@en ;
   rdfs:label "ravninski kot"@sl ;
   rdfs:label "szög"@hu ;
   rdfs:label "unghi plan"@ro ;
@@ -10932,7 +10932,7 @@ quantitykind:PolarMomentOfInertia
   qudt:plainTextDescription "The polar moment of inertia is a quantity used to predict an object's ability to resist torsion, in objects (or segments of objects) with an invariant circular cross-section and no significant warping or out-of-plane deformation. It is used to calculate the angular displacement of an object subjected to a torque. It is analogous to the area moment of inertia, which characterizes an object's ability to resist bending. " ;
   qudt:symbol "J_{zz}" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Polar moment of inertia"@en ;
+  rdfs:label "Polar Moment of Inertia"@en ;
   skos:broader quantitykind:MomentOfInertia .
 
 quantitykind:Polarizability
@@ -10947,8 +10947,8 @@ quantitykind:Polarizability
   qudt:symbol "0173-1#Z4-BAJ365#002" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q869891> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Polarizability"@en-US ;
-  rdfs:label "polarisability"@en .
+  rdfs:label "Polarisability"@en ;
+  rdfs:label "Polarizability"@en-US .
 
 quantitykind:PolarizationField
   a qudt:QuantityKind ;
@@ -11028,12 +11028,12 @@ quantitykind:PotentialEnergy
   rdfs:label "Energia potencjalna"@pl ;
   rdfs:label "Energie potențială"@ro ;
   rdfs:label "Potansiyel enerji"@tr ;
+  rdfs:label "Potential Energy"@en ;
   rdfs:label "Tenaga keupayaan"@ms ;
   rdfs:label "energia potencial"@pt ;
   rdfs:label "energia potenziale"@it ;
   rdfs:label "energía potencial"@es ;
   rdfs:label "potenciální energie"@cs ;
-  rdfs:label "potential energy"@en ;
   rdfs:label "potentielle Energie"@de ;
   rdfs:label "énergie potentielle"@fr ;
   rdfs:label "потенциальная энергия"@ru ;
@@ -11060,6 +11060,7 @@ quantitykind:Power
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Kuasa"@ms ;
   rdfs:label "Leistung"@de ;
+  rdfs:label "Power"@en ;
   rdfs:label "Výkon"@cs ;
   rdfs:label "güç"@tr ;
   rdfs:label "moc"@pl ;
@@ -11068,7 +11069,6 @@ quantitykind:Power
   rdfs:label "potentia"@la ;
   rdfs:label "potenza"@it ;
   rdfs:label "potência"@pt ;
-  rdfs:label "power"@en ;
   rdfs:label "puissance"@fr ;
   rdfs:label "putere"@ro ;
   rdfs:label "teljesítmény , hőáramlás"@hu ;
@@ -11105,7 +11105,7 @@ quantitykind:PowerConstant
   qudt:plainTextDescription "Verhältnis, das den Zusammenhang zwischen der Dauerkraft zum Dauerstrom kennzeichnet"@de ;
   qudt:symbol "0173-1#Z4-BAJ330#003" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "power constant"@en-US .
+  rdfs:label "Power Constant"@en-US .
 
 quantitykind:PowerDensity
   a qudt:QuantityKind ;
@@ -11113,7 +11113,7 @@ quantitykind:PowerDensity
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-3D0 ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Power_density"^^xsd:anyURI ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "PowerDensity"@en .
+  rdfs:label "Power Density"@en .
 
 quantitykind:PowerFactor
   a qudt:QuantityKind ;
@@ -11127,6 +11127,7 @@ quantitykind:PowerFactor
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q750454> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Leistungsfaktor"@de ;
+  rdfs:label "Power Factor"@en ;
   rdfs:label "Współczynnik mocy"@pl ;
   rdfs:label "facteur de puissance"@fr ;
   rdfs:label "factor de potencia"@es ;
@@ -11135,7 +11136,6 @@ quantitykind:PowerFactor
   rdfs:label "fator de potência"@pt ;
   rdfs:label "fattore di potenza"@it ;
   rdfs:label "güç faktörü"@tr ;
-  rdfs:label "power factor"@en ;
   rdfs:label "Účiník"@cs ;
   rdfs:label "Коэффициент_мощности"@ru ;
   rdfs:label "ضریب توان"@fa ;
@@ -11151,7 +11151,7 @@ quantitykind:PowerPerArea
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-3D0 ;
   qudt:informativeReference "http://www.physicsforums.com/library.php?do=view_item&itemid=406"^^xsd:anyURI ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Power Per Area"@en .
+  rdfs:label "Power per Area"@en .
 
 quantitykind:PowerPerAreaAngle
   a qudt:QuantityKind ;
@@ -11163,7 +11163,7 @@ quantitykind:PowerPerAreaQuarticTemperature
   a qudt:QuantityKind ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H-4T-3D0 ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Power per area quartic temperature"@en .
+  rdfs:label "Power per Area Quartic Temperature"@en .
 
 quantitykind:PowerPerElectricCharge
   a qudt:QuantityKind ;
@@ -11171,7 +11171,7 @@ quantitykind:PowerPerElectricCharge
   qudt:hasDimensionVector qkdv:A0E-1L2I0M1H0T-4D0 ;
   qudt:plainTextDescription "\"Power Per Electric Charge\" is the amount of energy generated by a unit of electric charge." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Power Per Electric Charge"@en .
+  rdfs:label "Power per Electric Charge"@en .
 
 quantitykind:PowerPerVolume
   a qudt:QuantityKind ;
@@ -11202,7 +11202,7 @@ quantitykind:PoyntingVector
   qudt:plainTextDescription "\"Poynting Vector\" is the vector product of the electric field strength $\\mathbf{E}$ and the magnetic field strength $\\mathbf{H}\" of the electromagnetic field at a given point. The flux of the Poynting vector through a closed surface is equal to the electromagnetic power passing through this surface. For a periodic electromagnetic field, the time average of the Poynting vector is a vector of which, with certain reservations, the direction may be considered as being the direction of propagation of electromagnetic energy and the magnitude considered as being the average electromagnetic power flux density." ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q504186> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Poynting vector"@en ;
+  rdfs:label "Poynting Vector"@en ;
   rdfs:label "Poynting-Vektor"@de ;
   rdfs:label "vecteur de Poynting"@fr ;
   rdfs:label "vector de Poynting"@es ;
@@ -11227,6 +11227,7 @@ quantitykind:Pressure
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q39552> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Druck"@de ;
+  rdfs:label "Pressure"@en ;
   rdfs:label "Tekanan"@ms ;
   rdfs:label "Tlak"@cs ;
   rdfs:label "basınç"@tr ;
@@ -11237,7 +11238,6 @@ quantitykind:Pressure
   rdfs:label "pressio"@la ;
   rdfs:label "pression"@fr ;
   rdfs:label "pressione"@it ;
-  rdfs:label "pressure"@en ;
   rdfs:label "pressão"@pt ;
   rdfs:label "tlak"@sl ;
   rdfs:label "Πίεση - τάση"@el ;
@@ -11266,7 +11266,7 @@ quantitykind:PressureBasedAmountOfSubstanceConcentration
   qudt:plainTextDescription "Quotient Molarität (Quotient aus der Stoffmenge eines gelösten Stoffes und dem Volumen der Lösung) dividiert durch den zugehörigen Druck"@de ;
   qudt:symbol "0173-1#Z4-BAJ307#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "pressure-based amount-of-substance concentration"@en-US .
+  rdfs:label "Pressure-based Amount-of-substance Concentration"@en-US .
 
 quantitykind:PressureBasedDensity
   a qudt:QuantityKind ;
@@ -11275,7 +11275,7 @@ quantitykind:PressureBasedDensity
   qudt:plainTextDescription "Quotient aus Dichte dividiert durch den zugehörigen Druck"@de ;
   qudt:symbol "0173-1#Z4-BAJ299#003" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "pressure-based density"@en-US .
+  rdfs:label "Pressure-based Density"@en-US .
 
 quantitykind:PressureBasedDynamicViscosity
   a qudt:QuantityKind ;
@@ -11284,7 +11284,7 @@ quantitykind:PressureBasedDynamicViscosity
   qudt:plainTextDescription "Quotient aus der dynamischen Viskosität dividiert durch den zugehörigen Druck"@de ;
   qudt:symbol "0173-1#Z4-BAJ300#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "pressure-based dynamic viscosity"@en-US .
+  rdfs:label "Pressure-based Dynamic Viscosity"@en-US .
 
 quantitykind:PressureBasedElectricCurrent
   a qudt:QuantityKind ;
@@ -11293,7 +11293,7 @@ quantitykind:PressureBasedElectricCurrent
   qudt:plainTextDescription "Quotient elektrische Stromstärke dividiert durch den zugehörigen Druck"@de ;
   qudt:symbol "0173-1#Z4-BAJ309#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "pressure-based electric current"@en-US .
+  rdfs:label "Pressure-based Electric Current"@en-US .
 
 quantitykind:PressureBasedElectricVoltage
   a qudt:QuantityKind ;
@@ -11302,7 +11302,7 @@ quantitykind:PressureBasedElectricVoltage
   qudt:plainTextDescription "Quotient elektrischer Spannung dividiert durch den zugehörigen Druck"@de ;
   qudt:symbol "0173-1#Z4-BAJ301#003" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "pressure-based electric voltage"@en-US .
+  rdfs:label "Pressure-based Electric Voltage"@en-US .
 
 quantitykind:PressureBasedKinematicViscosity
   a qudt:QuantityKind ;
@@ -11311,7 +11311,7 @@ quantitykind:PressureBasedKinematicViscosity
   qudt:plainTextDescription "Quotient aus der dynamischen Viskosität und der Dichte eines Stoffes dividiert durch den zugehörigen Druck"@de ;
   qudt:symbol "0173-1#Z4-BAJ303#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "pressure-based kinematic viscosity"@en-US .
+  rdfs:label "Pressure-based Kinematic Viscosity"@en-US .
 
 quantitykind:PressureBasedLength
   a qudt:QuantityKind ;
@@ -11320,7 +11320,7 @@ quantitykind:PressureBasedLength
   qudt:plainTextDescription "Quotient Länge dividiert durch den zugehörigen Druck"@de ;
   qudt:symbol "0173-1#Z4-BAJ304#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "pressure-based length"@en-US .
+  rdfs:label "Pressure-based Length"@en-US .
 
 quantitykind:PressureBasedMass
   a qudt:QuantityKind ;
@@ -11329,7 +11329,7 @@ quantitykind:PressureBasedMass
   qudt:plainTextDescription "Quotient Masse dividiert durch den zugehörigen Druck"@de ;
   qudt:symbol "0173-1#Z4-BAJ305#003" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "pressure-based mass"@en-US .
+  rdfs:label "Pressure-based Mass"@en-US .
 
 quantitykind:PressureBasedMassFlow
   a qudt:QuantityKind ;
@@ -11338,7 +11338,7 @@ quantitykind:PressureBasedMassFlow
   qudt:plainTextDescription "Quotient Massenstrom dividiert durch den zugehörigen Druck"@de ;
   qudt:symbol "0173-1#Z4-BAJ310#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "pressure-based mass flow"@en-US .
+  rdfs:label "Pressure-based Mass Flow"@en-US .
 
 quantitykind:PressureBasedMolality
   a qudt:QuantityKind ;
@@ -11347,13 +11347,13 @@ quantitykind:PressureBasedMolality
   qudt:plainTextDescription "Quotient Molalität dividiert durch den zugehörigen Druck"@de ;
   qudt:symbol "0173-1#Z4-BAJ306#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "pressure-based molality"@en-US .
+  rdfs:label "Pressure-based Molality"@en-US .
 
 quantitykind:PressureBasedQuantity
   a qudt:QuantityKind ;
   qudt:hasDimensionVector qkdv:NotApplicable ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "pressure-based quantity"@en-US .
+  rdfs:label "Pressure-based Quantity"@en-US .
 
 quantitykind:PressureBasedTemperature
   a qudt:QuantityKind ;
@@ -11362,7 +11362,7 @@ quantitykind:PressureBasedTemperature
   qudt:plainTextDescription "Quotient Temperatur dividiert durch den zugehörigen Druck"@de ;
   qudt:symbol "0173-1#Z4-BAJ308#003" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "pressure-based temperature"@en-US .
+  rdfs:label "Pressure-based Temperature"@en-US .
 
 quantitykind:PressureBasedVelocity
   a qudt:QuantityKind ;
@@ -11371,7 +11371,7 @@ quantitykind:PressureBasedVelocity
   qudt:plainTextDescription "Quotient Geschwindigkeit dividiert durch den zugehörigen Druck"@de ;
   qudt:symbol "0173-1#Z4-BAJ302#001" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "pressure-based velocity"@en-US .
+  rdfs:label "Pressure-based Velocity"@en-US .
 
 quantitykind:PressureBasedVolume
   a qudt:QuantityKind ;
@@ -11380,7 +11380,7 @@ quantitykind:PressureBasedVolume
   qudt:plainTextDescription "Quotient Volumen dividiert durch den zugehörigen Druck"@de ;
   qudt:symbol "0173-1#Z4-BAJ312#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "pressure-based volume"@en-US .
+  rdfs:label "Pressure-based Volume"@en-US .
 
 quantitykind:PressureBasedVolumeFlow
   a qudt:QuantityKind ;
@@ -11389,7 +11389,7 @@ quantitykind:PressureBasedVolumeFlow
   qudt:plainTextDescription "Quotient Volumenstrom dividiert durch den zugehörigen Druck"@de ;
   qudt:symbol "0173-1#Z4-BAJ311#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "pressure-based volume flow"@en-US .
+  rdfs:label "Pressure-based Volume Flow"@en-US .
 
 quantitykind:PressureBurningRateConstant
   a qudt:QuantityKind ;
@@ -11427,8 +11427,8 @@ quantitykind:PressureGradient
   qudt:plainTextDescription "Differenzdruck dividiert durch die zugehörige Länge"@de ;
   qudt:symbol "0173-1#Z4-BAJ313#003" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "pressure gradient" ;
-  rdfs:label "pressure gradient"@en-US .
+  rdfs:label "Pressure Gradient" ;
+  rdfs:label "Pressure Gradient"@en-US .
 
 quantitykind:PressureInRelationToVolumeFlow
   a qudt:QuantityKind ;
@@ -11437,14 +11437,14 @@ quantitykind:PressureInRelationToVolumeFlow
   qudt:plainTextDescription "an einer festgelegten Querschnittsfläche der Quotient Druck durch den Volumenstrom, der durch diese Querschnittsfläche hindurchgeht"@de ;
   qudt:symbol "0173-1#Z4-BAJ290#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "pressure in relation to volume flow"@en-US .
+  rdfs:label "Pressure in Relation to Volume Flow"@en-US .
 
 quantitykind:PressureInRelationToVolumeFlowRate
   a qudt:QuantityKind ;
   qudt:hasDimensionVector qkdv:A0E0L-4I0M1H0T-1D0 ;
   qudt:iec61360Code "0112/2///62720#UAD145" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "pressure in relation to volume flow rate" .
+  rdfs:label "Pressure in Relation to Volume Flow Rate" .
 
 quantitykind:PressureLossPerLength
   a qudt:QuantityKind ;
@@ -11514,7 +11514,7 @@ quantitykind:ProductOfInertia_X
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T0D0 ;
   qudt:plainTextDescription "A measure of a body's dynamic (or coupled) imbalance resulting in a precession when rotating about an axis other than the body's principal axis." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Product of Inertia in the X axis"@en ;
+  rdfs:label "Product of Inertia in the X Axis"@en ;
   skos:broader quantitykind:ProductOfInertia .
 
 quantitykind:ProductOfInertia_Y
@@ -11531,7 +11531,7 @@ quantitykind:ProductOfInertia_Y
   other than the body's principal axis.
   """ ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Product of Inertia in the Y axis"@en ;
+  rdfs:label "Product of Inertia in the Y Axis"@en ;
   skos:broader quantitykind:ProductOfInertia .
 
 quantitykind:ProductOfInertia_Z
@@ -11544,7 +11544,7 @@ quantitykind:ProductOfInertia_Z
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T0D0 ;
   qudt:plainTextDescription "A measure of a body's dynamic (or coupled) imbalance resulting in a precession when rotating about an axis other than the body's principal axis." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Product of Inertia in the Z axis"@en ;
+  rdfs:label "Product of Inertia in the Z Axis"@en ;
   skos:broader quantitykind:ProductOfInertia .
 
 quantitykind:PropagationCoefficient
@@ -11556,7 +11556,7 @@ quantitykind:PropagationCoefficient
   qudt:latexSymbol "$\\gamma$"^^qudt:LatexString ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q1434913> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Propagation coefficient"@en ;
+  rdfs:label "Propagation Coefficient"@en ;
   vaem:todo "belongs to SOQ-ISO" .
 
 quantitykind:QualityFactor
@@ -11583,8 +11583,8 @@ quantitykind:QuantityOfLight
   qudt:plainTextDescription "in Form von Licht aufgebrachte Arbeit einer Lichtquelle als Produkt aus dem von der Lichtquelle ausgehenden Lichtstrom Φ und der Zeit t, während dieser ausgestrahlt wird"@de ;
   qudt:symbol "0173-1#Z4-BAJ243#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "quantity of light" ;
-  rdfs:label "quantity of light"@en-US .
+  rdfs:label "Quantity of Light" ;
+  rdfs:label "Quantity of Light"@en-US .
 
 quantitykind:QuantumNumber
   a qudt:QuantityKind ;
@@ -11709,6 +11709,7 @@ quantitykind:RadiantEnergy
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q10932713> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Işınım erkesi"@tr ;
+  rdfs:label "Radiant Energy"@en ;
   rdfs:label "Strahlungsenergie"@de ;
   rdfs:label "Tenaga sinaran"@ms ;
   rdfs:label "energia promienista"@pl ;
@@ -11716,7 +11717,6 @@ quantitykind:RadiantEnergy
   rdfs:label "energia radiante"@pt ;
   rdfs:label "energie záření"@cs ;
   rdfs:label "energía radiante"@es ;
-  rdfs:label "radiant energy"@en ;
   rdfs:label "énergie rayonnante"@fr ;
   rdfs:label "энергия излучения"@ru ;
   rdfs:label "انرژی تابشی"@fa ;
@@ -11745,7 +11745,7 @@ quantitykind:RadiantEnergyExposure
   qudt:hasDimensionVector qkdv:A0E1L0I0M-1H0T1D0 ;
   qudt:iec61360Code "0112/2///62720#UAD149" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "radiant energy exposure" .
+  rdfs:label "Radiant Energy Exposure" .
 
 quantitykind:RadiantExposure
   a qudt:QuantityKind ;
@@ -11795,13 +11795,13 @@ quantitykind:RadiantFlux
   qudt:plainTextDescription "Radiant Flux, or radiant power, is the measure of the total power of electromagnetic radiation (including infrared, ultraviolet, and visible light). The power may be the total emitted from a source, or the total landing on a particular surface." ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q1253356> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
+  rdfs:label "Radiant Flux"@en ;
   rdfs:label "Strahlungsfluss"@de ;
   rdfs:label "flusso radiante"@it ;
   rdfs:label "flux énergétique"@fr ;
   rdfs:label "moc promieniowania"@pl ;
   rdfs:label "potencia radiante"@es ;
   rdfs:label "potência radiante"@pt ;
-  rdfs:label "radiant flux"@en ;
   rdfs:label "قدرة إشعاعية"@ar ;
   rdfs:label "放射パワー"@ja ;
   skos:altLabel "Strahlungsleistung"@de ;
@@ -11843,7 +11843,7 @@ quantitykind:RadioactiveDecay
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:iec61360Code "0112/2///62720#UAD152" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "radioactive decay" ;
+  rdfs:label "Radioactive Decay" ;
   skos:broader quantitykind:InverseTime .
 
 quantitykind:Radioactivity
@@ -11853,7 +11853,7 @@ quantitykind:Radioactivity
   qudt:plainTextDescription "Anzahl der spontanen Kernumwandlungen in einer gegebenen Menge eines Stoffes während eines hinreichend kleinen Zeitintervalls, dividiert durch dieses Zeitintervall, ausgedrückt als Quotient ∂N/∂t, wobei ∂N der Erwartungswert für die Anzahl der spontanen Übergänge aus diesem Zustand im Zeitintervall ∂t ist"@de ;
   qudt:symbol "0173-1#Z4-BAJ230#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "radioactivity"@en-US .
+  rdfs:label "Radioactivity"@en-US .
 
 quantitykind:Radiosity
   a qudt:QuantityKind ;
@@ -11900,8 +11900,8 @@ quantitykind:RankineTemperature
   qudt:plainTextDescription "Größe, die eine Temperaturskala benutzt, die wie die Kelvin-Skala beim absoluten Temperatur-Nullpunkt (0 K) ihren Nullwert hat, jedoch im Gegensatz zu dieser den Skalenabstand der Fahrenheit-Skala verwendet"@de ;
   qudt:symbol "0173-1#Z4-BAJ367#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Rankine temperature" ;
-  rdfs:label "Rankine temperature"@en-US ;
+  rdfs:label "Rankine Temperature" ;
+  rdfs:label "Rankine Temperature"@en-US ;
   skos:broader quantitykind:ThermodynamicTemperature .
 
 quantitykind:RateOfChange
@@ -11919,21 +11919,21 @@ quantitykind:RateOfRiseOfOffStateVoltage
   qudt:plainTextDescription "du/dt als zeitabhängige änderung der Spannung"@de ;
   qudt:symbol "0173-1#Z4-BAJ289#003" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "rise of off-state voltage"@en-US .
+  rdfs:label "Rise of Off-state Voltage"@en-US .
 
 quantitykind:RateOfRiseOfVoltage
   a qudt:QuantityKind ;
   qudt:hasDimensionVector qkdv:A0E-1L2I0M1H0T-4D0 ;
   qudt:iec61360Code "0112/2///62720#UAD153" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "rate of rise of voltage" .
+  rdfs:label "Rate of Rise of Voltage" .
 
 quantitykind:Ratio
   a qudt:QuantityKind ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:iec61360Code "0112/2///62720#UAD154" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "ratio" .
+  rdfs:label "Ratio" .
 
 quantitykind:RatioOfSpecificHeatCapacities
   a qudt:QuantityKind ;
@@ -12017,11 +12017,11 @@ quantitykind:ReactiveEnergy
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q12373673> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Blindenergie"@de ;
+  rdfs:label "Reactive Energy"@en ;
   rdfs:label "energia reativa"@pt ;
   rdfs:label "energia reattiva"@it ;
   rdfs:label "energía reactiva"@es ;
   rdfs:label "moc bierna – energia"@pl ;
-  rdfs:label "reactive energy"@en ;
   rdfs:label "énergie réactive"@fr ;
   rdfs:label "الطاقة التفاعلية"@ar ;
   rdfs:label "无功电能"@zh ;
@@ -12045,12 +12045,12 @@ quantitykind:ReactivePower
   rdfs:label "Blindleistung"@de ;
   rdfs:label "Jalový výkon"@cs ;
   rdfs:label "Kuasa reaktif"@ms ;
+  rdfs:label "Reactive Power"@en ;
   rdfs:label "moc bierna"@pl ;
   rdfs:label "potencia reactiva"@es ;
   rdfs:label "potenza reattiva"@it ;
   rdfs:label "potência reativa"@pt ;
   rdfs:label "puissance réactive"@fr ;
-  rdfs:label "reactive power"@en ;
   rdfs:label "reaktif güç"@tr ;
   rdfs:label "القدرة الكهربائية الردفعلية;الردية"@ar ;
   rdfs:label "توان راکتیو"@fa ;
@@ -12090,7 +12090,7 @@ quantitykind:ReciprocalElectricResistance
   qudt:plainTextDescription "Größe, deren Wert sich umgekehrt proportional zum Widerstandswert verhält"@de ;
   qudt:symbol "0173-1#Z4-BAJ375#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "reciprocal electric resistance"@en-US .
+  rdfs:label "Reciprocal Electric Resistance"@en-US .
 
 quantitykind:ReciprocalEnergy
   a qudt:QuantityKind ;
@@ -12099,7 +12099,7 @@ quantitykind:ReciprocalEnergy
   qudt:plainTextDescription "Kehrwert der Energie"@de ;
   qudt:symbol "0173-1#Z4-BAJ417#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "reciprocal energy"@en-US .
+  rdfs:label "Reciprocal Energy"@en-US .
 
 quantitykind:ReciprocalPlaneAngle
   a qudt:QuantityKind ;
@@ -12108,7 +12108,7 @@ quantitykind:ReciprocalPlaneAngle
   qudt:plainTextDescription "Größe, deren Wert sich umgekehrt proportional zum Winkelwert verhält"@de ;
   qudt:symbol "0173-1#Z4-BAJ376#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "reciprocal plane angle"@en-US .
+  rdfs:label "Reciprocal Plane Angle"@en-US .
 
 quantitykind:ReciprocalVoltage
   a qudt:QuantityKind ;
@@ -12117,7 +12117,7 @@ quantitykind:ReciprocalVoltage
   qudt:plainTextDescription "Größe, deren Wert sich umgekehrt proportional zum Spannungswert verhält"@de ;
   qudt:symbol "0173-1#Z4-BAJ371#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "reciprocal voltage"@en-US .
+  rdfs:label "Reciprocal Voltage"@en-US .
 
 quantitykind:RecombinationCoefficient
   a qudt:QuantityKind ;
@@ -12186,11 +12186,11 @@ quantitykind:RefractiveIndex
   rdfs:label "Indeks biasan"@ms ;
   rdfs:label "Index lomu"@cs ;
   rdfs:label "Indice de refracție"@ro ;
+  rdfs:label "Refractive Index"@en ;
   rdfs:label "Współczynnik załamania"@pl ;
   rdfs:label "indice de réfraction"@fr ;
   rdfs:label "indice di rifrazione"@it ;
   rdfs:label "kırılma indeksi"@tr ;
-  rdfs:label "refractive index"@en ;
   rdfs:label "índice de refracción"@es ;
   rdfs:label "índice refrativo"@pt ;
   rdfs:label "Показатель преломления"@ru ;
@@ -12393,8 +12393,8 @@ quantitykind:Repetency
   qudt:plainTextDescription "Größe, deren Wert sich umgekehrt proportional zum Längenwert verhält"@de ;
   qudt:symbol "0173-1#Z4-BAJ370#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "repetency" ;
-  rdfs:label "repetency"@en-US .
+  rdfs:label "Repetency" ;
+  rdfs:label "Repetency"@en-US .
 
 quantitykind:ResidualResistivity
   a qudt:QuantityKind ;
@@ -12431,7 +12431,7 @@ quantitykind:ResistanceBasedInductance
   qudt:plainTextDescription "Magnetfluss durch die Schleife, verursacht durch einen elektrischen Strom in der Schleife, dividiert durch das Produkt aus diesen Strom und dem Widerstand, der diesen Stromfluss behindert"@de ;
   qudt:symbol "0173-1#Z4-BAJ411#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "resistance-based inductance"@en-US .
+  rdfs:label "Resistance-based Inductance"@en-US .
 
 quantitykind:ResistanceRatio
   a qudt:QuantityKind ;
@@ -12488,7 +12488,7 @@ quantitykind:ResonanceEscapeProbabilityForFission
   qudt:plainTextDescription "Fraction of fission neutrons that manage to slow down from fission to thermal energies without being absorbed." ;
   qudt:symbol "p" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Resonance Escape Probability For Fission"@en ;
+  rdfs:label "Resonance Escape Probability for Fission"@en ;
   skos:broader quantitykind:Dimensionless .
 
 quantitykind:RespiratoryRate
@@ -12531,6 +12531,7 @@ quantitykind:RestMass
   rdfs:label "Jisim rehat"@ms ;
   rdfs:label "Klidová hmotnost"@cs ;
   rdfs:label "Mirovna masa"@sl ;
+  rdfs:label "Rest Mass"@en ;
   rdfs:label "Ruhemasse"@de ;
   rdfs:label "dinlenme kütlesi"@tr ;
   rdfs:label "masa invariante"@es ;
@@ -12539,7 +12540,6 @@ quantitykind:RestMass
   rdfs:label "massa a riposo"@it ;
   rdfs:label "massa de repouso"@pt ;
   rdfs:label "masse au repos"@fr ;
-  rdfs:label "rest mass"@en ;
   rdfs:label "инвариантная масса"@ru ;
   rdfs:label "جرم سکون"@fa ;
   rdfs:label "كتلة ساكنة"@ar ;
@@ -12628,14 +12628,14 @@ quantitykind:RotaryShock
   qudt:plainTextDescription "Produkt Drehmoment M in einem Zeitintervall mal Dauer dt dieses Zeitintervalls"@de ;
   qudt:symbol "0173-1#Z4-BAJ234#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "rotary shock"@en-US .
+  rdfs:label "Rotary Shock"@en-US .
 
 quantitykind:RotaryTranslatoryMotionConversion
   a qudt:QuantityKind ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T0D0 ;
   qudt:iec61360Code "0112/2///62720#UAD163" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "rotary-translatory motion conversion" .
+  rdfs:label "Rotary-translatory Motion Conversion" .
 
 quantitykind:RotationalFrequency
   a qudt:QuantityKind ;
@@ -12647,7 +12647,7 @@ quantitykind:RotationalFrequency
   qudt:qkdvDenominator qkdv:A0E0L0I0M0H0T1D0 ;
   qudt:qkdvNumerator qkdv:A0E0L0I0M0H0T0D1 ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "RotationalFrequency"@en ;
+  rdfs:label "Rotational Frequency"@en ;
   rdfs:seeAlso quantitykind:AngularFrequency ;
   rdfs:seeAlso quantitykind:AngularVelocity .
 
@@ -12680,7 +12680,7 @@ quantitykind:RotationalVelocity
   qudt:qkdvDenominator qkdv:A0E0L0I0M0H0T1D0 ;
   qudt:qkdvNumerator qkdv:A0E0L0I0M0H0T0D1 ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "RotationalFrequency"@en ;
+  rdfs:label "Rotational Frequency"@en ;
   rdfs:seeAlso quantitykind:AngularFrequency ;
   rdfs:seeAlso quantitykind:AngularVelocity .
 
@@ -12724,9 +12724,9 @@ quantitykind:SecondMomentOfArea
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Flächenträgheitsmoment"@de ;
   rdfs:label "Geometryczny moment bezwładności"@pl ;
+  rdfs:label "Second Moment of Area"@en ;
   rdfs:label "Segundo momento de área"@pt ;
   rdfs:label "moment quadratique"@fr ;
-  rdfs:label "second moment of area"@en ;
   rdfs:label "secondo momento di area"@it ;
   rdfs:label "segundo momento de érea"@es ;
   rdfs:label "گشتاور دوم سطح"@fa ;
@@ -12764,7 +12764,7 @@ quantitykind:SecondRadiationConstant
   qudt:plainTextDescription "Konstante im Planckschen Strahlungsgesetz über die Abhängigkeit der spektralen Dichte verschiedener Strahlungsgrößen von der Wellenlänge der elektromagnetischen Strahlung und der absoluten Temperatur beim schwarzen Strahler, welche sich zusammensetzt aus dem Produkt Plancksches Wirkungsquantum mal Lichtgeschwindigkeit bezogen auf die Boltzmann-Konstante"@de ;
   qudt:symbol "0173-1#Z4-BAJ428#001" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "second radiation constant"@en-US .
+  rdfs:label "Second Radiation Constant"@en-US .
 
 quantitykind:SectionAreaIntegral
   a qudt:QuantityKind ;
@@ -13031,6 +13031,7 @@ quantitykind:SolidAngle
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Prostorový úhel"@cs ;
   rdfs:label "Raumwinkel"@de ;
+  rdfs:label "Solid Angle"@en ;
   rdfs:label "Sudut padu"@ms ;
   rdfs:label "angle solide"@fr ;
   rdfs:label "angolo solido"@it ;
@@ -13038,7 +13039,6 @@ quantitykind:SolidAngle
   rdfs:label "katı cisimdeki açı"@tr ;
   rdfs:label "kąt bryłowy"@pl ;
   rdfs:label "prostorski kot"@sl ;
-  rdfs:label "solid angle"@en ;
   rdfs:label "térszög"@hu ;
   rdfs:label "unghi solid"@ro ;
   rdfs:label "ángulo sólido"@es ;
@@ -13089,7 +13089,7 @@ quantitykind:SoundEnergyDensity
   qudt:symbol "E" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q2230505> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Sound energy density"@en ;
+  rdfs:label "Sound Energy Density"@en ;
   skos:broader quantitykind:EnergyDensity ;
   vaem:todo "belongs to SOQ-ISO" .
 
@@ -13104,7 +13104,7 @@ quantitykind:SoundExposure
   qudt:symbol "E" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q2230528> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Sound exposure"@en ;
+  rdfs:label "Sound Exposure"@en ;
   vaem:todo "belongs to SOQ-ISO" .
 
 quantitykind:SoundExposureLevel
@@ -13116,7 +13116,7 @@ quantitykind:SoundExposureLevel
   qudt:symbol "L" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q87543983> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Sound exposure level"@en ;
+  rdfs:label "Sound Exposure Level"@en ;
   vaem:todo "belongs to SOQ-ISO" .
 
 quantitykind:SoundIntensity
@@ -13130,7 +13130,7 @@ quantitykind:SoundIntensity
   qudt:symbol "I" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q1140289> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Sound intensity"@en ;
+  rdfs:label "Sound Intensity"@en ;
   skos:broader quantitykind:PowerPerArea ;
   vaem:todo "belongs to SOQ-ISO" .
 
@@ -13143,7 +13143,7 @@ quantitykind:SoundParticleAcceleration
   qudt:symbol "a" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q7140491> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Sound particle acceleration"@en ;
+  rdfs:label "Sound Particle Acceleration"@en ;
   skos:broader quantitykind:Acceleration ;
   vaem:todo "belongs to SOQ-ISO" .
 
@@ -13172,8 +13172,8 @@ quantitykind:SoundParticleVelocity
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q336894> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Schallschnelle"@de ;
+  rdfs:label "Sound Particle Velocity"@en ;
   rdfs:label "prędkość akustyczna"@pl ;
-  rdfs:label "sound particle velocity"@en ;
   rdfs:label "velocidad acústica de una partícula"@es ;
   rdfs:label "velocidade acústica de uma partícula"@pt ;
   rdfs:label "velocità di spostamento"@it ;
@@ -13194,12 +13194,12 @@ quantitykind:SoundPower
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q1588477> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Schallleistung"@de ;
+  rdfs:label "Sound Power"@en ;
   rdfs:label "moc akustyczna"@pl ;
   rdfs:label "potencie acústica"@es ;
   rdfs:label "potenza sonora"@it ;
   rdfs:label "potência acústica"@pt ;
   rdfs:label "puissance acoustique"@fr ;
-  rdfs:label "sound power"@en ;
   rdfs:label "звуковая мощность"@ru ;
   rdfs:label "القدرة الصوتية"@ar ;
   rdfs:label "音源の音響出力"@ja ;
@@ -13216,7 +13216,7 @@ quantitykind:SoundPowerLevel
   qudt:symbol "L" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q2157873> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Sound power level"@en ;
+  rdfs:label "Sound Power Level"@en ;
   vaem:todo "belongs to SOQ-ISO" .
 
 quantitykind:SoundPressure
@@ -13229,7 +13229,7 @@ quantitykind:SoundPressure
   qudt:symbol "p" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q1068172> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Sound pressure"@en ;
+  rdfs:label "Sound Pressure"@en ;
   skos:broader quantitykind:Pressure ;
   vaem:todo "belongs to SOQ-ISO" .
 
@@ -13244,6 +13244,7 @@ quantitykind:SoundPressureLevel
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Hladina akustického tlaku"@cs ;
   rdfs:label "Schalldruckpegel"@de ;
+  rdfs:label "Sound Pressure Level"@en ;
   rdfs:label "Tahap medan"@ms ;
   rdfs:label "gerilim veya akım oranı"@tr ;
   rdfs:label "livello di pressione sonora"@it ;
@@ -13251,7 +13252,6 @@ quantitykind:SoundPressureLevel
   rdfs:label "niveau de pression acoustique"@fr ;
   rdfs:label "nivel de presión sonora"@es ;
   rdfs:label "nível de pressão acústica"@pt ;
-  rdfs:label "sound pressure level"@en ;
   rdfs:label "уровень звукового давления"@ru ;
   rdfs:label "سطح یک کمیت توان-ریشه"@fa ;
   rdfs:label "كمية جذر الطاقة"@ar ;
@@ -13270,7 +13270,7 @@ quantitykind:SoundReductionIndex
   qudt:symbol "R" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q2230459> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Sound reduction index"@en ;
+  rdfs:label "Sound Reduction Index"@en ;
   vaem:todo "belongs to SOQ-ISO" .
 
 quantitykind:SoundVolumeVelocity
@@ -13282,7 +13282,7 @@ quantitykind:SoundVolumeVelocity
   qudt:symbol "q" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q1640308> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Sound volume velocity"@en ;
+  rdfs:label "Sound Volume Velocity"@en ;
   vaem:todo "belongs to SOQ-ISO" .
 
 quantitykind:SourceVoltage
@@ -13492,7 +13492,7 @@ quantitykind:SpecificHeatCapacityAtConstantPressure
   qudt:symbol "c_p" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q75774282> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Specific heat capacity at constant pressure"@en ;
+  rdfs:label "Specific Heat Capacity at Constant Pressure"@en ;
   rdfs:seeAlso quantitykind:SpecificHeatCapacity ;
   rdfs:seeAlso quantitykind:SpecificHeatCapacityAtConstantVolume ;
   rdfs:seeAlso quantitykind:SpecificHeatCapacityAtSaturation .
@@ -13505,7 +13505,7 @@ quantitykind:SpecificHeatCapacityAtConstantVolume
   qudt:symbol "c_v" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q75774757> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Specific heat capacity at constant volume"@en ;
+  rdfs:label "Specific Heat Capacity at Constant Volume"@en ;
   rdfs:seeAlso quantitykind:SpecificHeatCapacity ;
   rdfs:seeAlso quantitykind:SpecificHeatCapacityAtConstantPressure ;
   rdfs:seeAlso quantitykind:SpecificHeatCapacityAtSaturation .
@@ -13657,8 +13657,8 @@ quantitykind:SpecificOpticalRotationalAbility
   qudt:plainTextDescription "materialspezifische Größe, die sich als Drehwinkel einer Substanz für eine bestimmte Wellenlänge und eine bestimmte Temperatur ergibt durch die Beziehung: Quotient aus gemessener Drehwinkel dividiert durch die Massenkonzentration und die durchstrahlte Wegstrecke"@de ;
   qudt:symbol "0173-1#Z4-BAJ425#001" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "specific optical rotational ability" ;
-  rdfs:label "specific optical rotational ability"@en-US .
+  rdfs:label "Specific Optical Rotational Ability" ;
+  rdfs:label "Specific Optical Rotational Ability"@en-US .
 
 quantitykind:SpecificOpticalRotatoryPower
   a qudt:QuantityKind ;
@@ -13702,7 +13702,7 @@ quantitykind:SpecificThrust
   qudt:informativeReference "https://en.wikipedia.org/wiki/Specific_thrust"^^xsd:anyURI ;
   qudt:plainTextDescription "Specific impulse (usually abbreviated Isp) is a way to describe the efficiency of rocket and jet engines. It represents the force with respect to the amount of propellant used per unit time.[1] If the \"amount\" of propellant is given in terms of mass (such as kilograms), then specific impulse has units of velocity. If it is given in terms of Earth-weight (such as kiloponds), then specific impulse has units of time. The conversion constant between the two versions of specific impulse is g. The higher the specific impulse, the lower the propellant flow rate required for a given thrust, and in the case of a rocket the less propellant is needed for a given delta-v per the Tsiolkovsky rocket equation." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Specific thrust"@en ;
+  rdfs:label "Specific Thrust"@en ;
   rdfs:seeAlso quantitykind:SpecificImpulse .
 
 quantitykind:SpecificVolume
@@ -13726,7 +13726,7 @@ quantitykind:SpecificWeight
   qudt:plainTextDescription "The specific weight, also known as the unit weight is a volume-specific quantity defined as the weight per unit volume of a material. Note that weight is defined as a force, distinct from mass." ;
   qudt:symbol "γ" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "specific weight"@en .
+  rdfs:label "Specific Weight"@en .
 
 quantitykind:SpectralAngularCrossSection
   a qudt:QuantityKind ;
@@ -13749,7 +13749,7 @@ quantitykind:SpectralConcentrationOfRadiantEnergyDensity
   qudt:plainTextDescription "Energieverteilung des Augenblickswertes der Strahlungsenergie, bezogen auf das Volumen des Ausbreitungsmediums"@de ;
   qudt:symbol "0173-1#Z4-BAJ379#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "spectral concentration of radiant energy density"@en-US .
+  rdfs:label "Spectral Concentration of Radiant Energy Density"@en-US .
 
 quantitykind:SpectralConcentrationOfVibrationalModes
   a qudt:QuantityKind ;
@@ -13758,7 +13758,7 @@ quantitykind:SpectralConcentrationOfVibrationalModes
   qudt:plainTextDescription "Anzahl von Vibrationsmodi in einem infinitesimalen Energie-Intervall der Kreisfrequenz, dividiert durch die Größe dieses Energie-Intervalls und durch das zugehörige Volumen"@de ;
   qudt:symbol "0173-1#Z4-BAJ431#001" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "spectral concentration of vibrational modes (in terms of angular frequency)"@en-US .
+  rdfs:label "Spectral Concentration of Vibrational Modes (in Terms of Angular Frequency)"@en-US .
 
 quantitykind:SpectralCrossSection
   a qudt:QuantityKind ;
@@ -13778,7 +13778,7 @@ quantitykind:SpectralDensityOfVibrationalModes
   qudt:hasDimensionVector qkdv:A0E0L-3I0M0H0T1D0 ;
   qudt:iec61360Code "0112/2///62720#UAD178" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "spectral density of vibrational modes" .
+  rdfs:label "Spectral Density of Vibrational Modes" .
 
 quantitykind:SpectralEmittance
   a qudt:QuantityKind ;
@@ -13826,7 +13826,7 @@ quantitykind:SpectralRadiantEnergyDensityInTermsOfWavelength
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:iec61360Code "0112/2///62720#UAD179" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "spectral radiant energy density in terms of wavelength" .
+  rdfs:label "Spectral Radiant Energy Density in Terms of Wavelength" .
 
 quantitykind:Speed
   a qudt:QuantityKind ;
@@ -13854,9 +13854,9 @@ quantitykind:SpeedOfLight
   rdfs:label "Lichtgeschwindigkeit"@de ;
   rdfs:label "Prędkość światła"@pl ;
   rdfs:label "Rychlost světla"@cs ;
+  rdfs:label "Speed of Light"@en ;
   rdfs:label "Velocidade da luz"@pt ;
   rdfs:label "Viteza luminii"@ro ;
-  rdfs:label "speed of light"@en ;
   rdfs:label "velocidad de la luz"@es ;
   rdfs:label "velocità della luce"@it ;
   rdfs:label "vitesse de la lumière"@fr ;
@@ -13886,9 +13886,9 @@ quantitykind:SpeedOfSound
   rdfs:label "Kelajuan bunyi"@ms ;
   rdfs:label "Schallgeschwindigkeit"@de ;
   rdfs:label "Ses hızı"@tr ;
+  rdfs:label "Speed of Sound"@en ;
   rdfs:label "prędkość dźwięku"@pl ;
   rdfs:label "rychlost zvuku"@cs ;
-  rdfs:label "speed of sound"@en ;
   rdfs:label "velocidad del sonido"@es ;
   rdfs:label "velocidade do som"@pt ;
   rdfs:label "velocità del suono"@it ;
@@ -13936,12 +13936,12 @@ quantitykind:Spin
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q133673> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Spin"@de ;
+  rdfs:label "Spin"@en ;
   rdfs:label "Spin"@ms ;
   rdfs:label "Spin"@ro ;
   rdfs:label "Spin"@tr ;
   rdfs:label "espín"@es ;
   rdfs:label "spin"@cs ;
-  rdfs:label "spin"@en ;
   rdfs:label "spin"@fr ;
   rdfs:label "spin"@it ;
   rdfs:label "spin"@pl ;
@@ -14029,7 +14029,7 @@ quantitykind:StateDensity
   qudt:plainTextDescription "Funktion der Energie in einem Festkörper, bestimmt durch die Anzahl von erlaubten Quantenzuständen im Energiebereich zwischen E und E+dE je Volumen des Materials dieses Festkörpers"@de ;
   qudt:symbol "0173-1#Z4-BAJ427#001" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "state density"@en-US .
+  rdfs:label "State Density"@en-US .
 
 quantitykind:StateDensityAsExpressionOfAngularFrequency
   a qudt:QuantityKind ;
@@ -14039,8 +14039,8 @@ quantitykind:StateDensityAsExpressionOfAngularFrequency
   qudt:plainTextDescription "Quotient aus Anzahl von Vibrationsmodi in einem infinitesimalen Intervall der Kreisfrequenz durch die Spannweite dieses Intervalls und das Volumen"@de ;
   qudt:symbol "0173-1#Z4-BAJ454#001" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "state density as expression of angular frequency)" ;
-  rdfs:label "state density as expression of angular frequency"@en-US .
+  rdfs:label "State Density as Expression of Angular Frequency)" ;
+  rdfs:label "State Density as Expression of Angular Frequency"@en-US .
 
 quantitykind:StateOfCharge
   a qudt:QuantityKind ;
@@ -14051,7 +14051,7 @@ quantitykind:StateOfCharge
   qudt:plainTextDescription "\"\"State of Charge\",quantifies the remaining capacity available in a battery at a given time and in relation to a given state of ageing." ;
   qudt:symbol "SoC" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "State of charge"@en ;
+  rdfs:label "State of Charge"@en ;
   skos:altLabel "Remaining battery energy level"@en ;
   skos:broader quantitykind:DimensionlessRatio .
 
@@ -14093,7 +14093,7 @@ quantitykind:StaticPressure
   qudt:symbol "p" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q2406217> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Static pressure"@en ;
+  rdfs:label "Static Pressure"@en ;
   skos:broader quantitykind:Pressure ;
   vaem:todo "belongs to SOQ-ISO" .
 
@@ -14234,7 +14234,7 @@ quantitykind:SunProtectionFactorOfAProduct
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:iec61360Code "0112/2///62720#UAD366" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "sun protection factor of a product" .
+  rdfs:label "Sun Protection Factor of a Product" .
 
 quantitykind:SuperconductionTransitionTemperature
   a qudt:QuantityKind ;
@@ -14307,14 +14307,14 @@ quantitykind:SurfaceRelatedVolumeFlow
   qudt:plainTextDescription "Quotient aus dem Volumen eines Stoffes, das durch eine vorgegebene Oberfläche hindurchgeht, und der dazu benötigten Zeit dividiert durch diese vorgegebene Fläche"@de ;
   qudt:symbol "0173-1#Z4-BAJ421#003" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "surface-related volume flow"@en-US .
+  rdfs:label "Surface-related Volume Flow"@en-US .
 
 quantitykind:SurfaceRelatedVolumeFlowRate
   a qudt:QuantityKind ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T-1D0 ;
   qudt:iec61360Code "0112/2///62720#UAD183" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "surface‑related volume flow rate" .
+  rdfs:label "Surface‑related Volume Flow Rate" .
 
 quantitykind:SurfaceTension
   a qudt:QuantityKind ;
@@ -14330,13 +14330,13 @@ quantitykind:SurfaceTension
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q170749> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Oberflächenspannung"@de ;
+  rdfs:label "Surface Tension"@en ;
   rdfs:label "Tegangan permukaan"@ms ;
   rdfs:label "Tensiune superficială"@ro ;
   rdfs:label "Yüzey gerilimi"@tr ;
   rdfs:label "napięcie powierzchniowe"@pl ;
   rdfs:label "povrchové napětí"@cs ;
   rdfs:label "površinska napetost"@sl ;
-  rdfs:label "surface tension"@en ;
   rdfs:label "tension superficielle"@fr ;
   rdfs:label "tensione superficiale"@it ;
   rdfs:label "tensión superficial"@es ;
@@ -14358,8 +14358,8 @@ quantitykind:SurgeImpedanceOfTheMedium
   qudt:plainTextDescription "in einem mechanischen System der flächenbezogene Quotient einer an einem Punkt angreifenden Kraft durch die resultierende Komponente der Teilchengeschwindigkeit in Richtung der Kraft"@de ;
   qudt:symbol "0173-1#Z4-BAJ323#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "surge impedance of the medium" ;
-  rdfs:label "surge impedance of the medium"@en-US .
+  rdfs:label "Surge Impedance of the Medium" ;
+  rdfs:label "Surge Impedance of the Medium"@en-US .
 
 quantitykind:Susceptance
   a qudt:QuantityKind ;
@@ -14385,7 +14385,7 @@ quantitykind:SymbolTransmissionRate
   qudt:plainTextDescription "Geschwindigkeit, mit der ein aus mehreren Bit bestehendes Symbol je Sekunde übertragen wird"@de ;
   qudt:symbol "0173-1#Z4-BAJ386#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "symbol transmission rate"@en-US .
+  rdfs:label "Symbol Transmission Rate"@en-US .
 
 quantitykind:SystolicBloodPressure
   a qudt:QuantityKind ;
@@ -14435,7 +14435,7 @@ quantitykind:TemperatureBasedAmountOfSubstanceConcentration
   qudt:plainTextDescription "Quotient aus Stoffmengenkonzentration dividiert durch die zugehörige Temperatur"@de ;
   qudt:symbol "0173-1#Z4-BAJ395#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "temperature-based amount-of-substance concentration"@en-US .
+  rdfs:label "Temperature-based Amount-of-substance Concentration"@en-US .
 
 quantitykind:TemperatureBasedDensity
   a qudt:QuantityKind ;
@@ -14444,7 +14444,7 @@ quantitykind:TemperatureBasedDensity
   qudt:plainTextDescription "Quotient aus Dichte dividiert durch die zugehörige Temperatur"@de ;
   qudt:symbol "0173-1#Z4-BAJ389#003" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "temperature-based density"@en-US .
+  rdfs:label "Temperature-based Density"@en-US .
 
 quantitykind:TemperatureBasedDynamicViscosity
   a qudt:QuantityKind ;
@@ -14453,7 +14453,7 @@ quantitykind:TemperatureBasedDynamicViscosity
   qudt:plainTextDescription "Quotient der dynamischen Viskosität dividiert durch die Temperatur"@de ;
   qudt:symbol "0173-1#Z4-BAJ390#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "temperature-based dynamic viscosity"@en-US .
+  rdfs:label "Temperature-based Dynamic Viscosity"@en-US .
 
 quantitykind:TemperatureBasedKinematicViscosity
   a qudt:QuantityKind ;
@@ -14462,7 +14462,7 @@ quantitykind:TemperatureBasedKinematicViscosity
   qudt:plainTextDescription "Quotient aus der dynamischen Viskosität und der Dichte eines Stoffes dividiert durch die zugehörige Temperatur"@de ;
   qudt:symbol "0173-1#Z4-BAJ392#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "temperature-based kinematic viscosity"@en-US .
+  rdfs:label "Temperature-based Kinematic Viscosity"@en-US .
 
 quantitykind:TemperatureBasedLength
   a qudt:QuantityKind ;
@@ -14471,7 +14471,7 @@ quantitykind:TemperatureBasedLength
   qudt:plainTextDescription "Quotient aus Länge dividiert durch die zugehörige Temperatur"@de ;
   qudt:symbol "0173-1#Z4-BAJ393#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "temperature-based length"@en-US .
+  rdfs:label "Temperature-based Length"@en-US .
 
 quantitykind:TemperatureBasedMass
   a qudt:QuantityKind ;
@@ -14480,7 +14480,7 @@ quantitykind:TemperatureBasedMass
   qudt:plainTextDescription "Quotient aus Masse dividiert durch die zugehörige Temperatur"@de ;
   qudt:symbol "0173-1#Z4-BAJ394#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "temperature-based mass"@en-US .
+  rdfs:label "Temperature-based Mass"@en-US .
 
 quantitykind:TemperatureBasedMassFlowRate
   a qudt:QuantityKind ;
@@ -14489,13 +14489,13 @@ quantitykind:TemperatureBasedMassFlowRate
   qudt:plainTextDescription "Quotient aus Massenstrom dividiert durch die zugehörige Temperatur"@de ;
   qudt:symbol "0173-1#Z4-BAJ396#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "temperature-based mass flow rate"@en-US .
+  rdfs:label "Temperature-based Mass Flow Rate"@en-US .
 
 quantitykind:TemperatureBasedQuantity
   a qudt:QuantityKind ;
   qudt:hasDimensionVector qkdv:NotApplicable ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "temperature-based quantity"@en-US .
+  rdfs:label "Temperature-based Quantity"@en-US .
 
 quantitykind:TemperatureBasedVelocity
   a qudt:QuantityKind ;
@@ -14504,7 +14504,7 @@ quantitykind:TemperatureBasedVelocity
   qudt:plainTextDescription "Quotient aus Geschwindigkeit dividiert durch die zugehörige Temperatur"@de ;
   qudt:symbol "0173-1#Z4-BAJ391#001" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "temperature-based velocity"@en-US .
+  rdfs:label "Temperature-based Velocity"@en-US .
 
 quantitykind:TemperatureBasedVolumeFlowRate
   a qudt:QuantityKind ;
@@ -14513,7 +14513,7 @@ quantitykind:TemperatureBasedVolumeFlowRate
   qudt:plainTextDescription "Quotient aus Volumenstrom dividiert durch die zugehörige Temperatur"@de ;
   qudt:symbol "0173-1#Z4-BAJ397#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "temperature-based volume flow rate"@en-US .
+  rdfs:label "Temperature-based Volume Flow Rate"@en-US .
 
 quantitykind:TemperatureDifference
   a qudt:QuantityKind ;
@@ -14523,7 +14523,7 @@ quantitykind:TemperatureDifference
   qudt:symbol "ΔT" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Temperaturdifferenz"@de ;
-  rdfs:label "temperature difference"@en ;
+  rdfs:label "Temperature Difference"@en ;
   skos:broader quantitykind:Temperature .
 
 quantitykind:TemperatureGradient
@@ -14589,7 +14589,7 @@ quantitykind:TemperatureRelatedMolarMass
   qudt:plainTextDescription "Molarität (Masse einer Substanz bezogen auf die Stoffmenge dieser Substanz ) dividiert durch die Temperatur"@de ;
   qudt:symbol "0173-1#Z4-BAJ443#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "temperature-related molar mass"@en-US .
+  rdfs:label "Temperature-related Molar Mass"@en-US .
 
 quantitykind:TemperatureRelatedVolume
   a qudt:QuantityKind ;
@@ -14598,7 +14598,7 @@ quantitykind:TemperatureRelatedVolume
   qudt:plainTextDescription "Volumen dividiert durch Temperatur"@de ;
   qudt:symbol "0173-1#Z4-BAJ398#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "temperature-related volume  "@en-US .
+  rdfs:label "Temperature-related Volume  "@en-US .
 
 quantitykind:TemperatureVariance
   a qudt:QuantityKind ;
@@ -14658,8 +14658,8 @@ quantitykind:ThermalCapacitance
   qudt:plainTextDescription "Quotient aus der zugeführten Wärmemenge und der Temperaturänderungen, die durch diese zugeführte Wärmemenge verursacht wird"@de ;
   qudt:symbol "0173-1#Z4-BAJ406#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "thermal capacitance" ;
-  rdfs:label "thermal capacitance"@en-US .
+  rdfs:label "Thermal Capacitance" ;
+  rdfs:label "Thermal Capacitance"@en-US .
 
 quantitykind:ThermalCoefficientOfLinearExpansion
   a qudt:QuantityKind ;
@@ -14668,7 +14668,7 @@ quantitykind:ThermalCoefficientOfLinearExpansion
   qudt:plainTextDescription "auf eine festgelegte Länge des Probekörpers bezogene mittlere relative Längenänderung dividiert durch die sie verursachende Temperaturänderung"@de ;
   qudt:symbol "0173-1#Z4-BAJ473#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "thermal coefficient of linear expansion"@en-US .
+  rdfs:label "Thermal Coefficient of Linear Expansion"@en-US .
 
 quantitykind:ThermalConductance
   a qudt:QuantityKind ;
@@ -14823,7 +14823,7 @@ quantitykind:ThermalInsulation
   qudt:plainTextDescription "Temperaturdifferenz zwischen zwei Oberflächen dividiert durch den flächenbezogenen Wärmestrom in der Richtung des Temperaturgradienten"@de ;
   qudt:symbol "0173-1#Z4-BAJ404#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "thermal insulation"@en-US .
+  rdfs:label "Thermal Insulation"@en-US .
 
 quantitykind:ThermalPower
   a qudt:QuantityKind ;
@@ -14847,12 +14847,12 @@ quantitykind:ThermalResistance
   qudt:symbol "R" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q899628> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
+  rdfs:label "Thermal Resistance"@en ;
   rdfs:label "opór cieplny"@cs ;
   rdfs:label "resistencia térmica"@es ;
   rdfs:label "resistenza termica"@it ;
   rdfs:label "resistência térmica"@pt ;
   rdfs:label "résistance thermique"@fr ;
-  rdfs:label "thermal resistance"@en ;
   rdfs:label "thermischer Widerstand"@de ;
   rdfs:label "مقاومة حرارية"@ar ;
   rdfs:label "热阻"@zh ;
@@ -14901,7 +14901,7 @@ quantitykind:ThermalUtilizationFactorForFission
   qudt:plainTextDescription "Probability that a neutron that gets absorbed does so in the fuel material." ;
   qudt:symbol "f" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Thermal Utilization Factor For Fission"@en ;
+  rdfs:label "Thermal Utilization Factor for Fission"@en ;
   skos:broader quantitykind:Dimensionless .
 
 quantitykind:ThermodynamicCriticalMagneticFluxDensity
@@ -14956,6 +14956,7 @@ In thermodynamics, in a system of which the entropy is considered as an independ
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Suhu termodinamik"@ms ;
   rdfs:label "Termodynamická teplota"@cs ;
+  rdfs:label "Thermodynamic Temperature"@en ;
   rdfs:label "abszolút hőmérséklet"@hu ;
   rdfs:label "temperatura termodinamica"@it ;
   rdfs:label "temperatura thermodynamica absoluta"@la ;
@@ -14966,7 +14967,6 @@ In thermodynamics, in a system of which the entropy is considered as an independ
   rdfs:label "temperatură termodinamică"@ro ;
   rdfs:label "température thermodynamique"@fr ;
   rdfs:label "termodinamik sıcaklık"@tr ;
-  rdfs:label "thermodynamic temperature"@en ;
   rdfs:label "thermodynamische Temperatur"@de ;
   rdfs:label "Απόλυτη"@el ;
   rdfs:label "Термодинамическая температура"@ru ;
@@ -15038,7 +15038,7 @@ quantitykind:ThrustToMassRatio
   qudt:qkdvDenominator qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:qkdvNumerator qkdv:A0E0L1I0M1H0T-2D0 ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Thrust To Mass Ratio"@en ;
+  rdfs:label "Thrust to Mass Ratio"@en ;
   skos:broader quantitykind:Acceleration .
 
 quantitykind:ThrustToWeightRatio
@@ -15048,7 +15048,7 @@ quantitykind:ThrustToWeightRatio
   qudt:latexSymbol "$\\psi$"^^qudt:LatexString ;
   qudt:plainTextDescription "Thrust-to-weight ratio is a ratio of thrust to weight of a rocket, jet engine, propeller engine, or a vehicle propelled by such an engine. It is a dimensionless quantity and is an indicator of the performance of the engine or vehicle." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Thrust To Weight Ratio"@en ;
+  rdfs:label "Thrust to Weight Ratio"@en ;
   skos:broader quantitykind:DimensionlessRatio .
 
 quantitykind:Tilt
@@ -15074,6 +15074,7 @@ quantitykind:Time
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q2199864> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Masa"@ms ;
+  rdfs:label "Time"@en ;
   rdfs:label "Zeit"@de ;
   rdfs:label "czas"@pl ;
   rdfs:label "idő"@hu ;
@@ -15082,7 +15083,6 @@ quantitykind:Time
   rdfs:label "temps"@fr ;
   rdfs:label "tempus"@la ;
   rdfs:label "tiempo"@es ;
-  rdfs:label "time"@en ;
   rdfs:label "timp"@ro ;
   rdfs:label "zaman"@tr ;
   rdfs:label "Čas"@cs ;
@@ -15108,7 +15108,7 @@ quantitykind:TimeAveragedSoundIntensity
   qudt:symbol "I" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q86827342> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Time averaged sound intensity"@en ;
+  rdfs:label "Time Averaged Sound Intensity"@en ;
   skos:broader quantitykind:SoundIntensity ;
   vaem:todo "belongs to SOQ-ISO" .
 
@@ -15145,7 +15145,7 @@ quantitykind:TimeRelatedLogarithmicRatio
   qudt:plainTextDescription "Logarithmus des Verhältnisses des Werts einer gegebenen Größe zum Wert einer Bezugsgröße gleicher Art dividiert durch die zugehörige Zeit"@de ;
   qudt:symbol "0173-1#Z4-BAJ415#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "time-related logarithmic ratio"@en-US .
+  rdfs:label "Time-related Logarithmic Ratio"@en-US .
 
 quantitykind:TimeTemperature
   a qudt:QuantityKind ;
@@ -15185,13 +15185,13 @@ t stands for time."""^^qudt:LatexString ;
   qudt:latexSymbol "$\\tau$"^^qudt:LatexString ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q48103> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
+  rdfs:label "Torque"@en ;
   rdfs:label "Torsionmoment"@de ;
   rdfs:label "coppia"@it ;
   rdfs:label "couple"@fr ;
   rdfs:label "moment obrotowy"@pl ;
   rdfs:label "momento de torção"@pt ;
   rdfs:label "par"@es ;
-  rdfs:label "torque"@en ;
   rdfs:label "عزم محورى"@ar ;
   rdfs:label "トルク"@ja ;
   rdfs:label "转矩"@zh ;
@@ -15209,8 +15209,8 @@ quantitykind:TorqueConstant
   qudt:plainTextDescription "Produkt aus der magnetischen Induktion, der Windungszahl und der von der Spule eingeschlossenen Fläche entsprechend der Steigung der Kurve des Verhältnisses Drehmoment des Motors zum Strom"@de ;
   qudt:symbol "0173-1#Z4-BAJ298#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "torque constant" ;
-  rdfs:label "torque constant"@en-US .
+  rdfs:label "Torque Constant" ;
+  rdfs:label "Torque Constant"@en-US .
 
 quantitykind:TorquePerAngle
   a qudt:QuantityKind ;
@@ -15229,7 +15229,7 @@ quantitykind:TorsionalRigidity
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:iec61360Code "0112/2///62720#UAD202" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "torsional rigidity" .
+  rdfs:label "Torsional Rigidity" .
 
 quantitykind:TorsionalSpringConstant
   a qudt:QuantityKind ;
@@ -15241,7 +15241,7 @@ quantitykind:TorsionalSpringConstant
   qudt:symbol "0173-1#Z4-BAJ448#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Federkonstante Drehfeder"@de ;
-  rdfs:label "torsional spring constant"@en .
+  rdfs:label "Torsional Spring Constant"@en .
 
 quantitykind:TotalAngularMomentum
   a qudt:QuantityKind ;
@@ -15381,7 +15381,7 @@ quantitykind:TotalRadiance
   qudt:plainTextDescription "Quotient aus der differentiellen Änderung der Energiefluenz dΨ im Zeitintervall dt: ψ = dΨ / dt; die Energieflussdichte ist identisch mit dem Produkt der Teilchenflussdichte und der mittleren Teilchenenergie"@de ;
   qudt:symbol "0173-1#Z4-BAJ318#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "total radiance"@en-US .
+  rdfs:label "Total Radiance"@en-US .
 
 quantitykind:TouchThresholds
   a qudt:QuantityKind ;
@@ -15401,8 +15401,8 @@ quantitykind:TrafficIntensity
   qudt:plainTextDescription "Anzahl aller gleichzeitig belegten Einrichtungen in einer bestimmten Gruppe von einrichtungen"@de ;
   qudt:symbol "0173-1#Z4-BAJ462#001" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "traffic intensity" ;
-  rdfs:label "traffic intensity"@en-US .
+  rdfs:label "Traffic Intensity" ;
+  rdfs:label "Traffic Intensity"@en-US .
 
 quantitykind:TransmissionRatioBetweenRotationAndTranslation
   a qudt:QuantityKind ;
@@ -15411,7 +15411,7 @@ quantitykind:TransmissionRatioBetweenRotationAndTranslation
   qudt:plainTextDescription "Zusammenhang zwischen Dreh- und Längsbewegung als Maß dafür, wie ein überstrichener Drehwinkel in eine lineare Wegstrecke umgesetzt wird"@de ;
   qudt:symbol "0173-1#Z4-BAJ400#003" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "transmission ratio between rotation and translation"@en-US .
+  rdfs:label "Transmission Ratio Between Rotation and Translation"@en-US .
 
 quantitykind:Transmittance
   a qudt:QuantityKind ;
@@ -15466,8 +15466,8 @@ quantitykind:Unbalance
   qudt:plainTextDescription "durch ungleichmäßige Masseverteilung bedingter, unruhiger Lauf rotierender Körper, ausgedrückt als Produkt aus dem Radius und einer zugehörigen Masse"@de ;
   qudt:symbol "0173-1#Z4-BAJ432#001" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "unbalance" ;
-  rdfs:label "unbalance"@en-US .
+  rdfs:label "Unbalance" ;
+  rdfs:label "Unbalance"@en-US .
 
 quantitykind:Unknown
   a qudt:QuantityKind ;
@@ -15580,13 +15580,13 @@ quantitykind:Velocity
   rdfs:label "Geschwindigkeit"@de ;
   rdfs:label "Halaju"@ms ;
   rdfs:label "Rychlost"@cs ;
+  rdfs:label "Velocity"@en ;
   rdfs:label "hitrost"@sl ;
   rdfs:label "hız"@tr ;
   rdfs:label "prędkość"@pl ;
   rdfs:label "velocidad"@es ;
   rdfs:label "velocidade"@pt ;
   rdfs:label "velocitas"@la ;
-  rdfs:label "velocity"@en ;
   rdfs:label "velocità"@it ;
   rdfs:label "vitesse"@fr ;
   rdfs:label "viteză"@ro ;
@@ -15631,7 +15631,7 @@ quantitykind:VibrationalDensityOfStates
   qudt:symbol "g" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q230895> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "Vibrational density of states"@en ;
+  rdfs:label "Vibrational Density of States"@en ;
   rdfs:seeAlso quantitykind:EnergyDensityOfStates .
 
 quantitykind:VideoFrameRate
@@ -15746,7 +15746,7 @@ quantitykind:VolumeDensityOfCharge
   qudt:plainTextDescription "räumliche Dichte der in einem Raumgebiet vom Volumen V enthaltenen elektrischen Ladung Q"@de ;
   qudt:symbol "0173-1#Z4-BAJ368#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "volume density of charge"@en-US .
+  rdfs:label "Volume Density of Charge"@en-US .
 
 quantitykind:VolumeFlowRate
   a qudt:QuantityKind ;
@@ -15879,14 +15879,14 @@ quantitykind:VolumetricBitDensity
   qudt:hasDimensionVector qkdv:A0E0L-3I0M0H0T0D0 ;
   qudt:iec61360Code "0112/2///62720#UAD241" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "volumic bit density" .
+  rdfs:label "Volumic Bit Density" .
 
 quantitykind:VolumetricElectricCharge
   a qudt:QuantityKind ;
   qudt:hasDimensionVector qkdv:A0E1L-3I0M0H0T1D0 ;
   qudt:iec61360Code "0112/2///62720#UAD242" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "volumic electric charge" .
+  rdfs:label "Volumic Electric Charge" .
 
 quantitykind:VolumetricEntityDensity
   a qudt:QuantityKind ;
@@ -15895,7 +15895,7 @@ quantitykind:VolumetricEntityDensity
   qudt:plainTextDescription "Größe, deren Wert sich umgekehrt proportional zum Volumenwert verhält"@de ;
   qudt:symbol "0173-1#Z4-BAJ377#003" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "volumetric entity density"@en-US .
+  rdfs:label "Volumetric Entity Density"@en-US .
 
 quantitykind:VolumetricFlux
   a qudt:QuantityKind ;
@@ -15923,7 +15923,7 @@ quantitykind:VolumetricOutputPower
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-3D0 ;
   qudt:iec61360Code "0112/2///62720#UAD243" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "volumic output power" .
+  rdfs:label "Volumic Output Power" .
 
 quantitykind:VolumicAmountOfSubstance
   a qudt:QuantityKind ;
@@ -15932,7 +15932,7 @@ quantitykind:VolumicAmountOfSubstance
   qudt:plainTextDescription "Größe proportional der Anzahl von Einzelteilchen festgelegter Art, die in einer gegebenen Substanzprobe enthalten sind, dividiert durch das zugehörige Volumen dieser Substanzprobe"@de ;
   qudt:symbol "0173-1#Z4-BAJ402#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "volumic amount of substance"@en-US .
+  rdfs:label "Volumic Amount of Substance"@en-US .
 
 quantitykind:VolumicDataQuantity
   a qudt:QuantityKind ;
@@ -15941,7 +15941,7 @@ quantitykind:VolumicDataQuantity
   qudt:plainTextDescription "Anzahl von Daten, die in der Regel abhängig von der jeweiligen Komplexität der Information oder deren Codierungsverfahren ist, dividiert durch das zugehörige Volumen"@de ;
   qudt:symbol "0173-1#Z4-BAJ401#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "volumic data quantity"@en-US .
+  rdfs:label "Volumic Data Quantity"@en-US .
 
 quantitykind:VolumicElectromagneticEnergy
   a qudt:QuantityKind ;
@@ -15966,7 +15966,7 @@ quantitykind:VolumicOutput
   qudt:plainTextDescription "Quotient freigesetzte Wärmeleistung durch Volumen"@de ;
   qudt:symbol "0173-1#Z4-BAJ366#003" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "volumic output"@en-US .
+  rdfs:label "Volumic Output"@en-US .
 
 quantitykind:Vorticity
   a qudt:QuantityKind ;
@@ -16044,7 +16044,7 @@ quantitykind:WaterVapourDiffusionCoefficient
   qudt:plainTextDescription "The Water vapour diffusion coefficient describes how easy vapour diffusion happens in a given material." ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Wasserdampfdiffusionsleitkoeffizient"@de ;
-  rdfs:label "Water vapour diffusion coefficient"@en .
+  rdfs:label "Water Vapour Diffusion Coefficient"@en .
 
 quantitykind:WaterVapourPermeability
   a qudt:QuantityKind ;
@@ -16054,8 +16054,8 @@ quantitykind:WaterVapourPermeability
   qudt:plainTextDescription "Masse des durch eine Fläche hindurchtretenden Wasserdampfes, dividiert durch den Flächeninhalt dieser Fläche, die Druckdifferenz und die dazugehörige Zeit"@de ;
   qudt:symbol "0173-1#Z4-BAJ446#001" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
-  rdfs:label "water vapour permeability" ;
-  rdfs:label "water vapour permeability"@en-US .
+  rdfs:label "Water Vapour Permeability" ;
+  rdfs:label "Water Vapour Permeability"@en-US .
 
 quantitykind:Wavelength
   a qudt:QuantityKind ;
@@ -16068,13 +16068,13 @@ quantitykind:Wavelength
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Jarak gelombang"@ms ;
   rdfs:label "Vlnové délka"@cs ;
+  rdfs:label "Wavelength"@en ;
   rdfs:label "Wellenlänge"@de ;
   rdfs:label "comprimento de onda"@pt ;
   rdfs:label "dalga boyu"@tr ;
   rdfs:label "longitud de onda"@es ;
   rdfs:label "longueur d'onde"@fr ;
   rdfs:label "lunghezza d'onda"@it ;
-  rdfs:label "wavelength"@en ;
   rdfs:label "длина волны"@ru ;
   rdfs:label "طول موج"@fa ;
   rdfs:label "波长"@zh ;
@@ -16100,13 +16100,13 @@ $k = \\frac{2\\pi}{\\lambda}= \\frac{2\\pi\\upsilon}{\\upsilon_p}=\\frac{\\omega
   rdfs:label "Liczba falowa"@pl ;
   rdfs:label "Repetenz"@de ;
   rdfs:label "Vlnové číslo"@cs ;
+  rdfs:label "Wavenumber"@en ;
   rdfs:label "dalga sayısı"@tr ;
   rdfs:label "nombre d'onde"@fr ;
   rdfs:label "numero d'onda"@it ;
   rdfs:label "número de ola"@es ;
   rdfs:label "número de onda"@pt ;
   rdfs:label "valovno število"@sl ;
-  rdfs:label "wavenumber"@en ;
   rdfs:label "Волновое число"@ru ;
   rdfs:label "عدد الموجة"@ar ;
   rdfs:label "عدد موج"@fa ;
@@ -16152,13 +16152,13 @@ quantitykind:Weight
   rdfs:label "Berat"@ms ;
   rdfs:label "Gewicht"@de ;
   rdfs:label "Siła ciężkości"@pl ;
+  rdfs:label "Weight"@en ;
   rdfs:label "forza peso"@it ;
   rdfs:label "greutate"@ro ;
   rdfs:label "peso"@es ;
   rdfs:label "peso"@pt ;
   rdfs:label "poids"@fr ;
   rdfs:label "tíha"@cs ;
-  rdfs:label "weight"@en ;
   rdfs:label "Вес"@ru ;
   rdfs:label "وزن"@ar ;
   rdfs:label "وزن"@fa ;
@@ -16207,6 +16207,7 @@ quantitykind:Work
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q42213> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Arbeit"@de ;
+  rdfs:label "Work"@en ;
   rdfs:label "delo"@sl ;
   rdfs:label "iş"@tr ;
   rdfs:label "kerja"@ms ;
@@ -16217,7 +16218,6 @@ quantitykind:Work
   rdfs:label "trabajo"@es ;
   rdfs:label "trabalho"@pt ;
   rdfs:label "travail"@fr ;
-  rdfs:label "work"@en ;
   rdfs:label "کار"@fa ;
   rdfs:label "कार्य"@hi ;
   rdfs:label "仕事量"@ja ;

--- a/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
+++ b/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
@@ -1888,12 +1888,12 @@ unit:BARAD
   qudt:exactMatch unit:BARYE ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasFactorUnit [
-    qudt:exponent -2 ;
-    qudt:hasUnit unit:CentiM ;
-  ] ;
-  qudt:hasFactorUnit [
     qudt:exponent 1 ;
     qudt:hasUnit unit:DYN ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent -2 ;
+    qudt:hasUnit unit:CentiM ;
   ] ;
   qudt:hasQuantityKind quantitykind:ForcePerArea ;
   qudt:hasQuantityKind quantitykind:VapourPressure ;
@@ -1981,12 +1981,12 @@ unit:BARYE
   qudt:exactMatch unit:BARAD ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasFactorUnit [
-    qudt:exponent -2 ;
-    qudt:hasUnit unit:CentiM ;
-  ] ;
-  qudt:hasFactorUnit [
     qudt:exponent 1 ;
     qudt:hasUnit unit:DYN ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent -2 ;
+    qudt:hasUnit unit:CentiM ;
   ] ;
   qudt:hasQuantityKind quantitykind:ForcePerArea ;
   qudt:hasQuantityKind quantitykind:VapourPressure ;
@@ -4183,11 +4183,11 @@ unit:C
   qudt:hasDimensionVector qkdv:A0E1L0I0M0H0T1D0 ;
   qudt:hasFactorUnit [
     qudt:exponent 1 ;
-    qudt:hasUnit unit:A ;
+    qudt:hasUnit unit:SEC ;
   ] ;
   qudt:hasFactorUnit [
     qudt:exponent 1 ;
-    qudt:hasUnit unit:SEC ;
+    qudt:hasUnit unit:A ;
   ] ;
   qudt:hasQuantityKind quantitykind:ElectricCharge ;
   qudt:iec61360Code "0112/2///62720#UAA130" ;
@@ -13589,12 +13589,12 @@ unit:ERG
   qudt:derivedUnitOfSystem sou:CGS-GAUSS ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:hasFactorUnit [
-    qudt:exponent 2 ;
-    qudt:hasUnit unit:CentiM ;
-  ] ;
-  qudt:hasFactorUnit [
     qudt:exponent -2 ;
     qudt:hasUnit unit:SEC ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent 2 ;
+    qudt:hasUnit unit:CentiM ;
   ] ;
   qudt:hasFactorUnit [
     qudt:exponent 1 ;
@@ -18653,12 +18653,12 @@ unit:GRAY
   qudt:derivedCoherentUnitOfSystem sou:SI ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-2D0 ;
   qudt:hasFactorUnit [
-    qudt:exponent -1 ;
-    qudt:hasUnit unit:KiloGM ;
-  ] ;
-  qudt:hasFactorUnit [
     qudt:exponent 1 ;
     qudt:hasUnit unit:J ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent -1 ;
+    qudt:hasUnit unit:KiloGM ;
   ] ;
   qudt:hasQuantityKind quantitykind:AbsorbedDose ;
   qudt:hasQuantityKind quantitykind:Kerma ;
@@ -19818,12 +19818,12 @@ unit:H
   qudt:derivedCoherentUnitOfSystem sou:SI ;
   qudt:hasDimensionVector qkdv:A0E-2L2I0M1H0T-2D0 ;
   qudt:hasFactorUnit [
-    qudt:exponent -1 ;
-    qudt:hasUnit unit:A ;
-  ] ;
-  qudt:hasFactorUnit [
     qudt:exponent 1 ;
     qudt:hasUnit unit:WB ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent -1 ;
+    qudt:hasUnit unit:A ;
   ] ;
   qudt:hasQuantityKind quantitykind:Inductance ;
   qudt:iec61360Code "0112/2///62720#UAA165" ;
@@ -21567,11 +21567,11 @@ unit:J
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:hasFactorUnit [
     qudt:exponent 1 ;
-    qudt:hasUnit unit:N ;
+    qudt:hasUnit unit:M ;
   ] ;
   qudt:hasFactorUnit [
     qudt:exponent 1 ;
-    qudt:hasUnit unit:M ;
+    qudt:hasUnit unit:N ;
   ] ;
   qudt:hasQuantityKind quantitykind:Energy ;
   qudt:hasQuantityKind quantitykind:ExchangeIntegral ;
@@ -22248,20 +22248,20 @@ unit:J-PER-M2-SEC0dot5-K
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E-2L2I0M1H-1T-2dot5D0 ;
   qudt:hasFactorUnit [
-    qudt:exponent 1 ;
-    qudt:hasUnit unit:J ;
+    qudt:exponent -1 ;
+    qudt:hasUnit unit:K ;
   ] ;
   qudt:hasFactorUnit [
-    qudt:exponent -2 ;
-    qudt:hasUnit unit:M ;
+    qudt:exponent 1 ;
+    qudt:hasUnit unit:J ;
   ] ;
   qudt:hasFactorUnit [
     qudt:exponent -0.5 ;
     qudt:hasUnit unit:SEC ;
   ] ;
   qudt:hasFactorUnit [
-    qudt:exponent -1 ;
-    qudt:hasUnit unit:K ;
+    qudt:exponent -2 ;
+    qudt:hasUnit unit:M ;
   ] ;
   qudt:hasQuantityKind quantitykind:ThermalInertia ;
   qudt:plainTextDescription "A unit of thermal inertia measured as Joules per meter squared per square root Seconds per degree Kelvin " ;
@@ -22283,12 +22283,12 @@ unit:J-PER-M2-SEC0pt5-K
     qudt:hasUnit unit:J ;
   ] ;
   qudt:hasFactorUnit [
-    qudt:exponent -2 ;
-    qudt:hasUnit unit:M ;
-  ] ;
-  qudt:hasFactorUnit [
     qudt:exponent -0.5 ;
     qudt:hasUnit unit:SEC ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent -2 ;
+    qudt:hasUnit unit:M ;
   ] ;
   qudt:hasFactorUnit [
     qudt:exponent -1 ;
@@ -23414,12 +23414,12 @@ unit:KN
   qudt:exactMatch unit:MI_N-PER-HR ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T-1D0 ;
   qudt:hasFactorUnit [
-    qudt:exponent -1 ;
-    qudt:hasUnit unit:HR ;
-  ] ;
-  qudt:hasFactorUnit [
     qudt:exponent 1 ;
     qudt:hasUnit unit:MI_N ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent -1 ;
+    qudt:hasUnit unit:HR ;
   ] ;
   qudt:hasQuantityKind quantitykind:LinearVelocity ;
   qudt:hasQuantityKind quantitykind:Velocity ;
@@ -31312,15 +31312,15 @@ unit:LB_F
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H0T-2D0 ;
   qudt:hasFactorUnit [
     qudt:exponent 1 ;
-    qudt:hasUnit unit:SLUG ;
-  ] ;
-  qudt:hasFactorUnit [
-    qudt:exponent 1 ;
     qudt:hasUnit unit:FT ;
   ] ;
   qudt:hasFactorUnit [
     qudt:exponent -2 ;
     qudt:hasUnit unit:SEC ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent 1 ;
+    qudt:hasUnit unit:SLUG ;
   ] ;
   qudt:hasQuantityKind quantitykind:Force ;
   qudt:iec61360Code "0112/2///62720#UAA696" ;
@@ -31842,12 +31842,12 @@ unit:LUX
   qudt:derivedCoherentUnitOfSystem sou:SI ;
   qudt:hasDimensionVector qkdv:A0E0L-2I1M0H0T0D0 ;
   qudt:hasFactorUnit [
-    qudt:exponent -2 ;
-    qudt:hasUnit unit:M ;
-  ] ;
-  qudt:hasFactorUnit [
     qudt:exponent 1 ;
     qudt:hasUnit unit:LM ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent -2 ;
+    qudt:hasUnit unit:M ;
   ] ;
   qudt:hasQuantityKind quantitykind:LuminousFluxPerArea ;
   qudt:iec61360Code "0112/2///62720#UAA723" ;
@@ -37927,12 +37927,12 @@ unit:MegaPA-M0dot5
   qudt:conversionMultiplierSN 1.0E6 ;
   qudt:hasDimensionVector qkdv:A0E0L-0dot5I0M1H0T-2D0 ;
   qudt:hasFactorUnit [
-    qudt:exponent 1 ;
-    qudt:hasUnit unit:MegaPA ;
-  ] ;
-  qudt:hasFactorUnit [
     qudt:exponent 0.5 ;
     qudt:hasUnit unit:M ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent 1 ;
+    qudt:hasUnit unit:MegaPA ;
   ] ;
   qudt:hasQuantityKind quantitykind:StressIntensityFactor ;
   qudt:plainTextDescription "1,000,000-fold of the derived unit Pascal Square Root Meter" ;
@@ -46464,15 +46464,15 @@ unit:N
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H0T-2D0 ;
   qudt:hasFactorUnit [
     qudt:exponent 1 ;
-    qudt:hasUnit unit:M ;
-  ] ;
-  qudt:hasFactorUnit [
-    qudt:exponent 1 ;
     qudt:hasUnit unit:KiloGM ;
   ] ;
   qudt:hasFactorUnit [
     qudt:exponent -2 ;
     qudt:hasUnit unit:SEC ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent 1 ;
+    qudt:hasUnit unit:M ;
   ] ;
   qudt:hasQuantityKind quantitykind:Force ;
   qudt:iec61360Code "0112/2///62720#UAA235" ;
@@ -46882,15 +46882,15 @@ unit:N-M-PER-W0dot5
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T0D0 ;
   qudt:hasFactorUnit [
     qudt:exponent 1 ;
+    qudt:hasUnit unit:M ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent 1 ;
     qudt:hasUnit unit:N ;
   ] ;
   qudt:hasFactorUnit [
     qudt:exponent -0.5 ;
     qudt:hasUnit unit:W ;
-  ] ;
-  qudt:hasFactorUnit [
-    qudt:exponent 1 ;
-    qudt:hasUnit unit:M ;
   ] ;
   qudt:hasFactorUnit [
     qudt:exponent 1 ;
@@ -49994,12 +49994,12 @@ unit:OHM
   qudt:dbpediaMatch "http://dbpedia.org/resource/Ohm"^^xsd:anyURI ;
   qudt:hasDimensionVector qkdv:A0E-2L2I0M1H0T-3D0 ;
   qudt:hasFactorUnit [
-    qudt:exponent -1 ;
-    qudt:hasUnit unit:A ;
-  ] ;
-  qudt:hasFactorUnit [
     qudt:exponent 1 ;
     qudt:hasUnit unit:V ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent -1 ;
+    qudt:hasUnit unit:A ;
   ] ;
   qudt:hasQuantityKind quantitykind:Impedance ;
   qudt:hasQuantityKind quantitykind:ModulusOfImpedance ;
@@ -51294,12 +51294,12 @@ unit:PA
   qudt:exactMatch unit:N-PER-M2 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasFactorUnit [
-    qudt:exponent 1 ;
-    qudt:hasUnit unit:N ;
-  ] ;
-  qudt:hasFactorUnit [
     qudt:exponent -2 ;
     qudt:hasUnit unit:M ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent 1 ;
+    qudt:hasUnit unit:N ;
   ] ;
   qudt:hasQuantityKind quantitykind:BulkModulus ;
   qudt:hasQuantityKind quantitykind:ForcePerArea ;
@@ -51472,12 +51472,12 @@ unit:PA-M0dot5
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L-0dot5I0M1H0T-2D0 ;
   qudt:hasFactorUnit [
-    qudt:exponent 1 ;
-    qudt:hasUnit unit:PA ;
-  ] ;
-  qudt:hasFactorUnit [
     qudt:exponent 0.5 ;
     qudt:hasUnit unit:M ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent 1 ;
+    qudt:hasUnit unit:PA ;
   ] ;
   qudt:hasQuantityKind quantitykind:StressIntensityFactor ;
   qudt:plainTextDescription "A metric unit for stress intensity factor and fracture toughness." ;
@@ -56504,12 +56504,12 @@ unit:PSI
   qudt:exactMatch unit:LB_F-PER-IN2 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasFactorUnit [
-    qudt:exponent 1 ;
-    qudt:hasUnit unit:LB_F ;
-  ] ;
-  qudt:hasFactorUnit [
     qudt:exponent -2 ;
     qudt:hasUnit unit:IN ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent 1 ;
+    qudt:hasUnit unit:LB_F ;
   ] ;
   qudt:hasQuantityKind quantitykind:ForcePerArea ;
   qudt:hasQuantityKind quantitykind:ModulusOfElasticity ;
@@ -60886,12 +60886,12 @@ unit:T
   qudt:derivedCoherentUnitOfSystem sou:SI ;
   qudt:hasDimensionVector qkdv:A0E-1L0I0M1H0T-2D0 ;
   qudt:hasFactorUnit [
-    qudt:exponent -2 ;
-    qudt:hasUnit unit:M ;
-  ] ;
-  qudt:hasFactorUnit [
     qudt:exponent 1 ;
     qudt:hasUnit unit:WB ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent -2 ;
+    qudt:hasUnit unit:M ;
   ] ;
   qudt:hasQuantityKind quantitykind:MagneticField ;
   qudt:hasQuantityKind quantitykind:MagneticFluxDensity ;
@@ -63207,12 +63207,12 @@ unit:V
   qudt:dbpediaMatch "http://dbpedia.org/resource/Volt"^^xsd:anyURI ;
   qudt:hasDimensionVector qkdv:A0E-1L2I0M1H0T-3D0 ;
   qudt:hasFactorUnit [
-    qudt:exponent -1 ;
-    qudt:hasUnit unit:A ;
-  ] ;
-  qudt:hasFactorUnit [
     qudt:exponent 1 ;
     qudt:hasUnit unit:W ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent -1 ;
+    qudt:hasUnit unit:A ;
   ] ;
   qudt:hasQuantityKind quantitykind:ElectricPotential ;
   qudt:hasQuantityKind quantitykind:ElectricPotentialDifference ;
@@ -63949,12 +63949,12 @@ unit:VAR
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasFactorUnit [
-    qudt:exponent 1 ;
-    qudt:hasUnit unit:J ;
-  ] ;
-  qudt:hasFactorUnit [
     qudt:exponent -1 ;
     qudt:hasUnit unit:SEC ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent 1 ;
+    qudt:hasUnit unit:J ;
   ] ;
   qudt:hasQuantityKind quantitykind:ReactivePower ;
   qudt:iec61360Code "0112/2///62720#UAB023" ;
@@ -64132,12 +64132,12 @@ unit:W
   qudt:derivedCoherentUnitOfSystem sou:SI ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:hasFactorUnit [
-    qudt:exponent 1 ;
-    qudt:hasUnit unit:J ;
-  ] ;
-  qudt:hasFactorUnit [
     qudt:exponent -1 ;
     qudt:hasUnit unit:SEC ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent 1 ;
+    qudt:hasUnit unit:J ;
   ] ;
   qudt:hasQuantityKind quantitykind:ElectricPower ;
   qudt:hasQuantityKind quantitykind:Power ;


### PR DESCRIPTION
## Summary

- **Build-time auto-fix**: adds a `sparqlUpdate` step that converts English `qudt:QuantityKind` and `qudt:Prefix` labels to title case at build time. Corrections are surfaced via the existing src-errors / `-Pfix` mechanism so they land in source after review.
- **`qfn:titleCase` SHACL function**: encapsulates the transformation — CamelCase splitting, per-word capitalisation with a `(?=[a-zA-Z])` lookahead (preserving isolated tokens like `e` in *base e*), and lowercasing of prepositions/conjunctions/articles (`of`, `per`, `in`, `for`, `and`, `to`, `a`, `an`, `by`, `as`, `the`, `at`).
- **Edge-case exclusions**: labels starting with `\p{Ll}-` (physics-symbol labels such as *g-Factor of Nucleus*) are excluded from auto-capitalisation; chemical/acronym labels like `CO2Equivalent` are naturally excluded because `qfn:titleCase` leaves them unchanged.
- **SHACL validation improvements**:
  - `RdfsLabelInTitleCaseShapeWarning` now targets only `qudt:QuantityKind` and `qudt:Prefix` (removed `PhysicalConstant`/`ConstantValue`, which follow CODATA naming conventions).
  - Fixed a long-standing false-negative in the title-case regex: labels like *Acceleration Of Gravity* were accepted because the `[^\p{Ll}]\p{Lu}` alternative matched any space + uppercase. Added an explicit OR condition to catch capitalised exception words.
  - Extended the regex to accept acronym-style consecutive uppercase letters (`CO2Equivalent`, `RF-Power Level`) and labels starting with `\p{Ll}-`.
  - `RdfsLabelInTitleCaseShapeViolation` (units) downgraded from `sh:Violation` to `sh:Warning`.
- **Build fix**: added a default value for `fix.profile.is.inactive` so rdfio 1.7.0 (which now resolves `${…}` as metadata-graph variables) no longer errors when the `-Pfix` profile is absent; the existing *"run `mvn -Pfix install`"* message is preserved.

## Test plan

- [x] `mvn install` on a clean checkout produces `target/src-errors/errors.txt` and the *"run `mvn -Pfix install`"* message
- [x] `mvn -Pfix install` succeeds and applies label corrections to source
- [x] Validation report contains no `sh:Warning` for `quantitykind:CO2Equivalent`, `quantitykind:GFactorOfNucleus`, or `quantitykind:RFPower`
- [x] Validation report contains no title-case warnings for `qudt:PhysicalConstant` entities
- [x] *Acceleration of Gravity* (formerly *Acceleration Of Gravity*) is corrected in source
