### PR TITLE
Update Quantity Kinds to ECLASS Release 16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
 
 ### Changed
 
+- Updated qudt:eclassCode values to match ECLASS Release 16.0
 - Updated maven plugins to achieve stable blank node ordering in TTL files. As a side effect, Java 25+ is now required for the maven build.
 
 ### Added

--- a/src/main/rdf/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL.ttl
+++ b/src/main/rdf/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL.ttl
@@ -427,7 +427,7 @@ quantitykind:ActivityRelatedByMass
   dcterms:description """$\\textit{Activity Related By Mass}$ is quantitative data of the radioactivity of the amount of a
     radionuclide in a particular state of energy at a defined point in time, divided by the related mass of this quantity.
   """^^qudt:LatexString ;
-  qudt:eclassCode "0173-1#Z4-BAJ342#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ342#005" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M-1H0T-1D0 ;
   qudt:plainTextDescription """quantitative Angabe der Radioaktivität einer Menge eines Radionuklids in einem bestimmten
     Energiezustand zu einem gegebenen Zeitpunkt dividiert durch die zugehörige Masse dieser Menge
@@ -436,7 +436,6 @@ quantitykind:ActivityRelatedByMass
     energy at a defined point in time, divided by the related mass of this quantity
   """@en ;
   qudt:specializationOf quantitykind:MassicActivity ;
-  qudt:symbol "0173-1#Z4-BAJ342#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Activity Related by Mass"@en-US .
 
@@ -1214,14 +1213,13 @@ quantitykind:AreicChargeDensityOrElectricFluxDensityOrElectricPolarization
   """@en ;
   qudt:deprecated true ;
   qudt:deprecatedInVersion "3.1.4" ;
-  qudt:eclassCode "0173-1#Z4-BAJ320#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ320#005" ;
   qudt:hasDimensionVector qkdv:A0E1L-2I0M0H0T1D0 ;
   qudt:plainTextDescription """auf einer Fläche mit dem Flächeninhalt A vorhandenen Ladung Q dividiert durch den Flächeninhalt A
     oder vektorielle Größe, die für einen gegebenen Punkt gleich der Summe der elektrischen Polarisation P und des Produkts aus
     der elektrischen Feldstärke E und der elektrischen Feldkonstante (Permittivität) ε₀ ist oder räumliche Dichte des elektrischen
     Moments molekularer Dipole
   """@de ;
-  qudt:symbol "0173-1#Z4-BAJ320#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "areic charge density or electric flux density or electric polarization"@en-US .
 
@@ -1230,12 +1228,11 @@ quantitykind:AreicDataVolume
   dcterms:description """volume of data, which is usually dependent on the respective complexity of the information or its coding
     procedure, divided by the related area
   """@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ321#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ321#004" ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T0D0 ;
   qudt:plainTextDescription """Anzahl von Daten, die in der Regel abhängig von der jeweiligen Komplexität der Information oder
     deren Codierungsverfahren ist, dividiert durch die zugehörige Fläche
   """@de ;
-  qudt:symbol "0173-1#Z4-BAJ321#002" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Areic Data Volume"@en-US .
 
@@ -1243,7 +1240,7 @@ quantitykind:AreicEnergyFlow
   a qudt:QuantityKind ;
   dcterms:description """energy in a defined direction of propagation through a surface perpendicular to this, divided by its area
   """@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ322#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ322#005" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-3D0 ;
   qudt:plainTextDescription """Leistung in festgelegter Ausbreitungsrichtung durch ein dazu senkrechtes Oberflächenelement,
     dividiert durch dessen Fläche
@@ -1270,7 +1267,7 @@ quantitykind:AreicHeatFlowRate
 quantitykind:AreicMass
   a qudt:QuantityKind ;
   dcterms:description "mass divided by the related area"@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ288#004" ;
+  qudt:eclassCode "0173-1#Z4-BAJ288#007" ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M1H0T0D0 ;
   qudt:iec61360Code "0112/2///62720#UAD014" ;
   qudt:plainTextDescription "Masse dividiert durch die zugehörige Fläche"@de ;
@@ -1287,7 +1284,6 @@ quantitykind:AreicTorque
   qudt:plainTextDescription """Quotient aus dem auf eine Fläche wirkenden, eine Verdrehung bzw. Abscherung verursachenden
     Drehmoment dividiert durch diese Fläche
   """@de ;
-  qudt:symbol "0173-1#Z4-BAJ420#001" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Areic Torque"@en-US .
 
@@ -1381,7 +1377,7 @@ quantitykind:AtomicEnergy
   dcterms:description """scalar quantity of elementary particles which is retained within a system following any change and, as
     saved energy, constitutes the capability of a physical system to carry out work
   """@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ291#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ291#005" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:plainTextDescription """skalare Größe von Elementarteilchen, die bei beliebiger Umwandlung innerhalb eines Systems erhalten
     bleibt und als gespeichertes Arbeitsvermögen die Fähigkeit eines physikalischen Systems darstellt, Arbeit zu verrichten
@@ -1433,7 +1429,7 @@ quantitykind:AtomicNumber
 quantitykind:AtomicStoppingPower
   a qudt:QuantityKind ;
   dcterms:description "ratio of the linear stopping power to the number density of the atoms in the medium"@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ292#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ292#004" ;
   qudt:exactMatch quantitykind:TotalAtomicStoppingPower ;
   qudt:hasDimensionVector qkdv:A0E0L4I0M1H0T-2D0 ;
   qudt:plainTextDescription "Quotient aus dem linearen Bremsvermögen und der Anzahldichte der Atome in dem Medium"@de ;
@@ -1586,7 +1582,7 @@ quantitykind:BandwidthLengthProduct
   dcterms:description """parameter of transmission media for determination of frequency and length restrictions as reciprocal
     value of the multimode distortion corresponding to the product of maximum pulse frequency and maximum transmission distance
   """@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ293#003" ;
