### PR TITLE
Fix applicableUnit tie-breaking; add specializationOf/organizedUnder disjointness validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
 
 ### Added
 
+- Added `qudt:SpecializationOfAndOrganizedUnderDisjointShape`, a Violation-severity QA check that fires when a non-deprecated quantity kind carries both an outgoing `qudt:specializationOf` and an outgoing `qudt:organizedUnder`. The two properties are mutually exclusive by design.
 - Added rigor to building the quantity kind commensurability families. Now, a quantity kind family now constitutes the necessary and sufficient requirement for commensurability.
 - Added code to automatically convert labels for quantity kinds into Title Case
 - Added qudt:eclassCode
@@ -32,6 +33,7 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
 
 ### Fixed
 
+- Fixed `inferApplicableUnits` to union units from all equidistant unit-bearing ancestors instead of arbitrarily picking one. The previous `ORDER BY … LIMIT 1` pattern was non-deterministic when two parents sat at the same minimum distance; the new query computes `MIN(?steps)` and keeps every ancestor at that distance, deterministically unioning their units.
 - Fixed a missing qudt:element property for datatype:ONstate and datatype:OFFstate
 
 ## [3.3.0] - 2026-05-25

--- a/src/build/inference/inferApplicableUnits.ttl
+++ b/src/build/inference/inferApplicableUnits.ttl
@@ -47,43 +47,63 @@ sq:qkRule
                  (CONCAT("Applicable units are those of ",
                    REPLACE(STR(?qk),"http://qudt.org/vocab/quantitykind/","quantitykind:")) as ?comment)
             WHERE {
+                # Step 1: find the minimum path length to any unit-bearing non-deprecated ancestor.
+                # Two ancestors at the same minimum distance (multi-parent tie) both qualify.
                 {
-                    SELECT
-                        $this
-                        ?qk
-                        ?steps
+                    SELECT $this (MIN(?s) AS ?minSteps)
                     WHERE {
                         {
-                            SELECT
-                                $this
-                                ?qk
-                                (COUNT(*) as ?steps)
+                            SELECT $this ?qk2 (COUNT(*) AS ?s)
                             WHERE {
-                                $this (skos:broader|qudt:organizedUnder)* ?mid .
-                                ?mid (skos:broader|qudt:organizedUnder)* ?qk .
+                                $this (skos:broader|qudt:organizedUnder)* ?mid2 .
+                                ?mid2 (skos:broader|qudt:organizedUnder)* ?qk2 .
                             }
-                            GROUP BY $this ?qk
+                            GROUP BY $this ?qk2
                         }
                         FILTER EXISTS {
-                            ?unit qudt:hasQuantityKind ?qk .
+                            ?u qudt:hasQuantityKind ?qk2 .
                             {
-                                  ?unit a qudt:Unit .
+                                  ?u a qudt:Unit .
                             } UNION {
-                                  ?unit a qudt:CurrencyUnit .
+                                  ?u a qudt:CurrencyUnit .
                             }
                             FILTER NOT EXISTS {
-                                ?unit qudt:deprecated true
+                                ?u qudt:deprecated true
                             }
                         }
                         # do not source applicable units from a deprecated quantity kind;
-                        # $this then falls through to the nearest live ?qk
+                        # $this then falls through to the nearest live ancestor
                         FILTER NOT EXISTS {
-                            ?qk qudt:deprecated true
+                            ?qk2 qudt:deprecated true
                         }
-
                     }
-                    ORDER BY ASC(?steps)
-                    LIMIT 1
+                    GROUP BY $this
+                }
+                # Step 2: enumerate all unit-bearing ancestors at exactly the minimum distance,
+                # unioning their units.  For most quantity kinds this is a single ancestor (no tie);
+                # for multi-parent kinds such as SignalStrength all equidistant ancestors contribute.
+                {
+                    SELECT $this ?qk (COUNT(*) AS ?steps)
+                    WHERE {
+                        $this (skos:broader|qudt:organizedUnder)* ?mid .
+                        ?mid (skos:broader|qudt:organizedUnder)* ?qk .
+                    }
+                    GROUP BY $this ?qk
+                }
+                FILTER(?steps = ?minSteps)
+                FILTER EXISTS {
+                    ?unit qudt:hasQuantityKind ?qk .
+                    {
+                          ?unit a qudt:Unit .
+                    } UNION {
+                          ?unit a qudt:CurrencyUnit .
+                    }
+                    FILTER NOT EXISTS {
+                        ?unit qudt:deprecated true
+                    }
+                }
+                FILTER NOT EXISTS {
+                    ?qk qudt:deprecated true
                 }
                 ?unit qudt:hasQuantityKind ?qk .
                 {

--- a/src/main/rdf/validation/COLLECTION_QUDT_QA_TESTS_ALL.ttl
+++ b/src/main/rdf/validation/COLLECTION_QUDT_QA_TESTS_ALL.ttl
@@ -717,6 +717,26 @@ qudt:ScalingOfAndFactorUnitsPresent
   ] ;
   sh:targetClass qudt:Concept .
 
+qudt:SpecializationOfAndOrganizedUnderDisjointShape
+  a sh:NodeShape ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/collection/qa/all> ;
+  rdfs:label "Violation when a quantity kind has both outgoing qudt:specializationOf and qudt:organizedUnder" ;
+  sh:severity sh:Violation ;
+  sh:sparql [
+    a sh:SPARQLConstraint ;
+    sh:message "{$this} has both qudt:specializationOf {?specializationParent} and qudt:organizedUnder {?organizationParent}. A quantity kind must use at most one outgoing relation type: specializationOf asserts commensurability with the parent family; organizedUnder is a non-commensurate categorical grouping. Using both is contradictory." ;
+    sh:prefixes <http://qudt.org/$$QUDT_VERSION$$/collection/qa/allPrefixes> ;
+    sh:select """
+        SELECT $this ?specializationParent ?organizationParent
+        WHERE {
+          $this qudt:specializationOf ?specializationParent .
+          $this qudt:organizedUnder ?organizationParent .
+          FILTER NOT EXISTS { $this qudt:deprecated true }
+        }
+      """ ;
+  ] ;
+  sh:targetClass qudt:QuantityKind .
+
 qudt:SpecializationOfSameDimensionShape
   a sh:NodeShape ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/collection/qa/all> ;


### PR DESCRIPTION
## Context

PR #1481 ("Move commensurability inference onto the precise relations") introduced `qudt:specializationOf` and `qudt:organizedUnder` as distinct subproperties of `skos:broader`, replacing the single coarse `skos:broader` edge for quantity-kind hierarchy. Both relations still materialise to `skos:broader` via `materializeRelationSuperProperties.ttl`, but they carry different semantics:

- **`qudt:specializationOf`** — the child is commensurable with its parent; unit conversion is licensed within the resulting family.
- **`qudt:organizedUnder`** — the child is categorically related to the parent but is **not** commensurable; no unit conversion is implied.

Two latent defects became apparent once these precise relations were in place.

## Changes

### 1. `src/build/inference/inferApplicableUnits.ttl` — deterministic union on multi-parent ties

The previous algorithm walked `(skos:broader|qudt:organizedUnder)*` upward, found the nearest unit-bearing ancestor by `ORDER BY ASC(?steps) LIMIT 1`, and emitted that single ancestor's units. `LIMIT 1` is non-deterministic when two parents sit at the same minimum distance and both carry units: the SPARQL engine picks one arbitrarily.

**Live example:** `quantitykind:SignalStrength` has `qudt:specializationOf` edges to both `quantitykind:ElectricField` (3 units) and `quantitykind:ElectricFieldStrength` (10 units) — independent roots at distance 1. The build arbitrarily chose `ElectricField`'s 3 units, silently dropping the other 10.

**Fix:** Replace `ORDER BY ASC(?steps) LIMIT 1` with a two-subquery pattern:

1. Compute `MIN(?steps)` across all unit-bearing non-deprecated ancestors.
2. Keep every ancestor at exactly that minimum distance, then union their units.

For the common case (unique nearest ancestor) the result is identical. For tied ancestors the units are unioned deterministically. Quantity kinds with no unit-bearing ancestors continue to produce no `applicableUnit` triples.

The precise `specializationOf`/`organizedUnder` split that PR #1481 introduced makes this tie scenario more likely going forward (quantity kinds will increasingly have multiple typed parents at the same depth), so fixing the algorithm now avoids silent build-order sensitivity.

### 2. `src/main/rdf/validation/COLLECTION_QUDT_QA_TESTS_ALL.ttl` — disjointness constraint

Because `specializationOf` and `organizedUnder` assert contradictory things about commensurability, a quantity kind must use **at most one** of them as an outgoing relation type. No constraint previously enforced this.

Added `qudt:SpecializationOfAndOrganizedUnderDisjointShape` (`sh:Violation`) that fires when a non-deprecated quantity kind carries both an outgoing `qudt:specializationOf` and an outgoing `qudt:organizedUnder`.

## Test plan

- [ ] `mvn install` passes with no new violations
- [ ] Verify `target/inferred/applicableUnits.ttl` for `quantitykind:SignalStrength` now lists units from **both** `ElectricField` and `ElectricFieldStrength`
- [ ] Confirm no existing quantity kind triggers the new disjointness violation (currently zero have both relation types)

🤖 Generated with [Claude Code](https://claude.com/claude-code)