### PR TITLE
Add more mappings of Quantity Kinds to ECLASS Codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
 ### Added
 
 - Added `quantitykind:RadonExposure` (time-integrated radon activity concentration, ISO 16641), with the existing `unit:BQ-SEC-PER-M3` re-homed to it from `quantitykind:AbsoluteActivity` and the new `unit:BQ-HR-PER-M3` ([Henrike Fleischhack](https://github.com/henrikef)).
+- Added more mappings of quantity kinds to ECLASS codes
 
 ### Fixed
 

--- a/src/main/rdf/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL.ttl
+++ b/src/main/rdf/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL.ttl
@@ -104,6 +104,7 @@ quantitykind:AbsorbedDose
     the special name Gray ($Gy$).
   """^^qudt:LatexString ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Absorbed_dose"^^xsd:anyURI ;
+  qudt:eclassCode "0173-1#Z4-BAJ224#005" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-2D0 ;
   qudt:iec61360Code "0112/2///62720#UAD000" ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Absorbed_dose"^^xsd:anyURI ;
@@ -128,6 +129,7 @@ quantitykind:AbsorbedDoseRate
   dcterms:description """"Absorbed Dose Rate" is the absorbed dose of ionizing radiation imparted at a given location per unit of
     time (second, minute, hour, or day).
   """^^qudt:LatexString ;
+  qudt:eclassCode "0173-1#Z4-BAJ317#005" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-3D0 ;
   qudt:iec61360Code "0112/2///62720#UAD001" ;
   qudt:informativeReference "http://www.answers.com/topic/absorbed-dose-rate"^^xsd:anyURI ;
@@ -177,6 +179,7 @@ quantitykind:Acceleration
    motion in a circle at constant speed is also an acceleration, since the direction component of the velocity is changing.
   """^^qudt:LatexString ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Acceleration"^^xsd:anyURI ;
+  qudt:eclassCode "0173-1#Z4-BAJ271#006" ;
   qudt:exactMatch quantitykind:LinearAcceleration ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T-2D0 ;
   qudt:iec61360Code "0112/2///62720#UAD002" ;
@@ -343,6 +346,7 @@ quantitykind:ActivePower
   An $Active Power$ is, under periodic conditions, the mean value, taken over one period $T$, of the instantaneous power $p$. 
   In complex notation, $P = \\mathbf{Re} \\; \\underline{S}$, where $\\underline{S}$ is $\\textit{complex power}$.
   """^^qudt:LatexString ;
+  qudt:eclassCode "0173-1#Z4-BAJ277#005" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:iec61360Code "0112/2///62720#UAD003" ;
   qudt:informativeReference "http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=131-11-42"^^xsd:anyURI ;
@@ -557,6 +561,7 @@ quantitykind:AmountOfData
     (quantitykind:BitDataVolume) or bytes (quantitykind:ByteDataVolume). It is a counting quantity, distinct from the
     information-theoretic entropy carried by that data (see unit:SHANNON).
   """@en ;
+  qudt:eclassCode "0173-1#Z4-BAJ203#001" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:organizedUnder quantitykind:Count ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
@@ -574,6 +579,7 @@ quantitykind:AmountOfSubstance
     United States. One $pound-mole$ is exactly $453.59237 mol$.
   """^^qudt:LatexString ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Amount_of_substance"^^xsd:anyURI ;
+  qudt:eclassCode "0173-1#Z4-BAJ231#005" ;
   qudt:hasDimensionVector qkdv:A1E0L0I0M0H0T0D0 ;
   qudt:iec61360Code "0112/2///62720#UAD004" ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Amount_of_substance"^^xsd:anyURI ;
@@ -746,6 +752,7 @@ quantitykind:AngularAcceleration
   qudt:baseCGSUnitDimensions "U/T^2" ;
   qudt:baseSIUnitDimensions "$/s^2$"^^qudt:LatexString ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Angular_acceleration"^^xsd:anyURI ;
+  qudt:eclassCode "0173-1#Z4-BAJ412#004" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-2D0 ;
   qudt:iec61360Code "0112/2///62720#UAD006" ;
   qudt:siExactMatch si-quantity:ACCA ;
@@ -774,6 +781,7 @@ quantitykind:AngularCrossSection
   dcterms:description """"Angular Cross-section" is the cross-section for ejecting or scattering a particle into an elementary
     cone, divided by the solid angle $d\\Omega$ of that cone.
   """^^qudt:LatexString ;
+  qudt:eclassCode "0173-1#Z4-BAJ414#004" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T0D0 ;
   qudt:iec61360Code "0112/2///62720#UAD007" ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Cross_section_(physics)"^^xsd:anyURI ;
@@ -870,6 +878,7 @@ quantitykind:AngularMomentum
     reference, the rotation associated with angular momentum is sometimes spoken of as being measured relative to the fixed stars.
   """^^qudt:LatexString ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Angular_momentum"^^xsd:anyURI ;
+  qudt:eclassCode "0173-1#Z4-BAJ263#004" ;
   qudt:exactMatch quantitykind:AngularImpulse ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-1D0 ;
   qudt:iec61360Code "0112/2///62720#UAD403" ;
@@ -913,6 +922,7 @@ quantitykind:AngularVelocity
   dcterms:description """Angular Velocity refers to how fast an object rotates or revolves relative to another point.
   """^^qudt:LatexString ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Angular_velocity"^^xsd:anyURI ;
+  qudt:eclassCode "0173-1#Z4-BAJ413#005" ;
   qudt:exactMatch quantitykind:AngularFrequency ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:iec61360Code "0112/2///62720#UAD009" ;
@@ -953,6 +963,7 @@ quantitykind:AngularWavenumber
   dcterms:description """"wavenumber" is the spatial frequency of a wave - the number of waves that exist over a specified
     distance. More formally, it is the reciprocal of the wavelength. It is also the magnitude of the wave vector.
   """^^qudt:LatexString ;
+  qudt:eclassCode "0173-1#Z4-BAJ410#005" ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M0H0T0D0 ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Wavenumber"^^xsd:anyURI ;
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
@@ -1030,6 +1041,7 @@ quantitykind:ApparentPower
     two-terminal circuit and the rms electric current I in the element or circuit. Under sinusoidal conditions, the apparent power
     is the modulus of the complex power.
   """^^qudt:LatexString ;
+  qudt:eclassCode "0173-1#Z4-BAJ274#004" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:iec61360Code "0112/2///62720#UAD011" ;
   qudt:informativeReference "http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=131-11-41"^^xsd:anyURI ;
@@ -2119,6 +2131,7 @@ quantitykind:Capacitance
     electric charge stored for a given electric potential. Capacitance is a scalar-valued quantity.
   """^^qudt:LatexString ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Capacitance"^^xsd:anyURI ;
+  qudt:eclassCode "0173-1#Z4-BAJ207#005" ;
   qudt:hasDimensionVector qkdv:A0E2L-2I0M-1H0T4D0 ;
   qudt:iec61360Code "0112/2///62720#UAD021" ;
   qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
@@ -2264,6 +2277,7 @@ quantitykind:CatalyticActivity
     concentration. Source(s): <a href="http://www.answers.com/topic/catalytic-activity-biochemistry">www.answers.com</a>
   """^^qudt:LatexString ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Catalysis"^^xsd:anyURI ;
+  qudt:eclassCode "0173-1#Z4-BAJ445#001" ;
   qudt:hasDimensionVector qkdv:A1E0L0I0M0H0T-1D0 ;
   qudt:iec61360Code "0112/2///62720#UAD022" ;
   qudt:iec61360Code "0112/2///62720#UAD367" ;
@@ -2304,6 +2318,7 @@ quantitykind:CelsiusTemperature
     temperature of the triple point of water.
   """^^qudt:LatexString ;
   prov:wasDerivedFrom quantitykind:ThermodynamicTemperature ;
+  qudt:eclassCode "0173-1#Z4-BAJ273#002" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H1T0D0 ;
   qudt:iec61360Code "0112/2///62720#UAD023" ;
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI ;
@@ -2690,6 +2705,7 @@ quantitykind:Compressibility
   dcterms:description """Compressibility is a measure of the relative volume change of a fluid or solid as a response to a
     pressure (or mean stress) change.
   """^^qudt:LatexString ;
+  qudt:eclassCode "0173-1#Z4-BAJ374#005" ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M-1H0T2D0 ;
   qudt:iec61360Code "0112/2///62720#UAD024" ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Compressibility"^^xsd:anyURI ;
@@ -2794,6 +2810,7 @@ quantitykind:Conductivity
   dcterms:isReplacedBy quantitykind:ElectricConductivity ;
   qudt:deprecated true ;
   qudt:deprecatedInVersion "3.1.11" ;
+  qudt:eclassCode "0173-1#Z4-BAJ329#005" ;
   qudt:hasDimensionVector qkdv:A0E2L-3I0M-1H0T3D0 ;
   qudt:iec61360Code "0112/2///62720#UAD025" ;
   qudt:informativeReference "http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=121-12-03"^^xsd:anyURI ;
@@ -2944,6 +2961,7 @@ quantitykind:Count
 quantitykind:CountRate
   a qudt:QuantityKind ;
   dcterms:description "A measure of a number of items counted per time period."^^qudt:LatexString ;
+  qudt:eclassCode "0173-1#Z4-BAJ206#006" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:informativeReference "https://standards.buildingsmart.org/IFC/RELEASE/IFC4/ADD2/HTML/link/ifcintegercountratemeasure.htm"^^xsd:anyURI ;
   qudt:plainTextDescription """This measure may be used for measuring integer units per second or per hour. For example, it may be
@@ -2988,6 +3006,7 @@ quantitykind:CrossSection
     target particle and for a specified reaction or process produced by incident charged or uncharged particles of specified type
     and energy, it is the mean number of such reactions or processes divided by the incident-particle fluence.
   """^^qudt:LatexString ;
+  qudt:eclassCode "0173-1#Z4-BAJ449#001" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T0D0 ;
   qudt:iec61360Code "0112/2///62720#UAD026" ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Cross_section_(physics)"^^xsd:anyURI ;
@@ -3276,6 +3295,7 @@ quantitykind:DataTransmissionRate
     quantitykind:DataRate for the transmission context specifically (DataRate itself also covers non-transmission
     contexts, such as storage read/write or bus throughput).
   """@en ;
+  qudt:eclassCode "0173-1#Z4-BAJ216#001" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:specializationOf quantitykind:DataRate ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
@@ -3438,6 +3458,7 @@ quantitykind:Density
     although this quantity is more properly called specific weight.
   """^^qudt:LatexString ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Density"^^xsd:anyURI ;
+  qudt:eclassCode "0173-1#Z4-BAJ282#006" ;
   qudt:exactMatch quantitykind:MassDensity ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M1H0T0D0 ;
   qudt:iec61360Code "0112/2///62720#UAD029" ;
@@ -3754,6 +3775,7 @@ quantitykind:Dissipance
 quantitykind:Distance
   a qudt:QuantityKind ;
   dcterms:description "\"Distance\" is a numerical description of how far apart objects are. "^^qudt:LatexString ;
+  qudt:eclassCode "0173-1#Z4-BAJ199#006" ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T0D0 ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Distance"^^xsd:anyURI ;
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=43012"^^xsd:anyURI ;
@@ -3818,6 +3840,7 @@ quantitykind:DoseEquivalent
     upon the part of the body irradiated, the time and volume over which the dose was spread, even the species of the subject.
   """^^qudt:LatexString ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Equivalent_dose"^^xsd:anyURI ;
+  qudt:eclassCode "0173-1#Z4-BAJ222#005" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M0H0T-2D0 ;
   qudt:iec61360Code "0112/2///62720#UAD033" ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Equivalent_dose"^^xsd:anyURI ;
@@ -4006,6 +4029,7 @@ quantitykind:DynamicViscosity
   a qudt:QuantityKind ;
   dcterms:description """A measure of the molecular frictional resistance of a fluid as calculated using Newton's law.
   """^^qudt:LatexString ;
+  qudt:eclassCode "0173-1#Z4-BAJ283#005" ;
   qudt:exactMatch quantitykind:Viscosity ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-1D0 ;
   qudt:iec61360Code "0112/2///62720#UAD035" ;
@@ -4168,6 +4192,7 @@ quantitykind:ElectricCharge
     charge is carried by discrete particles and can be positive or negative. The sign convention is such that the elementary
     electric charge $e$, that is, the charge of the proton, is positive. The SI derived unit of electric charge is the coulomb.
   """^^qudt:LatexString ;
+  qudt:eclassCode "0173-1#Z4-BAJ419#005" ;
   qudt:hasDimensionVector qkdv:A0E1L0I0M0H0T1D0 ;
   qudt:iec61360Code "0112/2///62720#UAD037" ;
   qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
@@ -4342,6 +4367,7 @@ quantitykind:ElectricConductivity
     current density $J$ to the electric field, $E$: $J = \\sigma E$. In isotropic materials, conductivity is scalar-valued,
     however in general, conductivity is a tensor-valued quantity.
   """^^qudt:LatexString ;
+  qudt:eclassCode "0173-1#Z4-BAJ329#005" ;
   qudt:hasDimensionVector qkdv:A0E2L-3I0M-1H0T3D0 ;
   qudt:iec61360Code "0112/2///62720#UAD025" ;
   qudt:informativeReference "http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=121-12-03"^^xsd:anyURI ;
@@ -4377,6 +4403,7 @@ quantitykind:ElectricCurrent
    on which the International System of Units, SI, is based.
   """^^rdf:HTML ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Electric_current"^^xsd:anyURI ;
+  qudt:eclassCode "0173-1#Z4-BAJ268#006" ;
   qudt:hasDimensionVector qkdv:A0E1L0I0M0H0T0D0 ;
   qudt:iec61360Code "0112/2///62720#UAD039" ;
   qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
@@ -4420,6 +4447,7 @@ quantitykind:ElectricCurrentDensity
     surface $S$ is defined as $I = \\int_S J \\cdot e_n dA$, where $e_ndA$ is the vector surface element.
   """^^qudt:LatexString ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Current_density"^^xsd:anyURI ;
+  qudt:eclassCode "0173-1#Z4-BAJ315#005" ;
   qudt:hasDimensionVector qkdv:A0E1L-2I0M0H0T0D0 ;
   qudt:iec61360Code "0112/2///62720#UAD040" ;
   qudt:informativeReference "http://maxwells-equations.com/density/current.php"^^xsd:anyURI ;
@@ -4536,6 +4564,7 @@ quantitykind:ElectricDipoleMoment
     electric dipole moment of a substance within a domain is the vector sum of electric dipole moments of all electric dipoles
     included in the domain.
   """^^qudt:LatexString ;
+  qudt:eclassCode "0173-1#Z4-BAJ236#004" ;
   qudt:hasDimensionVector qkdv:A0E1L1I0M0H0T1D0 ;
   qudt:iec61360Code "0112/2///62720#UAD041" ;
   qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
@@ -4663,6 +4692,7 @@ quantitykind:ElectricFieldStrength
   dcterms:description """$\\textit{Electric Field Strength}$ is the magnitude and direction of an electric field, expressed by the
     value of $E$, also referred to as $\\color{indigo} {\\textit{electric field intensity}}$ or simply the electric field.
   """^^qudt:LatexString ;
+  qudt:eclassCode "0173-1#Z4-BAJ285#006" ;
   qudt:hasDimensionVector qkdv:A0E-1L1I0M1H0T-3D0 ;
   qudt:iec61360Code "0112/2///62720#UAD042" ;
   qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
@@ -4837,6 +4867,7 @@ quantitykind:ElectricPotential
     to the point at infinity. If the electric field is static, that is time independent, then the choice of the path is arbitrary;
     however if the electric field is time dependent, taking the integral a different paths will produce different results.
   """^^qudt:LatexString ;
+  qudt:eclassCode "0173-1#Z4-BAJ210#001" ;
   qudt:exactMatch quantitykind:ElectricPotentialDifference ;
   qudt:exactMatch quantitykind:EnergyPerElectricCharge ;
   qudt:exactMatch quantitykind:Voltage ;
@@ -5090,6 +5121,7 @@ quantitykind:ElectromagneticPermeability
     permeability is $\\textit{Magnetic Reluctivity}$.
   """^^qudt:LatexString ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Permeability"^^xsd:anyURI ;
+  qudt:eclassCode "0173-1#Z4-BAJ362#004" ;
   qudt:exactMatch quantitykind:Permeability ;
   qudt:hasDimensionVector qkdv:A0E-2L1I0M1H0T-2D0 ;
   qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
@@ -5280,6 +5312,7 @@ quantitykind:Energy
   a qudt:QuantityKind ;
   dcterms:description "Energy is the quantity characterizing the ability of a system to do work."^^qudt:LatexString ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Energy"^^xsd:anyURI ;
+  qudt:eclassCode "0173-1#Z4-BAJ218#001" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:iec61360Code "0112/2///62720#UAD071" ;
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI ;
@@ -5340,6 +5373,7 @@ quantitykind:EnergyDensity
   qudt:baseSIUnitDimensions "$m^{-1} \\cdot kg \\cdot s^{-2}$"^^qudt:LatexString ;
   qudt:baseUSCustomaryUnitDimensions "$L^{-1} \\cdot M \\cdot T^{-2}$"^^qudt:LatexString ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Energy_density"^^xsd:anyURI ;
+  qudt:eclassCode "0173-1#Z4-BAJ316#005" ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H0T-2D0 ;
   qudt:iec61360Code "0112/2///62720#UAD047" ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Energy_density"^^xsd:anyURI ;
@@ -6294,6 +6328,7 @@ quantitykind:Force
     vector quantity (has both a magnitude and direction), force also is a vector quantity.
   """^^qudt:LatexString ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Force"^^xsd:anyURI ;
+  qudt:eclassCode "0173-1#Z4-BAJ212#005" ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H0T-2D0 ;
   qudt:iec61360Code "0112/2///62720#UAD054" ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Force"^^xsd:anyURI ;
@@ -6409,6 +6444,7 @@ quantitykind:Frequency
     wavenumber.
   """^^qudt:LatexString ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Frequency"^^xsd:anyURI ;
+  qudt:eclassCode "0173-1#Z4-BAJ257#004" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:iec61360Code "0112/2///62720#UAD056" ;
   qudt:latexDefinition """$f = 1/T$, where $T$ is a period.
@@ -7072,6 +7108,7 @@ quantitykind:HallCoefficient
   dcterms:description """"Hall Coefficient" is defined as the ratio of the induced electric field to the product of the current
     density and the applied magnetic field.
   """^^qudt:LatexString ;
+  qudt:eclassCode "0173-1#Z4-BAJ423#001" ;
   qudt:hasDimensionVector qkdv:A0E-1L3I0M0H0T-1D0 ;
   qudt:iec61360Code "0112/2///62720#UAD060" ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Hall_effect"^^xsd:anyURI ;
@@ -7472,6 +7509,7 @@ quantitykind:Illuminance
     intensity of the incident light, wavelength-weighted by the luminosity function to correlate with human brightness perception.
   """^^qudt:LatexString ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Illuminance"^^xsd:anyURI ;
+  qudt:eclassCode "0173-1#Z4-BAJ201#001" ;
   qudt:hasDimensionVector qkdv:A0E0L-2I1M0H0T0D0 ;
   qudt:iec61360Code "0112/2///62720#UAD062" ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Illuminance"^^xsd:anyURI ;
@@ -8029,6 +8067,7 @@ quantitykind:InverseMagneticFlux
 
 quantitykind:InverseMass
   a qudt:QuantityKind ;
+  qudt:eclassCode "0173-1#Z4-AAB646#005" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M-1H0T0D0 ;
   qudt:iec61360Code "0112/2///62720#UAD157" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
@@ -8184,6 +8223,7 @@ quantitykind:IonicStrength
   a qudt:QuantityKind ;
   dcterms:description """The "Ionic Strength" of a solution is a measure of the concentration of ions in that solution.
   """^^qudt:LatexString ;
+  qudt:eclassCode "0173-1#Z4-BAJ344#005" ;
   qudt:hasDimensionVector qkdv:A1E0L0I0M-1H0T0D0 ;
   qudt:iec61360Code "0112/2///62720#UAD067" ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Ionic_strength"^^xsd:anyURI ;
@@ -8694,6 +8734,7 @@ quantitykind:LengthPerElectricCurrent
 
 quantitykind:LengthRatio
   a qudt:QuantityKind ;
+  qudt:eclassCode "0173-1#Z4-AAY385#003" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:organizedUnder quantitykind:DimensionlessRatio ;
   qudt:qkdvDenominator qkdv:A0E0L1I0M0H0T0D0 ;
@@ -8946,6 +8987,7 @@ quantitykind:LinearEnergyTransfer
 
 quantitykind:LinearExpansionCoefficient
   a qudt:QuantityKind ;
+  qudt:eclassCode "0173-1#Z4-BAJ373#005" ;
   qudt:expression "$lnr-exp-coef$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H-1T0D0 ;
   qudt:iec61360Code "0112/2///62720#UAD399" ;
@@ -9207,6 +9249,7 @@ quantitykind:LineicPower
 
 quantitykind:LineicQuantity
   a qudt:QuantityKind ;
+  qudt:eclassCode "0173-1#Z4-BAJ242#001" ;
   qudt:hasDimensionVector qkdv:NotApplicable ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Lineic Quantity"@en-US .
@@ -9421,6 +9464,7 @@ quantitykind:LogarithmicFrequencyInterval
   dcterms:description """The binary (base-2) logarithm of the ratio of two frequencies, whereby the frequency forming the
     numerator is greater than the frequency forming the denominator. Its corresponding unit is the octave.
   """@en ;
+  qudt:eclassCode "0173-1#Z4-BAJ338#004" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:iec61360Code "0112/2///62720#UAD083" ;
   qudt:latexDefinition "$G = \\log_{2}(f2/f1)$, where $f1$ and $f2 \\geq f1$ are frequencies of two tones."^^qudt:LatexString ;
@@ -9558,6 +9602,7 @@ quantitykind:LongRangeOrderParameter
 quantitykind:LorenzCoefficient
   a qudt:QuantityKind ;
   dcterms:description "\"Lorenz Coefficient\" is part mof the Lorenz curve."^^qudt:LatexString ;
+  qudt:eclassCode "0173-1#Z4-BAJ429#001" ;
   qudt:hasDimensionVector qkdv:A0E-2L4I0M2H-2T-6D0 ;
   qudt:iec61360Code "0112/2///62720#UAD087" ;
   qudt:informativeReference "http://www.matter.org.uk/diffraction/geometry/lattice_vectors.htm"^^xsd:anyURI ;
@@ -9659,6 +9704,7 @@ quantitykind:Luminance
     solid angle.
   """^^qudt:LatexString ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Luminance"^^xsd:anyURI ;
+  qudt:eclassCode "0173-1#Z4-BAJ286#004" ;
   qudt:hasDimensionVector qkdv:A0E0L-2I1M0H0T0D0 ;
   qudt:iec61360Code "0112/2///62720#UAD090" ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Luminance"^^xsd:anyURI ;
@@ -9679,6 +9725,7 @@ quantitykind:LuminousEfficacy
     Depending on context, the power can be either the radiant flux of the source's output, or it can be the total electric power
     consumed by the source.
   """^^qudt:LatexString ;
+  qudt:eclassCode "0173-1#Z4-BAJ335#005" ;
   qudt:expression "$lm/w$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L-2I1M-1H0T3D0 ;
   qudt:iec61360Code "0112/2///62720#UAD091" ;
@@ -9744,6 +9791,7 @@ quantitykind:LuminousExposure
   a qudt:QuantityKind ;
   dcterms:description "Luminous Exposure is the time-integrated illuminance."^^qudt:LatexString ;
   qudt:altSymbol "Hv" ;
+  qudt:eclassCode "0173-1#Z4-BAJ232#005" ;
   qudt:hasDimensionVector qkdv:A0E0L-2I1M0H0T1D0 ;
   qudt:iec61360Code "0112/2///62720#UAD093" ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Exposure_(photography)#Photometric_and_radiometric_exposure"^^xsd:anyURI ;
@@ -9762,6 +9810,7 @@ quantitykind:LuminousFlux
    in that luminous flux is adjusted to reflect the varying sensitivity of the human eye to different wavelengths of light.
   """^^qudt:LatexString ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Luminous_flux"^^xsd:anyURI ;
+  qudt:eclassCode "0173-1#Z4-BAJ220#005" ;
   qudt:hasDimensionVector qkdv:A0E0L0I1M0H0T0D0 ;
   qudt:iec61360Code "0112/2///62720#UAD094" ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Luminous_flux"^^xsd:anyURI ;
@@ -9839,6 +9888,7 @@ quantitykind:LuminousIntensity
     sensitivity of the human eye to different wavelengths.
   """^^qudt:LatexString ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Luminous_intensity"^^xsd:anyURI ;
+  qudt:eclassCode "0173-1#Z4-BAJ219#005" ;
   qudt:hasDimensionVector qkdv:A0E0L0I1M0H0T0D0 ;
   qudt:iec61360Code "0112/2///62720#UAD095" ;
   qudt:plainTextDescription """Luminous Intensity is a measure of the wavelength-weighted power emitted by a light source in a
@@ -10123,6 +10173,7 @@ quantitykind:MagneticDipoleMoment
     Moment is a vector-valued quantity. For a particle or nucleus, vector quantity causing an increment $\\Delta W = -\\mu \\cdot
     B$ to its energy $W$ in an external magnetic field with magnetic flux density $B$.
   """^^qudt:LatexString ;
+  qudt:eclassCode "0173-1#Z4-BAJ451#001" ;
   qudt:hasDimensionVector qkdv:A0E-1L3I0M1H0T-2D0 ;
   qudt:iec61360Code "0112/2///62720#UAD096" ;
   qudt:informativeReference "http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=121-11-55"^^xsd:anyURI ;
@@ -10242,6 +10293,7 @@ quantitykind:MagneticFlux
     penetrates.
   """^^qudt:LatexString ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Magnetic_flux"^^xsd:anyURI ;
+  qudt:eclassCode "0173-1#Z4-BAJ229#005" ;
   qudt:expression "$magnetic-flux$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E-1L2I0M1H0T-2D0 ;
   qudt:iec61360Code "0112/2///62720#UAD099" ;
@@ -10360,6 +10412,7 @@ quantitykind:MagneticMoment
     loop area, and the unit vector normal to the loop plane, the direction of which corresponds to the loop orientation. "Magnetic
     Moment" is also referred to as "Magnetic Area Moment", and is not to be confused with Magnetic Dipole Moment.
   """^^qudt:LatexString ;
+  qudt:eclassCode "0173-1#Z4-BAJ244#004" ;
   qudt:exactMatch quantitykind:MagneticAreaMoment ;
   qudt:hasDimensionVector qkdv:A0E1L2I0M0H0T0D0 ;
   qudt:iec61360Code "0112/2///62720#UAD097" ;
@@ -10493,6 +10546,7 @@ quantitykind:MagneticVectorPotential
     potential is not unique since any irrotational vector field quantity can be added to a given magnetic vector potential without
     changing its rotation. Under static conditions the magnetic vector potential is often chosen so that its divergence is zero.
   """^^qudt:LatexString ;
+  qudt:eclassCode "0173-1#Z4-BAJ340#005" ;
   qudt:hasDimensionVector qkdv:A0E-1L1I0M1H0T-2D0 ;
   qudt:iec61360Code "0112/2///62720#UAD103" ;
   qudt:informativeReference "http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=121-11-23"^^xsd:anyURI ;
@@ -10594,6 +10648,7 @@ quantitykind:Mass
     object's resistance to acceleration. The SI unit of mass is the kilogram ($kg$)
   """^^qudt:LatexString ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Mass"^^xsd:anyURI ;
+  qudt:eclassCode "0173-1#Z4-BAJ213#005" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T0D0 ;
   qudt:iec61360Code "0112/2///62720#UAD104" ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Mass"^^xsd:anyURI ;
@@ -10667,6 +10722,7 @@ quantitykind:MassAttenuationCoefficient
   dcterms:description """"Mass Attenuation Coefficient" is a measurement of how strongly a chemical species or substance absorbs
     or scatters light at a given wavelength, per unit mass.
   """^^qudt:LatexString ;
+  qudt:eclassCode "0173-1#Z4-BAJ349#005" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M-1H0T0D0 ;
   qudt:iec61360Code "0112/2///62720#UAD105" ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Mass_attenuation_coefficient"^^xsd:anyURI ;
@@ -10875,6 +10931,7 @@ quantitykind:MassFlowRate
     although sometimes $\\mu$ is used. The SI units are $kg s-1$.
   """^^qudt:LatexString ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Mass_flow_rate"^^xsd:anyURI ;
+  qudt:eclassCode "0173-1#Z4-BAJ284#006" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-1D0 ;
   qudt:iec61360Code "0112/2///62720#UAD107" ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Mass_flow_rate"^^xsd:anyURI ;
@@ -10903,6 +10960,7 @@ quantitykind:MassFraction
   a qudt:QuantityKind ;
   dcterms:description """The "Mass Fraction" is the fraction of one substance with mass to the mass of the total mixture .
   """^^qudt:LatexString ;
+  qudt:eclassCode "0173-1#Z4-BAJ350#005" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Mass_fraction_(chemistry)"^^xsd:anyURI ;
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
@@ -11410,6 +11468,7 @@ quantitykind:MechanicalImpedance
     at the point of application, $Z_m = F/v$. Its coherent unit is the newton second per metre (N·s/m), historically called the
     mechanical ohm. Contrast quantitykind:MechanicalSurfaceImpedance, which is a force per unit area divided by velocity.
   """^^qudt:LatexString ;
+  qudt:eclassCode "0173-1#Z4-BAJ351#005" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-1D0 ;
   qudt:iec61360Code "0112/2///62720#UAD115" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q6421317> ;
@@ -11539,6 +11598,7 @@ quantitykind:Mobility
     an electric field. The average drift speed imparted to a charged particle in a medium by an electric field, divided by the
     electric field strength.
   """^^qudt:LatexString ;
+  qudt:eclassCode "0173-1#Z4-BAJ352#004" ;
   qudt:hasDimensionVector qkdv:A0E1L0I0M-1H0T2D0 ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Electron_mobility"^^xsd:anyURI ;
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
@@ -11724,6 +11784,7 @@ quantitykind:MolarAttenuationCoefficient
   dcterms:description """"Molar Attenuation Coefficient" is a measurement of how strongly a chemical species or substance absorbs
     or scatters light at a given wavelength, per amount of substance.
   """^^qudt:LatexString ;
+  qudt:eclassCode "0173-1#Z4-BAJ356#004" ;
   qudt:exactMatch quantitykind:MolarAbsorptionCoefficient ;
   qudt:hasDimensionVector qkdv:A-1E0L2I0M0H0T0D0 ;
   qudt:iec61360Code "0112/2///62720#UAD120" ;
@@ -11744,6 +11805,7 @@ quantitykind:MolarConductivity
   dcterms:description """"Molar Conductivity" is the conductivity of an electrolyte solution divided by the molar concentration of
     the electrolyte, and so measures the efficiency with which a given electrolyte conducts electricity in solution.
   """^^qudt:LatexString ;
+  qudt:eclassCode "0173-1#Z4-BAJ354#004" ;
   qudt:hasDimensionVector qkdv:A-1E2L0I0M-1H0T3D0 ;
   qudt:iec61360Code "0112/2///62720#UAD121" ;
   qudt:informativeReference "http://encyclopedia2.thefreedictionary.com/molar+conductivity"^^xsd:anyURI ;
@@ -11905,6 +11967,7 @@ quantitykind:MolarMass
     is $kg/mol$.
   """^^qudt:LatexString ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Molar_mass"^^xsd:anyURI ;
+  qudt:eclassCode "0173-1#Z4-BAJ287#005" ;
   qudt:hasDimensionVector qkdv:A-1E0L0I0M1H0T0D0 ;
   qudt:iec61360Code "0112/2///62720#UAD125" ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Molar_mass"^^xsd:anyURI ;
@@ -12008,6 +12071,7 @@ quantitykind:MolarVolume
     molar volume can be measured by X-ray crystallography.
   """^^qudt:LatexString ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Molar_volume"^^xsd:anyURI ;
+  qudt:eclassCode "0173-1#Z4-BAJ357#004" ;
   qudt:hasDimensionVector qkdv:A-1E0L3I0M0H0T0D0 ;
   qudt:iec61360Code "0112/2///62720#UAD127" ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Molar_volume"^^xsd:anyURI ;
@@ -12136,6 +12200,7 @@ quantitykind:MomentOfInertia
   a qudt:QuantityKind ;
   dcterms:description """The rotational inertia or resistance to change in direction or speed of rotation about a defined axis.
   """^^qudt:LatexString ;
+  qudt:eclassCode "0173-1#Z4-BAJ246#006" ;
   qudt:exactMatch quantitykind:RotationalMass ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T0D0 ;
   qudt:iec61360Code "0112/2///62720#UAD128" ;
@@ -13063,6 +13128,7 @@ quantitykind:ParticleFluence
    intersect a unit area in a specific time interval of interest, and has units of $m^{-2}$
     (number of particles per meter squared).
   """^^qudt:LatexString ;
+  qudt:eclassCode "0173-1#Z4-BAJ387#004" ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M0H0T0D0 ;
   qudt:iec61360Code "0112/2///62720#UAD133" ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Fluence"^^xsd:anyURI ;
@@ -13265,6 +13331,7 @@ quantitykind:Permittivity
     tensor-valued.
   """^^qudt:LatexString ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Permittivity"^^xsd:anyURI ;
+  qudt:eclassCode "0173-1#Z4-BAJ439#006" ;
   qudt:hasDimensionVector qkdv:A0E2L-3I0M-1H0T4D0 ;
   qudt:iec61360Code "0112/2///62720#UAD136" ;
   qudt:informativeReference "http://maxwells-equations.com/materials/permittivity.php"^^xsd:anyURI ;
@@ -13404,6 +13471,7 @@ quantitykind:PhotoThresholdOfAwarenessFunction
 quantitykind:PhotonIntensity
   a qudt:QuantityKind ;
   dcterms:description "A measure of flux of photons per solid angle"^^qudt:LatexString ;
+  qudt:eclassCode "0173-1#Z4-BAJ364#005" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T-1D0 ;
   qudt:iec61360Code "0112/2///62720#UAD137" ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Photon_counting"^^xsd:anyURI ;
@@ -13543,6 +13611,7 @@ quantitykind:PlaneAngle
     $180^\\circ$, supplementary angles; if $360^\\circ$, explementary angles.
   """^^qudt:LatexString ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Plane_angle"^^xsd:anyURI ;
+  qudt:eclassCode "0173-1#Z4-BAJ205#007" ;
   qudt:exactMatch quantitykind:Angle ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:iec61360Code "0112/2///62720#UAD140" ;
@@ -13768,6 +13837,7 @@ quantitykind:Power
   """^^qudt:LatexString ;
   qudt:altSymbol "p" ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Power"^^xsd:anyURI ;
+  qudt:eclassCode "0173-1#Z4-BAJ214#001" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:iec61360Code "0112/2///62720#UAD003" ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Power"^^xsd:anyURI ;
@@ -14092,6 +14162,7 @@ quantitykind:PressureBasedMolality
 
 quantitykind:PressureBasedQuantity
   a qudt:QuantityKind ;
+  qudt:eclassCode "0173-1#Z4-BAJ235#001" ;
   qudt:hasDimensionVector qkdv:NotApplicable ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Pressure-based Quantity"@en-US .
@@ -14150,6 +14221,7 @@ quantitykind:PressureBurningRateIndex
 
 quantitykind:PressureCoefficient
   a qudt:QuantityKind ;
+  qudt:eclassCode "0173-1#Z4-BAJ378#004" ;
   qudt:expression "$pres-coef$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M1H-1T-2D0 ;
   qudt:iec61360Code "0112/2///62720#UAD143" ;
@@ -14207,6 +14279,7 @@ quantitykind:PressureLossPerLength
 
 quantitykind:PressureRatio
   a qudt:QuantityKind ;
+  qudt:eclassCode "0173-1#Z4-BAJ314#004" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:iec61360Code "0112/2///62720#UAD226" ;
   qudt:organizedUnder quantitykind:DimensionlessRatio ;
@@ -14565,6 +14638,7 @@ quantitykind:RadiantExposure
     the integral over time of the radiant flux density. Also known as exposure.
   """^^qudt:LatexString ;
   qudt:abbreviation "J-PER-CM2" ;
+  qudt:eclassCode "0173-1#Z4-BAJ294#005" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-2D0 ;
   qudt:iec61360Code "0112/2///62720#UAD150" ;
   qudt:informativeReference "http://omlc.ogi.edu/education/ece532/class1/irradiance.html"^^xsd:anyURI ;
@@ -14649,6 +14723,7 @@ quantitykind:RadiantIntensity
   dcterms:description """Radiant Intensity is a measure of the intensity of electromagnetic radiation. It is defined as power per
     unit solid angle.
   """^^qudt:LatexString ;
+  qudt:eclassCode "0173-1#Z4-BAJ385#004" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:iec61360Code "0112/2///62720#UAD151" ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Radiant_intensity"^^xsd:anyURI ;
@@ -14944,6 +15019,7 @@ quantitykind:ReactivePower
     value of the reactive power is equal to the non-active power. The ISO (and SI) unit for reactive power is the voltampere. The
     special name $\\textit{var}$ and symbol $\\textit{var}$ are given in IEC 60027 1.
   """^^qudt:LatexString ;
+  qudt:eclassCode "0173-1#Z4-BAJ272#004" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-3D0 ;
   qudt:iec61360Code "0112/2///62720#UAD155" ;
   qudt:informativeReference "http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=131-11-44"^^xsd:anyURI ;
@@ -15367,6 +15443,7 @@ quantitykind:Reluctance
     causes magnetic flux to follow the path of least magnetic reluctance. It is a scalar, extensive quantity, akin to electrical
     resistance.
   """^^qudt:LatexString ;
+  qudt:eclassCode "0173-1#Z4-BAJ265#005" ;
   qudt:hasDimensionVector qkdv:A0E2L-2I0M-1H0T2D0 ;
   qudt:iec61360Code "0112/2///62720#UAD159" ;
   qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
@@ -15456,6 +15533,7 @@ quantitykind:ResistanceRatio
 quantitykind:Resistivity
   a qudt:QuantityKind ;
   dcterms:description "\"Resistivity\" is the inverse of the conductivity when this inverse exists."^^qudt:LatexString ;
+  qudt:eclassCode "0173-1#Z4-BAJ369#005" ;
   qudt:hasDimensionVector qkdv:A0E-2L3I0M1H0T-3D0 ;
   qudt:iec61360Code "0112/2///62720#UAD161" ;
   qudt:informativeReference "http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=121-12-04"^^xsd:anyURI ;
@@ -15642,6 +15720,7 @@ quantitykind:RichardsonConstant
   a qudt:QuantityKind ;
   dcterms:description """"Richardson Constant" is a constant used in developing thermionic emission current density for a metal.
   """^^qudt:LatexString ;
+  qudt:eclassCode "0173-1#Z4-BAJ453#001" ;
   qudt:hasDimensionVector qkdv:A0E1L-2I0M0H-2T0D0 ;
   qudt:iec61360Code "0112/2///62720#UAD162" ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Thermionic_emission"^^xsd:anyURI ;
@@ -15802,6 +15881,7 @@ quantitykind:SecondMomentOfArea
     to bending and deflection. The deflection of an object under load depends not only on the load, but also on the geometry of
     the object's cross-section.
   """^^qudt:LatexString ;
+  qudt:eclassCode "0173-1#Z4-BAJ239#006" ;
   qudt:hasDimensionVector qkdv:A0E0L4I0M0H0T0D0 ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Second_moment_of_area"^^xsd:anyURI ;
   qudt:plainTextDescription """The second moment of area is a property of a physical object that can be used to predict its
@@ -15910,6 +15990,7 @@ quantitykind:SeebeckCoefficient
   dcterms:description """"Seebeck Coefficient", or thermopower, or thermoelectric power of a material is a measure of the
     magnitude of an induced thermoelectric voltage in response to a temperature difference across that material.
   """^^qudt:LatexString ;
+  qudt:eclassCode "0173-1#Z4-BAJ430#001" ;
   qudt:hasDimensionVector qkdv:A0E-1L2I0M1H-1T-3D0 ;
   qudt:iec61360Code "0112/2///62720#UAD169" ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Thermopower"^^xsd:anyURI ;
@@ -16114,6 +16195,7 @@ quantitykind:Slowing-DownDensity
   dcterms:isReplacedBy quantitykind:SlowingDownDensity ;
   qudt:deprecated true ;
   qudt:deprecatedInVersion "3.2.0" ;
+  qudt:eclassCode "0173-1#Z4-BAJ296#004" ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M0H0T-1D0 ;
   qudt:iec61360Code "0112/2///62720#UAD170" ;
   qudt:informativeReference "http://encyclopedia2.thefreedictionary.com/slowing-down+density"^^xsd:anyURI ;
@@ -16168,6 +16250,7 @@ quantitykind:SlowingDownDensity
   dcterms:description """"Slowing-Down Density" is a measure of the rate at which neutrons lose energy in a nuclear reactor
     through collisions; equal to the number of neutrons that fall below a given energy per unit volume per unit time.
   """^^qudt:LatexString ;
+  qudt:eclassCode "0173-1#Z4-BAJ296#004" ;
   qudt:hasDimensionVector qkdv:A0E0L-3I0M0H0T-1D0 ;
   qudt:iec61360Code "0112/2///62720#UAD170" ;
   qudt:informativeReference "http://encyclopedia2.thefreedictionary.com/slowing-down+density"^^xsd:anyURI ;
@@ -16219,6 +16302,7 @@ quantitykind:SolidAngle
     angle will always be between 0 and 4*pi.
   """^^qudt:LatexString ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Solid_angle"^^xsd:anyURI ;
+  qudt:eclassCode "0173-1#Z4-BAJ266#005" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:iec61360Code "0112/2///62720#UAD171" ;
   qudt:plainTextDescription """The solid angle subtended by a surface S is defined as the surface area of a unit sphere covered by
@@ -16312,6 +16396,7 @@ quantitykind:SoundExposure
   dcterms:description """Sound Exposure is the energy of the A-weighted sound calculated over the measurement time(s). For a given
     period of time, an increase of 10 dB(A) in sound pressure level corresponds to a tenfold increase in E.
   """^^qudt:LatexString ;
+  qudt:eclassCode "0173-1#Z4-BAJ461#003" ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M2H0T-3D0 ;
   qudt:iec61360Code "0112/2///62720#UAD172" ;
   qudt:informativeReference "http://www.acoustic-glossary.co.uk/definitions-s.htm"^^xsd:anyURI ;
@@ -17078,6 +17163,7 @@ quantitykind:SpecificVolume
   dcterms:description """"Specific Volume" ($\\nu$) is the volume occupied by a unit of mass of a material. It is equal to the
     inverse of density.
   """^^qudt:LatexString ;
+  qudt:eclassCode "0173-1#Z4-BAJ383#007" ;
   qudt:hasDimensionVector qkdv:A0E0L3I0M-1H0T0D0 ;
   qudt:iec61360Code "0112/2///62720#UAD175" ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Specific_volume"^^xsd:anyURI ;
@@ -17151,6 +17237,7 @@ quantitykind:SpectralCrossSection
   dcterms:description """"Spectral Cross-section" is the cross-section for a process in which the energy of the ejected or
     scattered particle is in an interval of energy, divided by the range $dE$ of this interval.
   """^^qudt:LatexString ;
+  qudt:eclassCode "0173-1#Z4-BAJ381#004" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M-1H0T2D0 ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Cross_section_(physics)"^^xsd:anyURI ;
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
@@ -17870,6 +17957,7 @@ quantitykind:SurfaceTension
   dcterms:description """"Surface Tension" is a contractive tendency of the surface of a liquid that allows it to resist an
     external force.
   """^^qudt:LatexString ;
+  qudt:eclassCode "0173-1#Z4-BAJ360#005" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H0T-2D0 ;
   qudt:iec61360Code "0112/2///62720#UAD184" ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Surface_tension"^^xsd:anyURI ;
@@ -17991,6 +18079,7 @@ quantitykind:Temperature
     temperature difference and the thermal conductivity.
   """^^qudt:LatexString ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Temperature"^^xsd:anyURI ;
+  qudt:eclassCode "0173-1#Z4-BAJ202#001" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H1T0D0 ;
   qudt:iec61360Code "0112/2///62720#UAD374" ;
   qudt:plainTextDescription """Temperature is a physical property of matter that quantitatively expresses the common notions of
@@ -18076,6 +18165,7 @@ quantitykind:TemperatureBasedMassFlowRate
 
 quantitykind:TemperatureBasedQuantity
   a qudt:QuantityKind ;
+  qudt:eclassCode "0173-1#Z4-BAJ250#001" ;
   qudt:hasDimensionVector qkdv:NotApplicable ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/quantitykind> ;
   rdfs:label "Temperature-based Quantity"@en-US .
@@ -18167,6 +18257,7 @@ quantitykind:TemperatureRateOfChange
 
 quantitykind:TemperatureRatio
   a qudt:QuantityKind ;
+  qudt:eclassCode "0173-1#Z4-BAJ399#004" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:iec61360Code "0112/2///62720#UAD228" ;
   qudt:organizedUnder quantitykind:DimensionlessRatio ;
@@ -18285,6 +18376,7 @@ quantitykind:ThermalCoefficientOfLinearExpansion
 quantitykind:ThermalConductance
   a qudt:QuantityKind ;
   dcterms:description "This quantity is also called \"Heat Transfer Coefficient\"."^^qudt:LatexString ;
+  qudt:eclassCode "0173-1#Z4-BAJ408#004" ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H-1T-3D0 ;
   qudt:iec61360Code "0112/2///62720#UAD189" ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Thermal_insulation"^^xsd:anyURI ;
@@ -18304,6 +18396,7 @@ quantitykind:ThermalConductivity
     temperature gradient.
   """^^qudt:LatexString ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Thermal_conductivity"^^xsd:anyURI ;
+  qudt:eclassCode "0173-1#Z4-BAJ407#005" ;
   qudt:expression "$thermal-k$"^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H-1T-3D0 ;
   qudt:iec61360Code "0112/2///62720#UAD380" ;
@@ -18500,6 +18593,7 @@ quantitykind:ThermalResistance
     $\\frac{m^2 \\cdot K}{W}$.
   """^^qudt:LatexString ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Thermal_resistance"^^xsd:anyURI ;
+  qudt:eclassCode "0173-1#Z4-BAJ409#005" ;
   qudt:hasDimensionVector qkdv:A0E0L-2I0M-1H1T3D0 ;
   qudt:iec61360Code "0112/2///62720#UAD193" ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Thermal_resistance"^^xsd:anyURI ;
@@ -18527,6 +18621,7 @@ quantitykind:ThermalResistivity
   dcterms:description """The reciprocal of thermal conductivity is thermal resistivity, measured in $kelvin-metres$ per watt ($K
     \\cdot m/W$).
   """^^qudt:LatexString ;
+  qudt:eclassCode "0173-1#Z4-BAJ465#005" ;
   qudt:hasDimensionVector qkdv:A0E0L-1I0M-1H1T3D0 ;
   qudt:iec61360Code "0112/2///62720#UAD194" ;
   qudt:wikidataMatch <http://www.wikidata.org/entity/Q66311516> ;
@@ -18540,6 +18635,7 @@ quantitykind:ThermalTransmittance
     thermal transmittance is closely related to that of thermal resistance. The thermal resistance of a structure is the
     reciprocal of its thermal transmittance.
   """^^qudt:LatexString ;
+  qudt:eclassCode "0173-1#Z4-BAJ405#005" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M1H-1T-3D0 ;
   qudt:iec61360Code "0112/2///62720#UAD195" ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Thermal_transmittance"^^xsd:anyURI ;
@@ -18629,6 +18725,7 @@ quantitykind:ThermodynamicTemperature
     is a base quantity in the International System of Quantities, ISQ, on which the International System of Units, SI, is based.
   """ ;
   qudt:dbpediaMatch "http://dbpedia.org/page/Thermodynamic_temperature"^^xsd:anyURI ;
+  qudt:eclassCode "0173-1#Z4-BAJ275#002" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H1T0D0 ;
   qudt:iec61360Code "0112/2///62720#UAD196" ;
   qudt:latexSymbol "$\\Theta$"^^qudt:LatexString ;
@@ -18778,6 +18875,7 @@ quantitykind:Time
     events and the intervals between them, and to quantify the motions of objects.
   """^^qudt:LatexString ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Time"^^xsd:anyURI ;
+  qudt:eclassCode "0173-1#Z4-BAJ217#006" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T1D0 ;
   qudt:iec61360Code "0112/2///62720#UAD197" ;
   qudt:plainTextDescription """Time is a basic component of the measuring system used to sequence events, to compare the durations
@@ -18911,6 +19009,7 @@ quantitykind:Torque
     momentum: $τ = dL/dt$ where, L is the angular momentum vector t stands for time.
   """^^qudt:LatexString ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Torque"^^xsd:anyURI ;
+  qudt:eclassCode "0173-1#Z4-BAJ233#005" ;
   qudt:exactMatch quantitykind:MomentOfForce ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T-2D0 ;
   qudt:iec61360Code "0112/2///62720#UAD200" ;
@@ -19120,6 +19219,7 @@ quantitykind:TotalLinearStoppingPower
   dcterms:description """The "Total Linear Stopping Power" is defined as the average energy loss of the particle per unit path
     length.
   """^^qudt:LatexString ;
+  qudt:eclassCode "0173-1#Z4-BAJ337#004" ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M1H0T-2D0 ;
   qudt:iec61360Code "0112/2///62720#UAD203" ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Stopping_power_(particle_radiation)"^^xsd:anyURI ;
@@ -19139,6 +19239,7 @@ quantitykind:TotalMassStoppingPower
     are very different just because of the different density. One therefore often divides S(E) by the density of the material to
     obtain the "Mass Stopping Power". The mass stopping power then depends only very little on the density of the material.
   """^^qudt:LatexString ;
+  qudt:eclassCode "0173-1#Z4-BAJ348#004" ;
   qudt:hasDimensionVector qkdv:A0E0L4I0M0H0T-2D0 ;
   qudt:iec61360Code "0112/2///62720#UAD204" ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Stopping_power_(particle_radiation)"^^xsd:anyURI ;
@@ -19435,6 +19536,7 @@ quantitykind:Velocity
     describes only how fast an object is moving, whereas velocity gives both how fast and in what direction the object is moving.
   """^^qudt:LatexString ;
   qudt:dbpediaMatch "http://dbpedia.org/resource/Velocity"^^xsd:anyURI ;
+  qudt:eclassCode "0173-1#Z4-BAJ281#006" ;
   qudt:exactMatch quantitykind:LinearVelocity ;
   qudt:hasDimensionVector qkdv:A0E0L1I0M0H0T-1D0 ;
   qudt:iec61360Code "0112/2///62720#UAD236" ;
@@ -19596,6 +19698,7 @@ quantitykind:Voltage
     is electric field strength. For an irrotational electric field, the voltage is independent of the path between the two points
     $a$ and $b$.
   """^^qudt:LatexString ;
+  qudt:eclassCode "0173-1#Z4-BAJ267#005" ;
   qudt:exactMatch quantitykind:ElectricPotential ;
   qudt:exactMatch quantitykind:ElectricPotentialDifference ;
   qudt:exactMatch quantitykind:EnergyPerElectricCharge ;
@@ -19730,6 +19833,7 @@ quantitykind:VolumeFraction
     prior to mixing. Volume fraction is also called volume concentration in ideal solutions where the volumes of the constituents
     are additive (the volume of the solution is equal to the sum of the volumes of its ingredients).
   """^^qudt:LatexString ;
+  qudt:eclassCode "0173-1#Z4-BAJ403#005" ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
   qudt:iec61360Code "0112/2///62720#UAD240" ;
   qudt:informativeReference "https://en.wikipedia.org/wiki/Volume_fraction"^^xsd:anyURI ;


### PR DESCRIPTION
Updated statistics (see #1472 for previous numbers):

* ECLASS Release 16.0 contains 279 `<unitsml:Quantity />` definitions.
* With this PR, there are 254 quantity kinds that have an `qudt:eclassCode` assigned.
    * 22 quantity kinds with an `qudt:eclassCode`  are deprecated.
    * 232 quantity kinds with an `qudt:eclassCode` are not deprecated.
    * In total, there are now 259 `qudt:eclassCode` statements.
