### PR TITLE
Normalize loop3d community extension IRIs to extension/loop3d/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
 ### Changed
 
 - Changed all qudt:symbol annotations with an ECLASS IRDI to qudt:eclassCode
+- Moved the `loop3d` community extension's graph IRIs from `http://qudt.org/community/loop3d` (and `…/community/loop3d/voc`) to `http://qudt.org/extension/loop3d` (and `…/extension/loop3d/voc`), with the maintainer's agreement, so that all community extensions live under a consistent `extension/{id}/` path. The vocabulary content (units) is unchanged.
 
 ### Deprecated
 

--- a/src/main/rdf/community/extensions/loop3d/README.md
+++ b/src/main/rdf/community/extensions/loop3d/README.md
@@ -6,15 +6,15 @@ The _profile_ is a specification formulated according to [the W3C's Profiles Voc
 
 The current profile elements are stored as files in this repository folder but should be accessed or refered to by their QUDT web addresses (persistent identifiers):
 
-* the Loop3D profile - <http://qudt.org/community/loop3d>
-  * the units vocabulary - <http://qudt.org/community/loop3d/voc>
+* the Loop3D profile - <http://qudt.org/extension/loop3d>
+  * the units vocabulary - <http://qudt.org/extension/loop3d/voc>
 
 ### Profile technical access
 
 Those elements can be accessed in _Linked Data_ forms via their web addresses too, i.e. as HTML web pages for humans (the default) or RDF documents for machines. _Content Negotiation_ can be used to get the RDF forms, for example a `curl` (command line program) request like this for the vocabulary in the _Turtle_ RDF format:
 
 ```bash
-curl -L -H 'Accept: text/turtle' http://qudt.org/community/loop3d/voc
+curl -L -H 'Accept: text/turtle' http://qudt.org/extension/loop3d/voc
 ```
 
 ## Contact

--- a/src/main/rdf/community/extensions/loop3d/VOCAB_QUDT-LOOP3D-UNITS.ttl
+++ b/src/main/rdf/community/extensions/loop3d/VOCAB_QUDT-LOOP3D-UNITS.ttl
@@ -7,7 +7,7 @@
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix unit: <http://qudt.org/vocab/unit/> .
 
-<http://qudt.org/community/loop3d/voc>
+<http://qudt.org/extension/loop3d/voc>
   a owl:Ontology, skos:ConceptScheme ;
   owl:imports <http://qudt.org/$$QUDT_VERSION$$/schema/qudt> ;
   owl:imports <http://www.w3.org/2004/02/skos/core> ;
@@ -53,7 +53,7 @@ unit:DEG
   skos:notation "DEG" ;
   skos:notation "deg" ;
   skos:prefLabel "Degree" ;
-  skos:topConceptOf <http://qudt.org/community/loop3d/voc> .
+  skos:topConceptOf <http://qudt.org/extension/loop3d/voc> .
 
 unit:KiloGM-PER-CentiM3
   a skos:Concept ;
@@ -61,7 +61,7 @@ unit:KiloGM-PER-CentiM3
   skos:altLabel "kilogram per cubic centimeter"@en-US ;
   skos:definition "Kilogram per cubic centimetre is an SI derived unit of density, defined by mass in kilograms divided by volume in cubic centimetres. The official SI symbolic abbreviation is $kg \\cdot cm^{-3}$, or equivalently either $kg/cm^3$."@en ;
   skos:prefLabel "kilogram per cubic centimetre"@en ;
-  skos:topConceptOf <http://qudt.org/community/loop3d/voc> .
+  skos:topConceptOf <http://qudt.org/extension/loop3d/voc> .
 
 unit:KiloGM-PER-M3
   a skos:Concept ;
@@ -69,7 +69,7 @@ unit:KiloGM-PER-M3
   skos:altLabel "kilogram per cubic meter"@en-US ;
   skos:definition "Kilogram per cubic metre is an SI derived unit of density, defined by mass in kilograms divided by volume in cubic metres. The official SI symbolic abbreviation is $kg \\cdot m^{-3}$, or equivalently either $kg/m^3$."@en ;
   skos:prefLabel "kilogram per cubic metre"@en ;
-  skos:topConceptOf <http://qudt.org/community/loop3d/voc> .
+  skos:topConceptOf <http://qudt.org/extension/loop3d/voc> .
 
 unit:M
   a skos:Concept ;
@@ -79,7 +79,7 @@ unit:M
   skos:notation "M" ;
   skos:notation "m" ;
   skos:prefLabel "Meter"@en ;
-  skos:topConceptOf <http://qudt.org/community/loop3d/voc> .
+  skos:topConceptOf <http://qudt.org/extension/loop3d/voc> .
 
 unit:MegaYR
   a skos:Concept ;
@@ -89,7 +89,7 @@ unit:MegaYR
   skos:notation "Myr" ;
   skos:notation "ma" ;
   skos:prefLabel "Million Years"@en ;
-  skos:topConceptOf <http://qudt.org/community/loop3d/voc> .
+  skos:topConceptOf <http://qudt.org/extension/loop3d/voc> .
 
 unit:MilliM
   a skos:Concept ;
@@ -98,7 +98,7 @@ unit:MilliM
   skos:notation "MM" ;
   skos:notation "mm" ;
   skos:prefLabel "Millimeter" ;
-  skos:topConceptOf <http://qudt.org/community/loop3d/voc> .
+  skos:topConceptOf <http://qudt.org/extension/loop3d/voc> .
 
 unit:PERCENT
   a skos:Concept ;
@@ -106,7 +106,7 @@ unit:PERCENT
   skos:definition "\"Percent\" is a unit for  'Dimensionless Ratio' expressed as $\\%$."@en ;
   skos:notation "%" ;
   skos:prefLabel "Percent" ;
-  skos:topConceptOf <http://qudt.org/community/loop3d/voc> .
+  skos:topConceptOf <http://qudt.org/extension/loop3d/voc> .
 
 unit:SUSCEPTIBILITY_MAG
   a skos:Concept ;
@@ -114,6 +114,6 @@ unit:SUSCEPTIBILITY_MAG
   skos:definition "Magnetic susceptibility is a dimensionless proportionality constant that indicates the degree of magnetization of a material in response to an applied magnetic field.  Here M = chi * H. Where M is the magnetization of the material (the magnetic dipole moment per unit volume), measured in amperes per meter, and H is the magnetic field strength, also measured in amperes per meter. Chi is therefore a dimensionless quantity."@en ;
   skos:notation "chi" ;
   skos:prefLabel "Magnetic Susceptibility" ;
-  skos:topConceptOf <http://qudt.org/community/loop3d/voc> .
+  skos:topConceptOf <http://qudt.org/extension/loop3d/voc> .
 
 

--- a/src/main/rdf/community/extensions/loop3d/profile.html
+++ b/src/main/rdf/community/extensions/loop3d/profile.html
@@ -189,7 +189,7 @@
     <script type="application/ld+json">
       [
   {
-    "@id": "http://qudt.org/community/loop3d",
+    "@id": "http://qudt.org/extension/loop3d",
     "@type": [
       "https://schema.org/DefinedTermSet"
     ],
@@ -213,7 +213,7 @@
     <h2 style="display:none;">Metadata</h2>
     <dl>
         <dt>URI</dt>
-        <dd><code>http://qudt.org/community/loop3d</code></dd>
+        <dd><code>http://qudt.org/extension/loop3d</code></dd>
         
         <dt><a class="proplink" href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/publisher">Publisher</a>(s)</dt>
         <dd>
@@ -251,13 +251,13 @@
         <dt><a class="proplink" href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/modified">Modified</a></dt>
         <dd>2020-12-27</dd>
         <dt>Profile RDF</dt>
-        <dd><a href="http://qudt.org/community/loop3d.ttl">RDF (turtle)</a></dd>
+        <dd><a href="http://qudt.org/extension/loop3d.ttl">RDF (turtle)</a></dd>
         <dt>Version Control Repository</dt>
         <dd><a href="https://github.com/qudt/qudt-public-repo/tree/master/community/loop3d">https://github.com/qudt/qudt-public-repo/tree/master/community/loop3d</a></dd>        
     </dl>
       <dt><a class="proplink" href="https://www.w3.org/TR/dx-prof/#Property:hasResource">Has Resource Descriptor(s)</a></dt>
     <dd>
-          <a href="#http://qudt.org/community/loop3d/voc">Loop3D Profile Vocabulary</a><br/>
+          <a href="#http://qudt.org/extension/loop3d/voc">Loop3D Profile Vocabulary</a><br/>
     </dd>
     <h2>Description</h2>
     <div id="comment">
@@ -272,7 +272,7 @@
   
   
   
-      <div class="entity resource_descriptor" id="http://qudt.org/community/loop3d/voc">
+      <div class="entity resource_descriptor" id="http://qudt.org/extension/loop3d/voc">
     <h3>Loop3D Profile Vocabulary</h3>
     <table>
         <tr>
@@ -283,7 +283,7 @@
         <tr>
           <th><a class="proplink" href="https://www.w3.org/TR/dx-prof/#Property:hasArtifact">Artifact</a></th>
           <td>
-            <a href="http://qudt.org/community/loop3d/voc">http://qudt.org/community/loop3d/voc</a>
+            <a href="http://qudt.org/extension/loop3d/voc">http://qudt.org/extension/loop3d/voc</a>
           </td>
         </tr>
         

--- a/src/main/rdf/community/extensions/loop3d/profile.ttl
+++ b/src/main/rdf/community/extensions/loop3d/profile.ttl
@@ -29,26 +29,26 @@
   sdo:name "SURROUND Australia Pty Ltd" ;
   sdo:url <https://surroundaustralia.com> .
 
-<http://qudt.org/community/loop3d>
+<http://qudt.org/extension/loop3d>
   a prof:Profile ;
   dcterms:created "2020-12-04"^^xsd:date ;
   dcterms:creator <https://orcid.org/0000-0002-8742-7730> ;
   dcterms:modified "2020-12-27"^^xsd:date ;
   dcterms:publisher <http://qudt.org> ;
   dcterms:title "Loop3D Profile" ;
-  prof:hasResource <http://qudt.org/community/loop3d/voc> ;
+  prof:hasResource <http://qudt.org/extension/loop3d/voc> ;
   skos:definition """This profile is of QUDT contains Units used by the Loop3D ontology.
     
 The general domain of the Loop3D ontology is geology and geoscience."""@en .
 
-<http://qudt.org/community/loop3d/voc>
+<http://qudt.org/extension/loop3d/voc>
   a prof:ResourceDescriptor ;
   dcterms:conformsTo <http://www.w3.org/TR/swbp-skos-core-spec> ;
   dcterms:description "A SKOS vocabulary of Units and other class instances from the QUDT ontology, used by the Loop3D ontology." ;
   dcterms:format "text/html" ;
   dcterms:format "text/turtle" ;
   dcterms:title "Loop3D Profile Vocabulary"@en ;
-  prof:hasArtifact <http://qudt.org/community/loop3d/voc> ;
+  prof:hasArtifact <http://qudt.org/extension/loop3d/voc> ;
   prof:hasRole role:vocabulary .
 
 

--- a/src/main/rdf/community/extensions/loop3d/voc.html
+++ b/src/main/rdf/community/extensions/loop3d/voc.html
@@ -189,7 +189,7 @@
     <script type="application/ld+json">
       [
   {
-    "@id": "http://qudt.org/community/loop3d/voc",
+    "@id": "http://qudt.org/extension/loop3d/voc",
     "@type": [
       "https://schema.org/DefinedTermSet"
     ],
@@ -218,7 +218,7 @@
       <h2 style="display:none;">Concept Scheme</h2>
       <dl>
           <dt>URI</dt>
-          <dd><code>http://qudt.org/community/loop3d/voc</code></dd>
+          <dd><code>http://qudt.org/extension/loop3d/voc</code></dd>
           <dt><a class="proplink" href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/publisher">Publisher</a>(s)</dt>
           <dd>
               
@@ -255,7 +255,7 @@
           <dt><a class="proplink" href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/modified">Modified</a></dt>
           <dd>2020-12-04</dd>
           <dt>Vocabulary RDF</dt>
-          <dd><a href="http://qudt.org/community/loop3d/voc.ttl">RDF (turtle)</a></dd>
+          <dd><a href="http://qudt.org/extension/loop3d/voc.ttl">RDF (turtle)</a></dd>
           <dt>Version Control Repository</dt>
           <dd><a href="https://github.com/qudt/qudt-public-repo/tree/master/community/loop3d">https://github.com/qudt/qudt-public-repo/tree/master/community/loop3d</a></dd>              
       </dl>


### PR DESCRIPTION
## The problem

QUDT community extensions should live under a consistent `http://qudt.org/extension/{id}/…` IRI prefix so they can be published and resolved uniformly. The `loop3d` extension was the one exception: its graph IRIs sat under `http://qudt.org/community/loop3d` (and `…/community/loop3d/voc`), a relic of how it was originally contributed.

We deliberately did **not** change this unilaterally — `loop3d`'s structure (`profile.ttl` + `voc`) is a deliberate W3C/VocPub layout maintained by the Loop3D community (SURROUND Australia tooling), and the IRI is referenced in their downstream data.

## The change

With the maintainer's explicit agreement (Loop3D will update their in-house data), move the declared graph IRIs:

- `http://qudt.org/community/loop3d`     → `http://qudt.org/extension/loop3d`
- `http://qudt.org/community/loop3d/voc` → `http://qudt.org/extension/loop3d/voc`

across the five `loop3d` files (`VOCAB_QUDT-LOOP3D-UNITS.ttl`, `profile.ttl`, `profile.html`, `voc.html`, `README.md`).

`loop3d` keeps its own internal `voc`/`profile` structure within the new prefix — consistent with the convention that QUDT-authored extensions follow `extension/{id}/vocab/{name}` while community-authored ones may keep their own layout under `extension/{id}/`.

**Unit/vocabulary content is unchanged** — this is purely the graph IRIs.

## Notes

- Stale GitHub source-tree links in the maintainer's generated HTML (`github.com/qudt/qudt-public-repo/tree/master/community/loop3d`) were left as-is — they are pre-existing and unrelated to the qudt.org IRI.
- **Follow-on (qudt-r2, separate):** the `communityextensions` publish target derives each graph's server path from its declared IRI, so `loop3d` will publish at `/extension/loop3d/voc` automatically; a `301` redirect from the old `/community/loop3d/voc` will be added for the transition.

## Verification

`mvn clean install -Dqudt.supported.extensions=loop3d -Dqudt.allInOne.extensions=loop3d` — green. Declared ontology IRIs and built dist confirmed at the new `extension/loop3d/...` paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)