### PR TITLE
Add BIT_COUNT/BYTE_COUNT counting units for BitDataVolume/ByteDataVolume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
 
 ### Added
 
+- Added `unit:BIT_COUNT` and `unit:BYTE_COUNT`, counting-sense units (as opposed to the information-entropy `unit:BIT`/`unit:BYTE`) for `quantitykind:BitDataVolume` and `quantitykind:ByteDataVolume`, which are now `organizedUnder quantitykind:Count`; cross-linked with `rdfs:seeAlso`.
 - Added a release-pipeline validation gate that checks the distribution zip — archive integrity, presence of the core artifacts (units, quantity kinds, the normative SHACL schema, and the all-in-one files), and a sanity floor on the Turtle-file count — before the GitHub Release is published and before the qudt-r2 website publish is triggered, so a corrupted or incomplete build cannot reach the live site. When a release aborts before the GitHub Release is published, the workflow now also deletes the tag and branch that `release:prepare` had already pushed, so the same version can simply be re-run without manual cleanup.
 - Added a version-increment guard to the Release workflow: the requested release version must be a single step from the last released `vX.Y.Z` tag (PATCH+1, MINOR+1 with PATCH reset, or MAJOR+1 with MINOR/PATCH reset), failing fast otherwise. The `next_snapshot_version` input is now optional and defaults to the release version with PATCH+1 and `-SNAPSHOT` (e.g. `3.4.1` → `3.4.2-SNAPSHOT`) when left blank.
 

--- a/src/main/rdf/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL.ttl
+++ b/src/main/rdf/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL.ttl
@@ -1715,6 +1715,7 @@ quantitykind:BitDataVolume
   """@en ;
   qudt:eclassCode "0173-1#Z4-BAJ436#002" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
+  qudt:organizedUnder quantitykind:Count ;
   qudt:plainTextDescription """Bezeichnung für eine bestimmte Anzahl von Daten auf Basis der Binärziffer Bit (en: Basic
     Indissoluble Information Unit, dt: kleinstmögliche Informationseinheit), welche nur den Zustand 1 oder 0 annehmen kann
   """@de ;
@@ -1939,6 +1940,7 @@ quantitykind:ByteDataVolume
   dcterms:description "particular quantity of data based on a string consisting of 8 bits"@en ;
   qudt:eclassCode "0173-1#Z4-BAJ435#004" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
+  qudt:organizedUnder quantitykind:Count ;
   qudt:plainTextDescription "Anzahl von Daten auf Basis einer Zeichenfolge, die aus je 8 Bit besteht"@de ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Byte Data Volume"@en-US .

--- a/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
+++ b/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
@@ -2528,9 +2528,8 @@ unit:BIT
     bit. It is thus the amount of information carried by a choice between two equally likely outcomes. One bit corresponds to
     about 0.693 nats (ln(2)), or 0.301 hartleys (log10(2)).
   <p><em>Note:</em> This unit represents the information-entropy bit (conversionMultiplier = ln(2)),
-  not the count-of-binary-digits bit used in phrases such as "a 64-bit integer". Its extended
-  dimension vector has N=0, reflecting the continuous information-theoretic interpretation. A
-  separate counting unit (N=1) for the binary-digit usage may be defined in a future version.</p>
+  not the count-of-binary-digits bit used in phrases such as "a 64-bit integer". For that usage,
+  see <a href="../vocab/unit#BIT_COUNT">unit:BIT_COUNT</a>.</p>
   """^^rdf:HTML ;
   qudt:applicableSystem sou:ASU ;
   qudt:applicableSystem sou:CGS ;
@@ -2556,7 +2555,8 @@ unit:BIT
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q8805> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Bit" ;
-  rdfs:label "Bit"@en .
+  rdfs:label "Bit"@en ;
+  rdfs:seeAlso unit:BIT_COUNT .
 
 unit:BIT-PER-M
   a qudt:Unit ;
@@ -2623,6 +2623,20 @@ unit:BIT-PER-SEC
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Bit per Second" ;
   rdfs:label "Bit per Second"@en .
+
+unit:BIT_COUNT
+  a qudt:CountingUnit, qudt:Unit ;
+  dcterms:description """$\\textit{Bit Count}$ is a unit for the count-of-binary-digits usage of "bit", as in "a 64-bit integer",
+    distinct from the information-entropy bit (see unit:BIT).
+  """^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0 ;
+  qudt:conversionMultiplierSN 1.0E0 ;
+  qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
+  qudt:unitForQuantityKind quantitykind:BitDataVolume ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
+  rdfs:label "Bit (count)" ;
+  rdfs:label "Bit (count)"@en ;
+  rdfs:seeAlso unit:BIT .
 
 unit:BQ
   a qudt:DerivedUnit, qudt:Unit ;