+  qudt:eclassCode "0173-1#Z4-BAJ293#005" ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T-1D0 ;
   qudt:plainTextDescription """Parameter von Übertragungsmedien zur Bestimmung der Frequenz- und Längenrestriktionen als reziproke
     Wert der Modendispersion entsprechend dem Produkt aus maximaler Impulsfrequenz mal maximaler Übertragungsstrecke
@@ -1614,7 +1610,7 @@ quantitykind:Basicity
 quantitykind:BatteryCapacity
   a qudt:QuantityKind ;
   dcterms:description "quantity of electricity or electrical charge which a fully charged battery can supply under specified conditions as a product of discharge current and discharge time"@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ270#003" ;
+  qudt:eclassCode "0173-1#Z4-BAJ270#006" ;
   qudt:hasDimensionVector qkdv:A0E1L0I0M0H0T1D0 ;
   qudt:iec61360Code "0112/2///62720#UAD017" ;
   qudt:plainTextDescription "Elektrizitätsmenge oder elektrische Ladung, die eine vollgeladenen Batterie unter festgelegten Bedingungen abgeben kann als Produkt aus Entladestrom und Entladezeit"@de ;
@@ -1750,7 +1746,7 @@ quantitykind:BitDataVolume
   dcterms:description """name for a particular quantity of data on the basis of the binary digit "Bit" (basic indissoluble
     information unit) which can only assume a state of 1 or 0
   """@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ436#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ436#005" ;
   qudt:exactMatch quantitykind:DatasetOfBits ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:plainTextDescription """Bezeichnung für eine bestimmte Anzahl von Daten auf Basis der Binärziffer Bit (en: Basic
@@ -1771,7 +1767,7 @@ quantitykind:BitRate
 quantitykind:BitTransmissionRate
   a qudt:QuantityKind ;
   dcterms:description "speed with which one bit will be transmitted per second"@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ295#003" ;
+  qudt:eclassCode "0173-1#Z4-BAJ295#006" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:plainTextDescription "Geschwindigkeit, mit der Binärzeichen übertragen werden"@de ;
   qudt:specializationOf quantitykind:BitRate ;
@@ -1975,7 +1971,7 @@ quantitykind:BurstFactor
 quantitykind:ByteDataVolume
   a qudt:QuantityKind ;
   dcterms:description "particular quantity of data based on a string consisting of 8 bits"@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ435#004" ;
+  qudt:eclassCode "0173-1#Z4-BAJ435#007" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:plainTextDescription "Anzahl von Daten auf Basis einer Zeichenfolge, die aus je 8 Bit besteht"@de ;
   qudt:specializationOf quantitykind:AmountOfData ;
@@ -1993,7 +1989,7 @@ quantitykind:ByteRate
 quantitykind:ByteTransmissionRate
   a qudt:QuantityKind ;
   dcterms:description "speed with which 8 bits are transmitted"@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ297#003" ;
+  qudt:eclassCode "0173-1#Z4-BAJ297#006" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:plainTextDescription "Geschwindigkeit, mit der 8 Binärzeichen übertragen werden"@de ;
   qudt:specializationOf quantitykind:ByteRate ;
@@ -2388,7 +2384,7 @@ quantitykind:CharacteristicNumber
   dcterms:description """quantity of dimension one (as a result of measuring technology theory) which clarifies facts, states or
     developments and is used as a scale e.g. to represent causes and effects of events
   """@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ279#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ279#004" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:organizedUnder quantitykind:Dimensionless ;
   qudt:plainTextDescription """Größe der Dimension 1 (als Ergebnis der metrisierenden Messtheorie), die Sachverhalte, Zustände
@@ -3130,7 +3126,7 @@ quantitykind:CurrentLinkage
 quantitykind:CurrentOfTheAmountOfSubstance
   a qudt:QuantityKind ;
   dcterms:description "ratio of the amount of substance divided by the related time"@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ384#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ384#004" ;
   qudt:exactMatch quantitykind:MolarFlowRate ;
   qudt:hasDimensionVector qkdv:A1E0L0I0M0H0T-1D0 ;
   qudt:plainTextDescription "Quotient Stoffmenge dividiert durch die zugehörige Zeit"@de ;
@@ -3184,7 +3180,7 @@ quantitykind:CurvatureFromRadius
 quantitykind:CutoffCurrentRating
   a qudt:QuantityKind ;
   dcterms:description "cut-off current parameter as rating for fuses and switches, derived from the so-called Joule integral"@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ325#003" ;
+  qudt:eclassCode "0173-1#Z4-BAJ325#005" ;
   qudt:hasDimensionVector qkdv:A0E2L0I0M0H0T1D0 ;
   qudt:plainTextDescription """Durchlassstrom-Kennwert als Bemessungsgröße für Sicherungen und Schalter, welcher abgeleitet ist
     aus dem sogenannten Joule-Integral
@@ -5011,7 +5007,7 @@ quantitykind:ElectricalConductance
   dcterms:description """measure of the capability of a material to conduct electric current, the value of which is defined as the
     reciprocal of the electrical resistance
   """@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ223#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ223#005" ;
   qudt:exactMatch quantitykind:Conductance ;
   qudt:hasDimensionVector qkdv:A0E2L-2I0M-1H0T3D0 ;
   qudt:iec61360Code "0112/2///62720#UAD038" ;
@@ -5039,7 +5035,7 @@ quantitykind:ElectricalResistance
     wenn die freien Ladungsträger in diesen Stoffen durch elektrische Felder und/oder elektrische Potentiale in Bewegung gesetzt
     werden
   """@de ;
-  qudt:eclassCode "0173-1#Z4-BAJ215#003" ;
+  qudt:eclassCode "0173-1#Z4-BAJ215#006" ;
   qudt:hasDimensionVector qkdv:A0E-2L2I0M1H0T-3D0 ;
   qudt:iec61360Code "0112/2///62720#UAD045" ;
   qudt:siExactMatch si-quantity:ELRE ;
@@ -5325,7 +5321,7 @@ quantitykind:Energy
 quantitykind:EnergyContent
   a qudt:QuantityKind ;
   dcterms:description "saved quantity of energy which can be used physically or chemically"@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ319#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ319#005" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:iec61360Code "0112/2///62720#UAD046" ;
   qudt:plainTextDescription "gespeicherte Energiemenge, die physikalisch oder chemisch nutzbar ist"@de ;
@@ -5985,7 +5981,7 @@ quantitykind:ExposureOfIonizingRadiation
     total charge of the ions of one sign produced in the air of mass ∂m when all of the electrons (and positrons) liberated by
     photons in this mass element are completely stopped
   """@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ326#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ326#005" ;
   qudt:exactMatch quantitykind:Exposure ;
   qudt:hasDimensionVector qkdv:A0E1L0I0M-1H0T1D0 ;
   qudt:plainTextDescription """Maß für die Wirkung eines elektromagnetischen Feldes auf Materie in Form der Ionisation, die die
@@ -6018,7 +6014,7 @@ quantitykind:ExposureRate
 quantitykind:ExposureRateOfIonizingRadiation
   a qudt:QuantityKind ;
   dcterms:description "ratio between the exposure of ionizing radiation dJ in a time interval and the duration dt of this interval"@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ327#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ327#004" ;
   qudt:exactMatch quantitykind:ExposureRate ;
   qudt:hasDimensionVector qkdv:A0E1L0I0M-1H0T0D0 ;
   qudt:plainTextDescription "Quotient Ionendosis dJ in einem Zeitintervall durch Dauer dt dieses Zeitintervalls"@de ;
@@ -6100,7 +6096,7 @@ quantitykind:FailureRate
     a resource will fall within a defined interval (t, t + Δt), and the duration of this interval if Δt approaches zero and the
     unit is in an operational state at the beginning of the interval
   """@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ466#003" ;
+  qudt:eclassCode "0173-1#Z4-BAJ466#006" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:iec61360Code "0112/2///62720#UAD051" ;
   qudt:organizedUnder quantitykind:CountRate ;
@@ -6623,7 +6619,7 @@ quantitykind:GasLeakRate
   dcterms:description """ratio of the pV value of a gas (product of pressure and volume of a given quantity of gas at the
     respective temperature) flowing through a pipe cross-section during a time interval and the related interval
   """@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ324#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ324#004" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-2D0 ;
   qudt:iec61360Code "0112/2///62720#UAD057" ;
   qudt:plainTextDescription """Quotient aus dem pV-Wert eines Gases (Produkt aus Druck und Volumen einer bestimmten Menge eines
@@ -7542,8 +7538,8 @@ quantitykind:Impedance
 quantitykind:Impulse
   a qudt:QuantityKind ;
   dcterms:description "product of force and time"@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ241#002" ;
-  qudt:eclassCode "0173-1#Z4-BAJ262#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ241#004" ;
+  qudt:eclassCode "0173-1#Z4-BAJ262#004" ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H0T-1D0 ;
   qudt:iec61360Code "0112/2///62720#UAD063" ;
   qudt:plainTextDescription "Produkt aus Kraft und Zeit"@de ;
@@ -8426,7 +8422,7 @@ quantitykind:KinematicViscosityOrDiffusionConstantOrThermalDiffusivity
   """@en ;
   qudt:deprecated true ;
   qudt:deprecatedInVersion "3.1.4" ;
-  qudt:eclassCode "0173-1#Z4-BAJ328#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ328#005" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-1D0 ;
   qudt:plainTextDescription """Quotient aus der dynamischen Viskosität und der Dichte eines Stoffes oder Quotient
     Diffusionsstromdichte durch Gradient der Ladungsträgerdichte oder Quotient Wärmeleitfähigkeit durch Wärmekapazität
@@ -8481,7 +8477,7 @@ quantitykind:KineticOrThermalEnergy
   """@en ;
   qudt:deprecated true ;
   qudt:deprecatedInVersion "3.1.4" ;
-  qudt:eclassCode "0173-1#Z4-BAJ280#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ280#005" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:plainTextDescription """Energie, die in der Bewegung eines Körpers steckt und sich aus Translationsenergie und
     Rotationsenergie zusammen setzt, die durch die Bewegung dieses Körpers gegenüber einem anderen System und durch seine Masse
@@ -9141,7 +9137,7 @@ quantitykind:LinearVelocity
 quantitykind:LinearVoltageCoefficient
   a qudt:QuantityKind ;
   dcterms:description "ratio identifying the relationship between induced voltage and velocity"@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ336#003" ;
+  qudt:eclassCode "0173-1#Z4-BAJ336#005" ;
   qudt:hasDimensionVector qkdv:A0E-1L1I0M1H0T-2D0 ;
   qudt:plainTextDescription "Verhältnis, das den Zusammenhang zwischen induzierter Spannung zur Geschwindigkeit kennzeichnet"@de ;
   qudt:specializationOf quantitykind:MagneticFluxPerLength ;
@@ -9163,7 +9159,7 @@ quantitykind:LineicDataVolume
   dcterms:description """number of data, usually dependent on the respective information complexity or its coding procedure,
     divided by the related length
   """@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ331#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ331#004" ;
   qudt:exactMatch quantitykind:LinearBitDensity ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T0D0 ;
   qudt:plainTextDescription """Anzahl von Daten, die in der Regel abhängig von der jeweiligen Komplexität der Information oder
@@ -9180,7 +9176,7 @@ quantitykind:LineicLogarithmicRatio
   dcterms:isReplacedBy quantitykind:Log10RatioPerLength ;
   qudt:deprecated true ;
   qudt:deprecatedInVersion "3.5.0" ;
-  qudt:eclassCode "0173-1#Z4-BAJ332#003" ;
+  qudt:eclassCode "0173-1#Z4-BAJ332#005" ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T0D0 ;
   qudt:plainTextDescription """Logarithmus des Verhältnisses des Werts einer gegebenen Größe zum Wert einer Bezugsgröße gleicher
     Art dividiert durch die zugehörige Länge
@@ -9191,7 +9187,7 @@ quantitykind:LineicLogarithmicRatio
 quantitykind:LineicMass
   a qudt:QuantityKind ;
   dcterms:description "ratio between mass divided by the related length"@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ341#003" ;
+  qudt:eclassCode "0173-1#Z4-BAJ341#006" ;
   qudt:exactMatch quantitykind:MassPerLength ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T0D0 ;
   qudt:iec61360Code "0112/2///62720#UAD079" ;
@@ -9202,7 +9198,7 @@ quantitykind:LineicMass
 quantitykind:LineicPower
   a qudt:QuantityKind ;
   dcterms:description "power divided by the associated length"@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ418#003" ;
+  qudt:eclassCode "0173-1#Z4-BAJ418#005" ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H0T-3D0 ;
   qudt:iec61360Code "0112/2///62720#UAD080" ;
   qudt:plainTextDescription "Leistung dividiert durch die zugehörige Länge"@de ;
@@ -9218,7 +9214,7 @@ quantitykind:LineicQuantity
 quantitykind:LineicResistance
   a qudt:QuantityKind ;
   dcterms:description "ratio of resistance divided by length"@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ333#003" ;
+  qudt:eclassCode "0173-1#Z4-BAJ333#005" ;
   qudt:exactMatch quantitykind:LinearResistance ;
   qudt:hasDimensionVector qkdv:A0E-2L1I0M1H0T-3D0 ;
   qudt:iec61360Code "0112/2///62720#UAD081" ;
@@ -9231,7 +9227,7 @@ quantitykind:LineicResolution
   dcterms:description """graphic resolution capacity of output devices such as printers or of data acquisition such as scanners,
     as a number of pixels per length
   """@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ438#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ438#004" ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T0D0 ;
   qudt:plainTextDescription """grafisches Auflösungsvermögen von Ausgabegeräten wie Druckern oder von Datenerfassungsgeräten wie
     Scannern als Anzahl der Bildpunkte je Länge
@@ -9313,7 +9309,7 @@ quantitykind:Log10Ratio
   dcterms:description """The common (base-10) logarithm of the ratio between the value of a defined quantity and the value of a
     reference quantity of the same type.
   """@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ441#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ441#005" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:iec61360Code "0112/2///62720#UAD085" ;
   qudt:siExactMatch si-quantity:RLGB ;
@@ -9327,7 +9323,7 @@ quantitykind:Log10RatioPerLength
     quantity of the same type, divided by the length over which the ratio arises. Typically used for attenuation or gain along a
     cable or transmission path, in bels or decibels per unit length.
   """@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ332#003" ;
+  qudt:eclassCode "0173-1#Z4-BAJ332#005" ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T0D0 ;
   qudt:iec61360Code "0112/2///62720#UAD078" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
@@ -9349,7 +9345,7 @@ quantitykind:LogERatio
   dcterms:description """The natural (base-e) logarithm of the ratio between the value of a given quantity and the value of a
     reference quantity of the same type (base of logarithm: e = 2.718...).
   """@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ440#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ440#005" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:iec61360Code "0112/2///62720#UAD086" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
@@ -9397,7 +9393,7 @@ quantitykind:LogarithmRatioToBase10
   dcterms:isReplacedBy quantitykind:Log10Ratio ;
   qudt:deprecated true ;
   qudt:deprecatedInVersion "3.5.0" ;
-  qudt:eclassCode "0173-1#Z4-BAJ441#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ441#005" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:iec61360Code "0112/2///62720#UAD085" ;
   qudt:siExactMatch si-quantity:RLGB ;
@@ -9412,7 +9408,7 @@ quantitykind:LogarithmRatioToBaseE
   dcterms:isReplacedBy quantitykind:LogERatio ;
   qudt:deprecated true ;
   qudt:deprecatedInVersion "3.5.0" ;
-  qudt:eclassCode "0173-1#Z4-BAJ440#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ440#005" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:plainTextDescription """natürlicher Logarithmus des Verhältnisses des Werts einer gegebenen Größe zum Wert einer
     Bezugsgröße gleicher Art (Basis des Logarithmus: e = 2,718...)
@@ -9610,7 +9606,7 @@ quantitykind:Loudness
     assigned the loudness 1 sone, and a tone which is identified by the listeners as being n-times as loud as that identified by 1
     sone is assigned the loudness n sone
   """@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ334#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ334#004" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:iec61360Code "0112/2///62720#UAD088" ;
   qudt:organizedUnder quantitykind:Dimensionless ;
@@ -9628,7 +9624,7 @@ quantitykind:LoudnessLevel
     corresponds to the sound pressure level of a reference sound specified in dB which comprises a wave coming from the front with
     a frequency of 1000 Hz and assessed to be just as loud as the noise
   """@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ361#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ361#005" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:iec61360Code "0112/2///62720#UAD089" ;
   qudt:organizedUnder quantitykind:Dimensionless ;
@@ -9731,7 +9727,7 @@ quantitykind:LuminousExitance
   dcterms:description """$\\textit{Luminous Exitance}$ is the ratio of the luminous flux dΦ, leaving an element of the surface
     containing the point, by the area dA of that element.
   """^^qudt:LatexString ;
-  qudt:eclassCode "0173-1#Z4-BAJ382#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ382#005" ;
   qudt:hasDimensionVector qkdv:A0E0L-2I1M0H0T0D0 ;
   qudt:iec61360Code "0112/2///62720#UAD092" ;
   qudt:plainTextDescription """Luminous Exitance is the ratio of the luminous flux dΦ, leaving an element of the surface
@@ -10339,7 +10335,7 @@ quantitykind:MagneticFluxDensityOrMagneticPolarization
   dcterms:isReplacedBy quantitykind:MagneticFluxDensity ;
   qudt:deprecated true ;
   qudt:deprecatedInVersion "3.1.4" ;
-  qudt:eclassCode "0173-1#Z4-BAJ221#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ221#005" ;
   qudt:hasDimensionVector qkdv:A0E-1L0I0M1H0T-2D0 ;
   qudt:plainTextDescription """vektorielle Feldgröße B, die auf jedes geladene Teilchen, das eine Geschwindigkeit v hat, eine
     Kraft F ausübt, die gleich dem Produkt aus dem Vektorprodukt v x B und der elektrischen Ladung Q des Teilchens ist oder
@@ -10895,7 +10891,7 @@ quantitykind:MassFlowRate
 quantitykind:MassFluxDensity
   a qudt:QuantityKind ;
   dcterms:description "product of flow velocity and density"@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ264#003" ;
+  qudt:eclassCode "0173-1#Z4-BAJ264#005" ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M1H0T-1D0 ;
   qudt:iec61360Code "0112/2///62720#UAD108" ;
   qudt:plainTextDescription "Produkt aus Strömungsgeschwindigkeit und Dichte"@de ;
@@ -11120,7 +11116,7 @@ quantitykind:MassRatioOfWaterVapourToDryGas
 quantitykind:MassRelatedElectricalCurrent
   a qudt:QuantityKind ;
   dcterms:description "electrical current intensity divided by the associated mass"@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ347#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ347#004" ;
   qudt:exactMatch quantitykind:MassicElectricCurrent ;
   qudt:hasDimensionVector qkdv:A0E1L0I0M-1H0T0D0 ;
   qudt:plainTextDescription "elektrische Stromstärke dividiert durch die zugehörige Masse"@de ;
@@ -11179,7 +11175,7 @@ quantitykind:MassicElectricCurrent
 quantitykind:MassicHeatCapacity
   a qudt:QuantityKind ;
   dcterms:description "ratio of heat capacity divided by mass"@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ345#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ345#005" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H-1T-2D0 ;
   qudt:iec61360Code "0112/2///62720#UAD112" ;
   qudt:plainTextDescription "Quotient Wärmekapazität dividiert durch Masse"@de ;
@@ -11189,7 +11185,7 @@ quantitykind:MassicHeatCapacity
 quantitykind:MassicPower
   a qudt:QuantityKind ;
   dcterms:description "ratio energy divided by time and related mass"@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ343#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ343#004" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-3D0 ;
   qudt:iec61360Code "0112/2///62720#UAD113" ;
   qudt:plainTextDescription "Quotient Energie durch Zeit und durch zugehöriger Masse"@de ;
@@ -11200,7 +11196,7 @@ quantitykind:MassicPower
 quantitykind:MassicTorque
   a qudt:QuantityKind ;
   dcterms:description "ratio of  torque divided by the mass to be moved"@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ442#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ442#004" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-2D0 ;
   qudt:iec61360Code "0112/2///62720#UAD114" ;
   qudt:plainTextDescription "Quotient Drehmoment dividiert durch die Masse, die bewegt oder befördert wird"@de ;
@@ -11452,7 +11448,7 @@ quantitykind:MechanicalTension
   dcterms:description """at a point of a body upon which a force acts which attempts to change the shape of the body, the limit
     value of the ratio between the force and area of a flat surface around this point when the dimensions approach zero
   """@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ204#005" ;
+  qudt:eclassCode "0173-1#Z4-BAJ204#008" ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:plainTextDescription """an einem Punkt eines Körpers, an dem eine Kraft angreift, welche die Form des Körpers zu verändern
     sucht, der Grenzwert des Quotienten Kraft durch Fläche einer ebenen Oberfläche um diesen Punkt, wenn deren Abmessungen gegen
@@ -11765,7 +11761,7 @@ quantitykind:MolarConductivity
 quantitykind:MolarDensity
   a qudt:QuantityKind ;
   dcterms:description "quantity whose value is inversely proportional to the quantity of material"@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ372#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ372#004" ;
   qudt:exactMatch quantitykind:InverseAmountOfSubstance ;
   qudt:hasDimensionVector qkdv:A-1E0L0I0M0H0T0D0 ;
   qudt:plainTextDescription "Größe, deren Wert sich umgekehrt proportional zu Stoffmengenwert verhält"@de ;
@@ -11986,7 +11982,7 @@ quantitykind:MolarRefractivity
 quantitykind:MolarThermalCapacity
   a qudt:QuantityKind ;
   dcterms:description "thermal capacity divided by the amount of substance"@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ355#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ355#004" ;
   qudt:exactMatch quantitykind:MolarHeatCapacity ;
   qudt:hasDimensionVector qkdv:A-1E0L2I0M1H-1T-2D0 ;
   qudt:plainTextDescription "auf die Stoffmenge bezogene Wärmekapazität"@de ;
@@ -11996,7 +11992,7 @@ quantitykind:MolarThermalCapacity
 quantitykind:MolarThermodynamicEnergy
   a qudt:QuantityKind ;
   dcterms:description "energy in relation to the amount of a substance"@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ353#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ353#004" ;
   qudt:hasDimensionVector qkdv:A-1E0L2I0M1H0T-2D0 ;
   qudt:plainTextDescription "auf die Stoffmenge bezogene Energie"@de ;
   qudt:specializationOf quantitykind:MolarEnergy ;
@@ -12283,7 +12279,7 @@ quantitykind:MotorConstant
     constant $K_t = \\tau / I$ (see quantitykind:TorqueConstant) and the back-EMF constant $K_e = V / \\omega$, both of which have
     the dimension of magnetic flux and are numerically equal to one another in coherent SI units.
   """^^qudt:LatexString ;
-  qudt:eclassCode "0173-1#Z4-BAJ358#003" ;
+  qudt:eclassCode "0173-1#Z4-BAJ358#005" ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0dot5H0T-0dot5D0 ;
   qudt:iec61360Code "0112/2///62720#UAD129" ;
   qudt:latexDefinition "$K_m = \\frac{\\tau}{\\sqrt{P}}$, where $\\tau$ is the motor torque and $P$ is the power dissipated in the windings."^^qudt:LatexString ;
@@ -12408,7 +12404,7 @@ quantitykind:NeutralRatio
   dcterms:description """ratio between two physical variables of the same type, expressed as a number which describes the
     relationship between these variables where the units are cancelled against each other
   """@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ359#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ359#005" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:organizedUnder quantitykind:DimensionlessRatio ;
   qudt:plainTextDescription """Quotient aus zwei physikalischen Größen gleicher Art als Zahl, welche das Verhältnis dieser Größen
@@ -13050,7 +13046,7 @@ quantitykind:ParticleCurrentDensity
    perpendicular to a surface equal to the net number of particles crossing that surface
    in the positive direction per unit area and per unit time.
   """^^qudt:LatexString ;
-  qudt:eclassCode "0173-1#Z4-BAJ388#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ388#005" ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T-1D0 ;
   qudt:iec61360Code "0112/2///62720#UAD132" ;
   qudt:organizedUnder quantitykind:ParticleFluenceRate ;
@@ -13420,7 +13416,7 @@ quantitykind:PhotonLuminance
   dcterms:description """ratio between the photon flux at a point on a surface and in a given direction and the product of the
     solid angle and the orthogonal projection of this element on a plane perpendicular to the given direction
   """@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ363#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ363#005" ;
   qudt:exactMatch quantitykind:PhotonRadiance ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T-1D0 ;
   qudt:iec61360Code "0112/2///62720#UAD138" ;
@@ -13484,7 +13480,7 @@ quantitykind:PictureElement
   dcterms:description """smallest element of a display space (cell size) of a digitized two-dimensional field representation of an
     image which has an address (x and y coordinates corresponding to its position in the field) and a specific brightness value
   """@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ437#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ437#004" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:iec61360Code "0112/2///62720#UAD299" ;
   qudt:plainTextDescription """kleinstes Element einer Darstellungsfläche (Zellgröße) einer digitalisierten zweidimensionalen
@@ -13642,7 +13638,7 @@ quantitykind:Polarizability
   """^^qudt:LatexString ;
   dcterms:description "measure of the deformability of the electron shell of molecules and atoms"@en ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Polarizability"^^xsd:anyURI ;
-  qudt:eclassCode "0173-1#Z4-BAJ365#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ365#004" ;
   qudt:hasDimensionVector qkdv:A0E2L0I0M-1H0T4D0 ;
   qudt:iec61360Code "0112/2///62720#UAD141" ;
   qudt:latexSymbol "$\\alpha$"^^qudt:LatexString ;
@@ -13825,7 +13821,7 @@ quantitykind:PowerAreaPerSolidAngle
 quantitykind:PowerConstant
   a qudt:QuantityKind ;
   dcterms:description "ratio indicating the relationship between continuous power and continuous current"@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ330#003" ;
+  qudt:eclassCode "0173-1#Z4-BAJ330#005" ;
   qudt:hasDimensionVector qkdv:A0E-1L1I0M1H0T-2D0 ;
   qudt:plainTextDescription "Verhältnis, das den Zusammenhang zwischen der Dauerkraft zum Dauerstrom kennzeichnet"@de ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
@@ -14003,7 +13999,7 @@ quantitykind:PressureBasedAmountOfSubstanceConcentration
   dcterms:description """ratio between the amount-of-substance concentration of a dissolved material (its amount of substance
     divided by the volume of the solution) and the related pressure
   """@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ307#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ307#004" ;
   qudt:hasDimensionVector qkdv:A1E0L-2I0M-1H0T2D0 ;
   qudt:plainTextDescription """Quotient Molarität (Quotient aus der Stoffmenge eines gelösten Stoffes und dem Volumen der Lösung)
     dividiert durch den zugehörigen Druck
@@ -14014,7 +14010,7 @@ quantitykind:PressureBasedAmountOfSubstanceConcentration
 quantitykind:PressureBasedDensity
   a qudt:QuantityKind ;
   dcterms:description "ratio of density divided by the related pressure"@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ299#003" ;
+  qudt:eclassCode "0173-1#Z4-BAJ299#005" ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T2D0 ;
   qudt:plainTextDescription "Quotient aus Dichte dividiert durch den zugehörigen Druck"@de ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
@@ -14023,7 +14019,7 @@ quantitykind:PressureBasedDensity
 quantitykind:PressureBasedDynamicViscosity
   a qudt:QuantityKind ;
   dcterms:description "ratio of dynamic viscosity divided by the related pressure"@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ300#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ300#004" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T1D0 ;
   qudt:plainTextDescription "Quotient aus der dynamischen Viskosität dividiert durch den zugehörigen Druck"@de ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
@@ -14032,7 +14028,7 @@ quantitykind:PressureBasedDynamicViscosity
 quantitykind:PressureBasedElectricCurrent
   a qudt:QuantityKind ;
   dcterms:description "ratio of electric current divided by the related pressure"@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ309#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ309#004" ;
   qudt:hasDimensionVector qkdv:A0E1L1I0M-1H0T2D0 ;
   qudt:plainTextDescription "Quotient elektrische Stromstärke dividiert durch den zugehörigen Druck"@de ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
@@ -14041,7 +14037,7 @@ quantitykind:PressureBasedElectricCurrent
 quantitykind:PressureBasedElectricVoltage
   a qudt:QuantityKind ;
   dcterms:description "ratio of electric voltage divided by the related pressure"@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ301#003" ;
+  qudt:eclassCode "0173-1#Z4-BAJ301#005" ;
   qudt:hasDimensionVector qkdv:A0E-1L3I0M0H0T-1D0 ;
   qudt:plainTextDescription "Quotient elektrischer Spannung dividiert durch den zugehörigen Druck"@de ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
@@ -14050,7 +14046,7 @@ quantitykind:PressureBasedElectricVoltage
 quantitykind:PressureBasedKinematicViscosity
   a qudt:QuantityKind ;
   dcterms:description "ratio of dynamic viscosity and density of the material divided by the related pressure"@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ303#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ303#004" ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M-1H0T1D0 ;
   qudt:plainTextDescription """Quotient aus der dynamischen Viskosität und der Dichte eines Stoffes dividiert durch den
     zugehörigen Druck
@@ -14061,7 +14057,7 @@ quantitykind:PressureBasedKinematicViscosity
 quantitykind:PressureBasedLength
   a qudt:QuantityKind ;
   dcterms:description "ratio of length divided by the related pressure"@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ304#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ304#004" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M-1H0T2D0 ;
   qudt:plainTextDescription "Quotient Länge dividiert durch den zugehörigen Druck"@de ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
@@ -14070,7 +14066,7 @@ quantitykind:PressureBasedLength
 quantitykind:PressureBasedMass
   a qudt:QuantityKind ;
   dcterms:description "ratio of mass divided by the related pressure"@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ305#003" ;
+  qudt:eclassCode "0173-1#Z4-BAJ305#005" ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T2D0 ;
   qudt:plainTextDescription "Quotient Masse dividiert durch den zugehörigen Druck"@de ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
@@ -14079,7 +14075,7 @@ quantitykind:PressureBasedMass
 quantitykind:PressureBasedMassFlow
   a qudt:QuantityKind ;
   dcterms:description "ratio of mass flow divided by the related pressure"@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ310#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ310#004" ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T1D0 ;
   qudt:plainTextDescription "Quotient Massenstrom dividiert durch den zugehörigen Druck"@de ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
@@ -14088,7 +14084,7 @@ quantitykind:PressureBasedMassFlow
 quantitykind:PressureBasedMolality
   a qudt:QuantityKind ;
   dcterms:description "ratio of molality divided by the related pressure"@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ306#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ306#004" ;
   qudt:hasDimensionVector qkdv:A1E0L1I0M-2H0T2D0 ;
   qudt:plainTextDescription "Quotient Molalität dividiert durch den zugehörigen Druck"@de ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
@@ -14103,7 +14099,7 @@ quantitykind:PressureBasedQuantity
 quantitykind:PressureBasedTemperature
   a qudt:QuantityKind ;
   dcterms:description "ratio of temperature divided by the related pressure"@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ308#003" ;
+  qudt:eclassCode "0173-1#Z4-BAJ308#005" ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M-1H1T2D0 ;
   qudt:plainTextDescription "Quotient Temperatur dividiert durch den zugehörigen Druck"@de ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
@@ -14121,7 +14117,7 @@ quantitykind:PressureBasedVelocity
 quantitykind:PressureBasedVolume
   a qudt:QuantityKind ;
   dcterms:description "ratio of volume divided by the related pressure"@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ312#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ312#004" ;
   qudt:hasDimensionVector qkdv:A0E0L4I0M-1H0T2D0 ;
   qudt:plainTextDescription "Quotient Volumen dividiert durch den zugehörigen Druck"@de ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
@@ -14130,7 +14126,7 @@ quantitykind:PressureBasedVolume
 quantitykind:PressureBasedVolumeFlow
   a qudt:QuantityKind ;
   dcterms:description "ratio of volume flow divided by the related pressure"@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ311#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ311#004" ;
   qudt:hasDimensionVector qkdv:A0E0L4I0M-1H0T1D0 ;
   qudt:plainTextDescription "Quotient Volumenstrom dividiert durch den zugehörigen Druck"@de ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
@@ -14167,7 +14163,7 @@ quantitykind:PressureCoefficient
 quantitykind:PressureGradient
   a qudt:QuantityKind ;
   dcterms:description "differential pressure divided by the associated length"@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ313#003" ;
+  qudt:eclassCode "0173-1#Z4-BAJ313#006" ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M1H0T-2D0 ;
   qudt:iec61360Code "0112/2///62720#UAD144" ;
   qudt:plainTextDescription "Differenzdruck dividiert durch die zugehörige Länge"@de ;
@@ -14179,7 +14175,7 @@ quantitykind:PressureInRelationToVolumeFlow
   dcterms:description """ratio between pressure and the volume flow at a given cross-sectional area, passing through this
     cross-sectional area
   """@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ290#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ290#004" ;
   qudt:exactMatch quantitykind:PressureInRelationToVolumeFlowRate ;
   qudt:hasDimensionVector qkdv:A0E0L-4I0M1H0T-1D0 ;
   qudt:plainTextDescription """an einer festgelegten Querschnittsfläche der Quotient Druck durch den Volumenstrom, der durch diese
@@ -14353,7 +14349,7 @@ quantitykind:QuantityOfLight
   dcterms:description """work of a light source provided in the form of light as the product of the luminous flux Φ produced by
     the light source and the time t for which this is radiated
   """@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ243#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ243#004" ;
   qudt:exactMatch quantitykind:LuminousEnergy ;
   qudt:hasDimensionVector qkdv:A0E0L0I1M0H0T1D0 ;
   qudt:iec61360Code "0112/2///62720#UAD147" ;
@@ -14695,7 +14691,7 @@ quantitykind:Radioactivity
     small period of time divided by this period, expressed as a ratio ∂N/∂t, where ∂N is the expected value for the number of
     spontaneous transformations from this state within the time period ∂t
   """@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ230#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ230#005" ;
   qudt:exactMatch quantitykind:Activity ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:plainTextDescription """Anzahl der spontanen Kernumwandlungen in einer gegebenen Menge eines Stoffes während eines
@@ -14806,7 +14802,7 @@ quantitykind:RateOfChangeOfFrequency
 quantitykind:RateOfRiseOfOffStateVoltage
   a qudt:QuantityKind ;
   dcterms:description "du/dt as time dependent change in voltage"@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ289#003" ;
+  qudt:eclassCode "0173-1#Z4-BAJ289#005" ;
   qudt:hasDimensionVector qkdv:A0E-1L2I0M1H0T-4D0 ;
   qudt:plainTextDescription "du/dt als zeitabhängige änderung der Spannung"@de ;
   qudt:specializationOf quantitykind:RateOfRiseOfVoltage ;
@@ -15006,7 +15002,7 @@ quantitykind:ReactorTimeConstant
 quantitykind:ReciprocalElectricResistance
   a qudt:QuantityKind ;
   dcterms:description "quantity whose value is inversely proportional to the resistance value"@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ375#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ375#005" ;
   qudt:exactMatch quantitykind:Conductance ;
   qudt:hasDimensionVector qkdv:A0E2L-2I0M-1H0T3D0 ;
   qudt:plainTextDescription "Größe, deren Wert sich umgekehrt proportional zum Widerstandswert verhält"@de ;
@@ -15016,7 +15012,7 @@ quantitykind:ReciprocalElectricResistance
 quantitykind:ReciprocalEnergy
   a qudt:QuantityKind ;
   dcterms:description "multiplicative inverse of energy"@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ417#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ417#004" ;
   qudt:exactMatch quantitykind:InverseEnergy ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M-1H0T2D0 ;
   qudt:iec61360Code "0112/2///62720#UAD155" ;
@@ -15027,7 +15023,7 @@ quantitykind:ReciprocalEnergy
 quantitykind:ReciprocalPlaneAngle
   a qudt:QuantityKind ;
   dcterms:description "quantity whose value is inversely proportional to the angle value"@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ376#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ376#004" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:plainTextDescription "Größe, deren Wert sich umgekehrt proportional zum Winkelwert verhält"@de ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
@@ -15036,7 +15032,7 @@ quantitykind:ReciprocalPlaneAngle
 quantitykind:ReciprocalVoltage
   a qudt:QuantityKind ;
   dcterms:description "quantity whose value is inversely proportional to the voltage value"@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ371#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ371#004" ;
   qudt:hasDimensionVector qkdv:A0E1L-2I0M-1H0T3D0 ;
   qudt:plainTextDescription "Größe, deren Wert sich umgekehrt proportional zum Spannungswert verhält"@de ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
@@ -15391,7 +15387,7 @@ quantitykind:Reluctance
 quantitykind:Repetency
   a qudt:QuantityKind ;
   dcterms:description "quantity whose value  is inversely proportional to the length value"@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ370#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ370#005" ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T0D0 ;
   qudt:iec61360Code "0112/2///62720#UAD160" ;
   qudt:plainTextDescription "Größe, deren Wert sich umgekehrt proportional zum Längenwert verhält"@de ;
@@ -15438,7 +15434,7 @@ quantitykind:ResistanceBasedInductance
   dcterms:description """magnetic flux through the loop, caused by an electric current in the loop, divided by the product of this
     current and the resistance which prevents the flow of current
   """@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ411#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ411#004" ;
   qudt:exactMatch quantitykind:InductanceBasedTimeConstant ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T1D0 ;
   qudt:plainTextDescription """Magnetfluss durch die Schleife, verursacht durch einen elektrischen Strom in der Schleife,
@@ -15665,7 +15661,7 @@ quantitykind:RiseOfOffStateVoltage
   dcterms:isReplacedBy quantitykind:RateOfRiseOfOffStateVoltage ;
   qudt:deprecated true ;
   qudt:deprecatedInVersion "3.2.0" ;
-  qudt:eclassCode "0173-1#Z4-BAJ289#003" ;
+  qudt:eclassCode "0173-1#Z4-BAJ289#005" ;
   qudt:hasDimensionVector qkdv:A0E-1L2I0M1H0T-4D0 ;
   qudt:plainTextDescription "du/dt als zeitabhängige änderung der Spannung"@de ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
@@ -15684,7 +15680,7 @@ quantitykind:Rotary-TranslatoryMotionConversion
 quantitykind:RotaryShock
   a qudt:QuantityKind ;
   dcterms:description "product of the moment of force M in a time interval multiplied by the duration of this interval"@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ234#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ234#004" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-1D0 ;
   qudt:plainTextDescription "Produkt Drehmoment M in einem Zeitintervall mal Dauer dt dieses Zeitintervalls"@de ;
   qudt:specializationOf quantitykind:AngularMomentum ;
@@ -17127,7 +17123,7 @@ quantitykind:SpectralConcentrationOfRadiantEnergyDensity
   dcterms:description """energy distribution of the instantaneous value of radiant energy in relation to the volume of the
     propagation medium
   """@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ379#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ379#004" ;
   qudt:exactMatch quantitykind:SpectralRadiantEnergyDensity ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M1H0T-2D0 ;
   qudt:plainTextDescription """Energieverteilung des Augenblickswertes der Strahlungsenergie, bezogen auf das Volumen des
@@ -17846,7 +17842,7 @@ quantitykind:SurfaceRelatedVolumeFlow
   dcterms:description """quotient of the volume of a material, which passes through a specified surface, and the therefor required
     time divided by this specified area
   """@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ421#003" ;
+  qudt:eclassCode "0173-1#Z4-BAJ421#006" ;
   qudt:exactMatch quantitykind:SurfaceRelatedVolumeFlowRate ;
   qudt:exactMatch quantitykind:VolumetricFlux ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T-1D0 ;
@@ -17912,7 +17908,7 @@ quantitykind:SurgeImpedanceOfTheMedium
   dcterms:description """in a mechanical system the area-related quotient of a force affecting to a point divided by the resulting
     component of the particle velocity in direction of the force
   """@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ323#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ323#004" ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M1H0T-1D0 ;
   qudt:iec61360Code "0112/2///62720#UAD185" ;
   qudt:plainTextDescription """in einem mechanischen System der flächenbezogene Quotient einer an einem Punkt angreifenden Kraft
@@ -17947,7 +17943,7 @@ quantitykind:Susceptance
 quantitykind:SymbolTransmissionRate
   a qudt:QuantityKind ;
   dcterms:description "rate, at which a symbol, consisting of one or more bits, is transmitted per second"@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ386#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ386#005" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:plainTextDescription "Geschwindigkeit, mit der ein aus mehreren Bit bestehendes Symbol je Sekunde übertragen wird"@de ;
   qudt:specializationOf quantitykind:DigitRate ;
@@ -18016,7 +18012,7 @@ quantitykind:TemperatureAmountOfSubstance
 quantitykind:TemperatureBasedAmountOfSubstanceConcentration
   a qudt:QuantityKind ;
   dcterms:description "ratio of material concentration divided by the related temperature"@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ395#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ395#004" ;
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H-1T0D0 ;
   qudt:plainTextDescription "Quotient aus Stoffmengenkonzentration dividiert durch die zugehörige Temperatur"@de ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
@@ -18025,7 +18021,7 @@ quantitykind:TemperatureBasedAmountOfSubstanceConcentration
 quantitykind:TemperatureBasedDensity
   a qudt:QuantityKind ;
   dcterms:description "ratio of density divided by the related temperature"@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ389#003" ;
+  qudt:eclassCode "0173-1#Z4-BAJ389#005" ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H-1T0D0 ;
   qudt:plainTextDescription "Quotient aus Dichte dividiert durch die zugehörige Temperatur"@de ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
@@ -18034,7 +18030,7 @@ quantitykind:TemperatureBasedDensity
 quantitykind:TemperatureBasedDynamicViscosity
   a qudt:QuantityKind ;
   dcterms:description "ratio of dynamic viscosity, divided by temperature"@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ390#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ390#004" ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H-1T-1D0 ;
   qudt:plainTextDescription "Quotient der dynamischen Viskosität dividiert durch die Temperatur"@de ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
@@ -18043,7 +18039,7 @@ quantitykind:TemperatureBasedDynamicViscosity
 quantitykind:TemperatureBasedKinematicViscosity
   a qudt:QuantityKind ;
   dcterms:description "ratio of dynamic viscosity and the density of a material, divided by the related temperature"@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ392#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ392#004" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H-1T-1D0 ;
   qudt:plainTextDescription """Quotient aus der dynamischen Viskosität und der Dichte eines Stoffes dividiert durch die zugehörige
     Temperatur
@@ -18054,7 +18050,7 @@ quantitykind:TemperatureBasedKinematicViscosity
 quantitykind:TemperatureBasedLength
   a qudt:QuantityKind ;
   dcterms:description "ratio of length divided by the related temperature"@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ393#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ393#004" ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H-1T0D0 ;
   qudt:plainTextDescription "Quotient aus Länge dividiert durch die zugehörige Temperatur"@de ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
@@ -18063,7 +18059,7 @@ quantitykind:TemperatureBasedLength
 quantitykind:TemperatureBasedMass
   a qudt:QuantityKind ;
   dcterms:description "ratio of mass divided by the related temperature"@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ394#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ394#004" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H-1T0D0 ;
   qudt:plainTextDescription "Quotient aus Masse dividiert durch die zugehörige Temperatur"@de ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
@@ -18072,7 +18068,7 @@ quantitykind:TemperatureBasedMass
 quantitykind:TemperatureBasedMassFlowRate
   a qudt:QuantityKind ;
   dcterms:description "ratio of mass flow divided by the related temperature"@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ396#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ396#004" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H-1T-1D0 ;
   qudt:plainTextDescription "Quotient aus Massenstrom dividiert durch die zugehörige Temperatur"@de ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
@@ -18096,7 +18092,7 @@ quantitykind:TemperatureBasedVelocity
 quantitykind:TemperatureBasedVolumeFlowRate
   a qudt:QuantityKind ;
   dcterms:description "ratio of volume flow divided by the related temperature"@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ397#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ397#004" ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H-1T-1D0 ;
   qudt:plainTextDescription "Quotient aus Volumenstrom dividiert durch die zugehörige Temperatur"@de ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
@@ -18159,7 +18155,7 @@ quantitykind:TemperatureRateOfChange
   dcterms:description """The "Temperature Rate of Change" measures the difference of a temperature per time (positive: rise,
     negative: fall), as for instance used with heat sensors. It is for example measured in K/s.
   """^^qudt:LatexString ;
-  qudt:eclassCode "0173-1#Z4-BAJ416#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ416#005" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H1T-1D0 ;
   qudt:iec61360Code "0112/2///62720#UAD186" ;
   qudt:plainTextDescription """The "Temperature Rate of Change" measures the difference of a temperature per time (positive: rise,
@@ -18182,7 +18178,7 @@ quantitykind:TemperatureRatio
 quantitykind:TemperatureRelatedMolarMass
   a qudt:QuantityKind ;
   dcterms:description "molarity (mass of a substance in relation to the amount of this substance) divided by temperature"@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ443#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ443#004" ;
   qudt:hasDimensionVector qkdv:A-1E0L0I0M1H-1T0D0 ;
   qudt:plainTextDescription """Molarität (Masse einer Substanz bezogen auf die Stoffmenge dieser Substanz ) dividiert durch die
     Temperatur
@@ -18193,7 +18189,7 @@ quantitykind:TemperatureRelatedMolarMass
 quantitykind:TemperatureRelatedVolume
   a qudt:QuantityKind ;
   dcterms:description "volume divided by temperature"@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ398#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ398#004" ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H-1T0D0 ;
   qudt:plainTextDescription "Volumen dividiert durch Temperatur"@de ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
@@ -18262,7 +18258,7 @@ quantitykind:ThermalCapacitance
   dcterms:description """ratio between the supplied quantity of heat and the temperature range caused by the supplied quantity of
     heat
   """@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ406#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ406#004" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H-1T-2D0 ;
   qudt:iec61360Code "0112/2///62720#UAD187" ;
   qudt:plainTextDescription """Quotient aus der zugeführten Wärmemenge und der Temperaturänderungen, die durch diese zugeführte
@@ -18276,7 +18272,7 @@ quantitykind:ThermalCoefficientOfLinearExpansion
   dcterms:description """median relative change in length over a specific length of the test piece, divided by the temperature
     range caused by it
   """@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ473#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ473#004" ;
   qudt:exactMatch quantitykind:LinearExpansionCoefficient ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H-1T0D0 ;
   qudt:iec61360Code "0112/2///62720#UAD188" ;
@@ -18473,7 +18469,7 @@ quantitykind:ThermalInsulation
   dcterms:description """temperature difference between two surfaces divided by areic heat flow rate in the direction of the
     temperature gradient
   """@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ404#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ404#004" ;
   qudt:exactMatch quantitykind:ThermalInsulance ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M-1H1T3D0 ;
   qudt:plainTextDescription """Temperaturdifferenz zwischen zwei Oberflächen dividiert durch den flächenbezogenen Wärmestrom in
@@ -18865,7 +18861,7 @@ quantitykind:TimeRelatedLogERatio
   dcterms:description """The natural (base-e) logarithm of the ratio of the value of a given quantity to the value of a reference
     quantity of the same type, divided by the related time. Its corresponding unit is the neper per second.
   """@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ415#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ415#005" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Time-related Logarithmic Ratio to Base e"@en-US ;
@@ -18879,7 +18875,7 @@ quantitykind:TimeRelatedLogarithmicRatio
   dcterms:isReplacedBy quantitykind:TimeRelatedLogERatio ;
   qudt:deprecated true ;
   qudt:deprecatedInVersion "3.5.0" ;
-  qudt:eclassCode "0173-1#Z4-BAJ415#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ415#005" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:plainTextDescription """Logarithmus des Verhältnisses des Werts einer gegebenen Größe zum Wert einer Bezugsgröße gleicher
     Art dividiert durch die zugehörige Zeit
@@ -18945,7 +18941,7 @@ quantitykind:TorqueConstant
   dcterms:description """product of magnetic induction, number of turns per unit length, and the area enclosed by the coil
     corresponding to the gradient of the curve representing the ratio between the torque of the motor and the current
   """@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ298#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ298#004" ;
   qudt:hasDimensionVector qkdv:A0E-1L2I0M1H0T-2D0 ;
   qudt:iec61360Code "0112/2///62720#UAD201" ;
   qudt:plainTextDescription """Produkt aus der magnetischen Induktion, der Windungszahl und der von der Spule eingeschlossenen
@@ -18982,7 +18978,7 @@ quantitykind:TorsionalSpringConstant
   dcterms:description """ratio between the turning moment for elastic deformation of a torsion spring and the related angle of
     rotation
   """@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ448#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ448#004" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Torsion_spring"^^xsd:anyURI ;
   qudt:plainTextDescription "Quotient Drehmoment zur elastischen Verformung einer Drehfeder durch den zugehörigen Drehwinkel"@de ;
@@ -19173,7 +19169,7 @@ quantitykind:TotalRadiance
   dcterms:description """ratio between the differential change in the energy fluence dΨ and the time interval dt: ψ = dΨ / dt; the
     total radiance is identical to the product of the particle flux density and the average energy of the particles
   """@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ318#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ318#004" ;
   qudt:exactMatch quantitykind:EnergyFluenceRate ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-3D0 ;
   qudt:plainTextDescription """Quotient aus der differentiellen Änderung der Energiefluenz dΨ im Zeitintervall dt: ψ = dΨ / dt;
@@ -19216,7 +19212,7 @@ quantitykind:TransmissionRatioBetweenRotationAndTranslation
   dcterms:description """relationship between rotational and longitudinal movements as a measure of how an angle is converted into
     a linear path
   """@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ400#003" ;
+  qudt:eclassCode "0173-1#Z4-BAJ400#005" ;
   qudt:exactMatch quantitykind:RotaryTranslatoryMotionConversion ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T0D0 ;
   qudt:plainTextDescription """Zusammenhang zwischen Dreh- und Längsbewegung als Maß dafür, wie ein überstrichener Drehwinkel in
@@ -19677,7 +19673,7 @@ quantitykind:Volume
 quantitykind:VolumeDensityOfCharge
   a qudt:QuantityKind ;
   dcterms:description "volume density of the electric charge Q present in a volume V"@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ368#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ368#005" ;
   qudt:exactMatch quantitykind:ElectricChargeVolumeDensity ;
   qudt:hasDimensionVector qkdv:A0E1L-3I0M0H0T1D0 ;
   qudt:plainTextDescription "räumliche Dichte der in einem Raumgebiet vom Volumen V enthaltenen elektrischen Ladung Q"@de ;
@@ -19759,7 +19755,7 @@ quantitykind:VolumeOrSectionModulus
   """@en ;
   qudt:deprecated true ;
   qudt:deprecatedInVersion "3.1.4" ;
-  qudt:eclassCode "0173-1#Z4-BAJ251#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ251#005" ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T0D0 ;
   qudt:plainTextDescription """der von einer Oberfläche eingeschlossene gesamte Rauminhalt, der für kartesische Koordinaten durch
     Integration nach folgender Gleichung ermittelt werden kann: V = ∫∫∫ dx dy dz oder bei einem homogenen Werkstoff Quotient
@@ -19843,7 +19839,7 @@ quantitykind:VolumetricElectricCharge
 quantitykind:VolumetricEntityDensity
   a qudt:QuantityKind ;
   dcterms:description "quantity whose value is inversely proportional to the volume value"@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ377#003" ;
+  qudt:eclassCode "0173-1#Z4-BAJ377#006" ;
   qudt:exactMatch quantitykind:InverseVolume ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M0H0T0D0 ;
   qudt:plainTextDescription "Größe, deren Wert sich umgekehrt proportional zum Volumenwert verhält"@de ;
@@ -19895,7 +19891,7 @@ quantitykind:VolumicAmountOfSubstance
   dcterms:description """quantity proportional to the number of single particles of a defined type present in a given sample,
     divided by the related volume of this sample
   """@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ402#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ402#004" ;
   qudt:hasDimensionVector qkdv:A1E0L-3I0M0H0T0D0 ;
   qudt:plainTextDescription """Größe proportional der Anzahl von Einzelteilchen festgelegter Art, die in einer gegebenen
     Substanzprobe enthalten sind, dividiert durch das zugehörige Volumen dieser Substanzprobe
@@ -19908,7 +19904,7 @@ quantitykind:VolumicDataQuantity
   dcterms:description """amount of data, which is usually dependent on the respective complexity of the information or its coding
     procedure, divided by the related volume
   """@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ401#002" ;
+  qudt:eclassCode "0173-1#Z4-BAJ401#004" ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M0H0T0D0 ;
   qudt:plainTextDescription """Anzahl von Daten, die in der Regel abhängig von der jeweiligen Komplexität der Information oder
     deren Codierungsverfahren ist, dividiert durch das zugehörige Volumen
@@ -19938,7 +19934,7 @@ quantitykind:VolumicElectromagneticEnergy
 quantitykind:VolumicOutput
   a qudt:QuantityKind ;
   dcterms:description "ratio released power divided by volume"@en ;
-  qudt:eclassCode "0173-1#Z4-BAJ366#003" ;
+  qudt:eclassCode "0173-1#Z4-BAJ366#005" ;
   qudt:exactMatch quantitykind:PowerDensity ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-3D0 ;
   qudt:plainTextDescription "Quotient freigesetzte Wärmeleistung durch Volumen"@de ;


### PR DESCRIPTION
* ECLASS Release 16.0 contains 279 `<unitsml:Quantity />` definitions.
* In QUDT 3.5.0, there are 150 quantity kinds that have an `qudt:eclassCode` assigned.
    * 20 quantity kinds with an `qudt:eclassCode`  are deprecated.
    * 130 quantity kinds with an `qudt:eclassCode` are not deprecated.
    * In total, there are 155 `qudt:eclassCode` statements.
* This PR updates the 155 statements so that they match the respective definition in ECLASS.
* There are some differences between ECLASS and QUDT w.r.t. dimensions:
    * A `<unitsml:Dimension />` definition can include `PlaneAngle` in addition to `AmountOfSubstance`, `ElectricCurrent`, `Length`, `LuminousIntensity`, `Mass`, `ThermodynamicTemperature`, and `Time`.
    * It models the `qudt:dimensionlessExponent` in a different way.
    * It doesn't have `qudt:qkdvNumerator` or `qudt:qkdvDenominator`.
