### PR TITLE
CI: force full pipeline run in Manual Validation Build fix pass (savepoint-resume stepDef bug)

### DIFF
--- a/.github/workflows/manual-validation-build.yml
+++ b/.github/workflows/manual-validation-build.yml
@@ -82,8 +82,14 @@ jobs:
         env:
           CI: ""   # allow fix logic to mutate in CI if it checks this flag
         run: |
-          echo "Running: mvn -Pfix install"
-          mvn -Pfix install
+          # forceRun disables savepoint resume: this step reuses target/ from the
+          # preceding "Build with Maven" step, and a resumed 'main' pipeline restarts
+          # past the <stepDef id="refresh-supported-extensions-vocab"> registration
+          # (which precedes savepoint 01-iec-links) while still hitting the downstream
+          # <invoke>, failing with "no <stepDef ...> has been registered". Remove once
+          # the rdfio plugin persists/pre-registers stepDefs across resume.
+          echo "Running: mvn -Pfix install -Drdfio.pipeline.forceRun=true"
+          mvn -Pfix install -Drdfio.pipeline.forceRun=true
           echo "----- Changes in working tree after -Pfix -----"
           git status --porcelain=1 || true
 


### PR DESCRIPTION
## Problem

The **Manual Validation Build** workflow fails in the **Fix pass (mutate src)** step with:

```
<invoke stepRef="refresh-supported-extensions-vocab">: no <stepDef id="refresh-supported-extensions-vocab"> has been registered.
Ensure the <stepDef> appears before <invoke> in the pipeline.
```

even though the `<stepDef>` (pom.xml ~line 1602) *does* precede every `<invoke>` in the `main` pipeline.

## Root cause

The workflow runs Maven twice against the same `target/` with no `clean` between:

1. **Build with Maven** → `mvn -Pzip install` (cold; writes savepoints, halts at the `-Pfix` gate)
2. **Fix pass** → `mvn -Pfix install` on that same tree

The second run resumes the `main` pipeline from the latest valid savepoint. The run log shows:

```
Latest valid <savepoint> is '01-iec-links' (step 9/114)
Resuming pipeline at savepoint
```

The `<stepDef>` registration lives in steps 1–8, **before** savepoint `01-iec-links`. Resuming at step 9 skips the registration but still executes the downstream `<invoke>`, so the step registry is empty → failure. rdfio does not persist / pre-register `<stepDef>`s across savepoint resume.

It doesn't reproduce with a plain local `mvn clean install` because that runs the pipeline cold from step 1.

## This change (stopgap)

Adds `-Drdfio.pipeline.forceRun=true` to the Fix pass invocation — the plugin's own documented override, printed in the failure log — which disables resume so the `<stepDef>` is re-registered. A comment marks it removable once rdfio fixes registration across resume.

Targets the actual trigger (resume) rather than blanket-wiping `target/` with `clean`; both force the same full pipeline run.

## Follow-up (not in this PR)

The underlying bug is plugin-side: any `<invoke>` after a savepoint is unsafe while its `<stepDef>` precedes that savepoint. The rdfio fix is to register all `<stepDef>`s up front (or persist them in savepoint state) so resume works everywhere — CI and local incremental builds — after which this stopgap can be reverted.

Workflow-only change; does not touch `src/main` or the RDF pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)