@@ -4358,6 +4372,9 @@ unit:BYTE
   a qudt:DerivedUnit, qudt:Unit ;
   dcterms:description """The byte is a unit of digital information in computing and telecommunications that most commonly consists
     of eight bits.
+  <p><em>Note:</em> This unit represents the information-entropy byte (conversionMultiplier = 8·ln(2)),
+  not the count-of-bytes usage used to express the size of a file or data volume. For that usage,
+  see <a href="../vocab/unit#BYTE_COUNT">unit:BYTE_COUNT</a>.</p>
   """^^rdf:HTML ;
   qudt:applicableSystem sou:ASU ;
   qudt:applicableSystem sou:CGS ;
@@ -4387,7 +4404,8 @@ unit:BYTE
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q8799> ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Byte" ;
-  rdfs:label "Byte"@en .
+  rdfs:label "Byte"@en ;
+  rdfs:seeAlso unit:BYTE_COUNT .
 
 unit:BYTE-PER-SEC
   a qudt:Unit ;
@@ -4403,6 +4421,25 @@ unit:BYTE-PER-SEC
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Byte per Second" ;
   rdfs:label "Byte per Second"@en .
+
+unit:BYTE_COUNT
+  a qudt:CountingUnit, qudt:Unit ;
+  dcterms:description """$\\textit{Byte Count}$ is a unit for the count-of-bytes usage of "byte", as used to express the size of a
+    file or data volume, distinct from the information-entropy byte (see unit:BYTE).
+  """^^qudt:LatexString ;
+  qudt:conversionMultiplier 8.0 ;
+  qudt:conversionMultiplierSN 8.0E0 ;
+  qudt:factorUnitScalar 8.0 ;
+  qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
+  qudt:hasFactorUnit [
+    qudt:exponent 1 ;
+    qudt:hasUnit unit:BIT_COUNT ;
+  ] ;
+  qudt:unitForQuantityKind quantitykind:ByteDataVolume ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
+  rdfs:label "Byte (count)" ;
+  rdfs:label "Byte (count)"@en ;
+  rdfs:seeAlso unit:BYTE .
 
 unit:BasePair
   a qudt:CountingUnit, qudt:Unit ;
@@ -14267,16 +14304,16 @@ unit:ERG
   qudt:derivedUnitOfSystem sou:CGS-GAUSS ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:hasFactorUnit [
-    qudt:exponent 1 ;
-    qudt:hasUnit unit:GM ;
-  ] ;
-  qudt:hasFactorUnit [
     qudt:exponent -2 ;
     qudt:hasUnit unit:SEC ;
   ] ;
   qudt:hasFactorUnit [
     qudt:exponent 2 ;
     qudt:hasUnit unit:CentiM ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent 1 ;
+    qudt:hasUnit unit:GM ;
   ] ;
   qudt:iec61360Code "0112/2///62720#UAA429" ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Erg?oldid=490293432"^^xsd:anyURI ;
@@ -15811,11 +15848,11 @@ unit:FT-LB_F_Energy
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:hasFactorUnit [
     qudt:exponent 1 ;
-    qudt:hasUnit unit:FT ;
+    qudt:hasUnit unit:LB_F ;
   ] ;
   qudt:hasFactorUnit [
     qudt:exponent 1 ;
-    qudt:hasUnit unit:LB_F ;
+    qudt:hasUnit unit:FT ;
   ] ;
   qudt:iec61360Code "0112/2///62720#UAA443" ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Foot-pound_force?oldid=453269257"^^xsd:anyURI ;
@@ -15843,11 +15880,11 @@ unit:FT-LB_F_Torque
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:hasFactorUnit [
     qudt:exponent 1 ;
-    qudt:hasUnit unit:FT ;
+    qudt:hasUnit unit:LB_F ;
   ] ;
   qudt:hasFactorUnit [
     qudt:exponent 1 ;
-    qudt:hasUnit unit:LB_F ;
+    qudt:hasUnit unit:FT ;
   ] ;
   qudt:iec61360Code "0112/2///62720#UAA443" ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Foot-pound_force?oldid=453269257"^^xsd:anyURI ;
