### PR TITLE
Materialize exactMatch symmetry for quantity kinds; propagate units across exactMatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
 
 ## [Unreleased]
 
+### Changed
+
+- The symmetric-relation inference (driven by `qudt:SymmetricRelation`, currently only `qudt:exactMatch`) now materialises the inverse triple for **quantity kinds** as well as units, so `qudt:exactMatch` need only be authored in one direction.
+- `qudt:unitForQuantityKind` is now propagated across the `qudt:exactMatch` equivalence closure before applicable-unit inference, so every member of an `exactMatch` clique shares the same applicable units even when a unit is authored on only one member. Applicable-unit inference itself still traverses `qudt:specializationOf` only; this pre-step is what lets it reach `exactMatch` siblings without crossing the relation directly.
+
 ## [3.4.0] - 2026-06-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
 
 ### Changed
 
-- The symmetric-relation inference (driven by `qudt:SymmetricRelation`, currently only `qudt:exactMatch`) now materialises the inverse triple for **quantity kinds** as well as units, so `qudt:exactMatch` need only be authored in one direction.
+- The symmetric-relation inference (driven by `qudt:SymmetricRelation`, currently only `qudt:exactMatch`) now materialises the inverse triple for **quantity kinds**, **physical constants**, and **prefixes**, as well as units, so `qudt:exactMatch` need only be authored in one direction. (Coordinate reference frames and datatypes also use `qudt:exactMatch` but aren't yet covered, pending a way to target their multi-level subclass hierarchies; see the `rdfs:comment` on `qudt:SymmetricRelationShape`.) Previously the inference was wired up for units only — broadening `sh:targetClass` to other classes had no effect unless their graph was also fed into the inference step, which it wasn't.
 - `qudt:unitForQuantityKind` is now propagated across the `qudt:exactMatch` equivalence closure before applicable-unit inference, so every member of an `exactMatch` clique shares the same applicable units even when a unit is authored on only one member. Applicable-unit inference itself still traverses `qudt:specializationOf` only; this pre-step is what lets it reach `exactMatch` siblings without crossing the relation directly.
 
 ## [3.4.0] - 2026-06-25

--- a/pom.xml
+++ b/pom.xml
@@ -1730,6 +1730,26 @@ validAspectDirs.each { aspectDir ->
                                         <toGraph>dist:vocab:VOCAB_QUDT-QUANTITY-KINDS-ALL.ttl</toGraph>
                                     </add>
 
+                                    <shaclInfer> <!-- fan qudt:unitForQuantityKind out across the qudt:exactMatch closure, so exactMatch siblings share applicable units; must precede the hasQuantityKind materialize below so propagated links are materialized too -->
+                                        <message>Propagating qudt:unitForQuantityKind across qudt:exactMatch</message>
+                                        <shapes>
+                                            <file>src/build/inference/propagateUnitForQuantityKindAcrossExactMatch.ttl</file>
+                                        </shapes>
+                                        <data>
+                                            <file>target/dist/schema/SCHEMA_QUDT.ttl</file>
+                                            <graph>dist:vocab:VOCAB_QUDT-QUANTITY-KINDS-ALL.ttl</graph>
+                                            <graph>dist:vocab:VOCAB_QUDT-UNITS-ALL.ttl</graph>
+                                        </data>
+                                        <inferred>
+                                            <graph>inferred:propagatedUnitForQuantityKind</graph>
+                                            <file>target/inferred/propagatedUnitForQuantityKind.ttl</file>
+                                        </inferred>
+                                    </shaclInfer>
+                                    <add>
+                                        <graph>inferred:propagatedUnitForQuantityKind</graph>
+                                        <toGraph>dist:vocab:VOCAB_QUDT-UNITS-ALL.ttl</toGraph>
+                                    </add>
+
                                     <shaclInfer> <!-- materialize qudt:hasQuantityKind from qudt:unitForQuantityKind / qudt:categorizedByQuantityKind (backward-compat super) before applicableUnit inference -->
                                         <message>Materializing qudt:hasQuantityKind from qudt:unitForQuantityKind / qudt:categorizedByQuantityKind</message>
                                         <shapes>

--- a/pom.xml
+++ b/pom.xml
@@ -1711,6 +1711,63 @@ validAspectDirs.each { aspectDir ->
                                     </sparqlUpdate>
                                     <savepoint><id>01-iec-links</id></savepoint>
 
+                                    <shaclInfer> <!-- materialize the inverse of qudt:exactMatch (and other symmetric relations) on quantity kinds; the unit-side equivalent runs later, see owl-subset-units -->
+                                        <message>Performing our custom subset of OWL inferences (quantity kinds)</message>
+                                        <shapes>
+                                            <file>src/build/inference/owl-subset.shapes.ttl</file>
+                                        </shapes>
+                                        <data>
+                                            <file>target/dist/schema/SCHEMA_QUDT.ttl</file>
+                                            <graph>dist:vocab:VOCAB_QUDT-QUANTITY-KINDS-ALL.ttl</graph>
+                                        </data>
+                                        <inferred>
+                                            <graph>inferred:owl-subset-quantitykinds</graph>
+                                            <file>target/inferred/owl-subset-quantitykinds.ttl</file>
+                                        </inferred>
+                                    </shaclInfer>
+                                    <add>
+                                        <graph>inferred:owl-subset-quantitykinds</graph>
+                                        <toGraph>dist:vocab:VOCAB_QUDT-QUANTITY-KINDS-ALL.ttl</toGraph>
+                                    </add>
+
+                                    <shaclInfer> <!-- materialize the inverse of qudt:exactMatch (and other symmetric relations) on physical constants -->
+                                        <message>Performing our custom subset of OWL inferences (physical constants)</message>
+                                        <shapes>
+                                            <file>src/build/inference/owl-subset.shapes.ttl</file>
+                                        </shapes>
+                                        <data>
+                                            <file>target/dist/schema/SCHEMA_QUDT.ttl</file>
+                                            <graph>dist:vocab:VOCAB_QUDT-CONSTANTS.ttl</graph>
+                                        </data>
+                                        <inferred>
+                                            <graph>inferred:owl-subset-constants</graph>
+                                            <file>target/inferred/owl-subset-constants.ttl</file>
+                                        </inferred>
+                                    </shaclInfer>
+                                    <add>
+                                        <graph>inferred:owl-subset-constants</graph>
+                                        <toGraph>dist:vocab:VOCAB_QUDT-CONSTANTS.ttl</toGraph>
+                                    </add>
+
+                                    <shaclInfer> <!-- materialize the inverse of qudt:exactMatch (and other symmetric relations) on prefixes -->
+                                        <message>Performing our custom subset of OWL inferences (prefixes)</message>
+                                        <shapes>
+                                            <file>src/build/inference/owl-subset.shapes.ttl</file>
+                                        </shapes>
+                                        <data>
+                                            <file>target/dist/schema/SCHEMA_QUDT.ttl</file>
+                                            <graph>dist:vocab:VOCAB_QUDT-PREFIXES.ttl</graph>
+                                        </data>
+                                        <inferred>
+                                            <graph>inferred:owl-subset-prefixes</graph>
+                                            <file>target/inferred/owl-subset-prefixes.ttl</file>
+                                        </inferred>
+                                    </shaclInfer>
+                                    <add>
+                                        <graph>inferred:owl-subset-prefixes</graph>
+                                        <toGraph>dist:vocab:VOCAB_QUDT-PREFIXES.ttl</toGraph>
+                                    </add>
+
                                     <shaclInfer> <!-- materialize skos:broader from qudt:specializationOf (backward-compat super) before any skos:broader-based inference -->
                                         <message>Materializing skos:broader from qudt:specializationOf</message>
                                         <shapes>

--- a/src/build/inference/owl-subset.shapes.ttl
+++ b/src/build/inference/owl-subset.shapes.ttl
@@ -18,6 +18,7 @@ qudt:
 
 qudt:SymmetricRelationShape
   a sh:NodeShape ;
+  rdfs:comment "qudt:exactMatch is also used on coordinate-frame and datatype instances (VOCAB_QUDT-COORDINATES.ttl, VOCAB_QUDT-DATATYPES.ttl), but those classes form multi-level subclass hierarchies not present in the schema data fed to this rule, and the affected instances aren't typed with a common umbrella class like qudt:Unit or qudt:Prefix are. Not yet covered by this shape; revisit." ;
   sh:rule [
     a sh:SPARQLRule ;
     rdfs:comment "Declare the inverse triples for symmetric relations" ;
@@ -38,6 +39,8 @@ qudt:SymmetricRelationShape
 """ ;
     sh:prefixes qudt: ;
   ] ;
+  sh:targetClass qudt:PhysicalConstant ;
+  sh:targetClass qudt:Prefix ;
   sh:targetClass qudt:QuantityKind ;
   sh:targetClass qudt:Unit .
 

--- a/src/build/inference/owl-subset.shapes.ttl
+++ b/src/build/inference/owl-subset.shapes.ttl
@@ -38,6 +38,7 @@ qudt:SymmetricRelationShape
 """ ;
     sh:prefixes qudt: ;
   ] ;
+  sh:targetClass qudt:QuantityKind ;
   sh:targetClass qudt:Unit .
 
 

--- a/src/build/inference/propagateUnitForQuantityKindAcrossExactMatch.ttl
+++ b/src/build/inference/propagateUnitForQuantityKindAcrossExactMatch.ttl
@@ -1,0 +1,36 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix qudt: <http://qudt.org/schema/qudt/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+
+qudt:
+  sh:declare [
+    sh:namespace "http://qudt.org/schema/qudt/"^^xsd:anyURI ;
+    sh:prefix "qudt" ;
+  ] .
+
+qudt:PropagateUnitForQuantityKindAcrossExactMatchShape
+  a sh:NodeShape ;
+  rdfs:comment "qudt:exactMatch is an equivalence (symmetric + transitive), so a unit that measures one member of an exactMatch clique measures every member. Applicable-unit inference deliberately traverses qudt:specializationOf only, so it never crosses qudt:exactMatch on its own; this rule first fans qudt:unitForQuantityKind out across the exactMatch closure, after which every clique member owns the unit directly (distance 0) and inferApplicableUnits picks it up unchanged. The (qudt:exactMatch|^qudt:exactMatch)+ path closes the clique regardless of which direction the authored edges run, so a unit need only be authored on one member." ;
+  sh:rule [
+    a sh:SPARQLRule ;
+    sh:construct """
+    CONSTRUCT {
+      $this qudt:unitForQuantityKind ?qkB .
+    }
+    WHERE {
+      $this qudt:unitForQuantityKind ?qkA .
+      ?qkA (qudt:exactMatch|^qudt:exactMatch)+ ?qkB .
+      FILTER (?qkA != ?qkB)
+      FILTER NOT EXISTS { $this qudt:deprecated true }
+      FILTER NOT EXISTS { ?qkB qudt:deprecated true }
+      FILTER NOT EXISTS { $this qudt:unitForQuantityKind ?qkB }
+    }
+    """ ;
+    sh:prefixes qudt: ;
+  ] ;
+  sh:targetClass qudt:CurrencyUnit ;
+  sh:targetClass qudt:Unit .
+
+


### PR DESCRIPTION
Two build-inference changes so `qudt:exactMatch`'s equivalence semantics are reflected in the released graph without hand-authoring every direction and every unit link.

## 1. Symmetric `exactMatch` for quantity kinds
The `qudt:SymmetricRelation` rule in `owl-subset.shapes.ttl` (which materializes the inverse triple for symmetric relations — currently just `qudt:exactMatch`) targeted **`qudt:Unit` only**, so quantity-kind `exactMatch` pairs were not symmetrized by the build and had to be authored in both directions by hand. The rule now also targets `qudt:QuantityKind`. `exactMatch` need only be authored once.

## 2. Propagate `qudt:unitForQuantityKind` across the `exactMatch` closure
`inferApplicableUnits` deliberately traverses `qudt:specializationOf` only, so it never crosses `exactMatch`; that's why a unit had to be authored on **both** members of an `exactMatch` pair for both to receive it. A new rule (`propagateUnitForQuantityKindAcrossExactMatch.ttl`) fans `qudt:unitForQuantityKind` out across the `(qudt:exactMatch|^qudt:exactMatch)+` closure **before** applicable-unit inference, so every clique member then owns the unit directly (distance 0) and `inferApplicableUnits` picks it up unchanged. Wired into `pom.xml` ahead of the `hasQuantityKind` materialize step so the propagated links are materialized too. A unit now need only be authored on one clique member.

## Effect / verification
- **No-op on current `main`** — every `exactMatch` clique is already fully dual-authored, so the released `applicableUnit`/`exactMatch` triples are unchanged (no regression); the change matters going forward (author once).
- Rule logic proven with an isolated rdflib test of the CONSTRUCT: a unit authored on one member propagates to siblings reached **forward** and via the **inverse** edge, **transitively** (multi-hop), while correctly excluding self and deprecated kinds.
- Full `mvn install` is green.

Follow-up (not in this PR): a `qudt:TransitiveRelation` rule mirroring `qudt:SymmetricRelation`, to materialize the transitive closure of `exactMatch` so multi-member cliques (e.g. the 4-clique `ElectricPotential`/`ElectricPotentialDifference`/`EnergyPerElectricCharge`/`Voltage`) can be authored as a spanning set rather than all pairs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)