### PR TITLE
Harden the Release workflow: zip validation, failure cleanup, version guard, snapshot default

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,6 +120,51 @@ jobs:
         env:
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Guard the irreversible steps that follow: the GitHub Release asset and the qudt-r2
+      # website publish both consume this exact zip, and qudt-r2 deploys it to the live site
+      # without re-checking it. The build pipeline already SHACL-validates the RDF content, so
+      # this gate targets packaging corruption (truncated/incomplete zip, missing core files).
+      - name: Validate release zip
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          zips=(target/checkout/target/qudt-public-repo-*.zip)
+          if [ ${#zips[@]} -ne 1 ]; then
+            echo "Expected exactly one release zip, found ${#zips[@]}: ${zips[*]:-none}" >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+          zip="${zips[0]}"
+          echo "Validating $zip"
+
+          # 1. Integrity: the archive is complete and not corrupted
+          unzip -t "$zip" > /dev/null
+
+          listing="$(unzip -Z1 "$zip")"
+
+          # 2. Core artifacts are present
+          required=(
+            "vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl"
+            "vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL.ttl"
+            "schema/shacl/SCHEMA_QUDT_NoOWL.ttl"
+            "QUDT-all-in-one-OWL.ttl"
+            "QUDT-all-in-one-SHACL.ttl"
+          )
+          for f in "${required[@]}"; do
+            if ! grep -qxF "$f" <<< "$listing"; then
+              echo "Release zip is missing required entry: $f" >> "$GITHUB_STEP_SUMMARY"
+              exit 1
+            fi
+          done
+
+          # 3. Sanity floor on Turtle count (catches a well-formed but near-empty build)
+          ttl_count="$(grep -c '\.ttl$' <<< "$listing" || true)"
+          if [ "${ttl_count:-0}" -lt 20 ]; then
+            echo "Release zip contains only ${ttl_count} .ttl files (expected >= 20)" >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+          echo "Release zip validated: ${ttl_count} .ttl files, all core artifacts present." >> "$GITHUB_STEP_SUMMARY"
+
       # Read version changelog
       - id: get-changelog
         name: Get version changelog

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,6 +184,7 @@ jobs:
           EOF
           cat src/build/release/release-body-footer.md >> target/release-body.md
       - name: Release
+        id: gh_release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: v${{ inputs.release_version }}
@@ -242,3 +243,19 @@ jobs:
       # print the summary
       - name: Print summary
         run: echo "Release ${{ inputs.release_version }} was built and published on GitHub." >> $GITHUB_STEP_SUMMARY
+
+      # If the release aborted before the GitHub Release was published (e.g. the zip validation
+      # gate failed), release:prepare has already pushed the tag v<version> and the release branch.
+      # The leftover tag makes the "Check if tag exists" guard abort any re-run of this version, so
+      # clean both up. This is gated on the Release step NOT having succeeded: once the Release is
+      # published the tag is real (and qudt-r2 may already have deployed it), so we must not delete it.
+      - name: Clean up release tag and branch on failed release
+        if: failure() && steps.gh_release.outcome != 'success'
+        env:
+          version: ${{ inputs.release_version }}
+          branch: ${{ steps.create_release_branch.outputs.branch_name }}
+        run: |
+          git push origin ":refs/tags/v${version}" || echo "No remote tag v${version} to delete"
+          if [ -n "${branch:-}" ]; then
+            git push origin --delete "${branch}" || echo "No remote branch ${branch} to delete"
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,8 @@ on:
         required: true
         type: string
       next_snapshot_version:
-        description: 'Next SNAPSHOT version (such as 2.4-SNAPSHOT)'
-        required: true
+        description: 'Next SNAPSHOT version. Leave blank to default to the release version with PATCH+1 and -SNAPSHOT (e.g. 3.4.1 -> 3.4.2-SNAPSHOT).'
+        required: false
         type: string
       previous_release_year:
         description: 'The Year (YYYY) the last release was published'
@@ -54,6 +54,53 @@ jobs:
         run: |
           echo Tag v${{ inputs.release_version }} already exists, release aborted >> $GITHUB_STEP_SUMMARY
           exit 1
+
+      # Guard against fat-fingered versions: the release must be a single increment of the last
+      # released vX.Y.Z tag (PATCH+1, MINOR+1 with PATCH reset, or MAJOR+1 with MINOR/PATCH reset).
+      # Also resolve the next SNAPSHOT version, defaulting to release_version with PATCH+1 when the
+      # input was left blank, and expose it as an output for the build and PR-body steps.
+      - name: Validate version and resolve next snapshot
+        id: resolve_versions
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          release_version: ${{ inputs.release_version }}
+          next_snapshot_input: ${{ inputs.next_snapshot_version }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$release_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "release_version '$release_version' must be of the form X.Y.Z" >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+          IFS='.' read -r RMAJ RMIN RPAT <<< "$release_version"
+
+          last="$(gh api --paginate "repos/${REPO}/tags" --jq '.[].name' \
+            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+            | sed 's/^v//' \
+            | sort -t. -k1,1n -k2,2n -k3,3n \
+            | tail -n1 || true)"
+
+          if [[ -z "$last" ]]; then
+            echo "No previous vX.Y.Z release tag found; skipping increment check."
+          else
+            IFS='.' read -r LMAJ LMIN LPAT <<< "$last"
+            if [[ ( "$RMAJ" == "$LMAJ" && "$RMIN" == "$LMIN" && "$RPAT" == "$((LPAT+1))" ) \
+               || ( "$RMAJ" == "$LMAJ" && "$RMIN" == "$((LMIN+1))" && "$RPAT" == "0" ) \
+               || ( "$RMAJ" == "$((LMAJ+1))" && "$RMIN" == "0" && "$RPAT" == "0" ) ]]; then
+              echo "Version check OK: $last -> $release_version"
+            else
+              echo "release_version $release_version is not a single increment of last release $last (allowed: $LMAJ.$LMIN.$((LPAT+1)), $LMAJ.$((LMIN+1)).0, or $((LMAJ+1)).0.0)" >> "$GITHUB_STEP_SUMMARY"
+              exit 1
+            fi
+          fi
+
+          if [[ -n "${next_snapshot_input}" ]]; then
+            next_snapshot="${next_snapshot_input}"
+          else
+            next_snapshot="${RMAJ}.${RMIN}.$((RPAT+1))-SNAPSHOT"
+          fi
+          echo "Next snapshot version: $next_snapshot"
+          echo "next_snapshot_version=${next_snapshot}" >> "$GITHUB_OUTPUT"
 
       # Set up java with maven cache
       - uses: actions/checkout@v3
@@ -115,7 +162,7 @@ jobs:
           mvn -Pzip -B release:clean release:prepare release:perform \
             -DtagNameFormat="v@{project.version}" \
             -DreleaseVersion=${{ inputs.release_version }} \
-            -DdevelopmentVersion=${{ inputs.next_snapshot_version }} \
+            -DdevelopmentVersion=${{ steps.resolve_versions.outputs.next_snapshot_version }} \
             -Darguments="-DqudtPrevReleaseYear=${{ inputs.previous_release_year }} -DqudtPrevReleaseMonth=${{ inputs.previous_release_month }}"
         env:
           password: ${{ secrets.GITHUB_TOKEN }}
@@ -220,7 +267,7 @@ jobs:
             Automated release through workflow: '${{ github.workflow }}'
             Triggered by: ${{ github.triggering_actor }}
             Version: ${{ inputs.release_version }}
-            Next development version: ${{ inputs.next_snapshot_version }}
+            Next development version: ${{ steps.resolve_versions.outputs.next_snapshot_version }}
             
             # Next Steps
             

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
 
 ## [Unreleased]
 
+### Added
+
+- Added a release-pipeline validation gate that checks the distribution zip — archive integrity, presence of the core artifacts (units, quantity kinds, the normative SHACL schema, and the all-in-one files), and a sanity floor on the Turtle-file count — before the GitHub Release is published and before the qudt-r2 website publish is triggered, so a corrupted or incomplete build cannot reach the live site.
+
 ## [3.4.0] - 2026-06-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
 ### Added
 
 - Added a release-pipeline validation gate that checks the distribution zip — archive integrity, presence of the core artifacts (units, quantity kinds, the normative SHACL schema, and the all-in-one files), and a sanity floor on the Turtle-file count — before the GitHub Release is published and before the qudt-r2 website publish is triggered, so a corrupted or incomplete build cannot reach the live site. When a release aborts before the GitHub Release is published, the workflow now also deletes the tag and branch that `release:prepare` had already pushed, so the same version can simply be re-run without manual cleanup.
+- Added a version-increment guard to the Release workflow: the requested release version must be a single step from the last released `vX.Y.Z` tag (PATCH+1, MINOR+1 with PATCH reset, or MAJOR+1 with MINOR/PATCH reset), failing fast otherwise. The `next_snapshot_version` input is now optional and defaults to the release version with PATCH+1 and `-SNAPSHOT` (e.g. `3.4.1` → `3.4.2-SNAPSHOT`) when left blank.
 
 ## [3.4.0] - 2026-06-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
 
 ### Added
 
-- Added a release-pipeline validation gate that checks the distribution zip — archive integrity, presence of the core artifacts (units, quantity kinds, the normative SHACL schema, and the all-in-one files), and a sanity floor on the Turtle-file count — before the GitHub Release is published and before the qudt-r2 website publish is triggered, so a corrupted or incomplete build cannot reach the live site.
+- Added a release-pipeline validation gate that checks the distribution zip — archive integrity, presence of the core artifacts (units, quantity kinds, the normative SHACL schema, and the all-in-one files), and a sanity floor on the Turtle-file count — before the GitHub Release is published and before the qudt-r2 website publish is triggered, so a corrupted or incomplete build cannot reach the live site. When a release aborts before the GitHub Release is published, the workflow now also deletes the tag and branch that `release:prepare` had already pushed, so the same version can simply be re-run without manual cleanup.
 
 ## [3.4.0] - 2026-06-25
 


### PR DESCRIPTION
Hardens the `Release` workflow against the failure modes surfaced while reviewing the 3.4.0 release. Four independent changes, each a separate commit.

## 1. Validate the distribution zip before publishing or deploying
A new gate runs after the Maven build, **before** the GitHub Release is published and before the qudt-r2 website-publish dispatch (qudt-r2 deploys this exact zip to the live site without re-checking it). Checks:
- archive integrity (`unzip -t`),
- presence of core artifacts (units, quantity kinds, the normative SHACL schema, both all-in-one files),
- a sanity floor on the Turtle-file count.

Targets packaging corruption; content is already SHACL-validated upstream, so the gate stays fast and dependency-free.

## 2. Auto-clean tag and branch when a release aborts pre-publish
If the release fails before the GitHub Release is published (most likely at the new gate), `release:prepare` has already pushed the tag `v<version>` and the release branch — which would make the "Check if tag exists" guard block any re-run. An `if: failure()` step now deletes them, **gated on the Release step not having succeeded** so a published release (whose later steps failed) keeps its tag.

## 3. Version-increment guard
The requested `release_version` must be a single step from the last released `vX.Y.Z` tag — PATCH+1, MINOR+1 (PATCH reset), or MAJOR+1 (MINOR/PATCH reset) — failing fast otherwise, to catch fat-fingered versions before anything is built.

## 4. Auto-default the next snapshot
`next_snapshot_version` is now optional; left blank it defaults to `release_version` with PATCH+1 and `-SNAPSHOT` (e.g. `3.4.1` → `3.4.2-SNAPSHOT`). The build and PR-body steps read the resolved value.

All changes verified locally (YAML parse, good/truncated-zip cases, increment accept/reject matrix, live tag lookup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)