@@ -17033,12 +17070,12 @@ unit:G
   qudt:factorUnitScalar 9.80665 ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T-2D0 ;
   qudt:hasFactorUnit [
-    qudt:exponent 1 ;
-    qudt:hasUnit unit:M ;
-  ] ;
-  qudt:hasFactorUnit [
     qudt:exponent -2 ;
     qudt:hasUnit unit:SEC ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent 1 ;
+    qudt:hasUnit unit:M ;
   ] ;
   qudt:iec61360Code "0112/2///62720#UAA521" ;
   qudt:symbol "G" ;
@@ -17066,12 +17103,12 @@ unit:GALILEO
   qudt:derivedUnitOfSystem sou:CGS-GAUSS ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T-2D0 ;
   qudt:hasFactorUnit [
-    qudt:exponent -2 ;
-    qudt:hasUnit unit:SEC ;
-  ] ;
-  qudt:hasFactorUnit [
     qudt:exponent 1 ;
     qudt:hasUnit unit:CentiM ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent -2 ;
+    qudt:hasUnit unit:SEC ;
   ] ;
   qudt:iec61360Code "0112/2///62720#UAB042" ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Gal?oldid=482010741"^^xsd:anyURI ;
@@ -20979,12 +21016,12 @@ unit:H
   qudt:derivedCoherentUnitOfSystem sou:SI ;
   qudt:hasDimensionVector qkdv:A0E-2L2I0M1H0T-2D0 ;
   qudt:hasFactorUnit [
-    qudt:exponent 1 ;
-    qudt:hasUnit unit:WB ;
-  ] ;
-  qudt:hasFactorUnit [
     qudt:exponent -1 ;
     qudt:hasUnit unit:A ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent 1 ;
+    qudt:hasUnit unit:WB ;
   ] ;
   qudt:iec61360Code "0112/2///62720#UAA165" ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Henry?oldid=491435978"^^xsd:anyURI ;
@@ -23567,20 +23604,20 @@ unit:J-PER-M2-SEC0dot5-K
   qudt:conversionMultiplierSN 1.0E0 ;
   qudt:hasDimensionVector qkdv:A0E-2L2I0M1H-1T-2dot5D0 ;
   qudt:hasFactorUnit [
-    qudt:exponent 1 ;
-    qudt:hasUnit unit:J ;
+    qudt:exponent -1 ;
+    qudt:hasUnit unit:K ;
   ] ;
   qudt:hasFactorUnit [
     qudt:exponent -0.5 ;
     qudt:hasUnit unit:SEC ;
   ] ;
   qudt:hasFactorUnit [
-    qudt:exponent -1 ;
-    qudt:hasUnit unit:K ;
-  ] ;
-  qudt:hasFactorUnit [
     qudt:exponent -2 ;
     qudt:hasUnit unit:M ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent 1 ;
+    qudt:hasUnit unit:J ;
   ] ;
   qudt:plainTextDescription """A unit of thermal inertia measured as Joules per meter squared per square root Seconds per degree
     Kelvin
@@ -33159,16 +33196,16 @@ unit:LB_F
   qudt:definedUnitOfSystem sou:USCS ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H0T-2D0 ;
   qudt:hasFactorUnit [
-    qudt:exponent -2 ;
-    qudt:hasUnit unit:SEC ;
-  ] ;
-  qudt:hasFactorUnit [
     qudt:exponent 1 ;
     qudt:hasUnit unit:SLUG ;
   ] ;
   qudt:hasFactorUnit [
     qudt:exponent 1 ;
     qudt:hasUnit unit:FT ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent -2 ;
+    qudt:hasUnit unit:SEC ;
   ] ;
   qudt:iec61360Code "0112/2///62720#UAA696" ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Pound-force?oldid=453191483"^^xsd:anyURI ;
@@ -40044,12 +40081,12 @@ unit:MegaPA-M0dot5
   qudt:conversionMultiplierSN 1.0E6 ;
   qudt:hasDimensionVector qkdv:A0E0L-0dot5I0M1H0T-2D0 ;
   qudt:hasFactorUnit [
-    qudt:exponent 0.5 ;
-    qudt:hasUnit unit:M ;
-  ] ;
-  qudt:hasFactorUnit [
     qudt:exponent 1 ;
     qudt:hasUnit unit:MegaPA ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent 0.5 ;
+    qudt:hasUnit unit:M ;
   ] ;
   qudt:plainTextDescription "1,000,000-fold of the derived unit Pascal Square Root Meter" ;
   qudt:symbol "MPa√m" ;
@@ -48989,16 +49026,16 @@ unit:N
   qudt:exactMatch unit:KiloGM-M-PER-SEC2 ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H0T-2D0 ;
   qudt:hasFactorUnit [
-    qudt:exponent 1 ;
-    qudt:hasUnit unit:KiloGM ;
-  ] ;
-  qudt:hasFactorUnit [
     qudt:exponent -2 ;
     qudt:hasUnit unit:SEC ;
   ] ;
   qudt:hasFactorUnit [
     qudt:exponent 1 ;
     qudt:hasUnit unit:M ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent 1 ;
+    qudt:hasUnit unit:KiloGM ;
   ] ;
   qudt:iec61360Code "0112/2///62720#UAA235" ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Newton?oldid=488427661"^^xsd:anyURI ;
@@ -52610,12 +52647,12 @@ unit:OHM
   qudt:dbpediaMatch "http://dbpedia.org/resource/Ohm"^^xsd:anyURI ;
   qudt:hasDimensionVector qkdv:A0E-2L2I0M1H0T-3D0 ;
   qudt:hasFactorUnit [
-    qudt:exponent 1 ;
-    qudt:hasUnit unit:V ;
-  ] ;
-  qudt:hasFactorUnit [
     qudt:exponent -1 ;
     qudt:hasUnit unit:A ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent 1 ;
+    qudt:hasUnit unit:V ;
   ] ;
   qudt:hasReciprocalUnit unit:S ;
   qudt:iec61360Code "0112/2///62720#UAA017" ;
@@ -54059,12 +54096,12 @@ unit:PA
   qudt:exactMatch unit:N-PER-M2 ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:hasFactorUnit [
-    qudt:exponent -2 ;
-    qudt:hasUnit unit:M ;
-  ] ;
-  qudt:hasFactorUnit [
     qudt:exponent 1 ;
     qudt:hasUnit unit:N ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent -2 ;
+    qudt:hasUnit unit:M ;
   ] ;
   qudt:hasReciprocalUnit unit:M2-PER-N ;
   qudt:iec61360Code "0112/2///62720#UAA258" ;
@@ -61966,12 +62003,12 @@ unit:R
   qudt:factorUnitScalar 0.000258 ;
   qudt:hasDimensionVector qkdv:A0E1L0I0M-1H0T1D0 ;
   qudt:hasFactorUnit [
-    qudt:exponent -1 ;
-    qudt:hasUnit unit:KiloGM ;
-  ] ;
-  qudt:hasFactorUnit [
     qudt:exponent 1 ;
     qudt:hasUnit unit:C ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent -1 ;
+    qudt:hasUnit unit:KiloGM ;
   ] ;
   qudt:iec61360Code "0112/2///62720#UAA275" ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Roentgen?oldid=491213233"^^xsd:anyURI ;
@@ -62017,11 +62054,11 @@ unit:RAD
   qudt:guidance "<p>See NIST section <a href=\"http://physics.nist.gov/Pubs/SP811/sec07.html#7.10\">SP811 section7.10</a></p>"^^rdf:HTML ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasFactorUnit [
-    qudt:exponent -1 ;
+    qudt:exponent 1 ;
     qudt:hasUnit unit:M ;
   ] ;
   qudt:hasFactorUnit [
-    qudt:exponent 1 ;
+    qudt:exponent -1 ;
     qudt:hasUnit unit:M ;
   ] ;
   qudt:iec61360Code "0112/2///62720#UAA966" ;
@@ -63619,11 +63656,11 @@ unit:SR
   qudt:derivedCoherentUnitOfSystem sou:SI ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:hasFactorUnit [
-    qudt:exponent -2 ;
+    qudt:exponent 2 ;
     qudt:hasUnit unit:M ;
   ] ;
   qudt:hasFactorUnit [
-    qudt:exponent 2 ;
+    qudt:exponent -2 ;
     qudt:hasUnit unit:M ;
   ] ;
   qudt:hasReciprocalUnit unit:M2-PER-M2 ;
@@ -63677,12 +63714,12 @@ unit:ST
   qudt:factorUnitScalar 0.0001 ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-1D0 ;
   qudt:hasFactorUnit [
-    qudt:exponent 2 ;
-    qudt:hasUnit unit:M ;
-  ] ;
-  qudt:hasFactorUnit [
     qudt:exponent -1 ;
     qudt:hasUnit unit:SEC ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent 2 ;
+    qudt:hasUnit unit:M ;
   ] ;
   qudt:iec61360Code "0112/2///62720#UAA281" ;
   qudt:informativeReference "http://www.efunda.com/glossary/units/units--kinematic_viscosity--stokes.cfm"^^xsd:anyURI ;
@@ -63898,12 +63935,12 @@ unit:SV
   qudt:derivedUnitOfSystem sou:SI ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-2D0 ;
   qudt:hasFactorUnit [
-    qudt:exponent -1 ;
-    qudt:hasUnit unit:KiloGM ;
-  ] ;
-  qudt:hasFactorUnit [
     qudt:exponent 1 ;
     qudt:hasUnit unit:J ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent -1 ;
+    qudt:hasUnit unit:KiloGM ;
   ] ;
   qudt:hasReciprocalUnit unit:KiloGM-PER-J ;
   qudt:iec61360Code "0112/2///62720#UAA284" ;
@@ -64152,12 +64189,12 @@ unit:T
   qudt:derivedCoherentUnitOfSystem sou:SI ;
   qudt:hasDimensionVector qkdv:A0E-1L0I0M1H0T-2D0 ;
   qudt:hasFactorUnit [
-    qudt:exponent 1 ;
-    qudt:hasUnit unit:WB ;
-  ] ;
-  qudt:hasFactorUnit [
     qudt:exponent -2 ;
     qudt:hasUnit unit:M ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent 1 ;
+    qudt:hasUnit unit:WB ;
   ] ;
   qudt:iec61360Code "0112/2///62720#UAA285" ;
   qudt:informativeReference "http://www.oxfordreference.com/view/10.1093/acref/9780198605225.001.0001/acref-9780198605225-e-1406?rskey=AzXBLd"^^xsd:anyURI ;
@@ -68637,12 +68674,12 @@ unit:WB
   qudt:derivedCoherentUnitOfSystem sou:SI ;
   qudt:hasDimensionVector qkdv:A0E-1L2I0M1H0T-2D0 ;
   qudt:hasFactorUnit [
-    qudt:exponent 1 ;
-    qudt:hasUnit unit:J ;
-  ] ;
-  qudt:hasFactorUnit [
     qudt:exponent -1 ;
     qudt:hasUnit unit:A ;
+  ] ;
+  qudt:hasFactorUnit [
+    qudt:exponent 1 ;
+    qudt:hasUnit unit:J ;
   ] ;
   qudt:hasReciprocalUnit unit:A-PER-J ;
   qudt:iec61360Code "0112/2///62720#UAA317" ;


### PR DESCRIPTION
## Summary

`unit:BIT` and `unit:BYTE` are information-entropy units (`conversionMultiplier` = ln(2) / 8·ln(2)), not the plain count-of-binary-digits usage used in phrases like "a 64-bit integer" or to express file/data-volume sizes. `unit:BIT`'s own description already flagged this gap. `quantitykind:BitDataVolume` and `quantitykind:ByteDataVolume` existed but had zero `applicableUnit`.

- Added `unit:BIT_COUNT` (`qudt:CountingUnit`, `conversionMultiplier` 1.0) → `unitForQuantityKind BitDataVolume`
- Added `unit:BYTE_COUNT` (`qudt:CountingUnit`, `hasFactorUnit BIT_COUNT` × 8, `conversionMultiplier` 8.0) → `unitForQuantityKind ByteDataVolume`
- `BitDataVolume` and `ByteDataVolume` are now `qudt:organizedUnder quantitykind:Count`
- Cross-linked `unit:BIT`↔`unit:BIT_COUNT` and `unit:BYTE`↔`unit:BYTE_COUNT` with `rdfs:seeAlso`, and updated the `unit:BIT`/`unit:BYTE` descriptions to point to the new counting-sense units

Build (including `-Pfix`) has been run locally by the maintainer and passes.

## Test plan

- [ ] `quantitykind:BitDataVolume` has `applicableUnit unit:BIT_COUNT`
- [ ] `quantitykind:ByteDataVolume` has `applicableUnit unit:BYTE_COUNT`
- [ ] `unit:BYTE_COUNT` conversion multiplier resolves to 8.0 relative to `unit:BIT_COUNT`
- [ ] `unit:BIT`/`unit:BYTE` (entropy units) are unaffected in their existing `InformationEntropy`/`ShannonDiversityIndex` links

🤖 Generated with [Claude Code](https://claude.com/claude-code)